### PR TITLE
Add Intel XPU support to Triton backend

### DIFF
--- a/comfy_kitchen/backends/triton/__init__.py
+++ b/comfy_kitchen/backends/triton/__init__.py
@@ -36,6 +36,7 @@ def _build_constraints() -> dict:
     )
 
     cuda_devices = frozenset({"cuda"})
+    triton_devices = frozenset({"cuda", "xpu"})
     standard_floats = frozenset({torch.float32, torch.float16, torch.bfloat16})
 
     return {
@@ -47,7 +48,7 @@ def _build_constraints() -> dict:
                     dtypes=frozenset({torch.float8_e4m3fn, torch.float8_e5m2}),
                 ),
             },
-            default_devices=cuda_devices,
+            default_devices=triton_devices,
         ),
         "dequantize_per_tensor_fp8": FunctionConstraints(
             params={
@@ -57,7 +58,7 @@ def _build_constraints() -> dict:
                 "scale": ParamConstraint(dtypes=frozenset({torch.float32})),
                 "output_type": ParamConstraint(dtypes=standard_floats),
             },
-            default_devices=cuda_devices,
+            default_devices=triton_devices,
         ),
         "quantize_nvfp4": FunctionConstraints(
             params={
@@ -90,7 +91,7 @@ def _build_constraints() -> dict:
                 "x": ParamConstraint(dtypes=standard_floats),
                 "freqs_cis": ParamConstraint(dtypes=standard_floats),
             },
-            default_devices=cuda_devices,
+            default_devices=triton_devices,
         ),
         "apply_rope": FunctionConstraints(
             params={
@@ -98,7 +99,7 @@ def _build_constraints() -> dict:
                 "xk": ParamConstraint(dtypes=standard_floats),
                 "freqs_cis": ParamConstraint(dtypes=standard_floats),
             },
-            default_devices=cuda_devices,
+            default_devices=triton_devices,
         ),
     }
 
@@ -109,11 +110,14 @@ def _register():
     from comfy_kitchen.registry import registry
 
     if not _TRITON_AVAILABLE:
-        registry.mark_unavailable("triton", _TRITON_ERROR)
+        registry.mark_unavailable("triton", _TRITON_ERROR or "Triton not available")
         return
 
-    if not torch.cuda.is_available():
-        registry.mark_unavailable("triton", "CUDA not available on this system")
+    has_cuda = torch.cuda.is_available()
+    has_xpu = hasattr(torch, "xpu") and torch.xpu.is_available()
+
+    if not has_cuda and not has_xpu:
+        registry.mark_unavailable("triton", "Neither CUDA nor XPU available on this system")
         return
 
     registry.register(
@@ -124,4 +128,3 @@ def _register():
 
 
 _register()
-


### PR DESCRIPTION
This PR adds Intel XPU (Arc/Data Center GPU) support to the Triton backend.

## Changes
- Add 'xpu' to supported devices in Triton backend constraints
- Detect XPU availability alongside CUDA in backend registration
- Triton kernels (FP8, RoPE) now work on Intel Arc/Data Center GPUs

NVFP4 operations still require CUDA (PTX assembly) and will fall back to eager mode on XPU.

## Benchmarks

Tested on Intel Arc Pro B60 (PyTorch 2.11.0.dev+xpu):

| Operation | Size | Time | Throughput |
|-----------|------|------|------------|
| FP8 Quantize | 256x256 | 0.022ms | 2.9 GE/s |
| FP8 Quantize | 1024x1024 | 0.022ms | 48.3 GE/s |
| FP8 Quantize | 4096x4096 | 0.215ms | 78.1 GE/s |
| FP8 Dequantize | 256x256 | 0.021ms | 3.1 GE/s |
| FP8 Dequantize | 1024x1024 | 0.022ms | 48.5 GE/s |
| FP8 Dequantize | 4096x4096 | 0.147ms | 113.9 GE/s |
| RoPE | B=1,H=8,S=128,D=64 | 0.024ms | 2.7 GE/s |
| RoPE | B=2,H=32,S=1024,D=128 | 0.351ms | 23.9 GE/s |
| RoPE | B=4,H=32,S=2048,D=128 | 0.841ms | 39.9 GE/s |