### PR TITLE
Fix __version__ to read from package metadata instead of hardcoded string

### DIFF
--- a/comfy_kitchen/__init__.py
+++ b/comfy_kitchen/__init__.py
@@ -16,7 +16,12 @@ from .exceptions import (
 # Import registry and exceptions
 from .registry import registry
 
-__version__ = "0.1.0"
+try:
+    from importlib.metadata import version, PackageNotFoundError
+
+    __version__ = version("comfy-kitchen")
+except PackageNotFoundError:
+    __version__ = "0.0.0"  # Fallback for editable/dev installs
 
 __all__ = [
     # Exceptions

--- a/comfy_kitchen/backends/cuda/dlpack_bindings.cpp
+++ b/comfy_kitchen/backends/cuda/dlpack_bindings.cpp
@@ -553,8 +553,6 @@ NB_MODULE(_C, m) {
     // Feature availability flag (computed at module load time)
     m.attr("HAS_CUBLASLT") = comfy::CublasLtRuntime::instance().is_available();
 
-    // Add version info
-    m.attr("__version__") = "0.1.0";
     m.attr("__nanobind__") = true;
     m.attr("__stable_abi__") = true;
 }


### PR DESCRIPTION
## Problem

`comfy_kitchen.__version__` reports `"0.1.0"` regardless of the actual installed version. This has been the case since the first release — the version string was hardcoded in two places and never updated during any version bump:

```python
# comfy_kitchen/__init__.py (line 19)
__version__ = "0.1.0"
```

```cpp
// comfy_kitchen/backends/cuda/dlpack_bindings.cpp (line 557)
m.attr("__version__") = "0.1.0";
```

Every version bump commit (0.1.6 → 0.2.0, 0.2.2, 0.2.3, 0.2.5, 0.2.6, 0.2.7) only modified `pyproject.toml`, leaving these hardcoded strings unchanged.

### Real-world impact

This caused significant debugging confusion in our production inference pipeline. When investigating CUDA backend issues, our startup diagnostics reported `comfy-kitchen 0.1.0` at runtime. Since version 0.1.0 was the initial release with known limitations, we spent considerable time trying to force-upgrade the package — only to discover that `pip show comfy-kitchen` correctly reported 0.2.7 all along. The `__version__` attribute was simply wrong.

The mismatch between `importlib.metadata.version("comfy-kitchen")` (correct: `0.2.7`) and `comfy_kitchen.__version__` (wrong: `0.1.0`) is confusing for anyone doing version checks or runtime diagnostics.

## Fix

**`comfy_kitchen/__init__.py`**: Replace the hardcoded string with `importlib.metadata.version()`, which reads from the package metadata set by `pyproject.toml` — the single source of truth. Includes a `PackageNotFoundError` fallback for editable/dev installs.

```python
# Before
__version__ = "0.1.0"

# After
try:
    from importlib.metadata import version, PackageNotFoundError
    __version__ = version("comfy-kitchen")
except PackageNotFoundError:
    __version__ = "0.0.0"  # Fallback for editable/dev installs
```

**`dlpack_bindings.cpp`**: Removed the hardcoded `m.attr("__version__") = "0.1.0"` from the C++ nanobind module. The Python-level `__version__` is the canonical source, and nobody accesses `_C.__version__` directly.

This is the [recommended approach](https://packaging.python.org/en/latest/guides/single-sourcing-package-version/#importlib-metadata) for single-sourcing the package version in modern Python packaging.

---

*Generated with [Claude Code](https://claude.ai/claude-code)*