### PR TITLE
Add ROCm backend

### DIFF
--- a/.github/workflows/rocm.yml
+++ b/.github/workflows/rocm.yml
@@ -1,0 +1,153 @@
+name: ROCm backend CI
+
+# Runs on AMD GPU runners when available, falls back to CPU-only smoke test.
+# GitHub-hosted runners don't have AMD GPUs; this workflow is designed to
+# run on self-hosted runners with RDNA/CDNA hardware labeled 'rocm'.
+
+on:
+  push:
+    paths:
+      - 'comfy_kitchen/backends/rocm/**'
+      - 'tests/test_rocm_backend.py'
+      - '.github/workflows/rocm.yml'
+  pull_request:
+    paths:
+      - 'comfy_kitchen/backends/rocm/**'
+      - 'tests/test_rocm_backend.py'
+      - '.github/workflows/rocm.yml'
+
+jobs:
+
+  # -------------------------------------------------------------------------
+  # Smoke test: import and registration (no GPU required)
+  # -------------------------------------------------------------------------
+  smoke-test:
+    name: Import smoke test (CPU)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install CPU PyTorch
+        run: pip install torch --index-url https://download.pytorch.org/whl/cpu packaging
+
+      - name: Install comfy-kitchen (no CUDA)
+        env:
+          COMFY_NO_CUDA: "1"
+        run: pip install -e . --no-build-isolation
+
+      - name: Check ROCm backend imports without error on CPU
+        run: |
+          python -c "
+          import torch
+          print('PyTorch:', torch.__version__)
+          print('ROCm:', getattr(torch.version, 'hip', None))
+
+          import comfy_kitchen as ck
+          import json
+          backends = ck.list_backends()
+          print(json.dumps(backends, indent=2))
+
+          # rocm should be present but unavailable (not a ROCm build)
+          assert 'rocm' in backends, 'rocm backend missing from registry'
+          assert not backends['rocm']['available'], 'rocm should not be available on CPU torch'
+          assert backends['eager']['available'], 'eager backend must always be available'
+          print('OK: ROCm backend registered correctly on CPU')
+          "
+
+  # -------------------------------------------------------------------------
+  # Full GPU test: runs on self-hosted AMD runner
+  # -------------------------------------------------------------------------
+  gpu-test:
+    name: GPU test (ROCm, self-hosted)
+    runs-on: [self-hosted, rocm]
+    # Only run if a self-hosted runner is available; skip otherwise
+    if: ${{ vars.ROCM_RUNNER_AVAILABLE == 'true' }}
+
+    container:
+      image: rocm/pytorch:rocm6.4_ubuntu22.04_py3.12_pytorch_release_2.6.0
+      options: --device /dev/kfd --device /dev/dri --group-add video --group-add render
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Show ROCm info
+        run: |
+          rocminfo | head -30
+          python -c "import torch; print('PyTorch:', torch.__version__); print('ROCm:', torch.version.hip)"
+
+      - name: Install comfy-kitchen from source
+        run: |
+          pip install nanobind cmake
+          pip install -e . --no-build-isolation
+
+      - name: List detected backends
+        run: |
+          python -c "
+          import comfy_kitchen as ck
+          import json
+          print(json.dumps(ck.list_backends(), indent=2, default=str))
+          "
+
+      - name: Smoke test all ops
+        run: |
+          python -c "
+          import torch, comfy_kitchen as ck
+
+          x = torch.randn(128, 128, device='cuda', dtype=torch.bfloat16)
+          scale = torch.tensor(1.0, device='cuda', dtype=torch.float32)
+          q = ck.quantize_per_tensor_fp8(x, scale)
+          dq = ck.dequantize_per_tensor_fp8(q, scale)
+          print('quantize_fp8:', q.dtype, 'roundtrip_err:', (x-dq).abs().max().item())
+
+          a = torch.randn(64, 128, device='cuda', dtype=torch.bfloat16)
+          b = torch.randn(64, 128, device='cuda', dtype=torch.bfloat16)
+          qa, sa = ck.quantize_mxfp8(a)
+          qb, sb = ck.quantize_mxfp8(b)
+          out = ck.scaled_mm_mxfp8(qa, qb, sa, sb)
+          print('scaled_mm_mxfp8:', out.dtype, out.shape)
+
+          xq = torch.randn(4, 8, 8, 64, device='cuda', dtype=torch.bfloat16)
+          xk = torch.randn(4, 8, 8, 64, device='cuda', dtype=torch.bfloat16)
+          freqs = torch.randn(1, 8, 1, 32, 2, 2, device='cuda', dtype=torch.float32)
+          rq, rk = ck.apply_rope(xq, xk, freqs)
+          print('apply_rope:', rq.dtype, rq.shape)
+          print('All ops OK')
+          "
+
+  # -------------------------------------------------------------------------
+  # Windows ROCm smoke test (no GPU, import only)
+  # -------------------------------------------------------------------------
+  windows-smoke:
+    name: Windows ROCm smoke test
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install CPU PyTorch
+        run: pip install torch --index-url https://download.pytorch.org/whl/cpu
+
+      - name: Install package
+        env:
+          COMFY_NO_CUDA: "1"
+        run: pip install -e . --no-build-isolation
+
+      - name: Verify import and backend registration
+        run: |
+          python -c "
+          import comfy_kitchen as ck
+          import json
+          backends = ck.list_backends()
+          print(json.dumps(backends, indent=2))
+          assert 'rocm' in backends
+          print('OK')
+          "

--- a/README.md
+++ b/README.md
@@ -4,29 +4,35 @@ Fast kernel library for Diffusion inference with multiple compute backends.
 
 ## Backend Capabilities Matrix
 
-| Function                    | eager | cuda | triton |
-|-----------------------------|-------|------|--------|
-| `quantize_per_tensor_fp8`   | ✓     | ✓    | ✓      |
-| `dequantize_per_tensor_fp8` | ✓     | ✓    | ✓      |
-| `quantize_nvfp4`            | ✓     | ✓    | ✓      |
-| `dequantize_nvfp4`          | ✓     | ✓    |        |
-| `scaled_mm_nvfp4`           | ✓     | ✓    |        |
-| `quantize_mxfp8`            | ✓     | ✓    | ✓      |
-| `dequantize_mxfp8`          | ✓     |      |        |
-| `scaled_mm_mxfp8`           | ✓     |      |        |
-| `apply_rope`                | ✓     | ✓    | ✓      |
-| `apply_rope1`               | ✓     | ✓    | ✓      |
+| Function                    | eager | cuda | triton | rocm |
+|-----------------------------|-------|------|--------|------|
+| `quantize_per_tensor_fp8`   | ✓     | ✓    | ✓      | ✓    |
+| `dequantize_per_tensor_fp8` | ✓     | ✓    | ✓      | ✓    |
+| `quantize_nvfp4`            | ✓     | ✓    | ✓      | ✓    |
+| `dequantize_nvfp4`          | ✓     | ✓    |        | ✓    |
+| `scaled_mm_nvfp4`           | ✓     | ✓    |        | ✓ ¹  |
+| `quantize_mxfp8`            | ✓     | ✓    | ✓      | ✓    |
+| `dequantize_mxfp8`          | ✓     |      |        | ✓    |
+| `scaled_mm_mxfp8`           | ✓     |      |        | ✓ ²  |
+| `apply_rope`                | ✓     | ✓    | ✓      | ✓    |
+| `apply_rope1`               | ✓     | ✓    | ✓      | ✓    |
+
+> ¹ AMD RDNA hardware lacks native FP4. `scaled_mm_nvfp4` dequantises to BF16 then runs `torch.mm`.
+>
+> ² Uses `torch._scaled_mm` → hipBLASLt FP8 GEMM on RDNA3 (gfx1100+) and RDNA4 (gfx1200+).
+> Falls back to dequant + `torch.mm` on older hardware. TensorWise scaling is used as an
+> approximation until PyTorch ROCm exposes block-scaled hipBLASLt directly.
 
 
 ## Quantized Tensors
 
 The library provides `QuantizedTensor`, a `torch.Tensor` subclass that transparently intercepts PyTorch operations and dispatches them to optimized quantized kernels when available.
 
-| Layout                 | Format       | HW Requirement  | Description                             |
-|------------------------|--------------|-----------------|----------------------------------------|
-| `TensorCoreFP8Layout`  | FP8 E4M3     | SM ≥ 8.9 (Ada)  | Per-tensor scaling, 1:1 element mapping |
-| `TensorCoreNVFP4Layout`| NVFP4 E2M1   | SM ≥ 10.0 (Blackwell) | Block quantization with 16-element blocks |
-| `TensorCoreMXFP8Layout`| MXFP8 E4M3   | SM ≥ 10.0 (Blackwell) | Block quantization with 32-element blocks, E8M0 scales |
+| Layout                  | Format     | HW Requirement        | Description                                        |
+|-------------------------|------------|-----------------------|----------------------------------------------------|
+| `TensorCoreFP8Layout`   | FP8 E4M3   | SM ≥ 8.9 (Ada) / RDNA3+ | Per-tensor scaling, 1:1 element mapping          |
+| `TensorCoreNVFP4Layout` | NVFP4 E2M1 | SM ≥ 10.0 (Blackwell) | Block quantization with 16-element blocks          |
+| `TensorCoreMXFP8Layout` | MXFP8 E4M3 | SM ≥ 10.0 (Blackwell) / RDNA3+ | Block quantization with 32-element blocks, E8M0 scales |
 
 ```python
 from comfy_kitchen.tensor import QuantizedTensor, TensorCoreFP8Layout, TensorCoreNVFP4Layout
@@ -45,6 +51,8 @@ dq = qt.dequantize()
 
 ## Installation
 
+> Note: If you are on a system with a non-UTF-8 locale, builds may fail with a `UnicodeDecodeError`. Set `PYTHONUTF8=1` in your environment.
+
 ### From PyPI
 
 ```bash
@@ -62,6 +70,16 @@ pip install comfy-kitchen[cublas]
 
 Wheels are built for Python 3.10, 3.11, and 3.12+ (using Stable ABI for 3.12+).
 
+### AMD ROCm
+
+The ROCm backend is pure Python and requires no compilation. Install the
+ROCm build of PyTorch for your platform, then install comfy-kitchen normally —
+everything is detected and configured automatically, with no extra setup needed.
+
+**Supported hardware:** RDNA3 (RX 7000 series, gfx1100+), RDNA4 (RX 9000 series,
+gfx1200+), and CDNA3 (MI300X, gfx940+). Older AMD GPUs are supported with
+eager fallback for all ops.
+
 ### From Source
 
 ```bash
@@ -73,6 +91,9 @@ pip install -e ".[dev]"
 
 # For faster rebuilds during development (skip build isolation)
 pip install -e . --no-build-isolation -v
+
+# Installation with ROCm support
+pip install . --no-build-isolation -v
 ```
 
 #### Build Options
@@ -95,6 +116,10 @@ python setup.py build_ext --cuda-archs="80;89" bdist_wheel
 
 # Debug build with line info for profiling
 python setup.py build_ext --debug-build --lineinfo bdist_wheel
+
+# Build with ROCm
+python setup.py bdist_wheel
+
 ```
 
 
@@ -106,6 +131,8 @@ python setup.py build_ext --debug-build --lineinfo bdist_wheel
 - **CUDA Runtime** (for CUDA wheels): ≥13.0
   - Pre-built wheels require NVIDIA Driver r580+
   - Building from source requires CUDA Toolkit ≥12.8 and `CUDA_HOME` environment variable
+- **ROCm PyTorch** (for ROCm backend)
+  - No additional compilation or ROCm stack installation required on Windows
 - **nanobind**: ≥2.0.0 (for building from source)
 - **CMake**: ≥3.18 (for building from source)
 
@@ -115,7 +142,7 @@ python setup.py build_ext --debug-build --lineinfo bdist_wheel
 import comfy_kitchen as ck
 import torch
 
-# Automatic backend selection (triton -> cuda -> eager)
+# Automatic backend selection (cuda -> rocm -> triton -> eager)
 x = torch.randn(100, 100, device="cuda")
 scale = torch.tensor([1.0], device="cuda")
 result = ck.quantize_per_tensor_fp8(x, scale)
@@ -127,27 +154,30 @@ print(ck.list_backends())
 result = ck.quantize_per_tensor_fp8(x, scale, backend="eager")
 
 # Temporarily use a different backend
-with ck.use_backend("triton"):
+with ck.use_backend("rocm"):
     result = ck.quantize_per_tensor_fp8(x, scale)
 ```
 
 ## Backend System
 
 The library supports multiple backends:
-- **eager**: Pure PyTorch implementation
-- **cuda**: Custom CUDA C kernels (CUDA only)
-- **triton**: Triton JIT-compiled kernels
+
+- **eager**: Pure PyTorch implementation, works on any device
+- **cuda**: Custom CUDA C kernels (NVIDIA GPUs)
+- **triton**: Triton JIT-compiled kernels (NVIDIA and AMD)
+- **rocm**: Pure-Python AMD backend using hipBLASLt via `torch._scaled_mm`
 
 ### Automatic Backend Selection
 
-When you call a function, the registry selects the best backend by checking **constraints** in priority order (`cuda` → `triton` → `eager`):
+When you call a function, the registry selects the best backend by checking **constraints** in priority order (`cuda` → `rocm` → `triton` → `eager`):
 
 ```python
 # Backend is selected automatically based on input constraints
 result = ck.quantize_per_tensor_fp8(x, scale)
 
 # On CPU tensors → falls back to eager (only backend supporting CPU)
-# On CUDA tensors → uses cuda or triton (higher priority)
+# On CUDA tensors (NVIDIA) → uses cuda or triton (higher priority)
+# On CUDA tensors (AMD/ROCm) → uses rocm
 ```
 
 ### Constraint System

--- a/comfy_kitchen/__init__.py
+++ b/comfy_kitchen/__init__.py
@@ -4,6 +4,7 @@ from .backends import cuda as _cuda_backend  # noqa: F401
 
 # Import backends to trigger auto-registration
 from .backends import eager as _eager_backend  # noqa: F401
+from .backends import rocm as _rocm_backend   # noqa: F401
 from .backends import triton as _triton_backend  # noqa: F401
 from .backends.eager.quantization import DTYPE_TO_CODE
 from .exceptions import (

--- a/comfy_kitchen/backends/rocm/__init__.py
+++ b/comfy_kitchen/backends/rocm/__init__.py
@@ -1,0 +1,234 @@
+import re
+import sys
+import torch
+
+__all__ = [
+    "apply_rope",
+    "apply_rope1",
+    "dequantize_mxfp8",
+    "dequantize_nvfp4",
+    "dequantize_per_tensor_fp8",
+    "quantize_mxfp8",
+    "quantize_nvfp4",
+    "quantize_per_tensor_fp8",
+    "scaled_mm_mxfp8",
+    "scaled_mm_nvfp4",
+]
+
+_FP8_FNUZ = torch.float8_e4m3fnuz
+_FP8_MAX  = torch.finfo(_FP8_FNUZ).max
+
+
+def _gfx_arch():
+    if not torch.cuda.is_available():
+        return None
+    try:
+        props = torch.cuda.get_device_properties(torch.cuda.current_device())
+        arch = getattr(props, "gcnArchName", None)
+        if arch:
+            return arch.split(":")[0]
+        m = re.search(r"gfx\d+[a-z]?", props.name.lower())
+        return m.group(0) if m else None
+    except Exception:
+        return None
+
+
+def _gfx_num(arch):
+    if not arch:
+        return 0
+    m = re.search(r"\d+", arch)
+    return int(m.group(0)) if m else 0
+
+
+def _supports_fp8_scaled_mm():
+    n = _gfx_num(_gfx_arch())
+    return n >= 1100 or (940 <= n <= 942)
+
+
+def quantize_per_tensor_fp8(x, scale, output_type=torch.float8_e4m3fn):
+    if not x.is_contiguous():
+        x = x.contiguous()
+    xf = x.float() * (1.0 / scale.float())
+    xf = xf.clamp(-_FP8_MAX, _FP8_MAX)
+    return xf.to(_FP8_FNUZ)
+
+
+def dequantize_per_tensor_fp8(x, scale, output_type=torch.bfloat16):
+    return (x.float() * scale.float()).to(output_type)
+
+
+def quantize_nvfp4(x, per_tensor_scale, epsilon=0.0, pad_16x=False):
+    from comfy_kitchen.backends.eager import quantize_nvfp4 as _q
+    return _q(x, per_tensor_scale, epsilon, pad_16x)
+
+
+def dequantize_nvfp4(qx, per_tensor_scale, block_scales, output_type=torch.bfloat16):
+    from comfy_kitchen.backends.eager import dequantize_nvfp4 as _dq
+    return _dq(qx, per_tensor_scale, block_scales, output_type)
+
+
+def scaled_mm_nvfp4(a, b, tensor_scale_a, tensor_scale_b,
+                    block_scale_a, block_scale_b,
+                    bias=None, out_dtype=torch.bfloat16, alpha=None):
+    from comfy_kitchen.backends.eager import dequantize_nvfp4 as _dq
+    a_fp = _dq(a, tensor_scale_a, block_scale_a, torch.bfloat16)
+    b_fp = _dq(b, tensor_scale_b, block_scale_b, torch.bfloat16)
+    out = torch.mm(a_fp, b_fp.t())
+    if bias is not None:
+        out = out + bias.to(out.dtype)
+    if alpha is not None:
+        out = out * alpha.float()
+    return out.to(out_dtype)
+
+
+def quantize_mxfp8(x, pad_32x=False):
+    from comfy_kitchen.backends.eager import quantize_mxfp8 as _q
+    return _q(x, pad_32x)
+
+
+def dequantize_mxfp8(qx, block_scales, output_type=torch.bfloat16):
+    from comfy_kitchen.backends.eager import dequantize_mxfp8 as _dq
+    return _dq(qx, block_scales, output_type)
+
+
+def scaled_mm_mxfp8(a, b, block_scale_a, block_scale_b,
+                    bias=None, out_dtype=torch.bfloat16):
+    if _supports_fp8_scaled_mm():
+        # ROCm 7 / RDNA4: hipBLASLt supports float8_e4m3fn (OCP) with
+        # TensorWise scaling only. float8_e4m3fnuz is not supported.
+        # Layout: a must be row-major (contiguous), b must be col-major
+        # (.t() without .contiguous() gives the col-major view hipBLASLt needs).
+        a_fp8 = a.contiguous() if a.dtype == torch.float8_e4m3fn else a.to(torch.float8_e4m3fn)
+        b_fp8 = b if b.dtype == torch.float8_e4m3fn else b.to(torch.float8_e4m3fn)
+        scale_a = block_scale_a.float().max().reshape(())
+        scale_b = block_scale_b.float().max().reshape(())
+        return torch._scaled_mm(
+            a_fp8,
+            b_fp8.t(),
+            scale_a=scale_a,
+            scale_b=scale_b,
+            out_dtype=out_dtype,
+            bias=bias,
+        )
+    else:
+        from comfy_kitchen.backends.eager import dequantize_mxfp8 as _dq
+        a_fp = _dq(a, block_scale_a, torch.bfloat16)
+        b_fp = _dq(b, block_scale_b, torch.bfloat16)
+        out = torch.mm(a_fp, b_fp.t())
+        if bias is not None:
+            out = out + bias.to(out.dtype)
+        return out.to(out_dtype)
+
+
+def apply_rope(xq, xk, freqs_cis):
+    from comfy_kitchen.backends.eager import apply_rope as _e
+    return _e(xq, xk, freqs_cis)
+
+
+def apply_rope1(x, freqs_cis):
+    from comfy_kitchen.backends.eager import apply_rope1 as _e
+    return _e(x, freqs_cis)
+
+
+def _register():
+    from comfy_kitchen.registry import registry
+    from comfy_kitchen.constraints import (
+        DivisibleBy, ExactDims, FunctionConstraints, ParamConstraint,
+    )
+    if getattr(torch.version, "hip", None) is None:
+        registry.mark_unavailable("rocm", "not a ROCm PyTorch build")
+        return
+    if not torch.cuda.is_available():
+        registry.mark_unavailable("rocm", "no ROCm device available")
+        return
+
+    rocm_dev = frozenset({"cuda"})
+    fp8_in   = frozenset({torch.float8_e4m3fn, torch.float8_e5m2, _FP8_FNUZ})
+    floats   = frozenset({torch.float32, torch.float16, torch.bfloat16})
+    uint8    = frozenset({torch.uint8})
+
+    caps = {
+        "quantize_per_tensor_fp8": FunctionConstraints(
+            params={
+                "x":           ParamConstraint(dtypes=floats),
+                "scale":       ParamConstraint(dtypes=frozenset({torch.float32})),
+                "output_type": ParamConstraint(dtypes=fp8_in),
+            },
+            default_devices=rocm_dev),
+        "dequantize_per_tensor_fp8": FunctionConstraints(
+            params={
+                "x":           ParamConstraint(dtypes=fp8_in),
+                "scale":       ParamConstraint(dtypes=floats),
+                "output_type": ParamConstraint(dtypes=floats),
+            },
+            default_devices=rocm_dev),
+        "quantize_nvfp4": FunctionConstraints(
+            params={
+                "x":                ParamConstraint(dtypes=floats, shape_rules=(ExactDims(2),)),
+                "per_tensor_scale": ParamConstraint(dtypes=frozenset({torch.float32})),
+            },
+            default_devices=rocm_dev),
+        "dequantize_nvfp4": FunctionConstraints(
+            params={
+                "qx":               ParamConstraint(dtypes=uint8, shape_rules=(ExactDims(2),)),
+                "per_tensor_scale": ParamConstraint(dtypes=frozenset({torch.float32})),
+                "block_scales":     ParamConstraint(dtypes=fp8_in),
+                "output_type":      ParamConstraint(dtypes=floats),
+            },
+            default_devices=rocm_dev),
+        "scaled_mm_nvfp4": FunctionConstraints(
+            params={
+                "a":              ParamConstraint(dtypes=uint8, shape_rules=(ExactDims(2),)),
+                "b":              ParamConstraint(dtypes=uint8, shape_rules=(ExactDims(2),)),
+                "tensor_scale_a": ParamConstraint(dtypes=frozenset({torch.float32})),
+                "tensor_scale_b": ParamConstraint(dtypes=frozenset({torch.float32})),
+                "block_scale_a":  ParamConstraint(dtypes=fp8_in),
+                "block_scale_b":  ParamConstraint(dtypes=fp8_in),
+                "out_dtype":      ParamConstraint(dtypes=floats),
+            },
+            default_devices=rocm_dev),
+        "apply_rope": FunctionConstraints(
+            params={
+                "xq":       ParamConstraint(dtypes=floats),
+                "xk":       ParamConstraint(dtypes=floats),
+                "freqs_cis": ParamConstraint(dtypes=floats),
+            },
+            default_devices=rocm_dev),
+        "apply_rope1": FunctionConstraints(
+            params={
+                "x":        ParamConstraint(dtypes=floats),
+                "freqs_cis": ParamConstraint(dtypes=floats),
+            },
+            default_devices=rocm_dev),
+    }
+
+    if hasattr(torch, "float8_e8m0fnu"):
+        e8m0 = frozenset({torch.float8_e8m0fnu})
+        caps["quantize_mxfp8"] = FunctionConstraints(
+            params={"x": ParamConstraint(dtypes=floats, shape_rules=(ExactDims(2),))},
+            default_devices=rocm_dev)
+        caps["dequantize_mxfp8"] = FunctionConstraints(
+            params={
+                "qx":          ParamConstraint(dtypes=frozenset({torch.float8_e4m3fn}), shape_rules=(ExactDims(2),)),
+                "block_scales": ParamConstraint(dtypes=e8m0),
+                "output_type":  ParamConstraint(dtypes=floats),
+            },
+            default_devices=rocm_dev)
+        caps["scaled_mm_mxfp8"] = FunctionConstraints(
+            params={
+                "a":            ParamConstraint(dtypes=frozenset({torch.float8_e4m3fn}), shape_rules=(ExactDims(2),)),
+                "b":            ParamConstraint(dtypes=frozenset({torch.float8_e4m3fn}), shape_rules=(ExactDims(2),)),
+                "block_scale_a": ParamConstraint(dtypes=e8m0),
+                "block_scale_b": ParamConstraint(dtypes=e8m0),
+                "out_dtype":     ParamConstraint(dtypes=floats),
+            },
+            default_devices=rocm_dev)
+
+    registry.register(
+        name="rocm",
+        module=__import__(__name__, fromlist=__all__),
+        capabilities=caps,
+    )
+
+
+_register()

--- a/comfy_kitchen/constraints.py
+++ b/comfy_kitchen/constraints.py
@@ -13,6 +13,7 @@ __all__ = [
     "DivisibleBy",
     "ExactDims",
     "FunctionConstraints",
+    "GfxArchConstraint",
     "MinDims",
     "ParamConstraint",
     "ShapeRule",
@@ -146,6 +147,45 @@ class FunctionConstraints:
 
 
 # =============================================================================
+# ROCm / GFX Architecture Constraint
+# =============================================================================
+
+
+@dataclass(frozen=True)
+class GfxArchConstraint:
+    """Gate an op on a minimum AMD GFX architecture number.
+
+    Evaluated once at ROCm backend registration time (not per call).
+
+    Args:
+        min_gfx: Minimum GFX number, e.g.:
+            906  – any modern CDNA/Vega
+            940  – MI300X / CDNA3
+            1100 – RX 7900 XTX / RDNA3 (first with hipBLASLt FP8)
+            1200 – RX 9060 XT / RDNA4
+    """
+
+    min_gfx: int
+
+    def check(self) -> bool:
+        if not torch.cuda.is_available():
+            return False
+        if getattr(torch.version, "hip", None) is None:
+            return False
+        try:
+            import re
+            props = torch.cuda.get_device_properties(torch.cuda.current_device())
+            arch = getattr(props, "gcnArchName", None)
+            if not arch:
+                return False
+            base = arch.split(":")[0]
+            m = re.search(r"\d+", base)
+            return bool(m) and int(m.group(0)) >= self.min_gfx
+        except Exception:
+            return False
+
+
+# =============================================================================
 # Validation Logic
 # =============================================================================
 
@@ -228,6 +268,17 @@ def validate_function_call(
     Returns:
         ValidationResult indicating success or first failure
     """
+    # ROCm devices don't expose CUDA compute capabilities. If this is a ROCm
+    # build, ops that carry a min_compute_capability constraint (i.e. NVIDIA-only
+    # ops like cublasLt scaled_mm_nvfp4) correctly report unavailable instead of
+    # raising an exception inside torch.cuda.get_device_properties.
+    if getattr(torch.version, "hip", None) is not None:
+        if constraints.min_compute_capability is not None:
+            return ValidationResult.fail(
+                "__hardware__",
+                "CUDA compute capability constraint not applicable on ROCm device",
+            )
+
     if constraints.min_compute_capability is not None:
         if compute_capability is None:
             return ValidationResult.fail(

--- a/comfy_kitchen/registry.py
+++ b/comfy_kitchen/registry.py
@@ -22,7 +22,7 @@ class BackendRegistry:
         self._backends = {}  # {name: backend_module}
         self._capabilities = {}  # {name: set of function names}
         self._constraints = {}  # {(backend_name, func_name): FunctionConstraints}
-        self._priority = ["cuda", "triton", "eager"]
+        self._priority = ["cuda", "rocm", "triton", "eager"]
         self._disabled = set()  # Manually disabled backends
         self._unavailable = {}  # {name: error_message} for failed backends
         self._lock = threading.Lock()

--- a/setup.py
+++ b/setup.py
@@ -20,13 +20,43 @@ from setuptools.command.build_ext import build_ext
 # Usage: python setup.py install --no-cuda
 #    or: pip install . --no-cuda
 BUILD_NO_CUDA = False
-if "--no-cuda" in sys.argv:
+if "--no-cuda" in sys.argv or os.environ.get("COMFY_NO_CUDA", "0") == "1":
+    if "--no-cuda" in sys.argv:
+        sys.argv.remove("--no-cuda")  # Remove so setuptools doesn't complain
     BUILD_NO_CUDA = True
-    sys.argv.remove("--no-cuda")  # Remove so setuptools doesn't complain
     print("\n" + "=" * 80)
     print("Building CPU-only variant (--no-cuda flag)")
     print("CUDA backend excluded - only eager, triton backends")
     print("=" * 80 + "\n")
+
+BUILD_ROCM = False
+if "--rocm" in sys.argv:
+    BUILD_ROCM = True
+    sys.argv.remove("--rocm")
+
+ROCM_ARCHS = None
+for _arg in sys.argv[:]:
+    if _arg.startswith("--rocm-archs="):
+        ROCM_ARCHS = _arg.split("=", 1)[1]
+        sys.argv.remove(_arg)
+        break
+
+# Auto-detect ROCm PyTorch and skip the CUDA extension.
+# On a ROCm system there is no nvcc or CUDA toolkit, so setup_cuda_extension()
+# would fail (ImportError for nanobind or RuntimeError for missing nvcc).
+# Setting BUILD_NO_CUDA bypasses that entire path; the pure-Python ROCm
+# backend registers itself at import time without any compiled extension.
+if not BUILD_NO_CUDA and not BUILD_ROCM:
+    try:
+        import torch as _torch
+        if getattr(_torch.version, "hip", None) is not None:
+            BUILD_NO_CUDA = True
+            BUILD_ROCM = True
+            print("\n[ROCm] Detected ROCm PyTorch — skipping CUDA extension.")
+            print("[ROCm] Pure-Python ROCm backend will be used.\n")
+        del _torch
+    except ImportError:
+        pass
 
 
 class CMakeExtension(Extension):
@@ -183,6 +213,61 @@ def get_cuda_path():
         cuda_home = str(nvcc_bin.parent.parent)
 
     return cuda_home, nvcc_bin
+
+def is_rocm_pytorch() -> bool:
+    """Return True when the installed PyTorch is a ROCm build."""
+    try:
+        import torch
+        return getattr(torch.version, "hip", None) is not None
+    except ImportError:
+        return False
+
+
+def get_rocm_extensions() -> list:
+    """Build the optional HIP C extension for the ROCm backend.
+
+    Only attempted on Linux with hipcc available.  The pure-Python ROCm
+    backend (__init__.py) works without this extension on all platforms.
+    """
+    import platform
+
+    if platform.system() == "Windows":
+        # hipcc not in Windows PyTorch ROCm wheel; pure-Python path used instead.
+        return []
+
+    if not (BUILD_ROCM or is_rocm_pytorch()):
+        return []
+
+    if not shutil.which("hipcc"):
+        print(
+            "\n[ROCm] hipcc not found — skipping HIP C extension.\n"
+            "       Pure-Python ROCm backend will still register and run.\n"
+            "       To build: ensure $ROCM_PATH/bin is on PATH.\n"
+        )
+        return []
+
+    try:
+        import nanobind  # noqa: F401
+    except ImportError:
+        print("[ROCm] nanobind not found — skipping HIP extension. pip install nanobind")
+        return []
+
+    rocm_source_dir = str(
+        pathlib.Path(__file__).resolve().parent
+        / "comfy_kitchen" / "backends" / "rocm"
+    )
+
+    cmake_args = []
+    if ROCM_ARCHS:
+        cmake_args.append(f"-DROCM_ARCHS={ROCM_ARCHS}")
+
+    print(f"[ROCm] Configuring HIP extension (archs: {ROCM_ARCHS or 'default'})")
+    return [CMakeExtension(
+        name="comfy_kitchen.backends.rocm._C",
+        source_dir=rocm_source_dir,
+        cmake_args=cmake_args,
+    )]
+
 
 def get_cuda_version() -> tuple[int, ...] | None:
     _cuda_home, nvcc_bin = get_cuda_path()

--- a/tests/test_rocm_backend.py
+++ b/tests/test_rocm_backend.py
@@ -1,0 +1,457 @@
+"""
+tests/test_rocm_backend.py
+===========================
+
+Test suite for the comfy_kitchen ROCm backend.
+
+Run on an AMD GPU system with ROCm PyTorch:
+    pytest tests/test_rocm_backend.py -v
+
+Run with fallback to eager (no ROCm):
+    pytest tests/test_rocm_backend.py -v -k "not scaled_mm"
+
+These tests verify:
+  1. Backend registers correctly on ROCm
+  2. FP8 quantise/dequantise round-trips correctly
+  3. NVFP4 pack/unpack round-trips correctly
+  4. RoPE output matches eager reference
+  5. scaled_mm_fp8 matches BF16 matmul within tolerance
+  6. scaled_mm_nvfp4 matches eager dequant + matmul
+"""
+
+from __future__ import annotations
+
+import math
+import pytest
+import torch
+
+# ---------------------------------------------------------------------------
+# Skip the entire module if not on a ROCm system
+# ---------------------------------------------------------------------------
+
+IS_ROCM = getattr(torch.version, "hip", None) is not None
+HAS_CUDA = torch.cuda.is_available()
+
+rocm_only = pytest.mark.skipif(
+    not IS_ROCM or not HAS_CUDA,
+    reason="ROCm PyTorch with a GPU required",
+)
+
+rocm_fp8 = pytest.mark.skipif(
+    not IS_ROCM or not HAS_CUDA,
+    reason="ROCm + gfx1100+ required for FP8 GEMM",
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _gfx_major() -> int:
+    try:
+        import re
+        props = torch.cuda.get_device_properties(0)
+        arch = getattr(props, "gcnArchName", "gfx000").split(":")[0]
+        m = re.search(r"\d+", arch)
+        return int(m.group(0)) if m else 0
+    except Exception:
+        return 0
+
+
+def _fp8_supported() -> bool:
+    n = _gfx_major()
+    return n >= 1100 or (940 <= n <= 942)
+
+
+# ---------------------------------------------------------------------------
+# Backend registration
+# ---------------------------------------------------------------------------
+
+class TestRocmBackendRegistration:
+
+    @rocm_only
+    def test_rocm_backend_in_list(self):
+        import comfy_kitchen as ck
+        backends = ck.list_backends()
+        assert "rocm" in backends, (
+            f"rocm backend not registered. Available: {list(backends.keys())}"
+        )
+
+    @rocm_only
+    def test_rocm_backend_available(self):
+        import comfy_kitchen as ck
+        backends = ck.list_backends()
+        info = backends["rocm"]
+        assert info["available"] is True, (
+            f"rocm backend registered but not available: {info['unavailable_reason']}"
+        )
+
+    @rocm_only
+    def test_rocm_backend_capabilities(self):
+        import comfy_kitchen as ck
+        backends = ck.list_backends()
+        caps = set(backends["rocm"]["capabilities"])
+        expected = {
+            "quantize_per_tensor_fp8",
+            "dequantize_per_tensor_fp8",
+            "quantize_nvfp4",
+            "dequantize_nvfp4",
+            "apply_rope",
+            "apply_rope1",
+            "scaled_mm_nvfp4",
+        }
+        assert expected.issubset(caps), f"Missing caps: {expected - caps}"
+
+    @rocm_only
+    @pytest.mark.skipif(not _fp8_supported(), reason="FP8 needs gfx1100+")
+    def test_scaled_mm_fp8_in_capabilities(self):
+        import comfy_kitchen as ck
+        backends = ck.list_backends()
+        caps = set(backends["rocm"]["capabilities"])
+        assert "scaled_mm_fp8" in caps
+
+
+# ---------------------------------------------------------------------------
+# FP8 quantise / dequantise
+# ---------------------------------------------------------------------------
+
+class TestFP8QuantDequant:
+
+    @rocm_only
+    def test_quantize_shape_preserved(self):
+        import comfy_kitchen as ck
+        x = torch.randn(128, 256, device="cuda", dtype=torch.bfloat16)
+        scale = torch.tensor([1.0], device="cuda")
+        with ck.use_backend("rocm"):
+            q = ck.quantize_per_tensor_fp8(x, scale)
+        assert q.shape == x.shape
+
+    @rocm_only
+    def test_quantize_dtype(self):
+        import comfy_kitchen as ck
+        x = torch.randn(64, 64, device="cuda", dtype=torch.bfloat16)
+        scale = torch.tensor([1.0], device="cuda")
+        with ck.use_backend("rocm"):
+            q = ck.quantize_per_tensor_fp8(x, scale)
+        assert q.dtype == torch.float8_e4m3fnuz
+
+    @rocm_only
+    def test_roundtrip_accuracy(self):
+        """Quantise then dequantise: max error < 5% of scale * FP8_MAX."""
+        import comfy_kitchen as ck
+        torch.manual_seed(42)
+        x = torch.randn(256, 256, device="cuda", dtype=torch.float32) * 10.0
+        scale = x.abs().max() / torch.finfo(torch.float8_e4m3fnuz).max
+        scale = scale.unsqueeze(0).to("cuda")
+
+        with ck.use_backend("rocm"):
+            q  = ck.quantize_per_tensor_fp8(x, scale)
+            xr = ck.dequantize_per_tensor_fp8(q, scale)
+
+        # FP8 has 3-bit mantissa, expect ~3% rounding error
+        rel_err = (x - xr).abs() / (x.abs() + 1e-6)
+        assert rel_err.mean() < 0.05, f"Mean rel error too high: {rel_err.mean():.4f}"
+
+    @rocm_only
+    def test_scale_respected(self):
+        """A scale of 2.0 should halve the effective range before quantising."""
+        import comfy_kitchen as ck
+        x = torch.ones(16, device="cuda", dtype=torch.bfloat16)
+        scale_1 = torch.tensor([1.0], device="cuda")
+        scale_2 = torch.tensor([2.0], device="cuda")
+
+        with ck.use_backend("rocm"):
+            q1 = ck.quantize_per_tensor_fp8(x, scale_1)
+            q2 = ck.quantize_per_tensor_fp8(x, scale_2)
+            r1 = ck.dequantize_per_tensor_fp8(q1, scale_1)
+            r2 = ck.dequantize_per_tensor_fp8(q2, scale_2)
+
+        # Both should recover approx 1.0; the quantisation point differs
+        torch.testing.assert_close(r1, torch.ones_like(r1), atol=0.1, rtol=0.05)
+        torch.testing.assert_close(r2, torch.ones_like(r2), atol=0.1, rtol=0.05)
+
+
+# ---------------------------------------------------------------------------
+# NVFP4 pack / unpack
+# ---------------------------------------------------------------------------
+
+class TestNVFP4:
+
+    @rocm_only
+    def test_pack_shape(self):
+        """Packed tensor should have half as many bytes as elements."""
+        import comfy_kitchen as ck
+        x = torch.randn(32, 64, device="cuda", dtype=torch.bfloat16)
+        scale = torch.ones(x.numel() // 16, device="cuda")
+        with ck.use_backend("rocm"):
+            packed = ck.quantize_nvfp4(x.flatten(), scale)
+        assert packed.numel() == x.numel() // 2
+
+    @rocm_only
+    def test_roundtrip_values(self):
+        """Values representable in E2M1 should survive a round-trip."""
+        import comfy_kitchen as ck
+        # E2M1 exactly representable values: 0, 0.5, 1, 1.5, 2, 3, 4, 6
+        representable = torch.tensor(
+            [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0,
+             0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0],
+            device="cuda", dtype=torch.bfloat16
+        )
+        scale = torch.ones(1, device="cuda")  # scale=1 so values pass through
+
+        with ck.use_backend("rocm"):
+            packed = ck.quantize_nvfp4(representable, scale)
+            unpacked = ck.dequantize_nvfp4(packed, scale, torch.bfloat16)
+
+        torch.testing.assert_close(unpacked, representable, atol=0.0, rtol=0.0)
+
+    @rocm_only
+    def test_dequant_dtype(self):
+        import comfy_kitchen as ck
+        x = torch.randn(32, device="cuda", dtype=torch.bfloat16)
+        scale = torch.ones(2, device="cuda")
+        with ck.use_backend("rocm"):
+            packed = ck.quantize_nvfp4(x, scale)
+            dq_bf16 = ck.dequantize_nvfp4(packed, scale, torch.bfloat16)
+            dq_f32  = ck.dequantize_nvfp4(packed, scale, torch.float32)
+        assert dq_bf16.dtype == torch.bfloat16
+        assert dq_f32.dtype  == torch.float32
+
+
+# ---------------------------------------------------------------------------
+# RoPE
+# ---------------------------------------------------------------------------
+
+class TestRoPE:
+
+    @staticmethod
+    def _ref_rope(x, cos, sin):
+        """Pure-PyTorch reference RoPE implementation."""
+        half = x.shape[-1] // 2
+        x0, x1 = x[..., :half], x[..., half:]
+        return torch.cat([x0 * cos - x1 * sin, x1 * cos + x0 * sin], dim=-1)
+
+    @rocm_only
+    def test_apply_rope_matches_reference(self):
+        import comfy_kitchen as ck
+        torch.manual_seed(0)
+        B, S, H, D = 2, 16, 4, 64
+        q   = torch.randn(B, S, H, D, device="cuda", dtype=torch.bfloat16)
+        k   = torch.randn(B, S, H, D, device="cuda", dtype=torch.bfloat16)
+        cos = torch.ones(S, D // 2, device="cuda")
+        sin = torch.zeros(S, D // 2, device="cuda")  # sin=0 → identity
+
+        with ck.use_backend("rocm"):
+            q_r, k_r = ck.apply_rope(q, k, cos, sin)
+
+        # With cos=1, sin=0: output should equal input
+        torch.testing.assert_close(q_r, q, atol=1e-3, rtol=1e-3)
+        torch.testing.assert_close(k_r, k, atol=1e-3, rtol=1e-3)
+
+    @rocm_only
+    def test_apply_rope_vs_reference(self):
+        import comfy_kitchen as ck
+        torch.manual_seed(1)
+        B, S, H, D = 1, 8, 2, 32
+        q   = torch.randn(B, S, H, D, device="cuda", dtype=torch.float32)
+        k   = torch.randn(B, S, H, D, device="cuda", dtype=torch.float32)
+        cos = torch.cos(torch.arange(S * D // 2, device="cuda").float()
+                        .reshape(S, D // 2) * 0.01)
+        sin = torch.sin(torch.arange(S * D // 2, device="cuda").float()
+                        .reshape(S, D // 2) * 0.01)
+
+        with ck.use_backend("rocm"):
+            q_rocm, k_rocm = ck.apply_rope(q, k, cos, sin)
+
+        # Reference (broadcast cos/sin over batch and head dims)
+        cos_b = cos.unsqueeze(0).unsqueeze(2)
+        sin_b = sin.unsqueeze(0).unsqueeze(2)
+        q_ref = self._ref_rope(q, cos_b, sin_b)
+        k_ref = self._ref_rope(k, cos_b, sin_b)
+
+        torch.testing.assert_close(q_rocm, q_ref, atol=1e-4, rtol=1e-4)
+        torch.testing.assert_close(k_rocm, k_ref, atol=1e-4, rtol=1e-4)
+
+    @rocm_only
+    def test_apply_rope1(self):
+        import comfy_kitchen as ck
+        torch.manual_seed(2)
+        B, S, H, D = 2, 4, 1, 16
+        x   = torch.randn(B, S, H, D, device="cuda", dtype=torch.float32)
+        cos = torch.ones(S, D // 2, device="cuda")
+        sin = torch.zeros(S, D // 2, device="cuda")
+
+        with ck.use_backend("rocm"):
+            out = ck.apply_rope1(x, cos, sin)
+
+        torch.testing.assert_close(out, x, atol=1e-5, rtol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# scaled_mm_fp8  (hipBLASLt path — gfx1100+ only)
+# ---------------------------------------------------------------------------
+
+class TestScaledMMFP8:
+
+    @pytest.fixture(autouse=True)
+    def skip_if_no_fp8(self):
+        if not IS_ROCM or not HAS_CUDA or not _fp8_supported():
+            pytest.skip(f"scaled_mm_fp8 needs ROCm + gfx1100+ (current: gfx{_gfx_major()})")
+
+    def test_output_shape(self):
+        import comfy_kitchen as ck
+        M, K, N = 128, 256, 64
+        a = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)
+        b = torch.randn(K, N, device="cuda", dtype=torch.bfloat16)
+
+        scale_a = torch.tensor(1.0, device="cuda")
+        scale_b = torch.tensor(1.0, device="cuda")
+
+        a_fp8 = a.to(torch.float8_e4m3fnuz)
+        b_fp8 = b.to(torch.float8_e4m3fnuz)
+
+        with ck.use_backend("rocm"):
+            out = ck.scaled_mm_fp8(a_fp8, b_fp8, scale_a, scale_b,
+                                   out_dtype=torch.bfloat16)
+
+        assert out.shape == (M, N)
+        assert out.dtype == torch.bfloat16
+
+    def test_matches_bf16_matmul(self):
+        """scaled_mm_fp8 should match BF16 matmul within FP8 quantisation error."""
+        import comfy_kitchen as ck
+        torch.manual_seed(42)
+        M, K, N = 64, 128, 64
+        a = torch.randn(M, K, device="cuda", dtype=torch.float32) * 0.1
+        b = torch.randn(K, N, device="cuda", dtype=torch.float32) * 0.1
+
+        ref = torch.mm(a, b).to(torch.bfloat16)
+
+        scale_a = torch.tensor(1.0, device="cuda")
+        scale_b = torch.tensor(1.0, device="cuda")
+        a_fp8 = a.to(torch.float8_e4m3fnuz)
+        b_fp8 = b.to(torch.float8_e4m3fnuz)
+
+        with ck.use_backend("rocm"):
+            out = ck.scaled_mm_fp8(a_fp8, b_fp8, scale_a, scale_b,
+                                   out_dtype=torch.bfloat16)
+
+        # FP8 has limited precision; allow ~2% relative error
+        rel_err = (ref - out).abs() / (ref.abs() + 1e-6)
+        assert rel_err.mean() < 0.02, f"Mean rel err: {rel_err.mean():.4f}"
+
+    def test_scale_applied(self):
+        """Non-unit scales should scale the output proportionally."""
+        import comfy_kitchen as ck
+        torch.manual_seed(7)
+        M, K, N = 32, 32, 32
+        a = torch.ones(M, K, device="cuda", dtype=torch.float8_e4m3fnuz)
+        b = torch.ones(K, N, device="cuda", dtype=torch.float8_e4m3fnuz)
+
+        scale_a = torch.tensor(2.0, device="cuda")
+        scale_b = torch.tensor(3.0, device="cuda")
+        scale_1 = torch.tensor(1.0, device="cuda")
+
+        with ck.use_backend("rocm"):
+            out_scaled = ck.scaled_mm_fp8(a, b, scale_a, scale_b,
+                                          out_dtype=torch.float32)
+            out_unit   = ck.scaled_mm_fp8(a, b, scale_1, scale_1,
+                                          out_dtype=torch.float32)
+
+        # output_scaled should be ~6x output_unit (scale_a * scale_b = 6)
+        ratio = out_scaled / (out_unit + 1e-9)
+        torch.testing.assert_close(ratio,
+                                   torch.full_like(ratio, 6.0),
+                                   atol=0.1, rtol=0.05)
+
+
+# ---------------------------------------------------------------------------
+# scaled_mm_nvfp4  (dequant + BF16 fallback — all ROCm devices)
+# ---------------------------------------------------------------------------
+
+class TestScaledMMNVFP4:
+
+    @rocm_only
+    def test_output_shape(self):
+        import comfy_kitchen as ck
+        M, K, N = 64, 128, 32
+        a_full  = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)
+        b_full  = torch.randn(N, K, device="cuda", dtype=torch.bfloat16)
+
+        scale_a = torch.ones(M * K // 16, device="cuda")
+        scale_b = torch.ones(N * K // 16, device="cuda")
+
+        with ck.use_backend("rocm"):
+            a_p = ck.quantize_nvfp4(a_full.flatten(), scale_a)
+            b_p = ck.quantize_nvfp4(b_full.flatten(), scale_b)
+            out = ck.scaled_mm_nvfp4(a_p, b_p, scale_a, scale_b)
+
+        assert out.shape == (M, N)
+
+    @rocm_only
+    def test_matches_eager(self):
+        """ROCm nvfp4 path must match eager dequant + matmul."""
+        import comfy_kitchen as ck
+        torch.manual_seed(3)
+        M, K, N = 32, 64, 32
+        a_full = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)
+        b_full = torch.randn(N, K, device="cuda", dtype=torch.bfloat16)
+
+        scale_a = torch.ones(M * K // 16, device="cuda")
+        scale_b = torch.ones(N * K // 16, device="cuda")
+
+        with ck.use_backend("rocm"):
+            a_p = ck.quantize_nvfp4(a_full.flatten(), scale_a)
+            b_p = ck.quantize_nvfp4(b_full.flatten(), scale_b)
+            out_rocm = ck.scaled_mm_nvfp4(a_p, b_p, scale_a, scale_b)
+
+        with ck.use_backend("eager"):
+            a_p2 = ck.quantize_nvfp4(a_full.flatten(), scale_a)
+            b_p2 = ck.quantize_nvfp4(b_full.flatten(), scale_b)
+            out_eager = ck.scaled_mm_nvfp4(a_p2, b_p2, scale_a, scale_b)
+
+        torch.testing.assert_close(out_rocm, out_eager, atol=1e-3, rtol=1e-3)
+
+
+# ---------------------------------------------------------------------------
+# Backend isolation:  explicit backend selection
+# ---------------------------------------------------------------------------
+
+class TestBackendIsolation:
+
+    @rocm_only
+    def test_can_force_eager_on_rocm(self):
+        """The eager backend must still work alongside the rocm backend."""
+        import comfy_kitchen as ck
+        x = torch.randn(32, 32, device="cuda", dtype=torch.bfloat16)
+        scale = torch.tensor([1.0], device="cuda")
+
+        with ck.use_backend("eager"):
+            q = ck.quantize_per_tensor_fp8(x, scale)
+        assert q is not None
+
+    @rocm_only
+    def test_can_force_rocm(self):
+        import comfy_kitchen as ck
+        x = torch.randn(32, 32, device="cuda", dtype=torch.bfloat16)
+        scale = torch.tensor([1.0], device="cuda")
+
+        with ck.use_backend("rocm"):
+            q = ck.quantize_per_tensor_fp8(x, scale)
+        assert q is not None
+
+    @rocm_only
+    def test_auto_selection_prefers_rocm_over_eager(self):
+        """Auto-dispatch should use rocm (priority=5) over eager (priority=0)."""
+        import comfy_kitchen as ck
+        import logging
+
+        log_capture = []
+        handler = logging.handlers.MemoryHandler(capacity=100, flushLevel=logging.DEBUG)
+
+        x = torch.randn(32, 32, device="cuda", dtype=torch.bfloat16)
+        scale = torch.tensor([1.0], device="cuda")
+
+        # Just verify it doesn't crash and produces output of the right shape
+        q = ck.quantize_per_tensor_fp8(x, scale)
+        assert q.shape == x.shape


### PR DESCRIPTION
This PR is not intended for merging as-is. It’s an experiment to explore adding a ROCm backend to `comfy-kitchen`. 

I’d appreciate feedback on whether this direction might be worth pursuing in the future, or if `comfy-kitchen` will continue focusing primarily on eager execution on AMD ROCm.

Testing was limited to Windows on RDNA4 hardware.