### PR TITLE
Runtime cuBLAS linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,25 +44,19 @@ dq = qt.dequantize()
 ### From PyPI
 
 ```bash
-# Install with CUDA support (Linux/Windows)
+# Install default (Linux/Windows/MacOS)
 pip install comfy-kitchen
 
-# Install CPU-only version (any platform)
-pip install comfy-kitchen --prefer-binary --only-binary=:none:
+# Install with CUBLAS for NVFP4 (+Blackwell)
+pip install comfy-kitchen[cublas]
 ```
 
 ### Package Variants
 
-Two wheel variants are published to PyPI:
+- **CUDA wheels**: Linux x86_64 and Windows x64
+- **Pure Python wheel**: Any platform, eager and triton backends only
 
-| Wheel | Platforms | Backends | Notes |
-|-------|-----------|----------|-------|
-| `comfy_kitchen-X.Y.Z-cp312-abi3-manylinux_2_28_x86_64.whl` | Linux x86_64 | eager, cuda, triton | Requires CUDA 13.0+ runtime |
-| `comfy_kitchen-X.Y.Z-cp312-abi3-win_amd64.whl` | Windows x64 | eager, cuda, triton | Requires CUDA 13.0+ runtime |
-| `comfy_kitchen-X.Y.Z-py3-none-any.whl` | Any | eager, triton | Pure Python, no CUDA required |
-
-- **CUDA wheels** use Python's Stable ABI (`abi3`), so a single wheel works across Python 3.12, 3.13, 3.14+
-- **CPU-only wheel** is pure Python and works on any platform with Python 3.12+
+Wheels are built for Python 3.10, 3.11, and 3.12+ (using Stable ABI for 3.12+).
 
 ### From Source
 
@@ -81,12 +75,12 @@ pip install -e . --no-build-isolation -v
 
 These options require using `setup.py` directly (not `pip install`):
 
-| Option | Command | Description | Default |
-|--------|---------|-------------|---------|
-| `--no-cuda` | `python setup.py bdist_wheel --no-cuda` | Build CPU-only wheel (`py3-none-any`) | Enabled (build with CUDA) |
-| `--cuda-archs=...` | `python setup.py build_ext --cuda-archs="80;89"` | CUDA architectures to build for | `120f` (Linux), `80;89;120f` (Windows) |
-| `--debug-build` | `python setup.py build_ext --debug-build` | Build in debug mode with symbols | Disabled (Release) |
-| `--lineinfo` | `python setup.py build_ext --lineinfo` | Enable NVCC line info for profiling | Disabled |
+| Option | Command | Description | Default                                                                     |
+|--------|---------|-------------|-----------------------------------------------------------------------------|
+| `--no-cuda` | `python setup.py bdist_wheel --no-cuda` | Build CPU-only wheel (`py3-none-any`) | Enabled (build with CUDA)                                                   |
+| `--cuda-archs=...` | `python setup.py build_ext --cuda-archs="80;89"` | CUDA architectures to build for | `75-virtual;80;89;90a;100f;120f` (Linux), `75-virtual;80;89;120f` (Windows) |
+| `--debug-build` | `python setup.py build_ext --debug-build` | Build in debug mode with symbols | Disabled (Release)                                                          |
+| `--lineinfo` | `python setup.py build_ext --lineinfo` | Enable NVCC line info for profiling | Disabled                                                                    |
 
 ```bash
 # Build CPU-only wheel (pure Python, no CUDA required)
@@ -103,10 +97,10 @@ python setup.py build_ext --debug-build --lineinfo bdist_wheel
 
 ### Requirements
 
-- **Python**: ≥3.12 (uses Stable ABI - single wheel works across 3.12, 3.13, 3.14+)
+- **Python**: ≥3.10
 - **PyTorch**: ≥2.5.0
 - **CUDA Runtime** (for CUDA wheels): ≥13.0
-  - Pre-built wheels require CUDA 13.0+ drivers on the system
+  - Pre-built wheels require NVIDIA Driver r580+
   - Building from source requires CUDA Toolkit ≥12.8 and `CUDA_HOME` environment variable
 - **nanobind**: ≥2.0.0 (for building from source)
 - **CMake**: ≥3.18 (for building from source)
@@ -129,7 +123,7 @@ print(ck.list_backends())
 result = ck.quantize_per_tensor_fp8(x, scale, backend="eager")
 
 # Temporarily use a different backend
-with ck.use_backend("cuda"):
+with ck.use_backend("triton"):
     result = ck.quantize_per_tensor_fp8(x, scale)
 ```
 
@@ -158,7 +152,7 @@ Each backend declares constraints for its functions:
 
 | Constraint | Description |
 |------------|-------------|
-| **Device** | Which device types are supported (`cuda`, `cpu`) |
+| **Device** | Which device types are supported |
 | **Dtype** | Allowed input/output dtypes per parameter |
 | **Shape** | Shape requirements (e.g., 2D tensors, dimensions divisible by 16) |
 | **Compute Capability** | Minimum GPU architecture (e.g., SM 8.0 for FP8, SM 10.0 for NVFP4) |

--- a/comfy_kitchen/backends/cuda/CMakeLists.txt
+++ b/comfy_kitchen/backends/cuda/CMakeLists.txt
@@ -143,14 +143,17 @@ target_include_directories(_C PRIVATE
 )
 
 # Link libraries
+# Note: cuBLASLt is loaded dynamically at runtime via dlopen/LoadLibrary
 target_link_libraries(_C PRIVATE
     CUDA::cudart_static
-    CUDA::cublasLt
 )
 
 # On Windows, static cudart requires additional system libraries
 if(WIN32)
     target_link_libraries(_C PRIVATE ws2_32)
+else()
+    # Linux: need libdl for dlopen/dlsym
+    target_link_libraries(_C PRIVATE ${CMAKE_DL_LIBS})
 endif()
 
 # Ensure Python libraries are properly linked on Windows

--- a/comfy_kitchen/backends/cuda/__init__.py
+++ b/comfy_kitchen/backends/cuda/__init__.py
@@ -94,6 +94,7 @@ except Exception as e:
 from comfy_kitchen.backends.eager.quantization import DTYPE_TO_CODE  # noqa: E402
 from comfy_kitchen.float_utils import roundup  # noqa: E402
 
+_CUBLASLT_AVAILABLE = _EXT_AVAILABLE and getattr(_C, "HAS_CUBLASLT", False)
 _cublas_workspace: torch.Tensor | None = None
 
 
@@ -449,7 +450,7 @@ def _build_constraints() -> dict:
 
     cuda_devices = frozenset({"cuda"})
 
-    return {
+    constraints = {
         "quantize_per_tensor_fp8": FunctionConstraints(
             params={
                 "x": ParamConstraint(
@@ -508,35 +509,6 @@ def _build_constraints() -> dict:
             },
             default_devices=cuda_devices,
         ),
-        "scaled_mm_nvfp4": FunctionConstraints(
-            params={
-                "a": ParamConstraint(
-                    dtypes=frozenset({torch.uint8}),
-                    shape_rules=(ExactDims(2), DivisibleBy(dim=1, factor=16)),
-                ),
-                "b": ParamConstraint(
-                    dtypes=frozenset({torch.uint8}),
-                    shape_rules=(ExactDims(2), DivisibleBy(dim=1, factor=16)),
-                ),
-                "tensor_scale_a": ParamConstraint(
-                    dtypes=frozenset({torch.float32}),
-                ),
-                "tensor_scale_b": ParamConstraint(
-                    dtypes=frozenset({torch.float32}),
-                ),
-                "block_scale_a": ParamConstraint(
-                    dtypes=frozenset({torch.float8_e4m3fn}),
-                ),
-                "block_scale_b": ParamConstraint(
-                    dtypes=frozenset({torch.float8_e4m3fn}),
-                ),
-                "out_dtype": ParamConstraint(
-                    dtypes=frozenset({torch.float16, torch.bfloat16}),
-                ),
-            },
-            default_devices=cuda_devices,
-            min_compute_capability=(10, 0),
-        ),
         "apply_rope1": FunctionConstraints(
             params={
                 "x": ParamConstraint(
@@ -568,6 +540,39 @@ def _build_constraints() -> dict:
             default_devices=cuda_devices,
         ),
     }
+
+    if _CUBLASLT_AVAILABLE:
+        constraints["scaled_mm_nvfp4"] = FunctionConstraints(
+            params={
+                "a": ParamConstraint(
+                    dtypes=frozenset({torch.uint8}),
+                    shape_rules=(ExactDims(2), DivisibleBy(dim=1, factor=16)),
+                ),
+                "b": ParamConstraint(
+                    dtypes=frozenset({torch.uint8}),
+                    shape_rules=(ExactDims(2), DivisibleBy(dim=1, factor=16)),
+                ),
+                "tensor_scale_a": ParamConstraint(
+                    dtypes=frozenset({torch.float32}),
+                ),
+                "tensor_scale_b": ParamConstraint(
+                    dtypes=frozenset({torch.float32}),
+                ),
+                "block_scale_a": ParamConstraint(
+                    dtypes=frozenset({torch.float8_e4m3fn}),
+                ),
+                "block_scale_b": ParamConstraint(
+                    dtypes=frozenset({torch.float8_e4m3fn}),
+                ),
+                "out_dtype": ParamConstraint(
+                    dtypes=frozenset({torch.float16, torch.bfloat16}),
+                ),
+            },
+            default_devices=cuda_devices,
+            min_compute_capability=(10, 0),
+        )
+
+    return constraints
 
 
 def _register():

--- a/comfy_kitchen/backends/cuda/cublaslt_runtime.h
+++ b/comfy_kitchen/backends/cuda/cublaslt_runtime.h
@@ -1,0 +1,248 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cublasLt.h>
+#include <string>
+#include <mutex>
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <dlfcn.h>
+#endif
+
+namespace comfy {
+class CublasLtRuntime {
+public:
+    // Function pointer types for cuBLASLt functions we need
+    using cublasLtCreate_t = cublasStatus_t (*)(cublasLtHandle_t*);
+    using cublasLtDestroy_t = cublasStatus_t (*)(cublasLtHandle_t);
+    using cublasLtMatmul_t = cublasStatus_t (*)(
+        cublasLtHandle_t,
+        cublasLtMatmulDesc_t,
+        const void*,
+        const void*,
+        cublasLtMatrixLayout_t,
+        const void*,
+        cublasLtMatrixLayout_t,
+        const void*,
+        const void*,
+        cublasLtMatrixLayout_t,
+        void*,
+        cublasLtMatrixLayout_t,
+        const cublasLtMatmulAlgo_t*,
+        void*,
+        size_t,
+        cudaStream_t
+    );
+    using cublasLtMatmulDescCreate_t = cublasStatus_t (*)(
+        cublasLtMatmulDesc_t*,
+        cublasComputeType_t,
+        cudaDataType_t
+    );
+    using cublasLtMatmulDescDestroy_t = cublasStatus_t (*)(cublasLtMatmulDesc_t);
+    using cublasLtMatmulDescSetAttribute_t = cublasStatus_t (*)(
+        cublasLtMatmulDesc_t,
+        cublasLtMatmulDescAttributes_t,
+        const void*,
+        size_t
+    );
+    using cublasLtMatrixLayoutCreate_t = cublasStatus_t (*)(
+        cublasLtMatrixLayout_t*,
+        cudaDataType_t,
+        uint64_t,
+        uint64_t,
+        int64_t
+    );
+    using cublasLtMatrixLayoutDestroy_t = cublasStatus_t (*)(cublasLtMatrixLayout_t);
+    using cublasLtMatmulPreferenceCreate_t = cublasStatus_t (*)(cublasLtMatmulPreference_t*);
+    using cublasLtMatmulPreferenceDestroy_t = cublasStatus_t (*)(cublasLtMatmulPreference_t);
+    using cublasLtMatmulPreferenceSetAttribute_t = cublasStatus_t (*)(
+        cublasLtMatmulPreference_t,
+        cublasLtMatmulPreferenceAttributes_t,
+        const void*,
+        size_t
+    );
+    using cublasLtMatmulAlgoGetHeuristic_t = cublasStatus_t (*)(
+        cublasLtHandle_t,
+        cublasLtMatmulDesc_t,
+        cublasLtMatrixLayout_t,
+        cublasLtMatrixLayout_t,
+        cublasLtMatrixLayout_t,
+        cublasLtMatrixLayout_t,
+        cublasLtMatmulPreference_t,
+        int,
+        cublasLtMatmulHeuristicResult_t*,
+        int*
+    );
+
+    static CublasLtRuntime& instance() {
+        static CublasLtRuntime runtime;
+        return runtime;
+    }
+
+    bool is_available() const { return available_; }
+    const std::string& error_message() const { return error_message_; }
+
+    // Function pointers - only valid if is_available() returns true
+    cublasLtCreate_t cublasLtCreate = nullptr;
+    cublasLtDestroy_t cublasLtDestroy = nullptr;
+    cublasLtMatmul_t cublasLtMatmul = nullptr;
+    cublasLtMatmulDescCreate_t cublasLtMatmulDescCreate = nullptr;
+    cublasLtMatmulDescDestroy_t cublasLtMatmulDescDestroy = nullptr;
+    cublasLtMatmulDescSetAttribute_t cublasLtMatmulDescSetAttribute = nullptr;
+    cublasLtMatrixLayoutCreate_t cublasLtMatrixLayoutCreate = nullptr;
+    cublasLtMatrixLayoutDestroy_t cublasLtMatrixLayoutDestroy = nullptr;
+    cublasLtMatmulPreferenceCreate_t cublasLtMatmulPreferenceCreate = nullptr;
+    cublasLtMatmulPreferenceDestroy_t cublasLtMatmulPreferenceDestroy = nullptr;
+    cublasLtMatmulPreferenceSetAttribute_t cublasLtMatmulPreferenceSetAttribute = nullptr;
+    cublasLtMatmulAlgoGetHeuristic_t cublasLtMatmulAlgoGetHeuristic = nullptr;
+
+private:
+    CublasLtRuntime() {
+        load();
+    }
+
+    ~CublasLtRuntime() {
+        unload();
+    }
+
+    // Delete copy/move
+    CublasLtRuntime(const CublasLtRuntime&) = delete;
+    CublasLtRuntime& operator=(const CublasLtRuntime&) = delete;
+
+    void load() {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (load_attempted_) return;
+        load_attempted_ = true;
+
+#ifdef _WIN32
+        // Windows: cuBLAS 13.x (CUDA 13+)
+        const char* lib_names[] = {
+            "cublasLt64_13.dll",
+            "cublasLt64.dll",       // Fallback (may be 13.x)
+            nullptr
+        };
+        
+        for (const char** name = lib_names; *name != nullptr; ++name) {
+            handle_ = LoadLibraryA(*name);
+            if (handle_) break;
+        }
+        
+        if (!handle_) {
+            error_message_ = "cuBLASLt 13.x library not found (requires CUDA 13+)";
+            return;
+        }
+#else
+        // Linux: cuBLAS 13.x (CUDA 13+)
+        const char* lib_names[] = {
+            "libcublasLt.so.13",
+            "libcublasLt.so",       // Fallback (may be 13.x)
+            nullptr
+        };
+        
+        for (const char** name = lib_names; *name != nullptr; ++name) {
+            handle_ = dlopen(*name, RTLD_NOW | RTLD_GLOBAL);
+            if (handle_) break;
+        }
+        
+        if (!handle_) {
+            error_message_ = std::string("cuBLASLt 13.x library not found (requires CUDA 13+): ") + dlerror();
+            return;
+        }
+#endif
+
+        // Load all required function pointers
+        if (!load_symbols()) {
+            unload();
+            return;
+        }
+
+        available_ = true;
+    }
+
+    bool load_symbols() {
+#ifdef _WIN32
+#define LOAD_SYMBOL(name) \
+        name = reinterpret_cast<name##_t>(GetProcAddress(static_cast<HMODULE>(handle_), #name)); \
+        if (!name) { \
+            error_message_ = "Failed to load symbol: " #name; \
+            return false; \
+        }
+#else
+#define LOAD_SYMBOL(name) \
+        name = reinterpret_cast<name##_t>(dlsym(handle_, #name)); \
+        if (!name) { \
+            error_message_ = std::string("Failed to load symbol: " #name ": ") + dlerror(); \
+            return false; \
+        }
+#endif
+
+        LOAD_SYMBOL(cublasLtCreate);
+        LOAD_SYMBOL(cublasLtDestroy);
+        LOAD_SYMBOL(cublasLtMatmul);
+        LOAD_SYMBOL(cublasLtMatmulDescCreate);
+        LOAD_SYMBOL(cublasLtMatmulDescDestroy);
+        LOAD_SYMBOL(cublasLtMatmulDescSetAttribute);
+        LOAD_SYMBOL(cublasLtMatrixLayoutCreate);
+        LOAD_SYMBOL(cublasLtMatrixLayoutDestroy);
+        LOAD_SYMBOL(cublasLtMatmulPreferenceCreate);
+        LOAD_SYMBOL(cublasLtMatmulPreferenceDestroy);
+        LOAD_SYMBOL(cublasLtMatmulPreferenceSetAttribute);
+        LOAD_SYMBOL(cublasLtMatmulAlgoGetHeuristic);
+
+#undef LOAD_SYMBOL
+        return true;
+    }
+
+    void unload() {
+        if (handle_) {
+#ifdef _WIN32
+            FreeLibrary(static_cast<HMODULE>(handle_));
+#else
+            dlclose(handle_);
+#endif
+            handle_ = nullptr;
+        }
+        available_ = false;
+        
+        // Clear function pointers
+        cublasLtCreate = nullptr;
+        cublasLtDestroy = nullptr;
+        cublasLtMatmul = nullptr;
+        cublasLtMatmulDescCreate = nullptr;
+        cublasLtMatmulDescDestroy = nullptr;
+        cublasLtMatmulDescSetAttribute = nullptr;
+        cublasLtMatrixLayoutCreate = nullptr;
+        cublasLtMatrixLayoutDestroy = nullptr;
+        cublasLtMatmulPreferenceCreate = nullptr;
+        cublasLtMatmulPreferenceDestroy = nullptr;
+        cublasLtMatmulPreferenceSetAttribute = nullptr;
+        cublasLtMatmulAlgoGetHeuristic = nullptr;
+    }
+
+    void* handle_ = nullptr;
+    bool available_ = false;
+    bool load_attempted_ = false;
+    std::string error_message_;
+    std::mutex mutex_;
+};
+
+
+} // namespace comfy
+

--- a/comfy_kitchen/backends/cuda/ops/per_tensor_quantize.cu
+++ b/comfy_kitchen/backends/cuda/ops/per_tensor_quantize.cu
@@ -22,10 +22,10 @@
 #include <stdexcept>
 #include <string>
 
+namespace comfy {
+
 constexpr int kQMaxKernelThreads = 128;
 constexpr int kE4M3Alignment = 16;
-
-namespace comfy {
 
 namespace {
 
@@ -138,8 +138,8 @@ void launch_quantize_fp8_kernel(
 
     const float* scale_f = static_cast<const float*>(scale);
     
-    constexpr int vals_per_thread = kE4M3Alignment;
-    constexpr int vals_per_block = vals_per_thread * kQMaxKernelThreads;
+    constexpr int vals_per_thread = comfy::kE4M3Alignment;
+    constexpr int vals_per_block = vals_per_thread * comfy::kQMaxKernelThreads;
     const int blocks = static_cast<int>((numel + vals_per_block - 1) / vals_per_block);
 
     // Dispatch based on input and output dtypes
@@ -150,7 +150,7 @@ void launch_quantize_fp8_kernel(
         input_dtype_code, output_dtype_code, 
         InputType, OutputType, [&] {
             comfy::quantize_fp8_tensor_kernel<InputType, OutputType>
-                <<<blocks, kQMaxKernelThreads, 0, stream>>>(
+                <<<blocks, comfy::kQMaxKernelThreads, 0, stream>>>(
                     static_cast<const InputType*>(input),
                     static_cast<OutputType*>(output),
                     scale_f,
@@ -180,7 +180,7 @@ void launch_dequantize_fp8_kernel(
     const float* scale_f = static_cast<const float*>(scale);
 
     constexpr int vals_per_thread = 8;
-    constexpr int vals_per_block = vals_per_thread * kQMaxKernelThreads;
+    constexpr int vals_per_block = vals_per_thread * comfy::kQMaxKernelThreads;
     const int blocks = static_cast<int>((numel + vals_per_block - 1) / vals_per_block);
 
     // Dispatch based on input and output dtypes
@@ -190,7 +190,7 @@ void launch_dequantize_fp8_kernel(
         input_dtype_code, output_dtype_code,
         InputType, OutputType, [&] {
             comfy::dequantize_fp8_tensor_kernel<InputType, OutputType>
-                <<<blocks, kQMaxKernelThreads, 0, stream>>>(
+                <<<blocks, comfy::kQMaxKernelThreads, 0, stream>>>(
                     static_cast<const InputType*>(input),
                     static_cast<OutputType*>(output),
                     scale_f,

--- a/comfy_kitchen/backends/cuda/ops/quantize_nvfp4.cu
+++ b/comfy_kitchen/backends/cuda/ops/quantize_nvfp4.cu
@@ -26,13 +26,13 @@
 #include <stdexcept>
 
 
+namespace comfy {
+
 constexpr unsigned int kValsPerThread = 4; // Can only be 2 or 4
 constexpr unsigned int kBlockSize = 16; // Always 16 for NVFP4
 constexpr unsigned int kThreadsPerGroup = kBlockSize / kValsPerThread;  // 4 threads per group (with kValsPerThread=4)
 
-namespace comfy {
-    namespace {
-
+namespace {
 
 /*
  * FP4 E2M1 Block Quantization with E4M3 Scales
@@ -325,7 +325,7 @@ void launch_quantize_nvfp4_kernel(
     }
     
     // Check that dimensions are divisible by block size (16)
-    if (num_rows % kBlockSize != 0 || num_cols % kBlockSize != 0) {
+    if (num_rows % comfy::kBlockSize != 0 || num_cols % comfy::kBlockSize != 0) {
         throw std::runtime_error("num_rows and num_cols must be divisible by 16 for FP4 block quantization");
     }
     
@@ -337,7 +337,7 @@ void launch_quantize_nvfp4_kernel(
     
     // Each thread processes kValsPerThread values (same for both aligned and misaligned paths)
     constexpr int threads_per_block = 128;  // CUDA block size
-    const int64_t total_threads_needed = numel / kValsPerThread;
+    const int64_t total_threads_needed = numel / comfy::kValsPerThread;
     const int blocks = static_cast<int>((total_threads_needed + threads_per_block - 1) / threads_per_block);
     
     // Dispatch based on input dtype (only FP16/BF16 supported)
@@ -394,7 +394,7 @@ void launch_dequantize_nvfp4_kernel(
     }
     
     // Check that dimensions are divisible by block size (16)
-    if (num_rows % kBlockSize != 0 || num_cols % kBlockSize != 0) {
+    if (num_rows % comfy::kBlockSize != 0 || num_cols % comfy::kBlockSize != 0) {
         throw std::runtime_error("num_rows and num_cols must be divisible by 16 for FP4 block dequantization");
     }
     
@@ -403,7 +403,7 @@ void launch_dequantize_nvfp4_kernel(
     
     // Each thread processes kValsPerThread values
     constexpr int threads_per_block = 128;
-    const int64_t total_threads_needed = numel / kValsPerThread;
+    const int64_t total_threads_needed = numel / comfy::kValsPerThread;
     const int blocks = static_cast<int>((total_threads_needed + threads_per_block - 1) / threads_per_block);
     
     // Dispatch based on output dtype

--- a/comfy_kitchen/tensor/base.py
+++ b/comfy_kitchen/tensor/base.py
@@ -12,6 +12,8 @@ from typing import Any
 import torch
 import torch._dynamo
 
+logger = logging.getLogger(__name__)
+
 LAYOUTS = {}
 
 
@@ -346,7 +348,7 @@ class QuantizedTensor(torch.Tensor):
                     return op_handlers[parent_cls](qt, args, kwargs)
 
         # Step 3: Fallback to dequantization
-        logging.debug(f"QuantizedTensor: Unhandled op {func}, falling back to dequantize")
+        logger.debug(f"Unhandled op {func} for {layout_cls.__name__ if layout_cls else 'unknown'}, dequantizing")
         return cls._dequant_and_fallback(func, args, kwargs)
 
     @classmethod

--- a/setup.py
+++ b/setup.py
@@ -45,8 +45,8 @@ class CMakeBuildExt(build_ext):
     ]
 
     # Default values for options
-    DEFAULT_CUDA_ARCHS_WINDOWS = "80;89;120f" # No need for Datacenter GPUs
-    DEFAULT_CUDA_ARCHS_LINUX = "80;89;90a;100f;120f"  # + H100, B100
+    DEFAULT_CUDA_ARCHS_WINDOWS = "75-virtual;80;89;120f"  # No need for Datacenter GPUs
+    DEFAULT_CUDA_ARCHS_LINUX = "75-virtual;80;89;90a;100f;120f"  # + H100, B100
 
     def initialize_options(self):
         super().initialize_options()
@@ -65,9 +65,6 @@ class CMakeBuildExt(build_ext):
                 else self.DEFAULT_CUDA_ARCHS_LINUX
             )
 
-        # Validate cuda_archs format
-        if self.cuda_archs and not all(c in "0123456789;af" for c in self.cuda_archs.lower()):
-            raise ValueError(f"Invalid CUDA architectures: {self.cuda_archs}")
 
     def run(self):
         try:


### PR DESCRIPTION
Use dlopen/LoadLibrary to load cublas at runtime and only disable features that require it (NVFP4 GEMM)
Furthermore clean up c namespaces, add turing support (oldest possible compile target with CU13), update readme accoringly.