### PR TITLE
Fix FP8 tensor support on MPS backend for Apple Silicon Macs

### DIFF
--- a/comfy_kitchen/backends/eager/quantization.py
+++ b/comfy_kitchen/backends/eager/quantization.py
@@ -54,6 +54,15 @@ def quantize_per_tensor_fp8(
 def dequantize_per_tensor_fp8(
     x: torch.Tensor, scale: torch.Tensor, output_type: torch.dtype = torch.bfloat16
 ) -> torch.Tensor:
+    # Handle FP8 tensors on MPS (not natively supported)
+    if x.device.type == 'mps' and x.dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
+        # Move computation to CPU where FP8 is supported
+        x_cpu = x.cpu()
+        scale_cpu = scale.cpu()
+        dq_tensor = x_cpu.to(dtype=output_type) * scale_cpu.to(dtype=output_type)
+        return dq_tensor.to(x.device)
+    
+    # Normal path for other cases
     dq_tensor = x.to(dtype=output_type) * scale.to(dtype=output_type)
     return dq_tensor
 


### PR DESCRIPTION
**Problem**: 
Users on Apple Silicon Macs (MPS backend) encounter `TypeError: Trying to convert Float8_e4m3fn to the MPS backend but it does not have support for that dtype` when running FP8-quantized models through the sampler. This occurs because MPS does not natively support FP8 data type conversions.

**Related Issues**: 
- https://github.com/Comfy-Org/ComfyUI/issues/9255
- https://github.com/Comfy-Org/ComfyUI/issues/6995
- https://github.com/Comfy-Org/ComfyUI/issues/11817
- https://github.com/Comfy-Org/ComfyUI/issues/11626

(all report similar FP8/MPS compatibility issues)

**Previous Attempts & Limitations**:
1. **Force CPU execution** (`--cpu` flag): Makes generation prohibitively slow
2. **GGUF format**: Same performance issue as CPU execution  
3. **Model conversion to FP16**: Even after converting all WAN model to FP16 and using FP16 vae, text encoder, the sampler still produces FP8 tensors internally

The conversion script:

```python3
from safetensors.torch import load_file, save_file
import torch
import sys

if len(sys.argv) < 2:
    print("Usage: python3 convert-fp16.py <input_safetensors_file>")
    sys.exit(1)

path = sys.argv[1] # input file

def convert_safetensors_to_fp16(input_path):
    state_dict = load_file(input_path)
    fp16_state_dict = {}
    for key, value in state_dict.items():
        if value.dtype == torch.float8_e4m3fn:
            fp16_state_dict[key] = value.to(torch.float16)
        else:
            fp16_state_dict[key] = value
    
    # Save the new file
    output_path = path.replace(".safetensors", "") + "-fp16.safetensors"
    save_file(fp16_state_dict, output_path, metadata={"format": "pt"})
    print(f"Converted file saved to {output_path}")

convert_safetensors_to_fp16(path)
```

**Root Cause**:
The `comfy_kitchen` quantization library attempts direct FP8 tensor operations on MPS, which lacks FP8 support. The error occurs in `dequantize_per_tensor_fp8()` when trying to convert FP8 tensors to other formats on MPS.

**Solution**:
Add a device-aware fallback in `dequantize_per_tensor_fp8()`:
- Detect FP8 tensors on MPS devices
- Temporarily move tensors to CPU for FP8 conversion (which CPU supports)
- Return results to MPS for continued processing

This minimal fix enables FP8-quantized models to work on Apple Silicon while:
- Maintaining MPS acceleration for the majority of operations
- Avoiding performance penalties of full CPU execution
