### PR TITLE
Feat/svdquant w4a4 kitchen native

### DIFF
--- a/comfy_kitchen/__init__.py
+++ b/comfy_kitchen/__init__.py
@@ -33,12 +33,15 @@ __all__ = [
     # Backend configuration
     "disable_backend",
     "enable_backend",
+    "gemv_awq_w4a16",
     "list_backends",
     "quantize_mxfp8",
     "quantize_nvfp4",
     "quantize_per_tensor_fp8",
+    "quantize_svdquant_w4a4",
     "scaled_mm_mxfp8",
     "scaled_mm_nvfp4",
+    "scaled_mm_svdquant_w4a4",
     "set_backend_priority",
     "use_backend",
 ]
@@ -233,6 +236,90 @@ def scaled_mm_mxfp8(
     dtype_code = DTYPE_TO_CODE[out_dtype]
     return torch.ops.comfy_kitchen.scaled_mm_mxfp8(
         a, b, block_scale_a, block_scale_b, bias, dtype_code
+    )
+
+
+def quantize_svdquant_w4a4(
+    x: torch.Tensor,
+    smooth: torch.Tensor,
+    lora_down: torch.Tensor,
+    pad_size: int = 256,
+    act_unsigned: bool = False,
+    shift_value: float = 0.0,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Quantize activations to int4 with fused smoothing and LoRA down projection.
+
+    Args:
+        x: (M, K) bf16/fp16 input.
+        smooth: (K,) smoothing factor applied before quantization.
+        lora_down: (K, R) low-rank down projection weight.
+        pad_size: pad M to multiple of this value (default 256).
+        act_unsigned: if True, quantize activations into uint4 [0, 15].
+        shift_value: additive pre-smoothing shift used by fused GELU -> fc2.
+
+    Returns:
+        (quantized_x uint8 [M_pad, K//2], ascales [K//64, M_pad], lora_act fp32 [M_pad, R])
+    """
+    return torch.ops.comfy_kitchen.quantize_svdquant_w4a4(
+        x, smooth, lora_down, pad_size, act_unsigned, shift_value,
+    )
+
+
+def scaled_mm_svdquant_w4a4(
+    act: torch.Tensor,
+    wgt: torch.Tensor,
+    ascales: torch.Tensor,
+    wscales: torch.Tensor,
+    lora_act_in: torch.Tensor,
+    lora_up: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    act_unsigned: bool = False,
+) -> torch.Tensor:
+    """SVDQuant W4A4 GEMM with fused LoRA up projection.
+
+    Computes out = int4_matmul(act, wgt, ascales, wscales) + lora_act_in @ lora_up^T + bias.
+
+    Args:
+        act: (M, K//2) uint8 packed activations from quantize_svdquant_w4a4.
+        wgt: (N, K//2) int8 packed weights.
+        ascales: (K//64, M) activation scales.
+        wscales: (K//64, N) weight scales.
+        lora_act_in: (M, R) fp32 LoRA activations from quantize step.
+        lora_up: (N, R) LoRA up projection weight.
+        bias: optional (N,) bias.
+        act_unsigned: if True, activations are unsigned (e.g. after GELU).
+
+    Returns:
+        (M, N) output tensor.
+    """
+    return torch.ops.comfy_kitchen.scaled_mm_svdquant_w4a4(
+        act, wgt, ascales, wscales, lora_act_in, lora_up, bias, act_unsigned
+    )
+
+
+def gemv_awq_w4a16(
+    x: torch.Tensor,
+    qweight: torch.Tensor,
+    wscales: torch.Tensor,
+    wzeros: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    group_size: int = 64,
+) -> torch.Tensor:
+    """AWQ W4A16 quantized GEMV (for modulation-style layers called with small batch).
+
+    Args:
+        x: (..., K) bf16/fp16 input.
+        qweight: (N//4, K//2) int32 packed weight.
+        wscales: (K//group_size, N) per-group scales.
+        wzeros: (K//group_size, N) per-group zero points.
+        bias: optional (N,) bias.
+        group_size: quantization group size.
+
+    Returns:
+        (..., N) output tensor.
+    """
+    return torch.ops.comfy_kitchen.gemv_awq_w4a16(
+        x, qweight, wscales, wzeros, bias, group_size
     )
 
 

--- a/comfy_kitchen/__init__.py
+++ b/comfy_kitchen/__init__.py
@@ -245,23 +245,32 @@ def quantize_svdquant_w4a4(
     lora_down: torch.Tensor,
     pad_size: int = 256,
     act_unsigned: bool = False,
-    shift_value: float = 0.0,
+    lora_x: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Quantize activations to int4 with fused smoothing and LoRA down projection.
+    """Quantize activations to int4 with smoothing + LoRA down projection.
 
     Args:
-        x: (M, K) bf16/fp16 input.
+        x: (M, K) bf16/fp16 main-path input (caller pre-shifts if unsigned path).
         smooth: (K,) smoothing factor applied before quantization.
         lora_down: (K, R) low-rank down projection weight.
         pad_size: pad M to multiple of this value (default 256).
-        act_unsigned: if True, quantize activations into uint4 [0, 15].
-        shift_value: additive pre-smoothing shift used by fused GELU -> fc2.
+        act_unsigned: if True, quantize into uint4 [0, 15] (scale=max/15) for u4
+            MMA downstream. Caller must ensure x is non-negative — the shift
+            constant is a model-topology concern, not part of this op.
+        lora_x: (M, K) optional pre-shift activation for LoRA. Defaults to x.
+            Pass raw (un-shifted) x when x has been pre-shifted for unsigned path.
 
     Returns:
         (quantized_x uint8 [M_pad, K//2], ascales [K//64, M_pad], lora_act fp32 [M_pad, R])
+
+    Note: the returned lora_act is a fp32 buffer, but under the CUDA backend it
+    carries bf16-matmul precision (the output of a bf16 × bf16 torch matmul
+    upcast to fp32), not fp32-accumulated precision. The eager backend runs the
+    LoRA matmul in fp32 for numerical stability, which makes it a high-precision
+    reference rather than a bit-parity oracle for the CUDA path.
     """
     return torch.ops.comfy_kitchen.quantize_svdquant_w4a4(
-        x, smooth, lora_down, pad_size, act_unsigned, shift_value,
+        x, smooth, lora_down, pad_size, act_unsigned, lora_x,
     )
 
 
@@ -275,22 +284,31 @@ def scaled_mm_svdquant_w4a4(
     bias: torch.Tensor | None = None,
     act_unsigned: bool = False,
 ) -> torch.Tensor:
-    """SVDQuant W4A4 GEMM with fused LoRA up projection.
+    """SVDQuant W4A4 int4 GEMM + LoRA-up + bias.
 
     Computes out = int4_matmul(act, wgt, ascales, wscales) + lora_act_in @ lora_up^T + bias.
+    The int4 MMA + per-group dequant happens in one CUDA kernel. LoRA-up and
+    bias are applied in the wrapper (bf16 addmm_ into the bf16/fp16 output
+    buffer — faster than kernel fusion for small R, at the cost of the fp32
+    precision carried by lora_act_in). If LoRA-up precision ever becomes a
+    quality blocker, the correct next step is a dedicated cuBLASLt helper with
+    16-bit operand + fp32 accumulate (matches nunchaku's lora.cuh), not a
+    Python-level .float() upcast which would undo the memory/perf win.
 
     Args:
         act: (M, K//2) uint8 packed activations from quantize_svdquant_w4a4.
-        wgt: (N, K//2) int8 packed weights.
+        wgt: (N, K//2) int8 packed weights (natural row-major).
         ascales: (K//64, M) activation scales.
         wscales: (K//64, N) weight scales.
-        lora_act_in: (M, R) fp32 LoRA activations from quantize step.
+        lora_act_in: (M, R) fp32 LoRA activations from quantize step. Note:
+            the fp32 precision is dropped at the bf16 addmm_ below.
         lora_up: (N, R) LoRA up projection weight.
         bias: optional (N,) bias.
-        act_unsigned: if True, activations are unsigned (e.g. after GELU).
+        act_unsigned: if True, activations are interpreted as unsigned [0,15] by
+            u4.s4 MMA (for post-GELU+shift fc2). Caller pre-shifts.
 
     Returns:
-        (M, N) output tensor.
+        (M, N) output tensor (same dtype as lora_up).
     """
     return torch.ops.comfy_kitchen.scaled_mm_svdquant_w4a4(
         act, wgt, ascales, wscales, lora_act_in, lora_up, bias, act_unsigned

--- a/comfy_kitchen/backends/cuda/CMakeLists.txt
+++ b/comfy_kitchen/backends/cuda/CMakeLists.txt
@@ -88,6 +88,10 @@ endif()
 # Optimization flags
 list(APPEND CUDA_NVCC_FLAGS -O3)
 
+# Emit ptxas register/spill stats during build (useful for tuning the int4
+# kernels). No file-level reg cap — each kernel manages occupancy itself.
+list(APPEND CUDA_NVCC_FLAGS -Xptxas=-v)
+
 # Line info for profiling (Nsight Compute/Systems)
 # Can be enabled via setup.py --lineinfo
 if(NOT DEFINED COMFY_ENABLE_LINEINFO)
@@ -106,6 +110,8 @@ set(CUDA_SOURCES
     ops/quantize_mxfp8.cu
     ops/cublas_gemm_nvfp4.cu
     ops/apply_rope.cu
+    ops/quantize_svdquant_w4a4.cu
+    ops/scaled_mm_svdquant_w4a4.cu
 )
 
 set(CPP_SOURCES

--- a/comfy_kitchen/backends/cuda/__init__.py
+++ b/comfy_kitchen/backends/cuda/__init__.py
@@ -27,7 +27,9 @@ __all__ = [
     "quantize_mxfp8",
     "quantize_nvfp4",
     "quantize_per_tensor_fp8",
+    "quantize_svdquant_w4a4",
     "scaled_mm_nvfp4",
+    "scaled_mm_svdquant_w4a4",
 ]
 
 
@@ -130,9 +132,14 @@ def _wrap_for_dlpack(tensor: torch.Tensor):
     the default stream, breaking CUDA graph capture on non-default streams.
     See: https://github.com/pytorch/pytorch/pull/163242
 
+    Detaches first so nn.Parameter (requires_grad=True) inputs like bias
+    export without PyTorch's gradient-tracking refusal.
+
     Returns a PyCapsule containing the DLTensor that nanobind can import.
     """
     # stream=-1 tells PyTorch to skip synchronization (DLPack spec)
+    if tensor.requires_grad:
+        tensor = tensor.detach()
     return tensor.__dlpack__(stream=-1)
 
 
@@ -484,6 +491,139 @@ def apply_rope(
     return xq_out, xk_out
 
 
+# ---------------------------------------------------------------------------
+# SVDQuant W4A4 — native kitchen kernels (int4 MMA GEMM with per-group dequant).
+# ---------------------------------------------------------------------------
+
+_SVDQUANT_W4A4_GROUP_SIZE = 64
+
+
+def quantize_svdquant_w4a4(
+    x: torch.Tensor,
+    smooth: torch.Tensor,
+    lora_down: torch.Tensor,
+    pad_size: int = 256,
+    act_unsigned: bool = False,
+    lora_x: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """SVDQuant W4A4 activation quantize + smooth + LoRA-down (CUDA).
+
+    Kitchen-native layouts:
+      x         (M, K)       bf16/fp16  main-path input (pre-shifted if unsigned)
+      smooth    (K,)         bf16/fp16
+      lora_down (K, R)       bf16/fp16  natural row-major
+      lora_x    (M, K)       bf16/fp16  pre-shift x for LoRA (defaults to x)
+      q_x       (M_pad, K/2) int8       two int4 per byte
+      ascales   (K/G, M_pad) bf16/fp16  per-row per-group
+      lora_act  (M_pad, R)   fp32
+
+    act_unsigned=True selects scale=max/15 + clamp [0,15] (u4 bit patterns for
+    downstream u4.s4 MMA). Caller must ensure x is non-negative — shift is a
+    model-topology concern kept out of the kernel API. Pass lora_x=raw_x when
+    x was pre-shifted (LoRA operates on pre-quantization, pre-shift activations).
+    """
+    assert x.dim() == 2 and x.is_contiguous(), "x must be 2D contiguous"
+    M, K = x.shape
+    R = lora_down.shape[1]
+    M_pad = roundup(M, pad_size)
+    G = _SVDQUANT_W4A4_GROUP_SIZE
+    assert K % G == 0, f"K={K} must be divisible by group_size={G}"
+
+    q_x = torch.empty(M_pad, K // 2, dtype=torch.uint8, device=x.device)
+    ascales = torch.empty(K // G, M_pad, dtype=x.dtype, device=x.device)
+    lora_act = torch.empty(M_pad, R, dtype=torch.float32, device=x.device)
+
+    stream_ptr = torch.cuda.current_stream(x.device).cuda_stream
+    _C.svdquant_quantize_w4a4(
+        _wrap_for_dlpack(x),
+        _wrap_for_dlpack(smooth),
+        _wrap_for_dlpack(lora_down),
+        _wrap_for_dlpack(q_x),
+        _wrap_for_dlpack(ascales),
+        _wrap_for_dlpack(lora_act),
+        bool(act_unsigned),
+        stream_ptr,
+    )
+
+    # LoRA-down uses un-shifted, un-smoothed x (SVDQuant invariant). Pure bf16
+    # matmul: torch's bf16 @ bf16 returns a bf16 tensor, which we then upcast to
+    # the fp32 lora_act buffer. This is NOT the same as nunchaku's 16-bit-operand
+    # + fp32-accumulate LoRA path (src/kernels/zgemm/lora.cuh:164/284) — the
+    # bf16 output is effectively a rounded approximation to the fp32-accumulated
+    # result (~8e-3 abs error vs true fp32). Accepts lora_x to let callers keep
+    # LoRA on the raw pre-quantization activation when x has been pre-shifted.
+    lora_src = lora_x if lora_x is not None else x
+    if M > 0:
+        lora_act[:M].copy_(lora_src @ lora_down, non_blocking=True)
+    if M_pad > M:
+        lora_act[M:].zero_()
+    return q_x.view(torch.int8), ascales, lora_act
+
+
+def scaled_mm_svdquant_w4a4(
+    act: torch.Tensor,
+    wgt: torch.Tensor,
+    ascales: torch.Tensor,
+    wscales: torch.Tensor,
+    lora_act_in: torch.Tensor,
+    lora_up: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    act_unsigned: bool = False,
+) -> torch.Tensor:
+    """SVDQuant W4A4 int4 GEMM + LoRA-up + bias (CUDA).
+
+    int4 MMA + per-group dequant in one kernel; LoRA-up + bias are applied in
+    Python via cuBLAS bf16 addmm_ (see the body below — faster than in-kernel
+    fusion for R=96 and similar small ranks).
+
+    Kitchen-native layouts:
+      act         (M, K/2)   int8       two int4 per byte (signed or unsigned)
+      wgt         (N, K/2)   int8       signed int4 weight, natural row-major
+      ascales     (K/G, M)   bf16/fp16  per-row per-group
+      wscales     (K/G, N)   bf16/fp16  per-col per-group
+      lora_act_in (M, R)     fp32
+      lora_up     (N, R)     bf16/fp16
+      bias        (N,)       bf16/fp16  (optional)
+      out         (M, N)     bf16/fp16  (= lora_up.dtype)
+
+    act_unsigned: if True, A fragments go through u4.s4 MMA instead of s4.s4.
+    """
+    M = act.shape[0]
+    N = wgt.shape[0]
+    out = torch.empty(M, N, dtype=lora_up.dtype, device=act.device)
+    empty = torch.empty(0, dtype=lora_up.dtype, device=act.device)
+
+    stream_ptr = torch.cuda.current_stream(act.device).cuda_stream
+    _C.svdquant_scaled_mm_w4a4(
+        _wrap_for_dlpack(act.view(torch.uint8)),
+        _wrap_for_dlpack(wgt.view(torch.uint8)),
+        _wrap_for_dlpack(ascales),
+        _wrap_for_dlpack(wscales),
+        _wrap_for_dlpack(lora_act_in),
+        _wrap_for_dlpack(lora_up),
+        _wrap_for_dlpack(bias if bias is not None else empty),
+        _wrap_for_dlpack(out),
+        act_unsigned,
+        stream_ptr,
+    )
+
+    # LoRA-up + bias via bf16 addmm_. lora_act_in is fp32 but we drop it to bf16
+    # here before the matmul so `out` stays bf16/fp16 throughout — this avoids
+    # allocating a fp32 temporary, at the cost of the fp32 precision carried by
+    # lora_act_in. The (fp32 out_of_quantize) -> (bf16 truncate) -> (bf16 matmul)
+    # -> (bf16 addmm into out) chain is lossier than nunchaku's 16-bit-operand +
+    # fp32-accumulate LoRA (src/kernels/zgemm/lora.cuh:284); kitchen accepts that
+    # tradeoff for the memory/launch-count win. If that ever shows up in model
+    # quality, replace this pair of matmuls with a dedicated cuBLASLt helper
+    # (16-bit operand, fp32 accumulate) rather than Python-level .float() casts,
+    # which would undo the memory/perf gain that motivated the bf16 path.
+    lora_bf16 = lora_act_in.to(out.dtype)
+    out.addmm_(lora_bf16, lora_up.t())
+    if bias is not None:
+        out.add_(bias)
+    return out
+
+
 def _build_constraints() -> dict:
     from comfy_kitchen.constraints import (
         DivisibleBy,
@@ -591,6 +731,35 @@ def _build_constraints() -> dict:
                 ),
             },
             default_devices=cuda_devices,
+        ),
+        "quantize_svdquant_w4a4": FunctionConstraints(
+            params={
+                "x": ParamConstraint(
+                    dtypes=frozenset({torch.float16, torch.bfloat16}),
+                    shape_rules=(ExactDims(2), DivisibleBy(dim=1, factor=64)),
+                ),
+                "smooth": ParamConstraint(
+                    dtypes=frozenset({torch.float16, torch.bfloat16}),
+                ),
+                "lora_down": ParamConstraint(
+                    dtypes=frozenset({torch.float16, torch.bfloat16}),
+                    shape_rules=(ExactDims(2),),
+                ),
+            },
+            default_devices=cuda_devices,
+            min_compute_capability=(8, 0),
+        ),
+        "scaled_mm_svdquant_w4a4": FunctionConstraints(
+            params={
+                "act": ParamConstraint(dtypes=frozenset({torch.int8}), shape_rules=(ExactDims(2),)),
+                "wgt": ParamConstraint(dtypes=frozenset({torch.int8}), shape_rules=(ExactDims(2),)),
+                "ascales": ParamConstraint(dtypes=frozenset({torch.float16, torch.bfloat16})),
+                "wscales": ParamConstraint(dtypes=frozenset({torch.float16, torch.bfloat16})),
+                "lora_act_in": ParamConstraint(dtypes=frozenset({torch.float32})),
+                "lora_up": ParamConstraint(dtypes=frozenset({torch.float16, torch.bfloat16})),
+            },
+            default_devices=cuda_devices,
+            min_compute_capability=(8, 0),
         ),
     }
 

--- a/comfy_kitchen/backends/cuda/dlpack_bindings.cpp
+++ b/comfy_kitchen/backends/cuda/dlpack_bindings.cpp
@@ -128,6 +128,40 @@ extern "C" {
         int64_t orig_cols,
         int input_dtype_code,
         cudaStream_t stream);
+
+    // SVDQuant W4A4 — see ops/quantize_svdquant_w4a4.cu
+    void launch_svdquant_quantize_w4a4_kernel(
+        const void* x,
+        const void* smooth,
+        const void* lora_down,
+        void* q_x,
+        void* ascales,
+        void* lora_act,
+        int M,
+        int M_pad,
+        int K,
+        int R,
+        int input_dtype_code,
+        int act_unsigned,
+        cudaStream_t stream);
+
+    // SVDQuant W4A4 — see ops/scaled_mm_svdquant_w4a4.cu
+    void launch_svdquant_scaled_mm_w4a4_kernel(
+        const void* act,
+        const void* wgt,
+        const void* ascales,
+        const void* wscales,
+        const void* lora_act_in,
+        const void* lora_up,
+        const void* bias,
+        void* out,
+        int M,
+        int N,
+        int K,
+        int R,
+        int act_unsigned,
+        int out_dtype_code,
+        cudaStream_t stream);
 }
 
 // Nanobind wrapper for quantize_per_tensor_fp8
@@ -476,6 +510,70 @@ void apply_rope(
     );
 }
 
+// ---------------------------------------------------------------------------
+// SVDQuant W4A4 — nanobind/DLPack bindings for the native kitchen int4 kernels
+// (see ops/quantize_svdquant_w4a4.cu and ops/scaled_mm_svdquant_w4a4.cu).
+// ---------------------------------------------------------------------------
+
+static int svdquant_dtype_code(const nb::dlpack::dtype& dt) {
+    int c = map_dtype_to_code(dt);
+    if (c < 0) throw std::runtime_error("svdquant: unsupported dtype");
+    return c;
+}
+
+void svdquant_quantize_w4a4(
+    nb::ndarray<nb::device::cuda> x,           // (M, K) bf16/fp16 — pre-shifted if unsigned path
+    nb::ndarray<nb::device::cuda> smooth,      // (K,)
+    nb::ndarray<nb::device::cuda> lora_down,   // (K, R)
+    nb::ndarray<nb::device::cuda> q_x,         // (M_pad, K/2) int8
+    nb::ndarray<nb::device::cuda> ascales,     // (K/G, M_pad)
+    nb::ndarray<nb::device::cuda> lora_act,    // (M_pad, R) fp32
+    bool act_unsigned,
+    uintptr_t stream_ptr)
+{
+    int M = static_cast<int>(x.shape(0));
+    int K = static_cast<int>(x.shape(1));
+    int M_pad = static_cast<int>(q_x.shape(0));
+    int R = static_cast<int>(lora_down.shape(1));
+    int input_code = svdquant_dtype_code(x.dtype());
+
+    cudaStream_t stream = reinterpret_cast<cudaStream_t>(stream_ptr);
+    launch_svdquant_quantize_w4a4_kernel(
+        x.data(), smooth.data(), lora_down.data(),
+        q_x.data(), ascales.data(), lora_act.data(),
+        M, M_pad, K, R, input_code,
+        static_cast<int>(act_unsigned), stream);
+}
+
+void svdquant_scaled_mm_w4a4(
+    nb::ndarray<nb::device::cuda> act,           // (M, K/2) int8
+    nb::ndarray<nb::device::cuda> wgt,           // (N, K/2) int8
+    nb::ndarray<nb::device::cuda> ascales,       // (K/G, M)
+    nb::ndarray<nb::device::cuda> wscales,       // (K/G, N)
+    nb::ndarray<nb::device::cuda> lora_act_in,   // (M, R) fp32
+    nb::ndarray<nb::device::cuda> lora_up,       // (N, R)
+    nb::ndarray<nb::device::cuda> bias,          // (N,) or empty
+    nb::ndarray<nb::device::cuda> out,           // (M, N)
+    bool act_unsigned,
+    uintptr_t stream_ptr)
+{
+    int M = static_cast<int>(act.shape(0));
+    int N = static_cast<int>(wgt.shape(0));
+    int K = static_cast<int>(act.shape(1)) * 2;
+    int R = static_cast<int>(lora_act_in.shape(1));
+    int out_code = svdquant_dtype_code(out.dtype());
+
+    const void* bias_ptr = (bias.data() != nullptr && bias.size() > 0) ? bias.data() : nullptr;
+    cudaStream_t stream = reinterpret_cast<cudaStream_t>(stream_ptr);
+    launch_svdquant_scaled_mm_w4a4_kernel(
+        act.data(), wgt.data(),
+        ascales.data(), wscales.data(),
+        lora_act_in.data(), lora_up.data(), bias_ptr,
+        out.data(),
+        M, N, K, R,
+        static_cast<int>(act_unsigned), out_code, stream);
+}
+
 // Python module definition
 NB_MODULE(_C, m) {
     m.doc() = "comfy_kitchen CUDA kernels - nanobind + DLPack interface (NO PyTorch C++ dependencies)";
@@ -548,6 +646,32 @@ NB_MODULE(_C, m) {
           nb::arg("output"),
           nb::arg("block_scales"),
           nb::arg("pad_32x") = false,
+          nb::arg("stream_ptr"));
+
+    m.def("svdquant_quantize_w4a4", &svdquant_quantize_w4a4,
+          "SVDQuant W4A4: smooth + int4 quantize (LoRA-down is external). "
+          "act_unsigned selects scale=max/15 + clamp [0,15] for u4 MMA downstream; "
+          "caller must pre-shift x to be non-negative before calling (model-level concern).",
+          nb::arg("x"),
+          nb::arg("smooth"),
+          nb::arg("lora_down"),
+          nb::arg("q_x"),
+          nb::arg("ascales"),
+          nb::arg("lora_act"),
+          nb::arg("act_unsigned"),
+          nb::arg("stream_ptr"));
+
+    m.def("svdquant_scaled_mm_w4a4", &svdquant_scaled_mm_w4a4,
+          "SVDQuant W4A4: int4 GEMM with per-group dequant",
+          nb::arg("act"),
+          nb::arg("wgt"),
+          nb::arg("ascales"),
+          nb::arg("wscales"),
+          nb::arg("lora_act_in"),
+          nb::arg("lora_up"),
+          nb::arg("bias"),
+          nb::arg("out"),
+          nb::arg("act_unsigned"),
           nb::arg("stream_ptr"));
 
     // Feature availability flag (computed at module load time)

--- a/comfy_kitchen/backends/cuda/ops/quantize_svdquant_w4a4.cu
+++ b/comfy_kitchen/backends/cuda/ops/quantize_svdquant_w4a4.cu
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Kitchen CUDA SVDQuant W4A4: activation quantize + smooth.
+//
+// Signature (matches backends/eager/svdquant.py::quantize_svdquant_w4a4):
+//   in : x (M, K) bf16/fp16, smooth (K,) bf16/fp16, lora_down (K, R) bf16/fp16
+//   out: q_x      (M_pad, K/2) int8      packed int4 (signed or unsigned)
+//        ascales  (K/G, M_pad) bf16/fp16 per-row per-group scale
+//        lora_act (M_pad, R)   fp32      computed externally via cuBLAS bf16 matmul
+//                                        (see comfy_kitchen/backends/cuda/__init__.py;
+//                                        LoRA-down operates on pre-quantization x)
+//
+// Per-warp layout:
+//   kMRowsPerCTA warps per CTA (default 4), 1 warp (32 threads) per M row.
+//   Warp loops over K/G groups; each thread handles 2 consecutive K elements
+//   per group (32 × 2 = 64 = kGroupSize).
+//   Thread t writes byte q_x[m, g*32 + t] = pack(q[2t], q[2t+1]).
+//
+// kActUnsigned=true: scale = max/15, clamp [0, 15]  (for u4.s4 MMA downstream)
+// kActUnsigned=false: scale = max/7,  clamp [-7, 7] (for s4.s4 MMA downstream)
+// No shift: callers that need non-negative x (e.g., post-GELU+shift) pre-shift
+// at the layer level — see comfy_kitchen/tensor/svdquant_w4a4.py::_w4a4_forward.
+#include "svdquant_utils.cuh"
+
+#include <cuda_runtime.h>
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cstdint>
+
+namespace {
+
+using comfy::svdquant::kGroupSize;
+using comfy::svdquant::kInt4Max;
+using comfy::svdquant::pack_int4_pair;
+using comfy::svdquant::warp_absmax;
+
+template<typename InType>
+__device__ __forceinline__ float to_fp32(InType v);
+
+template<>
+__device__ __forceinline__ float to_fp32<__nv_bfloat16>(__nv_bfloat16 v) { return __bfloat162float(v); }
+
+template<>
+__device__ __forceinline__ float to_fp32<__half>(__half v) { return __half2float(v); }
+
+template<typename InType>
+__device__ __forceinline__ InType fp32_to_in(float v);
+
+template<>
+__device__ __forceinline__ __nv_bfloat16 fp32_to_in<__nv_bfloat16>(float v) { return __float2bfloat16(v); }
+
+template<>
+__device__ __forceinline__ __half fp32_to_in<__half>(float v) { return __float2half(v); }
+
+template<typename InType, bool kActUnsigned>
+__global__ void svdquant_quantize_w4a4_kernel(
+    const InType* __restrict__ x,          // (M, K)
+    const InType* __restrict__ smooth,     // (K,)
+    const InType* __restrict__ lora_down,  // (K, R)
+    int8_t* __restrict__ q_x,              // (M_pad, K/2)
+    InType* __restrict__ ascales,          // (K/G, M_pad)
+    float* __restrict__ lora_act,          // (M_pad, R)
+    int M, int M_pad, int K, int R)
+{
+    // CTA layout: kMRowsPerCTA warps, each warp handles one M row. The
+    // LoRA-down path is computed externally via cuBLAS bf16 matmul (see the
+    // Python wrapper), so this kernel only handles smooth + per-group int4
+    // quantize + pack. Multi-warp CTA still helps by amortizing kernel launch
+    // overhead and improving SM occupancy relative to 1-warp CTAs.
+    constexpr int kMRowsPerCTA = 4;
+    const int warp_id = threadIdx.x / 32;
+    const int t = threadIdx.x & 31;
+    const int m = blockIdx.x * kMRowsPerCTA + warp_id;
+    const bool warp_active = (m < M_pad);
+    const bool in_bounds = (m < M);
+
+    const int num_groups = K / kGroupSize;
+    const int K_half = K / 2;
+
+    // LoRA-down is computed externally (bf16 cuBLAS matmul). This kernel
+    // ignores the lora_down/lora_act pointers and the rank.
+    (void)lora_down;
+    (void)lora_act;
+    (void)R;
+
+    if (!warp_active) return;
+
+    for (int g = 0; g < num_groups; ++g) {
+        const int k0 = g * kGroupSize + t * 2;
+        const int k1 = k0 + 1;
+
+        float x0, x1, s0, s1;
+        if (in_bounds) {
+            x0 = to_fp32(x[m * K + k0]);
+            x1 = to_fp32(x[m * K + k1]);
+        } else {
+            x0 = 0.f; x1 = 0.f;
+        }
+        s0 = to_fp32(smooth[k0]);
+        s1 = to_fp32(smooth[k1]);
+
+        // ---- Quantize (smooth then per-group int4) ----
+        // kActUnsigned only changes the quantization grid (scale=max/15, clamp [0,15]).
+        // Any activation shift (e.g., GELU + 0.171875 for nunchaku unsigned path) is
+        // applied by the caller at the layer level, not inside this kernel — keeps
+        // kitchen ops orthogonal to model topology.
+        const float inv_s0 = (fabsf(s0) > 1e-10f) ? (1.f / s0) : 0.f;
+        const float inv_s1 = (fabsf(s1) > 1e-10f) ? (1.f / s1) : 0.f;
+        const float y0 = x0 * inv_s0;
+        const float y1 = x1 * inv_s1;
+
+        float local = fmaxf(fabsf(y0), fabsf(y1));
+        const float group_absmax = warp_absmax(local, 32);
+        constexpr int kQMax = kActUnsigned ? 15 : kInt4Max;  // 15 for u4, 7 for s4
+        const float scale = fmaxf(group_absmax / static_cast<float>(kQMax), 1e-10f);
+        const float inv_scale = 1.f / scale;
+
+        int q0 = __float2int_rn(y0 * inv_scale);
+        int q1 = __float2int_rn(y1 * inv_scale);
+        if constexpr (kActUnsigned) {
+            // Clamp to [0, 15] unsigned range. Values should be non-negative after
+            // shift; any residual negatives clamp to 0.
+            q0 = max(0, min(15, q0));
+            q1 = max(0, min(15, q1));
+        } else {
+            q0 = max(-kInt4Max, min(kInt4Max, q0));
+            q1 = max(-kInt4Max, min(kInt4Max, q1));
+        }
+        q_x[m * K_half + g * (kGroupSize / 2) + t] = pack_int4_pair(q0, q1);
+
+        if (t == 0) {
+            ascales[g * M_pad + m] = fp32_to_in<InType>(in_bounds ? scale : 0.f);
+        }
+
+    }
+
+}
+
+} // anonymous namespace
+
+extern "C" {
+
+void launch_svdquant_quantize_w4a4_kernel(
+    const void* x,
+    const void* smooth,
+    const void* lora_down,
+    void* q_x,
+    void* ascales,
+    void* lora_act,
+    int M,
+    int M_pad,
+    int K,
+    int R,
+    int input_dtype_code,
+    int act_unsigned,      // 0: signed [-7,7] + scale=max/7; 1: unsigned [0,15] + scale=max/15
+    cudaStream_t stream)
+{
+    if (K % comfy::svdquant::kGroupSize != 0) return;
+    // No rank cap: LoRA-down matmul is external, Python wrapper picks cuBLAS
+    // bf16 path which handles any R efficiently (benched at R={16..256}).
+
+    constexpr int kMRowsPerCTA = 4;
+    const dim3 grid((M_pad + kMRowsPerCTA - 1) / kMRowsPerCTA);
+    const dim3 block(kMRowsPerCTA * 32);
+
+    #define LAUNCH_QUANTIZE(InType, Unsigned)                                               \
+        svdquant_quantize_w4a4_kernel<InType, Unsigned><<<grid, block, 0, stream>>>(        \
+            reinterpret_cast<const InType*>(x),                                             \
+            reinterpret_cast<const InType*>(smooth),                                        \
+            reinterpret_cast<const InType*>(lora_down),                                     \
+            reinterpret_cast<int8_t*>(q_x),                                                 \
+            reinterpret_cast<InType*>(ascales),                                             \
+            reinterpret_cast<float*>(lora_act),                                             \
+            M, M_pad, K, R)
+
+    if (input_dtype_code == 2) {
+        if (act_unsigned) LAUNCH_QUANTIZE(__nv_bfloat16, true);
+        else              LAUNCH_QUANTIZE(__nv_bfloat16, false);
+    } else if (input_dtype_code == 1) {
+        if (act_unsigned) LAUNCH_QUANTIZE(__half, true);
+        else              LAUNCH_QUANTIZE(__half, false);
+    }
+    #undef LAUNCH_QUANTIZE
+}
+
+} // extern "C"

--- a/comfy_kitchen/backends/cuda/ops/scaled_mm_svdquant_w4a4.cu
+++ b/comfy_kitchen/backends/cuda/ops/scaled_mm_svdquant_w4a4.cu
@@ -1,0 +1,348 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Kitchen CUDA SVDQuant W4A4 int4 GEMM with per-group dequant.
+//
+// Tile layout:
+//   CTA  = 4 warps × 32 threads = 128 threads, warp grid 2×2
+//   CTA covers 32 M × 128 N output (each warp computes 16 M × 64 N)
+//   grid = (ceil(N/128), ceil(M/32))
+//
+// Per K iteration (BLOCK_K = kGroupSize = 64):
+//   A (32 M × 32 B/group) and B (128 N × 32 B/group) are CTA-cooperatively
+//   loaded into shmem via cp.async, triple-buffered (kStages=3).
+//   Each warp issues kNUnroll = 8 MMAs covering its 16M × 64N output tile.
+//
+// Dequant: int32 MMA output → fp32 scalar multiply-adds with per-group
+// ascale × wscale. fp32 accumulator (not fp16) for numerical robustness —
+// in production Qwen-Image-Edit, scale products (ascale × wscale) can reach
+// ~100 and per-MMA d_reg values can reach ~3000, so the per-term product
+// overflows fp16's ±65504 range mid-sampling and silently propagates NaN
+// (see ops/scaled_mm_svdquant_w4a4.cu accumulator declaration).
+//
+// act_unsigned: when true, A fragments are interpreted by u4.s4 MMA instead
+// of s4.s4 (enables +1 bit of activation precision for layers whose input
+// is known non-negative, e.g., post-GELU fc2 with nunchaku's +0.171875 shift
+// — caller applies the shift at the layer level; this kernel only picks the
+// MMA variant).
+//
+// LoRA-up + bias are applied externally in the Python wrapper via cuBLAS bf16
+// matmul + addmm_ (faster than in-kernel fusion for small R={16..256}; see
+// comfy_kitchen/backends/cuda/__init__.py::scaled_mm_svdquant_w4a4).
+#include "svdquant_utils.cuh"
+
+#include <cuda_runtime.h>
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cstdint>
+
+namespace {
+
+using comfy::svdquant::kGroupSize;
+using comfy::svdquant::mma_m16n8k64_s4s4s32;
+using comfy::svdquant::mma_m16n8k64_u4s4s32;
+using comfy::svdquant::cp_async_16b;
+using comfy::svdquant::cp_async_commit_group;
+using comfy::svdquant::cp_async_wait_group;
+
+constexpr int kStages = 3;  // opt10: 3-stage pipeline (smem 10→15 KB, same occupancy)
+
+constexpr int kMUnroll  = 1;               // MMA_M tiles per warp (each 16 M)
+constexpr int kWarpM    = kMUnroll * 16;   // 16 M rows per warp
+constexpr int kNUnroll  = 8;               // MMAs per K iter per warp (N dim)
+constexpr int kWarpN    = kNUnroll * 8;    // 64 N cols per warp
+constexpr int kWarpsM   = 2;               // warps stacked in M
+constexpr int kWarpsN   = 2;               // warps stacked in N
+constexpr int kNumWarps = kWarpsM * kWarpsN;      // 8
+constexpr int kBlockM   = kWarpM * kWarpsM;       // 64 M per CTA
+constexpr int kBlockN   = kWarpN * kWarpsN;       // 128 N per CTA
+constexpr int kBlockKBytes = kGroupSize / 2;      // 32 bytes of int4 per K group
+
+template<typename OutType>
+__device__ __forceinline__ OutType fp32_to_out(float v);
+
+template<>
+__device__ __forceinline__ __nv_bfloat16 fp32_to_out<__nv_bfloat16>(float v) {
+    return __float2bfloat16(v);
+}
+
+template<>
+__device__ __forceinline__ __half fp32_to_out<__half>(float v) {
+    return __float2half(v);
+}
+
+template<typename OutType>
+__device__ __forceinline__ float load_scale(const OutType* p) {
+    if constexpr (std::is_same_v<OutType, __nv_bfloat16>) return __bfloat162float(*p);
+    else return __half2float(*p);
+}
+
+template<typename OutType, bool kActUnsigned>
+__global__ void svdquant_scaled_mm_w4a4_kernel(
+    const int8_t* __restrict__ act,          // (M, K/2)
+    const int8_t* __restrict__ wgt,          // (N, K/2)
+    const OutType* __restrict__ ascales,     // (K/G, M)
+    const OutType* __restrict__ wscales,     // (K/G, N)
+    const float*   __restrict__ lora_act_in, // unused; epilogue is in Python
+    const OutType* __restrict__ lora_up,     // unused
+    const OutType* __restrict__ bias,        // unused
+    OutType* __restrict__ out,               // (M, N)
+    int M, int N, int K, int R)
+{
+    (void)lora_act_in; (void)lora_up; (void)bias; (void)R;
+
+    // CTA coordinates
+    const int cta_m = blockIdx.y * kBlockM;
+    const int cta_n = blockIdx.x * kBlockN;
+
+    // Warp layout within CTA
+    const int warp_id   = threadIdx.x >> 5;          // 0..kNumWarps-1
+    const int lane      = threadIdx.x & 31;
+    const int warp_m    = warp_id & (kWarpsM - 1);   // 0..kWarpsM-1
+    const int warp_n    = warp_id / kWarpsM;         // 0..kWarpsN-1
+
+    const int groupID      = lane >> 2;   // 0..7
+    const int tid_in_group = lane & 3;    // 0..3
+
+    // This warp's output M/N base
+    const int warp_m_base = cta_m + warp_m * kWarpM;
+    const int warp_n_base = cta_n + warp_n * kWarpN;
+
+    // Per-warp accumulator: kMUnroll M-tiles × kNUnroll N-chunks × 4 fp32.
+    // We accumulate in fp32 (not fp16) because in production Qwen-Image-Edit,
+    // per-group scale products ascale*wscale can reach ~100 and single-MMA d_reg
+    // values can reach ~3000, pushing the per-term contribution well past fp16's
+    // ±65504 range. fp16 accumulation overflow -> inf -> NaN propagation causes
+    // black-image mid-sampling failures that single-layer random parity tests miss.
+    // nunchaku works with fp16 because their calibration bounds scales tighter;
+    // kitchen's conservative choice is fp32 for end-to-end robustness.
+    float out_f[kMUnroll][kNUnroll][4];
+    #pragma unroll
+    for (int mi = 0; mi < kMUnroll; ++mi) {
+        #pragma unroll
+        for (int c = 0; c < kNUnroll; ++c) {
+            #pragma unroll
+            for (int i = 0; i < 4; ++i) out_f[mi][c][i] = 0.f;
+        }
+    }
+
+    const int K_half      = K / 2;
+    const int num_groups  = K / kGroupSize;
+
+    // Shared memory: double-buffered A and B tiles.
+    // B stage: kBlockN rows × kBlockKBytes bytes = 128 * 32 = 4 KB
+    // A stage: kBlockM rows × kBlockKBytes bytes =  32 * 32 = 1 KB
+    __shared__ alignas(16) int8_t smem_B[kStages][kBlockN * kBlockKBytes];
+    __shared__ alignas(16) int8_t smem_A[kStages][kBlockM * kBlockKBytes];
+
+    // ---------- Helper: issue async cp for B tile at group `g` into stage ----------
+    auto issue_B_load = [&](int g, int stage) {
+        if (g >= num_groups) return;
+        // 128 threads × (kBlockN/64 sweeps) × 16B per thread = 4 KB per stage
+        // We need kBlockN * kBlockKBytes = 4096 bytes. 128 threads × 16 B = 2 KB per sweep → 2 sweeps.
+        const int thread_idx = threadIdx.x;
+        #pragma unroll
+        for (int sweep = 0; sweep < 2; ++sweep) {
+            const int t = thread_idx + sweep * (kNumWarps * 32);
+            // each t loads one 16-byte chunk: n_row = t/2, half = t%2
+            if (t < kBlockN * 2) {
+                const int n_row = t >> 1;
+                const int half  = t & 1;
+                const int n_global = cta_n + n_row;
+                int8_t* dst = &smem_B[stage][n_row * kBlockKBytes + half * 16];
+                if (n_global < N) {
+                    const int8_t* src = wgt + n_global * K_half + g * kBlockKBytes + half * 16;
+                    cp_async_16b(dst, src);
+                } else {
+                    // Out-of-bounds rows: pad with zeros (use regular 16-byte zero store).
+                    reinterpret_cast<uint4*>(dst)[0] = {0, 0, 0, 0};
+                }
+            }
+        }
+    };
+
+    // ---------- Helper: issue async cp for A tile at group `g` into stage ----------
+    auto issue_A_load = [&](int g, int stage) {
+        if (g >= num_groups) return;
+        const int t = threadIdx.x;
+        if (t < kBlockM * 2) {
+            const int m_row = t >> 1;
+            const int half  = t & 1;
+            const int m_global = cta_m + m_row;
+            int8_t* dst = &smem_A[stage][m_row * kBlockKBytes + half * 16];
+            if (m_global < M) {
+                const int8_t* src = act + m_global * K_half + g * kBlockKBytes + half * 16;
+                cp_async_16b(dst, src);
+            } else {
+                reinterpret_cast<uint4*>(dst)[0] = {0, 0, 0, 0};
+            }
+        }
+    };
+
+    // ---------- Prime the pipeline: launch first (kStages-1) loads ----------
+    #pragma unroll
+    for (int s = 0; s < kStages - 1; ++s) {
+        issue_A_load(s, s);
+        issue_B_load(s, s);
+        cp_async_commit_group();
+    }
+
+    for (int g = 0; g < num_groups; ++g) {
+        // Start next iteration's load (stage = (g + kStages - 1) % kStages)
+        const int next_g = g + kStages - 1;
+        if (next_g < num_groups) {
+            const int next_stage = (g + kStages - 1) % kStages;
+            issue_A_load(next_g, next_stage);
+            issue_B_load(next_g, next_stage);
+        }
+        cp_async_commit_group();
+
+        // Wait for the load corresponding to current g (stages ahead of current)
+        cp_async_wait_group<kStages - 1>();
+        __syncthreads();
+
+        const int cur_stage = g % kStages;
+
+        // ---------- A loads from shmem for each of kMUnroll M-tiles ----------
+        uint32_t a_reg[kMUnroll][4];
+        float as_row0_arr[kMUnroll], as_row1_arr[kMUnroll];
+        #pragma unroll
+        for (int mi = 0; mi < kMUnroll; ++mi) {
+            const int m_tile_base = warp_m_base + mi * 16;
+            const int row0_m = m_tile_base + groupID;
+            const int row1_m = m_tile_base + groupID + 8;
+            const int row0_local = warp_m * kWarpM + mi * 16 + groupID;
+            const int row1_local = warp_m * kWarpM + mi * 16 + groupID + 8;
+            a_reg[mi][0] = a_reg[mi][1] = a_reg[mi][2] = a_reg[mi][3] = 0;
+            if (row0_m < M) {
+                const int8_t* rb = &smem_A[cur_stage][row0_local * kBlockKBytes];
+                a_reg[mi][0] = *reinterpret_cast<const uint32_t*>(rb + tid_in_group * 8);
+                a_reg[mi][2] = *reinterpret_cast<const uint32_t*>(rb + tid_in_group * 8 + 4);
+            }
+            if (row1_m < M) {
+                const int8_t* rb = &smem_A[cur_stage][row1_local * kBlockKBytes];
+                a_reg[mi][1] = *reinterpret_cast<const uint32_t*>(rb + tid_in_group * 8);
+                a_reg[mi][3] = *reinterpret_cast<const uint32_t*>(rb + tid_in_group * 8 + 4);
+            }
+            as_row0_arr[mi] = (row0_m < M) ? load_scale<OutType>(&ascales[g * M + row0_m]) : 0.f;
+            as_row1_arr[mi] = (row1_m < M) ? load_scale<OutType>(&ascales[g * M + row1_m]) : 0.f;
+        }
+
+        // Pre-load this K-iter's wscales into per-lane registers, hoisted out of
+        // the inner MMA loop so the compiler can schedule the loads ahead of MMAs.
+        const OutType* ws_base_g = &wscales[g * N];
+        float ws_regs[kNUnroll][2];
+        #pragma unroll
+        for (int cc = 0; cc < kNUnroll; ++cc) {
+            const int col0 = warp_n_base + cc * 8 + tid_in_group * 2 + 0;
+            const int col1 = warp_n_base + cc * 8 + tid_in_group * 2 + 1;
+            ws_regs[cc][0] = (col0 < N) ? load_scale<OutType>(&ws_base_g[col0]) : 0.f;
+            ws_regs[cc][1] = (col1 < N) ? load_scale<OutType>(&ws_base_g[col1]) : 0.f;
+        }
+
+        #pragma unroll
+        for (int c = 0; c < kNUnroll; ++c) {
+            const int b_col_local = (warp_n * kWarpN) + c * 8 + groupID;
+            const int b_col_global = cta_n + b_col_local;
+
+            uint32_t b_reg[2] = {0, 0};
+            if (b_col_local < kBlockN && b_col_global < N) {
+                const int8_t* row_base = &smem_B[cur_stage][b_col_local * kBlockKBytes];
+                b_reg[0] = *reinterpret_cast<const uint32_t*>(row_base + tid_in_group * 8);
+                b_reg[1] = *reinterpret_cast<const uint32_t*>(row_base + tid_in_group * 8 + 4);
+            }
+
+            const float ws_col0 = ws_regs[c][0];
+            const float ws_col1 = ws_regs[c][1];
+
+            // Reuse b_reg for each M-tile
+            #pragma unroll
+            for (int mi = 0; mi < kMUnroll; ++mi) {
+                int32_t c_reg[4] = {0, 0, 0, 0};
+                int32_t d_reg[4];
+                if constexpr (kActUnsigned) {
+                    mma_m16n8k64_u4s4s32(a_reg[mi], b_reg, c_reg, d_reg);
+                } else {
+                    mma_m16n8k64_s4s4s32(a_reg[mi], b_reg, c_reg, d_reg);
+                }
+
+                // fp32 dequant: out_f += cvt(d) * ascale * wscale. Slower than
+                // the fp16 hfma2 variant but avoids the overflow on large
+                // scale products (see accumulator declaration for rationale).
+                out_f[mi][c][0] += static_cast<float>(d_reg[0]) * as_row0_arr[mi] * ws_col0;
+                out_f[mi][c][1] += static_cast<float>(d_reg[1]) * as_row0_arr[mi] * ws_col1;
+                out_f[mi][c][2] += static_cast<float>(d_reg[2]) * as_row1_arr[mi] * ws_col0;
+                out_f[mi][c][3] += static_cast<float>(d_reg[3]) * as_row1_arr[mi] * ws_col1;
+            }
+        }
+    }
+    cp_async_wait_group<0>();  // drain pipeline
+
+    // ---------- Write output ----------
+    #pragma unroll
+    for (int mi = 0; mi < kMUnroll; ++mi) {
+        const int m_tile_base = warp_m_base + mi * 16;
+        const int row0_m = m_tile_base + groupID;
+        const int row1_m = m_tile_base + groupID + 8;
+        #pragma unroll
+        for (int c = 0; c < kNUnroll; ++c) {
+            const int n_chunk_base = warp_n_base + c * 8;
+            const int col0 = n_chunk_base + tid_in_group * 2 + 0;
+            const int col1 = n_chunk_base + tid_in_group * 2 + 1;
+
+            if (row0_m < M && col0 < N) out[row0_m * N + col0] = fp32_to_out<OutType>(out_f[mi][c][0]);
+            if (row0_m < M && col1 < N) out[row0_m * N + col1] = fp32_to_out<OutType>(out_f[mi][c][1]);
+            if (row1_m < M && col0 < N) out[row1_m * N + col0] = fp32_to_out<OutType>(out_f[mi][c][2]);
+            if (row1_m < M && col1 < N) out[row1_m * N + col1] = fp32_to_out<OutType>(out_f[mi][c][3]);
+        }
+    }
+}
+
+} // anonymous namespace
+
+extern "C" {
+
+void launch_svdquant_scaled_mm_w4a4_kernel(
+    const void* act,
+    const void* wgt,
+    const void* ascales,
+    const void* wscales,
+    const void* lora_act_in,
+    const void* lora_up,
+    const void* bias,
+    void* out,
+    int M,
+    int N,
+    int K,
+    int R,
+    int act_unsigned,
+    int out_dtype_code,
+    cudaStream_t stream)
+{
+    if (K % comfy::svdquant::kGroupSize != 0) return;
+
+    const dim3 grid((N + kBlockN - 1) / kBlockN, (M + kBlockM - 1) / kBlockM);
+    const dim3 block(kNumWarps * 32);  // 128 threads
+
+    #define LAUNCH_GEMM(OutType, Unsigned)                                                  \
+        svdquant_scaled_mm_w4a4_kernel<OutType, Unsigned><<<grid, block, 0, stream>>>(      \
+            reinterpret_cast<const int8_t*>(act),                                           \
+            reinterpret_cast<const int8_t*>(wgt),                                           \
+            reinterpret_cast<const OutType*>(ascales),                                      \
+            reinterpret_cast<const OutType*>(wscales),                                      \
+            reinterpret_cast<const float*>(lora_act_in),                                    \
+            reinterpret_cast<const OutType*>(lora_up),                                      \
+            reinterpret_cast<const OutType*>(bias),                                         \
+            reinterpret_cast<OutType*>(out),                                                \
+            M, N, K, R)
+
+    if (out_dtype_code == 2 /* bf16 */) {
+        if (act_unsigned) LAUNCH_GEMM(__nv_bfloat16, true);
+        else              LAUNCH_GEMM(__nv_bfloat16, false);
+    } else if (out_dtype_code == 1 /* fp16 */) {
+        if (act_unsigned) LAUNCH_GEMM(__half, true);
+        else              LAUNCH_GEMM(__half, false);
+    }
+    #undef LAUNCH_GEMM
+}
+
+} // extern "C"

--- a/comfy_kitchen/backends/cuda/ops/svdquant_utils.cuh
+++ b/comfy_kitchen/backends/cuda/ops/svdquant_utils.cuh
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Shared device helpers for SVDQuant W4A4 kernels.
+//
+// All code gated on __CUDA_ARCH__ >= 800. On older arches (sm_75) the
+// callers compile out the kernel body and installation is still valid;
+// the op simply raises at runtime.
+#pragma once
+
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <cuda_bf16.h>
+#include <cstdint>
+#include <cstdio>
+
+namespace comfy::svdquant {
+
+// Kitchen's group size for W4A4 int4 quantization.
+constexpr int kGroupSize = 64;
+// Symmetric int4 range [-7, 7] (we skip -8 to match nunchaku's absmax/7 scheme).
+constexpr int kInt4Max = 7;
+// Default padding multiple for M (activation batch).
+constexpr int kMPad = 256;
+
+// ---------------------------------------------------------------------------
+// int4 packing: two signed int4s per byte, row-major.
+//   byte & 0x0F  = q[n, 2k]    (low nibble,  sign-extended from 4 bits)
+//   byte >> 4    = q[n, 2k+1]  (high nibble, sign-extended from 4 bits)
+// ---------------------------------------------------------------------------
+__forceinline__ __device__ int8_t pack_int4_pair(int lo, int hi) {
+    uint32_t packed = (static_cast<uint32_t>(lo) & 0x0F) |
+                      ((static_cast<uint32_t>(hi) & 0x0F) << 4);
+    return static_cast<int8_t>(packed);
+}
+
+__forceinline__ __device__ void unpack_int4_pair(int8_t packed, int &lo, int &hi) {
+    int lo4 = packed & 0x0F;
+    int hi4 = (packed >> 4) & 0x0F;
+    lo = (lo4 >= 8) ? lo4 - 16 : lo4;
+    hi = (hi4 >= 8) ? hi4 - 16 : hi4;
+}
+
+// ---------------------------------------------------------------------------
+// Warp-level reductions. Uses full-warp mask 0xffffffff.
+// ---------------------------------------------------------------------------
+
+// absmax across the lower `width` lanes (power of 2).
+__forceinline__ __device__ float warp_absmax(float v, int width = 32) {
+    v = fabsf(v);
+#pragma unroll
+    for (int offset = width / 2; offset > 0; offset >>= 1) {
+        float other = __shfl_xor_sync(0xffffffffu, v, offset);
+        v = fmaxf(v, other);
+    }
+    return v;
+}
+
+// sum across the lower `width` lanes.
+__forceinline__ __device__ float warp_sum(float v, int width = 32) {
+#pragma unroll
+    for (int offset = width / 2; offset > 0; offset >>= 1) {
+        v += __shfl_xor_sync(0xffffffffu, v, offset);
+    }
+    return v;
+}
+
+// ---------------------------------------------------------------------------
+// Arch guard sentinel for kernel bodies.
+// Caller pattern:
+//   #if __CUDA_ARCH__ >= 800
+//     ... real kernel body ...
+//   #else
+//     comfy::svdquant::trap_pre_sm80();
+//   #endif
+// ---------------------------------------------------------------------------
+__forceinline__ __device__ void trap_pre_sm80() {
+    if (blockIdx.x == 0 && blockIdx.y == 0 && threadIdx.x == 0) {
+        printf("[svdquant_w4a4] int4 MMA requires sm_80 or newer.\n");
+    }
+    __trap();
+}
+
+// ---------------------------------------------------------------------------
+// mma.sync.aligned.m16n8k64.row.col.s32.s4.s4.s32
+//
+// Per-warp fragment shapes:
+//   A : 16 rows × 64 cols int4 → 4 × uint32 per lane
+//       lane i at (groupID=i/4, tid=i%4):
+//         a[0]: row=groupID,   cols=tid*16 + [0..7]   (8 int4 in one uint32)
+//         a[1]: row=groupID+8, cols=tid*16 + [0..7]
+//         a[2]: row=groupID,   cols=tid*16 + [8..15]
+//         a[3]: row=groupID+8, cols=tid*16 + [8..15]
+//   B : 64 rows × 8 cols int4 col-major → 2 × uint32 per lane
+//       b[0]: n=tid,    k=(groupID*8) + [0..7]
+//       b[1]: n=tid+4,  k=(groupID*8) + [0..7]
+//   D : 16 rows × 8 cols int32 → 4 × int32 per lane
+//       d[0]: row=groupID,   col=tid*2 + 0
+//       d[1]: row=groupID,   col=tid*2 + 1
+//       d[2]: row=groupID+8, col=tid*2 + 0
+//       d[3]: row=groupID+8, col=tid*2 + 1
+//
+// sm_80+ gates the inline asm at compile time; callers on older archs must
+// not dispatch to kernels that use this.
+// ---------------------------------------------------------------------------
+__forceinline__ __device__ void mma_m16n8k64_s4s4s32(
+    const uint32_t a[4], const uint32_t b[2], const int32_t c[4], int32_t d[4])
+{
+#if __CUDA_ARCH__ >= 800
+    asm volatile(
+        "mma.sync.aligned.m16n8k64.row.col.s32.s4.s4.s32 "
+        "{%0, %1, %2, %3}, "
+        "{%4, %5, %6, %7}, "
+        "{%8, %9}, "
+        "{%10, %11, %12, %13};\n"
+        : "=r"(d[0]), "=r"(d[1]), "=r"(d[2]), "=r"(d[3])
+        : "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]),
+          "r"(b[0]), "r"(b[1]),
+          "r"(c[0]), "r"(c[1]), "r"(c[2]), "r"(c[3]));
+#else
+    (void)a; (void)b; (void)c;
+    d[0] = d[1] = d[2] = d[3] = 0;
+#endif
+}
+
+// Unsigned-activation variant: A fragment treated as u4 [0,15], B as s4 [-8,7].
+// Used for layers with act_unsigned=True (e.g., post-GELU fc2 inputs shifted to
+// be non-negative). Bit patterns of A are interpreted as unsigned instead of
+// signed, doubling the effective quantization range ([0,15] vs [-7,7]).
+__forceinline__ __device__ void mma_m16n8k64_u4s4s32(
+    const uint32_t a[4], const uint32_t b[2], const int32_t c[4], int32_t d[4])
+{
+#if __CUDA_ARCH__ >= 800
+    asm volatile(
+        "mma.sync.aligned.m16n8k64.row.col.s32.u4.s4.s32 "
+        "{%0, %1, %2, %3}, "
+        "{%4, %5, %6, %7}, "
+        "{%8, %9}, "
+        "{%10, %11, %12, %13};\n"
+        : "=r"(d[0]), "=r"(d[1]), "=r"(d[2]), "=r"(d[3])
+        : "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]),
+          "r"(b[0]), "r"(b[1]),
+          "r"(c[0]), "r"(c[1]), "r"(c[2]), "r"(c[3]));
+#else
+    (void)a; (void)b; (void)c;
+    d[0] = d[1] = d[2] = d[3] = 0;
+#endif
+}
+
+// ---------------------------------------------------------------------------
+// cp.async.cg.shared.global — 16-byte async copy from GMEM to SMEM.
+// "cg" = "cache-global": bypass L1, go through L2 for smaller footprint.
+// ---------------------------------------------------------------------------
+__forceinline__ __device__ void cp_async_16b(void* smem_ptr, const void* gmem_ptr) {
+#if __CUDA_ARCH__ >= 800
+    uint32_t smem_int = __cvta_generic_to_shared(smem_ptr);
+    asm volatile(
+        "cp.async.cg.shared.global [%0], [%1], 16;\n"
+        : : "r"(smem_int), "l"(gmem_ptr));
+#else
+    *reinterpret_cast<uint4*>(smem_ptr) = *reinterpret_cast<const uint4*>(gmem_ptr);
+#endif
+}
+
+__forceinline__ __device__ void cp_async_commit_group() {
+#if __CUDA_ARCH__ >= 800
+    asm volatile("cp.async.commit_group;\n" ::);
+#endif
+}
+
+template<int N>
+__forceinline__ __device__ void cp_async_wait_group() {
+#if __CUDA_ARCH__ >= 800
+    asm volatile("cp.async.wait_group %0;\n" :: "n"(N));
+#endif
+}
+
+} // namespace comfy::svdquant

--- a/comfy_kitchen/backends/cuda/ops/svdquant_w4a4_PLAN.md
+++ b/comfy_kitchen/backends/cuda/ops/svdquant_w4a4_PLAN.md
@@ -1,0 +1,196 @@
+# Kitchen CUDA W4A4 kernel — historical design plan
+
+> **Status (2026-04)**: Design document kept for reference. Kernels are
+> implemented and in production — actual source is in this directory's
+> `quantize_svdquant_w4a4.cu` and `scaled_mm_svdquant_w4a4.cu`. File headers in
+> those `.cu` files document the current tile layout, pipeline depth, dequant
+> chain, and the act_unsigned mode. The phased rollout below describes the
+> order work was done, not the present architecture.
+
+**Original goal**: native implementation of `quantize_svdquant_w4a4` and
+`scaled_mm_svdquant_w4a4` that consumes **kitchen-native row-major** tensors.
+No nunchaku vendor code. sm_80+ (A100, L40, 4090, 5090 all supported).
+
+Performance target: match or approach nunchaku's vendored kernel (1.67 s/iter
+on RTX 5090 for Qwen-Image-Edit 20 steps @ 1024×1024).
+
+---
+
+## Layouts (kitchen-native, inputs to the kernels)
+
+All tensors are row-major contiguous; no fragment tile packing.
+
+| tensor | shape | dtype | notes |
+|---|---|---|---|
+| `x` (input activation) | (M, K) | bf16/fp16 | row-major |
+| `smooth` | (K,) | bf16/fp16 | per-channel smoothing |
+| `lora_down` | (K, R) | bf16/fp16 | SVDQuant down projection |
+| `qweight` | (N, K/2) | int8 | row-major; low nibble = q[n, 2k], high nibble = q[n, 2k+1]; values in [-8, 7] |
+| `wscales` | (K/G, N) | bf16/fp16 | per-group weight scale; G=64 for INT4 |
+| `lora_up` | (N, R) | bf16/fp16 | SVDQuant up projection |
+| `bias` | (N,) | bf16/fp16 | optional |
+
+**Outputs of `quantize_svdquant_w4a4`**:
+| tensor | shape | dtype | notes |
+|---|---|---|---|
+| `q_x` | (M_pad, K/2) | int8 | same packing as qweight |
+| `ascales` | (K/G, M_pad) | bf16/fp16 | per-row per-group scale |
+| `lora_act` | (M_pad, R) | fp32 | fp32 for accumulation stability |
+
+**Output of `scaled_mm_svdquant_w4a4`**: `out (M, N) bf16/fp16`.
+
+`M_pad = ceil(M / pad_size) * pad_size`, pad_size=256.
+
+---
+
+## Architecture
+
+Two CUDA kernels. Each launches one grid per forward call; no cuBLAS
+dependency for the int4 path.
+
+### Kernel A: `quantize_svdquant_w4a4`
+
+Fuses three ops over the activation tensor:
+1. `x_smooth = x / smooth` (broadcast along M)
+2. per-row per-group absmax → scale = absmax / 7 → int4 quantize + pack
+3. `lora_act = x @ lora_down`  (note: uses raw x, NOT smoothed x — matches
+   SVDQuant convention where lora_down is calibrated against un-smoothed input)
+
+**Tiling**:
+- `BLOCK_M = 32` (output tokens per CTA)
+- `BLOCK_N = 128` (input features per CTA, = nunchaku's BLOCK_N to match G=64 × 2)
+- grid: `(ceil(M / BLOCK_M), K / BLOCK_N)`
+- Each CTA has 4 warps
+
+**Per-CTA work**:
+- Load `x[M_offset:M_offset+BLOCK_M, K_offset:K_offset+BLOCK_N]` via cp.async
+- Load `smooth[K_offset:K_offset+BLOCK_N]` via cp.async
+- Load `lora_down[K_offset:K_offset+BLOCK_N, :]` via cp.async
+- Compute `x_smooth = x / smooth` in registers
+- Intra-warp reduce: within each 64-wide K group (so BLOCK_N/64 = 2 groups
+  per CTA), find absmax across the 64 K elements per row. XOR shfl tree
+  within warp.
+- Scale = absmax / 7; broadcast to all lanes in group via shfl
+- Quantize: `round(x_smooth / scale)` clamp to [-8, 7] → pack 2 int4s per byte
+- atomicAdd lora_act = x @ lora_down in fp32 (or use split-K)
+
+**Key challenge**: lora_act output atomicAdd across K blocks. Options:
+- (a) Use atomicAdd (simple but slow)
+- (b) Allocate lora_act as (K/BLOCK_N, M_pad, R) and split-K reduce later
+- (c) Compute LoRA in a separate grid after quantize finishes
+
+Option (a) is simplest. For Qwen R=96 it's manageable.
+
+### Kernel B: `scaled_mm_svdquant_w4a4`
+
+Fuses four ops:
+1. int4 GEMM: `q_act (M, K/2) @ qweight^T (K/2, N) → int32 (M, N)` via
+   `mma.m16n8k64.s4.s4.s32`
+2. Dequant: `out_fp = int32 * ascales[:, None] * wscales[None, :]`
+3. LoRA up: `out_fp += lora_act @ lora_up^T`
+4. Bias: `out_fp += bias`
+
+**Tiling**:
+- `BLOCK_M = 64`, `BLOCK_N = 128`, `BLOCK_K = 256` (4 groups of 64)
+- `WARP_M = 32`, `WARP_N = 64` → 2×2 warps per CTA
+- MMA m16n8k64: each warp covers (32 rows × 64 cols) per K-stage =
+  (WARP_M/16) × (WARP_N/8) = 2×8 = 16 MMA instructions per K-stage
+
+**Per-CTA work**:
+- Async load act chunk and wgt chunk into shmem
+- ldmatrix.sync.aligned.m8n8.x4 into int4 fragments
+- mma.m16n8k64.s4.s4.s32 to accumulate int32 psum
+- At end of K-loop: dequant by multiplying with (ascales × wscales) per group,
+  convert to fp32 accumulator
+- LoRA up: load lora_act (M_pad, R) fragment + lora_up (N, R) fragment,
+  do R-rank matmul in bf16, accumulate to fp32 out
+- Add bias (N,)
+- Write out as bf16/fp16
+
+**Key challenge**: int4 MMA lane mapping is nontrivial. Reference:
+- PTX ISA §9.7.14.5.12 (mma.m16n8k64 int4/int1)
+- NVIDIA CUTLASS examples/44_multi_gemm_ir for int4 GEMM skeleton
+
+---
+
+## File layout
+
+```
+comfy_kitchen/backends/cuda/ops/
+  quantize_svdquant_w4a4.cu   # kernel A
+  gemm_svdquant_w4a4.cu        # kernel B
+  svdquant_utils.cuh           # shared helpers (int4 pack/unpack device-side)
+```
+
+Plus:
+- `dlpack_bindings.cpp`: add `svdquant_quantize_w4a4` + `svdquant_scaled_mm_w4a4` nb::defs
+- `CMakeLists.txt`: add 2 sources to `CUDA_SOURCES`
+- `comfy_kitchen/backends/cuda/__init__.py`: Python wrappers + FunctionConstraints registration
+
+---
+
+## Phased development
+
+To de-risk the 30-40 hour effort, break into independently verifiable phases.
+
+### Phase 1: design + shared utilities (~4 hours)
+- Write `svdquant_utils.cuh`: device helpers for int4 pack/unpack, warp-level
+  absmax reduction
+- Build system: empty stubs for kernels A and B, verify CMake builds and
+  nanobind finds symbols
+- Kitchen `__init__.py` wrappers that raise `NotImplementedError`
+
+### Phase 2: bare-bones scaled_mm (no LoRA, no bias) (~10 hours)
+- Minimal int4×int4 → int32 MMA GEMM
+- Dequant to bf16 out
+- Unit test: compare to pure-PyTorch `unpack(q_act) * ascales @ (unpack(qweight) * wscales)^T`
+- Validate on layer 0 of Qwen-Image-Edit kitchen-native checkpoint
+- Target: rel_max < 1e-3 (bit-close to manual int32 accumulation)
+
+### Phase 3: bare-bones quantize (no LoRA) (~8 hours)
+- Per-row per-group absmax via warp XOR reduction
+- int4 packing
+- smooth division
+- Unit test: compare `q_x, ascales` to pure-PyTorch reference
+- Target: rel_max < 1e-3
+
+### Phase 4: fuse LoRA into both (~8 hours)
+- Quantize kernel: add `x @ lora_down` with fp32 atomicAdd
+- GEMM kernel: add `lora_act @ lora_up^T` accumulated into fp32 output path
+- Validate end-to-end: single layer parity < 5% (matches current eager tolerance)
+
+### Phase 5: bias + polish (~3 hours)
+- GEMM kernel: final bias add
+- Full ComfyUI end-to-end run — target < 3 s/iter
+
+### Phase 6: tuning (optional, ~5 hours)
+- Profile via ncu, tune BLOCK_M/N/K, pipelining depth
+- Target: within 1.5x of nunchaku vendor (so ~2.5 s/iter)
+
+---
+
+## Risks
+
+| risk | mitigation |
+|---|---|
+| int4 MMA lane mapping mis-decoded | write a minimal toy test first: feed 16×64 identity matrix, verify output matches scalar reference |
+| sm_120 (Blackwell RTX 5090) int4 MMA behavior differs from sm_80/89 | test on 5090 (primary dev GPU), reference behavior on sm_80 via code review |
+| atomicAdd on lora_act becomes serialized bottleneck | fallback: split-K allocation with reduction pass |
+| cp.async + ldmatrix sequencing bugs (shmem bank conflicts) | use CUTLASS swizzling patterns |
+| sm_75 requested by default CUDA archs (75-virtual;80;89;...) — no int4 MMA | skip sm_75 in COMFY_CUDA_ARCHS for svdquant sources, or fall back to eager |
+
+---
+
+## Open questions (to user before starting)
+
+1. **Target CUDA arch list**: current kitchen default is `75-virtual;80;89;90a;100f;120f`.
+   int4 MMA needs sm_80+. OK to narrow to `80;89;90a;100f;120f` for svdquant
+   sources? (other kitchen ops unaffected)
+2. **FP4 path**: do we need NVFP4 support now, or INT4 only? NVFP4 requires
+   sm_100 block-scale MMA. Propose INT4-only in phase B; FP4 if/when needed.
+3. **Interleaved vs separate quantize and GEMM dispatch**: current eager
+   splits these into two custom_ops, so CUDA mirrors that. OK to keep?
+4. **Build time tolerance**: naive approach compiles ~30 seconds; template-heavy
+   could be minutes. Acceptable?
+5. **Testing budget**: after each phase gate, should I run full ComfyUI e2e
+   (takes ~2 min) or just unit tests (~10 sec)? Recommend unit+ small e2e.

--- a/comfy_kitchen/backends/eager/__init__.py
+++ b/comfy_kitchen/backends/eager/__init__.py
@@ -4,13 +4,17 @@ __all__ = [
     "dequantize_mxfp8",
     "dequantize_nvfp4",
     "dequantize_per_tensor_fp8",
+    "gemv_awq_w4a16",
     "quantize_mxfp8",
     "quantize_nvfp4",
     "quantize_per_tensor_fp8",
+    "quantize_svdquant_w4a4",
     "scaled_mm_mxfp8",
     "scaled_mm_nvfp4",
+    "scaled_mm_svdquant_w4a4",
 ]
 
+from .awq import gemv_awq_w4a16
 from .quantization import (
     dequantize_mxfp8,
     dequantize_nvfp4,
@@ -22,6 +26,7 @@ from .quantization import (
     scaled_mm_nvfp4,
 )
 from .rope import apply_rope, apply_rope1
+from .svdquant import quantize_svdquant_w4a4, scaled_mm_svdquant_w4a4
 
 
 def _build_constraints() -> dict:
@@ -115,6 +120,48 @@ def _build_constraints() -> dict:
                 "xq": ParamConstraint(dtypes=standard_floats),
                 "xk": ParamConstraint(dtypes=standard_floats),
                 "freqs_cis": ParamConstraint(dtypes=standard_floats),
+            },
+            default_devices=all_devices,
+        ),
+        "quantize_svdquant_w4a4": FunctionConstraints(
+            params={
+                "x": ParamConstraint(dtypes=standard_floats, shape_rules=(ExactDims(2),)),
+                "smooth": ParamConstraint(dtypes=standard_floats, shape_rules=(ExactDims(1),)),
+                "lora_down": ParamConstraint(
+                    dtypes=standard_floats, shape_rules=(ExactDims(2),),
+                ),
+            },
+            default_devices=all_devices,
+        ),
+        "scaled_mm_svdquant_w4a4": FunctionConstraints(
+            params={
+                "act": ParamConstraint(
+                    dtypes=frozenset({torch.int8, torch.uint8}),
+                    shape_rules=(ExactDims(2),),
+                ),
+                "wgt": ParamConstraint(
+                    dtypes=frozenset({torch.int8}),
+                    shape_rules=(ExactDims(2),),
+                ),
+                "ascales": ParamConstraint(dtypes=standard_floats, shape_rules=(ExactDims(2),)),
+                "wscales": ParamConstraint(dtypes=standard_floats, shape_rules=(ExactDims(2),)),
+                "lora_act_in": ParamConstraint(
+                    dtypes=frozenset({torch.float32}),
+                    shape_rules=(ExactDims(2),),
+                ),
+                "lora_up": ParamConstraint(dtypes=standard_floats, shape_rules=(ExactDims(2),)),
+            },
+            default_devices=all_devices,
+        ),
+        "gemv_awq_w4a16": FunctionConstraints(
+            params={
+                "x": ParamConstraint(dtypes=standard_floats),
+                "qweight": ParamConstraint(
+                    dtypes=frozenset({torch.int8}),
+                    shape_rules=(ExactDims(2),),
+                ),
+                "wscales": ParamConstraint(dtypes=standard_floats, shape_rules=(ExactDims(2),)),
+                "wzeros": ParamConstraint(dtypes=standard_floats, shape_rules=(ExactDims(2),)),
             },
             default_devices=all_devices,
         ),

--- a/comfy_kitchen/backends/eager/awq.py
+++ b/comfy_kitchen/backends/eager/awq.py
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# AWQ W4A16 (4-bit weight, fp16/bf16 activation): eager pure-PyTorch
+# reference implementation plus torch.library dispatch.
+#
+# Kitchen-native storage layout (independent of the AWQ paper's CUDA layout):
+#
+#   qweight  (N, K // 2)       int8  — two unsigned int4 values per byte
+#                                     bits 0..3 -> column 2j   (range [0, 15])
+#                                     bits 4..7 -> column 2j+1 (range [0, 15])
+#   wscales  (K // G, N)       same fp dtype as compute
+#   wzeros   (K // G, N)       same fp dtype as compute — fp zero points
+#   bias     (N,)              fp   (optional)
+#
+# Forward math (per-group asymmetric):
+#   W[n, k] = (qweight[n, k] - 8) * wscales[k // G, n] + wzeros[k // G, n]
+#   y       = x @ W.T + bias
+
+import torch
+
+_DEFAULT_GROUP = 64
+
+
+def _unpack_uint4_row_major(packed: torch.Tensor) -> torch.Tensor:
+    """(..., K//2) int8 storing two uint4 per byte -> (..., K) int8 in [0, 15]."""
+    x32 = packed.to(torch.int32)
+    lo = x32 & 0x0F
+    hi = (x32 >> 4) & 0x0F
+    stacked = torch.stack([lo, hi], dim=-1)
+    return stacked.reshape(*packed.shape[:-1], -1).to(torch.int8)
+
+
+def gemv_awq_w4a16(
+    x: torch.Tensor,
+    qweight: torch.Tensor,
+    wscales: torch.Tensor,
+    wzeros: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    group_size: int = _DEFAULT_GROUP,
+) -> torch.Tensor:
+    """AWQ W4A16 GEMV / small-batch GEMM.
+
+    Args:
+        x: (M, K) or (K,) fp16/bf16 input.
+        qweight: (N, K // 2) int8 packed (kitchen-native row-major uint4).
+        wscales: (K // group_size, N) fp.
+        wzeros: (K // group_size, N) fp.
+        bias: (N,) fp or None.
+        group_size: quantization group size (default 64).
+
+    Returns:
+        Output with the input's leading shape and trailing dim N.
+    """
+    orig_shape = x.shape
+    x2d = x.reshape(-1, orig_shape[-1])
+    M, K = x2d.shape
+    if K % group_size != 0:
+        raise ValueError(f"K={K} not divisible by group_size={group_size}")
+
+    N, K_half = qweight.shape
+    if K_half * 2 != K:
+        raise ValueError(f"qweight K//2={K_half} inconsistent with x K={K}")
+
+    compute_dtype = wscales.dtype
+
+    # Dequantize: (qweight - 8) * wscales + wzeros
+    w_uint = _unpack_uint4_row_major(qweight).to(compute_dtype)  # (N, K)
+    w_groups = w_uint.view(N, K // group_size, group_size)
+    # wscales / wzeros are (K/G, N) — transpose to (N, K/G) for broadcasting
+    scales_ng = wscales.t().unsqueeze(-1)  # (N, K/G, 1)
+    zeros_ng = wzeros.t().unsqueeze(-1)
+    w_fp = ((w_groups - 8.0) * scales_ng + zeros_ng).view(N, K)
+
+    out = x2d.to(compute_dtype) @ w_fp.t()
+    if bias is not None:
+        out = out + bias
+    return out.reshape(*orig_shape[:-1], N)
+
+
+# =============================================================================
+# torch.library Custom Op Dispatch
+# =============================================================================
+
+
+@torch.library.custom_op("comfy_kitchen::gemv_awq_w4a16", mutates_args=())
+def _op_gemv_awq_w4a16(
+    x: torch.Tensor,
+    qweight: torch.Tensor,
+    wscales: torch.Tensor,
+    wzeros: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    group_size: int = _DEFAULT_GROUP,
+) -> torch.Tensor:
+    from comfy_kitchen.registry import registry
+
+    kwargs = {
+        "x": x, "qweight": qweight, "wscales": wscales, "wzeros": wzeros,
+        "bias": bias, "group_size": group_size,
+    }
+    impl = registry.get_implementation("gemv_awq_w4a16", kwargs=kwargs)
+    return impl(**kwargs)
+
+
+@_op_gemv_awq_w4a16.register_fake
+def _op_gemv_awq_w4a16_fake(x, qweight, wscales, wzeros, bias=None, group_size=64):
+    out_shape = (*x.shape[:-1], wscales.shape[1])
+    return torch.empty(out_shape, dtype=wscales.dtype, device=x.device)

--- a/comfy_kitchen/backends/eager/svdquant.py
+++ b/comfy_kitchen/backends/eager/svdquant.py
@@ -4,11 +4,26 @@
 # SVDQuant W4A4 (4-bit weight, 4-bit activation, SVD low-rank correction):
 # eager pure-PyTorch reference implementations plus torch.library dispatch.
 #
+# Two related but distinct int4 ranges appear in this module:
+#
+#   (a) Storage / nibble encoding   = the 4-bit two's-complement field can hold
+#                                     any value in [-8, 7] (signed) or [0, 15]
+#                                     (unsigned). Pack/unpack codecs handle the
+#                                     full range because that's what the physical
+#                                     bits can represent.
+#   (b) Quantizer emission range    = the clamp the quantizer actually applies.
+#                                     For absmax-symmetric quantization with
+#                                     scale = max/7 (nunchaku / kitchen CUDA
+#                                     contract), signed emission is [-7, 7] —
+#                                     we skip -8 so the dequant range is
+#                                     symmetric about zero. Unsigned emission
+#                                     is [0, 15] with scale = max/15.
+#
 # Kitchen-native storage layout (independent of any third-party kernel):
 #
-#   qweight       (N, K // 2)        int8  — two signed int4 values per byte
-#                                            bits 0..3 -> column 2j   (range [-8, 7])
-#                                            bits 4..7 -> column 2j+1 (range [-8, 7])
+#   qweight       (N, K // 2)        int8  — two int4 values per byte
+#                                            bits 0..3 -> column 2j   (nibble)
+#                                            bits 4..7 -> column 2j+1 (nibble)
 #   wscales       (K // 64, N)       same fp dtype as compute
 #   proj_down     (K, R)             fp
 #   proj_up       (N, R)             fp
@@ -34,9 +49,14 @@ import torch
 import torch.nn.functional as F
 
 _INT4_GROUP_SIZE = 64
-_INT4_MAX = 7  # signed int4 [-8, 7], symmetric scale uses 7
-_UINT4_MAX = 15  # unsigned int4 [0, 15], used by fused GELU -> fc2 path
-_GELU_UNSIGNED_SHIFT = 0.171875  # matches nunchaku's SHIFT_GELU
+# Quantizer emission ranges (not the same as the 4-bit storage range — see
+# module header). Symmetric absmax quantization uses scale = max/_INT4_MAX and
+# clamps to [-_INT4_MAX, +_INT4_MAX]; -8 is representable by the nibble but is
+# not emitted because it would break the dequant symmetry (nunchaku contract,
+# see /workspace/nunchaku/src/kernels/zgemm/gemm_w4a4.cuh:435).
+_INT4_MAX = 7   # signed quantizer range: [-7, 7], scale = max/7
+_UINT4_MAX = 15 # unsigned quantizer range: [0, 15], scale = max/15 (post-GELU+shift fc2)
+_GELU_UNSIGNED_SHIFT = 0.171875  # matches nunchaku's SHIFT_GELU constant
 
 
 def _ceil_div(a: int, b: int) -> int:
@@ -44,8 +64,12 @@ def _ceil_div(a: int, b: int) -> int:
 
 
 def _pack_int4_row_major(values: torch.Tensor) -> torch.Tensor:
-    """Pack (..., K) signed int4 values (int8 dtype, range [-8, 7]) into
-    (..., K // 2) int8 with two nibbles per byte (low = even column).
+    """Pack (..., K) int4 values into (..., K // 2) int8 (low = even column).
+
+    Storage-level codec: handles the full 4-bit field; the caller decides which
+    quantizer emission range to use. Inputs may contain any value that fits in
+    a nibble (signed [-8, 7] or unsigned [0, 15]); values outside get masked
+    via the & 0x0F below.
     """
     if values.shape[-1] % 2 != 0:
         raise ValueError(f"last dim must be even, got {values.shape[-1]}")
@@ -55,7 +79,13 @@ def _pack_int4_row_major(values: torch.Tensor) -> torch.Tensor:
 
 
 def _unpack_int4_row_major(packed: torch.Tensor) -> torch.Tensor:
-    """Inverse of _pack_int4_row_major. Returns int8 in [-8, 7]."""
+    """Inverse of _pack_int4_row_major with signed-nibble interpretation.
+
+    Storage-level codec: returns int8 across the full signed nibble range
+    [-8, 7]. This is wider than the quantizer's emission range [-7, 7] by
+    design — the codec must accept any bit pattern that could land in the
+    nibble.
+    """
     x32 = packed.to(torch.int32)
     lo = x32 & 0x0F
     hi = (x32 >> 4) & 0x0F
@@ -66,7 +96,11 @@ def _unpack_int4_row_major(packed: torch.Tensor) -> torch.Tensor:
 
 
 def _unpack_uint4_row_major(packed: torch.Tensor) -> torch.Tensor:
-    """Inverse of _pack_int4_row_major for unsigned nibble payloads."""
+    """Inverse of _pack_int4_row_major with unsigned-nibble interpretation.
+
+    Storage-level codec: returns int8 across the full unsigned nibble range
+    [0, 15] (used by the u4.s4 MMA path — post-GELU+shift fc2 activations).
+    """
     x32 = packed.to(torch.int32)
     lo = x32 & 0x0F
     hi = (x32 >> 4) & 0x0F
@@ -80,18 +114,25 @@ def quantize_svdquant_w4a4(
     lora_down: torch.Tensor,
     pad_size: int = 256,
     act_unsigned: bool = False,
-    shift_value: float = 0.0,
+    lora_x: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Quantize activations to int4 with fused smoothing and LoRA down projection.
+    """Quantize activations to int4 with smoothing + separate LoRA down projection.
 
     Args:
-        x: (M, K) bf16/fp16 input.
+        x: (M, K) bf16/fp16 — main-path input (may be shifted by caller for unsigned).
         smooth: (K,) per-channel smoothing factor applied before quantization.
-        lora_down: (K, R) low-rank down projection weight (fp32 accumulation).
+        lora_down: (K, R) low-rank down projection weight. The eager reference
+            here runs the matmul in fp32 for numerical stability; the CUDA
+            backend takes a lower-precision bf16 matmul path for memory/launch
+            savings. Do not use this eager result as a bitwise oracle for the
+            CUDA output — it is a high-precision reference, not a backend parity
+            target.
         pad_size: pad M to a multiple of this (default 256) to match downstream kernels.
-        act_unsigned: if True, quantize into uint4 [0, 15] instead of signed int4.
-        shift_value: additive shift applied before smoothing. Qwen Image MLP fc2
-            uses 0.171875 after GELU to enable unsigned activation quantization.
+        act_unsigned: if True, quantize into uint4 [0, 15] (scale=max/15) instead of
+            signed int4 [-7, 7] (scale=max/7). Selects MMA grid for downstream u4.s4.
+        lora_x: (M, K) bf16/fp16 — input for LoRA matmul. Defaults to x. Pass
+            separately when caller pre-shifts x (SVDQuant LoRA is mathematically
+            defined on pre-quantization, pre-shift activations).
 
     Returns:
         q_x: (M_pad, K // 2) int8 packed (2 int4 per byte, same layout as weight).
@@ -107,17 +148,22 @@ def quantize_svdquant_w4a4(
         raise ValueError(f"K={K} not divisible by group_size={group}")
     M_pad = _ceil_div(M, pad_size) * pad_size
 
-    # LoRA down: computed on the un-smoothed input (matches SVDQuant convention)
-    lora_act = x.float() @ lora_down.float()  # (M, R)
+    # LoRA down uses un-shifted, un-smoothed activation (SVDQuant invariant).
+    lora_src = lora_x if lora_x is not None else x
+    lora_act = lora_src.float() @ lora_down.float()  # (M, R)
 
     # Smooth (divide) + per-row per-group int4 quantization.
     # SmoothQuant: outliers are moved from activations to weights at calibration.
     # At inference, activations divide by smooth so they quantize cleanly.
-    x_smooth = (x + shift_value) / smooth
+    x_smooth = x / smooth
     groups = x_smooth.view(M, K // group, group)
     absmax = groups.abs().amax(dim=-1).clamp(min=1e-10)  # (M, K/G)
+    # Quantizer emission range: symmetric signed [-7, 7] or unsigned [0, 15].
+    # Signed clamp intentionally does NOT reach -8 even though the nibble can
+    # represent it — absmax/7 scaling assumes ±qmax symmetry and emitting -8
+    # would break dequant parity with nunchaku and kitchen CUDA.
     qmax = _UINT4_MAX if act_unsigned else _INT4_MAX
-    qmin = 0 if act_unsigned else (-_INT4_MAX - 1)
+    qmin = 0 if act_unsigned else -_INT4_MAX
     scales = absmax / qmax
     q_vals = (groups / scales.unsqueeze(-1)).round().clamp(qmin, qmax).to(torch.int8)
     q_vals = q_vals.reshape(M, K)
@@ -143,21 +189,35 @@ def scaled_mm_svdquant_w4a4(
     bias: torch.Tensor | None = None,
     act_unsigned: bool = False,
 ) -> torch.Tensor:
-    """SVDQuant W4A4 GEMM with fused LoRA up projection and optional bias.
+    """SVDQuant W4A4 int4 GEMM + LoRA up + optional bias (eager reference impl).
+
+    Semantic mirror of the CUDA path; used as a high-precision reference and on
+    non-CUDA devices. Numerical notes:
+
+    * Quantization grid and emission range match the CUDA kernel exactly
+      (signed absmax/7, unsigned absmax/15 — see module header).
+    * The LoRA-up branch here accumulates in fp32 for stability. The CUDA
+      wrapper takes a bf16 addmm_ path for memory/launch-count savings and
+      drops the fp32 lora_act_in precision. This eager output is therefore a
+      high-precision reference, not a bit-parity oracle for the CUDA backend.
+      Tests that compare the two paths should use tolerances consistent with
+      bf16 matmul (~8e-3 abs).
 
     Args:
         act: (M, K // 2) int8 packed activations from quantize_svdquant_w4a4.
-        wgt: (N, K // 2) int8 packed weights (kitchen-native layout).
+            Bit-pattern interpretation depends on act_unsigned (signed [-7,7]
+            vs unsigned [0,15]).
+        wgt: (N, K // 2) int8 packed weights (kitchen natural row-major).
         ascales: (K // 64, M) per-row per-group activation scales.
         wscales: (K // 64, N) per-group weight scales.
         lora_act_in: (M, R) fp32 LoRA down-projection activations.
-        lora_up: (N, R) fp LoRA up-projection weight.
-        bias: (N,) fp bias or None.
-        act_unsigned: if True, activations are stored as uint4 in [0, 15] with
-            an implicit -8 offset (used after GELU when activations are all positive).
+        lora_up: (N, R) LoRA up-projection weight.
+        bias: (N,) bias or None.
+        act_unsigned: if True, interpret packed activations as unsigned [0, 15]
+            (matches the u4.s4 MMA path used for post-GELU+shift fc2 layers).
 
     Returns:
-        out: (M, N) fp in the dtype of wscales/lora_up.
+        out: (M, N) in the dtype of wscales/lora_up.
     """
     M, K_half = act.shape
     N = wgt.shape[0]
@@ -207,7 +267,7 @@ def _op_quantize_svdquant_w4a4(
     lora_down: torch.Tensor,
     pad_size: int = 256,
     act_unsigned: bool = False,
-    shift_value: float = 0.0,
+    lora_x: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     from comfy_kitchen.registry import registry
 
@@ -217,7 +277,7 @@ def _op_quantize_svdquant_w4a4(
         "lora_down": lora_down,
         "pad_size": pad_size,
         "act_unsigned": act_unsigned,
-        "shift_value": shift_value,
+        "lora_x": lora_x,
     }
     impl = registry.get_implementation("quantize_svdquant_w4a4", kwargs=kwargs)
     return impl(**kwargs)
@@ -225,7 +285,7 @@ def _op_quantize_svdquant_w4a4(
 
 @_op_quantize_svdquant_w4a4.register_fake
 def _op_quantize_svdquant_w4a4_fake(
-    x, smooth, lora_down, pad_size=256, act_unsigned=False, shift_value=0.0,
+    x, smooth, lora_down, pad_size=256, act_unsigned=False, lora_x=None,
 ):
     M, K = x.shape
     R = lora_down.shape[1]

--- a/comfy_kitchen/backends/eager/svdquant.py
+++ b/comfy_kitchen/backends/eager/svdquant.py
@@ -1,0 +1,267 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# SVDQuant W4A4 (4-bit weight, 4-bit activation, SVD low-rank correction):
+# eager pure-PyTorch reference implementations plus torch.library dispatch.
+#
+# Kitchen-native storage layout (independent of any third-party kernel):
+#
+#   qweight       (N, K // 2)        int8  — two signed int4 values per byte
+#                                            bits 0..3 -> column 2j   (range [-8, 7])
+#                                            bits 4..7 -> column 2j+1 (range [-8, 7])
+#   wscales       (K // 64, N)       same fp dtype as compute
+#   proj_down     (K, R)             fp
+#   proj_up       (N, R)             fp
+#   smooth_factor (K,)               fp
+#   bias          (N,)               fp   (optional)
+#
+# Activation quantization produces:
+#   q_act   (M_pad, K // 2)          int8 (same packing as qweight)
+#   ascales (K // 64, M_pad)         fp
+#   lora_act (M_pad, R)              fp32
+#
+# Forward math (matches SmoothQuant convention — activation is DIVIDED by
+# smooth to reduce per-channel outliers; the calibrated residual weight
+# absorbs those outliers during offline quantization):
+#
+#   out = (x / smooth) @ (W_int4 * wscales_group).T
+#       + x @ proj_down @ proj_up.T
+#       + bias
+
+import math
+
+import torch
+import torch.nn.functional as F
+
+_INT4_GROUP_SIZE = 64
+_INT4_MAX = 7  # signed int4 [-8, 7], symmetric scale uses 7
+_UINT4_MAX = 15  # unsigned int4 [0, 15], used by fused GELU -> fc2 path
+_GELU_UNSIGNED_SHIFT = 0.171875  # matches nunchaku's SHIFT_GELU
+
+
+def _ceil_div(a: int, b: int) -> int:
+    return -(-a // b)
+
+
+def _pack_int4_row_major(values: torch.Tensor) -> torch.Tensor:
+    """Pack (..., K) signed int4 values (int8 dtype, range [-8, 7]) into
+    (..., K // 2) int8 with two nibbles per byte (low = even column).
+    """
+    if values.shape[-1] % 2 != 0:
+        raise ValueError(f"last dim must be even, got {values.shape[-1]}")
+    lo = values[..., 0::2].to(torch.int32) & 0x0F
+    hi = values[..., 1::2].to(torch.int32) & 0x0F
+    return (lo | (hi << 4)).to(torch.int8)
+
+
+def _unpack_int4_row_major(packed: torch.Tensor) -> torch.Tensor:
+    """Inverse of _pack_int4_row_major. Returns int8 in [-8, 7]."""
+    x32 = packed.to(torch.int32)
+    lo = x32 & 0x0F
+    hi = (x32 >> 4) & 0x0F
+    lo = torch.where(lo >= 8, lo - 16, lo)
+    hi = torch.where(hi >= 8, hi - 16, hi)
+    stacked = torch.stack([lo, hi], dim=-1)
+    return stacked.reshape(*packed.shape[:-1], -1).to(torch.int8)
+
+
+def _unpack_uint4_row_major(packed: torch.Tensor) -> torch.Tensor:
+    """Inverse of _pack_int4_row_major for unsigned nibble payloads."""
+    x32 = packed.to(torch.int32)
+    lo = x32 & 0x0F
+    hi = (x32 >> 4) & 0x0F
+    stacked = torch.stack([lo, hi], dim=-1)
+    return stacked.reshape(*packed.shape[:-1], -1).to(torch.int8)
+
+
+def quantize_svdquant_w4a4(
+    x: torch.Tensor,
+    smooth: torch.Tensor,
+    lora_down: torch.Tensor,
+    pad_size: int = 256,
+    act_unsigned: bool = False,
+    shift_value: float = 0.0,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Quantize activations to int4 with fused smoothing and LoRA down projection.
+
+    Args:
+        x: (M, K) bf16/fp16 input.
+        smooth: (K,) per-channel smoothing factor applied before quantization.
+        lora_down: (K, R) low-rank down projection weight (fp32 accumulation).
+        pad_size: pad M to a multiple of this (default 256) to match downstream kernels.
+        act_unsigned: if True, quantize into uint4 [0, 15] instead of signed int4.
+        shift_value: additive shift applied before smoothing. Qwen Image MLP fc2
+            uses 0.171875 after GELU to enable unsigned activation quantization.
+
+    Returns:
+        q_x: (M_pad, K // 2) int8 packed (2 int4 per byte, same layout as weight).
+        ascales: (K // 64, M_pad) same dtype as x — per-row per-group scales.
+        lora_act: (M_pad, R) fp32 LoRA activations.
+    """
+    if x.dim() != 2:
+        raise ValueError(f"expected 2D input, got shape {tuple(x.shape)}")
+    M, K = x.shape
+    rank = lora_down.shape[1]
+    group = _INT4_GROUP_SIZE
+    if K % group != 0:
+        raise ValueError(f"K={K} not divisible by group_size={group}")
+    M_pad = _ceil_div(M, pad_size) * pad_size
+
+    # LoRA down: computed on the un-smoothed input (matches SVDQuant convention)
+    lora_act = x.float() @ lora_down.float()  # (M, R)
+
+    # Smooth (divide) + per-row per-group int4 quantization.
+    # SmoothQuant: outliers are moved from activations to weights at calibration.
+    # At inference, activations divide by smooth so they quantize cleanly.
+    x_smooth = (x + shift_value) / smooth
+    groups = x_smooth.view(M, K // group, group)
+    absmax = groups.abs().amax(dim=-1).clamp(min=1e-10)  # (M, K/G)
+    qmax = _UINT4_MAX if act_unsigned else _INT4_MAX
+    qmin = 0 if act_unsigned else (-_INT4_MAX - 1)
+    scales = absmax / qmax
+    q_vals = (groups / scales.unsqueeze(-1)).round().clamp(qmin, qmax).to(torch.int8)
+    q_vals = q_vals.reshape(M, K)
+    q_packed = _pack_int4_row_major(q_vals)  # (M, K // 2)
+
+    if M_pad > M:
+        pad = M_pad - M
+        q_packed = F.pad(q_packed, (0, 0, 0, pad))
+        scales = F.pad(scales, (0, 0, 0, pad))
+        lora_act = F.pad(lora_act, (0, 0, 0, pad))
+
+    ascales = scales.t().contiguous().to(x.dtype)  # (K/G, M_pad)
+    return q_packed, ascales, lora_act
+
+
+def scaled_mm_svdquant_w4a4(
+    act: torch.Tensor,
+    wgt: torch.Tensor,
+    ascales: torch.Tensor,
+    wscales: torch.Tensor,
+    lora_act_in: torch.Tensor,
+    lora_up: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    act_unsigned: bool = False,
+) -> torch.Tensor:
+    """SVDQuant W4A4 GEMM with fused LoRA up projection and optional bias.
+
+    Args:
+        act: (M, K // 2) int8 packed activations from quantize_svdquant_w4a4.
+        wgt: (N, K // 2) int8 packed weights (kitchen-native layout).
+        ascales: (K // 64, M) per-row per-group activation scales.
+        wscales: (K // 64, N) per-group weight scales.
+        lora_act_in: (M, R) fp32 LoRA down-projection activations.
+        lora_up: (N, R) fp LoRA up-projection weight.
+        bias: (N,) fp bias or None.
+        act_unsigned: if True, activations are stored as uint4 in [0, 15] with
+            an implicit -8 offset (used after GELU when activations are all positive).
+
+    Returns:
+        out: (M, N) fp in the dtype of wscales/lora_up.
+    """
+    M, K_half = act.shape
+    N = wgt.shape[0]
+    K = K_half * 2
+    group = _INT4_GROUP_SIZE
+    compute_dtype = wscales.dtype
+
+    # --- weight dequantization ---
+    wgt_int = _unpack_int4_row_major(wgt).to(compute_dtype)  # (N, K)
+    wgt_g = wgt_int.view(N, K // group, group)
+    wscales_bng = wscales.t().unsqueeze(-1)  # (N, K/G, 1)
+    wgt_fp = (wgt_g * wscales_bng).view(N, K)
+
+    # --- activation dequantization ---
+    if act_unsigned:
+        act_int = _unpack_uint4_row_major(act)
+    else:
+        act_int = _unpack_int4_row_major(act)
+    act_int = act_int.to(compute_dtype).view(M, K // group, group)
+    ascales_mng = ascales.t().unsqueeze(-1)  # (M, K/G, 1)
+    act_fp = (act_int * ascales_mng).view(M, K)
+
+    out = act_fp @ wgt_fp.t()  # (M, N)
+
+    # LoRA up branch (in fp32 for accumulation stability)
+    lora_contribution = lora_act_in.float() @ lora_up.float().t()  # (M, N)
+    out = out + lora_contribution.to(out.dtype)
+
+    if bias is not None:
+        out = out + bias
+    return out
+
+
+# =============================================================================
+# torch.library Custom Op Dispatch
+# =============================================================================
+#
+# The custom ops live in eager because eager is always imported and acts as
+# the dispatcher host — consistent with rope.py. The actual implementation is
+# chosen at call time by the registry based on backend priority and constraints.
+
+
+@torch.library.custom_op("comfy_kitchen::quantize_svdquant_w4a4", mutates_args=())
+def _op_quantize_svdquant_w4a4(
+    x: torch.Tensor,
+    smooth: torch.Tensor,
+    lora_down: torch.Tensor,
+    pad_size: int = 256,
+    act_unsigned: bool = False,
+    shift_value: float = 0.0,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    from comfy_kitchen.registry import registry
+
+    kwargs = {
+        "x": x,
+        "smooth": smooth,
+        "lora_down": lora_down,
+        "pad_size": pad_size,
+        "act_unsigned": act_unsigned,
+        "shift_value": shift_value,
+    }
+    impl = registry.get_implementation("quantize_svdquant_w4a4", kwargs=kwargs)
+    return impl(**kwargs)
+
+
+@_op_quantize_svdquant_w4a4.register_fake
+def _op_quantize_svdquant_w4a4_fake(
+    x, smooth, lora_down, pad_size=256, act_unsigned=False, shift_value=0.0,
+):
+    M, K = x.shape
+    R = lora_down.shape[1]
+    M_pad = _ceil_div(M, pad_size) * pad_size
+    q_x = torch.empty(M_pad, K // 2, dtype=torch.int8, device=x.device)
+    ascales = torch.empty(K // _INT4_GROUP_SIZE, M_pad, dtype=x.dtype, device=x.device)
+    lora_act = torch.empty(M_pad, R, dtype=torch.float32, device=x.device)
+    return q_x, ascales, lora_act
+
+
+@torch.library.custom_op("comfy_kitchen::scaled_mm_svdquant_w4a4", mutates_args=())
+def _op_scaled_mm_svdquant_w4a4(
+    act: torch.Tensor,
+    wgt: torch.Tensor,
+    ascales: torch.Tensor,
+    wscales: torch.Tensor,
+    lora_act_in: torch.Tensor,
+    lora_up: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    act_unsigned: bool = False,
+) -> torch.Tensor:
+    from comfy_kitchen.registry import registry
+
+    kwargs = {
+        "act": act, "wgt": wgt, "ascales": ascales, "wscales": wscales,
+        "lora_act_in": lora_act_in, "lora_up": lora_up,
+        "bias": bias, "act_unsigned": act_unsigned,
+    }
+    impl = registry.get_implementation("scaled_mm_svdquant_w4a4", kwargs=kwargs)
+    return impl(**kwargs)
+
+
+@_op_scaled_mm_svdquant_w4a4.register_fake
+def _op_scaled_mm_svdquant_w4a4_fake(
+    act, wgt, ascales, wscales, lora_act_in, lora_up, bias=None, act_unsigned=False,
+):
+    M = act.shape[0]
+    N = wgt.shape[0]
+    return torch.empty(M, N, dtype=lora_up.dtype, device=act.device)

--- a/comfy_kitchen/tensor/__init__.py
+++ b/comfy_kitchen/tensor/__init__.py
@@ -12,6 +12,7 @@ from .base import (
 from .fp8 import TensorCoreFP8Layout
 from .mxfp8 import TensorCoreMXFP8Layout
 from .nvfp4 import TensorCoreNVFP4Layout
+from .svdquant_w4a4 import TensorCoreSVDQuantW4A4Layout
 
 __all__ = [
     "BaseLayoutParams",
@@ -20,6 +21,7 @@ __all__ = [
     "TensorCoreFP8Layout",
     "TensorCoreMXFP8Layout",
     "TensorCoreNVFP4Layout",
+    "TensorCoreSVDQuantW4A4Layout",
     "dequantize_args",
     "get_cuda_capability",
     "get_layout_class",
@@ -30,3 +32,4 @@ __all__ = [
 register_layout_class("TensorCoreFP8Layout", TensorCoreFP8Layout)
 register_layout_class("TensorCoreMXFP8Layout", TensorCoreMXFP8Layout)
 register_layout_class("TensorCoreNVFP4Layout", TensorCoreNVFP4Layout)
+register_layout_class("TensorCoreSVDQuantW4A4Layout", TensorCoreSVDQuantW4A4Layout)

--- a/comfy_kitchen/tensor/svdquant_w4a4.py
+++ b/comfy_kitchen/tensor/svdquant_w4a4.py
@@ -47,8 +47,10 @@ class TensorCoreSVDQuantW4A4Layout(QuantizedLayout):
         DeepCompressor pipeline to produce the pre-quantized tensors.
     """
 
-    # SVDQuant ships kernels for SM >= 8.0 (Ampere); kitchen dispatches to the
-    # nunchaku backend which enforces this via its own constraint system.
+    # m16n8k64 int4 MMA requires SM >= 8.0 (Ampere). The kitchen CUDA kernels
+    # in comfy_kitchen/backends/cuda/ops/{quantize,scaled_mm}_svdquant_w4a4.cu
+    # gate the PTX body on __CUDA_ARCH__ >= 800 and raise at runtime on older
+    # arches (see svdquant_utils.cuh::trap_pre_sm80).
     MIN_SM_VERSION = (8, 0)
 
     # Activation quantization is fused inside the kernel — do not pre-wrap
@@ -96,9 +98,11 @@ class TensorCoreSVDQuantW4A4Layout(QuantizedLayout):
         """Reconstruct the effective weight W_eff such that plain ``x @ W_eff.T + bias``
         reproduces the SVDQuant kernel output to bf16 precision.
 
-        Uses the kitchen kernel itself with an identity input — bit-exact with the
-        kernel's tile-interleaved packed layout without requiring us to replicate
-        that layout in Python.
+        Uses the kitchen kernel itself with an identity input rather than
+        reimplementing dequant in Python. Kitchen weight layout is natural
+        row-major packed int4 ``(N, K/2)`` — the kernel reads it directly, so
+        this path stays bit-exact with the actual compute path regardless of
+        per-group scaling / LoRA composition details.
         """
         out_features, _ = qdata.shape
         in_features = params.orig_shape[1]
@@ -146,7 +150,18 @@ def _w4a4_forward(
     weight_qt: "QuantizedTensor",
     bias: torch.Tensor | None,
 ) -> torch.Tensor:
-    """Compute y = x @ W^T + bias via nunchaku's fused int4 kernel."""
+    """Compute y = x @ W^T + bias via the int4 kernel.
+
+    For layers flagged ``act_unsigned`` (nunchaku convention: post-GELU fc2),
+    we apply the +0.171875 shift to the main-path activation here at the layer
+    so it falls into the unsigned [0, 15] quantization grid. LoRA continues to
+    use the raw un-shifted activation (SVDQuant invariant: LoRA is the residual
+    between full-precision W and the int4 approximation, computed on the
+    pre-quantization activation).
+
+    Kernel API stays shift-free — shift is a Qwen/Flux model-topology constant,
+    not a quantize-op parameter.
+    """
     qdata, wscales, smooth, proj_down, proj_up = TensorCoreSVDQuantW4A4Layout.get_plain_tensors(weight_qt)
     act_unsigned = bool(getattr(weight_qt._params, "act_unsigned", False))
 
@@ -154,12 +169,19 @@ def _w4a4_forward(
     x2d = input_tensor.reshape(-1, orig_shape[-1])
     M = x2d.shape[0]
 
+    if act_unsigned:
+        x_main = x2d + _GELU_UNSIGNED_SHIFT  # fed to quantize for unsigned grid
+        lora_x = x2d                         # LoRA always sees raw x
+    else:
+        x_main = x2d
+        lora_x = None                        # wrapper will fall back to x_main
+
     q_x, ascales, lora_act = ck.quantize_svdquant_w4a4(
-        x2d,
+        x_main,
         smooth=smooth,
         lora_down=proj_down,
         act_unsigned=act_unsigned,
-        shift_value=_GELU_UNSIGNED_SHIFT if act_unsigned else 0.0,
+        lora_x=lora_x,
     )
     out = ck.scaled_mm_svdquant_w4a4(
         act=q_x, wgt=qdata, ascales=ascales, wscales=wscales,

--- a/comfy_kitchen/tensor/svdquant_w4a4.py
+++ b/comfy_kitchen/tensor/svdquant_w4a4.py
@@ -1,0 +1,251 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# SVDQuant W4A4 (int4 weight, int4 activation, SVD low-rank correction) layout.
+
+"""SVDQuant W4A4 quantization layout for tensor cores.
+
+Each quantized linear stores:
+  qweight:       (N, K // 2)  int8        packed W4 residual
+  scale=wscales: (K // 64, N) bf16/fp16   per-group weight scales
+  proj_down:     (K, R)       bf16/fp16   SVD down projection (V^T)
+  proj_up:       (N, R)       bf16/fp16   SVD up projection (U)
+  smooth_factor: (K,)         bf16/fp16   input-side smoothing
+
+LoRA-style proj_down / proj_up recover the outlier-heavy singular directions
+that pure 4-bit quantization cannot represent; the dispatched kernel fuses
+activation quantization + low-rank correction + int4 matmul into a single call.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import torch
+
+import comfy_kitchen as ck
+
+from .base import BaseLayoutParams, QuantizedLayout, dequantize_args, register_layout_op
+
+if TYPE_CHECKING:
+    from .base import QuantizedTensor
+
+logger = logging.getLogger(__name__)
+
+_INT4_GROUP_SIZE = 64
+_GELU_UNSIGNED_SHIFT = 0.171875
+
+
+class TensorCoreSVDQuantW4A4Layout(QuantizedLayout):
+    """SVDQuant W4A4 weight quantization with low-rank correction.
+
+    Note:
+        Offline-quantized only — `quantize()` raises NotImplementedError because
+        SVDQuant factorization requires calibration (smooth_factor, proj_down,
+        proj_up) that must be computed from activation statistics. Use the
+        DeepCompressor pipeline to produce the pre-quantized tensors.
+    """
+
+    # SVDQuant ships kernels for SM >= 8.0 (Ampere); kitchen dispatches to the
+    # nunchaku backend which enforces this via its own constraint system.
+    MIN_SM_VERSION = (8, 0)
+
+    # Activation quantization is fused inside the kernel — do not pre-wrap
+    # the input with QuantizedTensor.from_float(). Consumers (e.g. ComfyUI's
+    # mixed_precision_ops.Linear) should read this flag before attempting to
+    # quantize an incoming float activation.
+    QUANTIZES_INPUT = False
+
+    @dataclass(frozen=True)
+    class Params(BaseLayoutParams):
+        """SVDQuant W4A4 parameters.
+
+        Inherits `scale` (= wscales), `orig_dtype`, `orig_shape` from
+        BaseLayoutParams. Adds the three tensors that parameterize the
+        low-rank correction and input smoothing, plus a logical-transpose flag
+        used by the aten.t / aten.mm dispatch path.
+        """
+        proj_down: torch.Tensor
+        proj_up: torch.Tensor
+        smooth_factor: torch.Tensor
+        act_unsigned: bool = False
+        transposed: bool = False
+
+        def _tensor_fields(self) -> list[str]:
+            return ["scale", "proj_down", "proj_up", "smooth_factor"]
+
+        def _validate_tensor_fields(self):
+            # Unlike per-tensor scale layouts, wscales is per-group and stays
+            # in the model compute dtype (bf16 / fp16) — do not coerce.
+            return
+
+    @classmethod
+    def quantize(
+        cls,
+        tensor: torch.Tensor,
+        **kwargs,
+    ) -> tuple[torch.Tensor, Params]:
+        raise NotImplementedError(
+            "SVDQuant W4A4 requires offline calibration (DeepCompressor). "
+            "Load pre-quantized tensors via `from_state_dict` instead."
+        )
+
+    @classmethod
+    def dequantize(cls, qdata: torch.Tensor, params: Params) -> torch.Tensor:
+        """Reconstruct the effective weight W_eff such that plain ``x @ W_eff.T + bias``
+        reproduces the SVDQuant kernel output to bf16 precision.
+
+        Uses the kitchen kernel itself with an identity input — bit-exact with the
+        kernel's tile-interleaved packed layout without requiring us to replicate
+        that layout in Python.
+        """
+        out_features, _ = qdata.shape
+        in_features = params.orig_shape[1]
+        device = qdata.device
+        dtype = params.orig_dtype
+
+        eye = torch.eye(in_features, dtype=dtype, device=device)
+        q_x, ascales, lora_act = ck.quantize_svdquant_w4a4(
+            eye, smooth=params.smooth_factor, lora_down=params.proj_down,
+        )
+        w_eff = ck.scaled_mm_svdquant_w4a4(
+            act=q_x, wgt=qdata, ascales=ascales, wscales=params.scale,
+            lora_act_in=lora_act, lora_up=params.proj_up, bias=None,
+        )[:in_features]
+        return w_eff.t().contiguous()
+
+    @classmethod
+    def get_plain_tensors(
+        cls, qtensor: QuantizedTensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        p = qtensor._params
+        return qtensor._qdata, p.scale, p.smooth_factor, p.proj_down, p.proj_up
+
+    @classmethod
+    def state_dict_tensors(cls, qdata: torch.Tensor, params: Params) -> dict[str, torch.Tensor]:
+        """Serialization mapping.
+
+        Suffixes compose onto the owning Parameter's key (typically `*.weight`),
+        producing for example `transformer_blocks.0.attn.to_q.weight`,
+        `...weight_scale`, `...weight_proj_down`, etc.
+        """
+        return {
+            "": qdata,
+            "_scale": params.scale,
+            "_proj_down": params.proj_down,
+            "_proj_up": params.proj_up,
+            "_smooth_factor": params.smooth_factor,
+        }
+
+
+# ==================== Linear Dispatch ====================
+
+def _w4a4_forward(
+    input_tensor: torch.Tensor,
+    weight_qt: "QuantizedTensor",
+    bias: torch.Tensor | None,
+) -> torch.Tensor:
+    """Compute y = x @ W^T + bias via nunchaku's fused int4 kernel."""
+    qdata, wscales, smooth, proj_down, proj_up = TensorCoreSVDQuantW4A4Layout.get_plain_tensors(weight_qt)
+    act_unsigned = bool(getattr(weight_qt._params, "act_unsigned", False))
+
+    orig_shape = input_tensor.shape
+    x2d = input_tensor.reshape(-1, orig_shape[-1])
+    M = x2d.shape[0]
+
+    q_x, ascales, lora_act = ck.quantize_svdquant_w4a4(
+        x2d,
+        smooth=smooth,
+        lora_down=proj_down,
+        act_unsigned=act_unsigned,
+        shift_value=_GELU_UNSIGNED_SHIFT if act_unsigned else 0.0,
+    )
+    out = ck.scaled_mm_svdquant_w4a4(
+        act=q_x, wgt=qdata, ascales=ascales, wscales=wscales,
+        lora_act_in=lora_act, lora_up=proj_up, bias=bias,
+        act_unsigned=act_unsigned,
+    )
+    out_features = qdata.shape[0]
+    return out[:M].reshape(*orig_shape[:-1], out_features)
+
+
+@register_layout_op(torch.ops.aten.t.default, TensorCoreSVDQuantW4A4Layout)
+def _handle_w4a4_t(qt, args, kwargs):
+    """Zero-copy logical transpose — flip the ``transposed`` flag.
+
+    Lets ``F.linear(x, W)`` decompose into ``x @ W.t()`` without reordering any
+    storage; ``mm`` / ``addmm`` handlers below unwind the flag.
+    """
+    import dataclasses
+
+    from .base import QuantizedTensor
+
+    input_tensor = args[0]
+    if not isinstance(input_tensor, QuantizedTensor):
+        return torch.ops.aten.t.default(*args, **kwargs)
+
+    old = input_tensor._params
+    new_params = dataclasses.replace(
+        old,
+        orig_shape=(old.orig_shape[1], old.orig_shape[0]),
+        transposed=not old.transposed,
+    )
+    return QuantizedTensor(input_tensor._qdata, "TensorCoreSVDQuantW4A4Layout", new_params)
+
+
+def _resolve_svdquant_rhs(rhs: "QuantizedTensor") -> "QuantizedTensor":
+    """Return rhs unchanged if it is logically transposed (represents W^T)."""
+    if not rhs._params.transposed:
+        raise RuntimeError(
+            "SVDQuant W4A4 GEMM expects the RHS to be W.T (stored W). "
+            "Use F.linear(x, W) or mm(x, W.t())."
+        )
+    return rhs
+
+
+@register_layout_op(torch.ops.aten.linear.default, TensorCoreSVDQuantW4A4Layout)
+def _handle_w4a4_linear(qt, args, kwargs):
+    """Direct F.linear(input, W, bias) → kitchen kernel."""
+    from .base import QuantizedTensor
+
+    input_tensor, weight = args[0], args[1]
+    bias = args[2] if len(args) > 2 else None
+
+    if not isinstance(weight, QuantizedTensor):
+        return torch.nn.functional.linear(*dequantize_args((input_tensor, weight, bias)))
+    if isinstance(input_tensor, QuantizedTensor):
+        input_tensor = input_tensor.dequantize()
+    if weight._params.transposed:
+        return torch.nn.functional.linear(input_tensor, weight.dequantize(), bias)
+    return _w4a4_forward(input_tensor, weight, bias)
+
+
+@register_layout_op(torch.ops.aten.mm.default, TensorCoreSVDQuantW4A4Layout)
+def _handle_w4a4_mm(qt, args, kwargs):
+    """Handle ``mm(x, W.t())`` — the decomposition F.linear takes when the weight
+    is a non-default tensor subclass.
+    """
+    from .base import QuantizedTensor
+
+    a, b = args[0], args[1]
+    if not isinstance(b, QuantizedTensor):
+        return torch.mm(*dequantize_args((a, b)))
+    if isinstance(a, QuantizedTensor):
+        a = a.dequantize()
+    b = _resolve_svdquant_rhs(b)
+    return _w4a4_forward(a, b, bias=None)
+
+
+@register_layout_op(torch.ops.aten.addmm.default, TensorCoreSVDQuantW4A4Layout)
+def _handle_w4a4_addmm(qt, args, kwargs):
+    """Handle ``addmm(bias, x, W.t())``."""
+    from .base import QuantizedTensor
+
+    bias, a, b = args[0], args[1], args[2]
+    if not isinstance(b, QuantizedTensor):
+        return torch.addmm(*dequantize_args((bias, a, b)))
+    if isinstance(a, QuantizedTensor):
+        a = a.dequantize()
+    b = _resolve_svdquant_rhs(b)
+    return _w4a4_forward(a, b, bias=bias)

--- a/tests/test_svdquant_w4a4.py
+++ b/tests/test_svdquant_w4a4.py
@@ -1,0 +1,307 @@
+"""SVDQuant W4A4 unit tests.
+
+Covers the op-level contract for kitchen's int4 quantize + scaled_mm:
+  - Quantizer emission range (signed [-7,7] / unsigned [0,15], absmax/qmax scheme).
+  - act_unsigned flag dispatch through wrapper → kernel.
+  - lora_x kwarg separation (LoRA sees pre-shift activation).
+  - Eager ↔ CUDA numerical agreement on synthetic data.
+
+Heavier parity against real nunchaku checkpoints lives outside the unit-test
+tree (kitchen is pure ops; model-checkpoint parity is a converter/integration
+concern).
+"""
+from __future__ import annotations
+
+import pytest
+import torch
+
+import comfy_kitchen as ck
+from comfy_kitchen.backends.eager.svdquant import (
+    _INT4_MAX,
+    _UINT4_MAX,
+    _unpack_int4_row_major,
+    _unpack_uint4_row_major,
+)
+
+from .conftest import assert_values_close, get_capable_backends
+
+
+_GROUP = 64
+
+
+# =============================================================================
+# Quantizer clamp contract (#3 regression guard)
+# =============================================================================
+
+
+class TestQuantizerClampContract:
+    """Eager signed quantize must emit values in [-_INT4_MAX, +_INT4_MAX]
+    (= [-7, 7]), matching the CUDA kernel and nunchaku's QVALUE_MAX_SIGNED=7.
+
+    -8 is representable by the signed nibble but intentionally not emitted —
+    absmax/7 scaling assumes ±qmax symmetry; emitting -8 would break dequant
+    parity with nunchaku (gemm_w4a4.cuh:435) and kitchen CUDA
+    (svdquant_utils.cuh:20). This class regression-guards that contract.
+    """
+
+    def test_constants(self):
+        assert _INT4_MAX == 7, f"_INT4_MAX drifted to {_INT4_MAX}"
+        assert _UINT4_MAX == 15, f"_UINT4_MAX drifted to {_UINT4_MAX}"
+
+    @pytest.mark.parametrize("scale_factor", [0.5, 3.0, 100.0])
+    def test_signed_clamp_normal_and_extreme(self, cuda_available, seed, scale_factor):
+        if not cuda_available:
+            pytest.skip("CUDA required for scaled_mm dispatch")
+        K = 128
+        x = torch.randn(4, K, dtype=torch.bfloat16, device="cuda") * scale_factor
+        smooth = torch.ones(K, dtype=torch.bfloat16, device="cuda")
+        lora_down = torch.zeros(K, 16, dtype=torch.bfloat16, device="cuda")
+
+        with ck.use_backend("eager"):
+            q_packed, _, _ = ck.quantize_svdquant_w4a4(
+                x, smooth, lora_down, pad_size=16, act_unsigned=False,
+            )
+        q_vals = _unpack_int4_row_major(q_packed[:4])
+        assert q_vals.min().item() >= -_INT4_MAX, (
+            f"scale_factor={scale_factor}: min={q_vals.min().item()} "
+            f"< -{_INT4_MAX} (eager regressed to [-8, 7])"
+        )
+        assert q_vals.max().item() <= _INT4_MAX
+
+    def test_signed_clamp_forced_negative_outlier(self, cuda_available, seed):
+        """Inject an extreme negative outlier that would clamp to -8 under the
+        broken [-8, 7] contract. The fix keeps it at -7.
+        """
+        if not cuda_available:
+            pytest.skip("CUDA required for scaled_mm dispatch")
+        K = 128
+        x = torch.randn(4, K, dtype=torch.bfloat16, device="cuda") * 5.0
+        x[0, 0] = -100.0  # forces negative saturation
+        smooth = torch.ones(K, dtype=torch.bfloat16, device="cuda")
+        lora_down = torch.zeros(K, 16, dtype=torch.bfloat16, device="cuda")
+
+        with ck.use_backend("eager"):
+            q_packed, _, _ = ck.quantize_svdquant_w4a4(
+                x, smooth, lora_down, pad_size=16, act_unsigned=False,
+            )
+        q_vals = _unpack_int4_row_major(q_packed[:4])
+        # Never -8 even on forced saturation
+        assert (q_vals != -8).all().item(), "eager emitted -8, regressed from absmax/7 contract"
+        assert q_vals.min().item() == -_INT4_MAX  # the outlier did saturate
+
+    def test_no_neg8_at_scale(self, cuda_available, seed):
+        """Bulk test across many samples."""
+        if not cuda_available:
+            pytest.skip("CUDA required for scaled_mm dispatch")
+        K = 128
+        x = torch.randn(256, K, dtype=torch.bfloat16, device="cuda") * 3.0
+        smooth = torch.ones(K, dtype=torch.bfloat16, device="cuda")
+        lora_down = torch.zeros(K, 16, dtype=torch.bfloat16, device="cuda")
+
+        with ck.use_backend("eager"):
+            q_packed, _, _ = ck.quantize_svdquant_w4a4(
+                x, smooth, lora_down, pad_size=256, act_unsigned=False,
+            )
+        q_vals = _unpack_int4_row_major(q_packed[:256])
+        neg8 = (q_vals == -8).sum().item()
+        assert neg8 == 0, f"{neg8} values emitted as -8 across {q_vals.numel()} samples"
+
+    def test_unsigned_clamp_range(self, cuda_available, seed):
+        """Unsigned path: emission must be in [0, 15]."""
+        if not cuda_available:
+            pytest.skip("CUDA required for scaled_mm dispatch")
+        K = 128
+        # Non-negative input (simulates post-GELU + shift)
+        x = torch.rand(4, K, dtype=torch.bfloat16, device="cuda") * 3.0 + 0.01
+        smooth = torch.ones(K, dtype=torch.bfloat16, device="cuda")
+        lora_down = torch.zeros(K, 16, dtype=torch.bfloat16, device="cuda")
+
+        with ck.use_backend("eager"):
+            q_packed, _, _ = ck.quantize_svdquant_w4a4(
+                x, smooth, lora_down, pad_size=16, act_unsigned=True,
+            )
+        q_vals = _unpack_uint4_row_major(q_packed[:4])
+        assert q_vals.min().item() >= 0
+        assert q_vals.max().item() <= _UINT4_MAX
+
+
+# =============================================================================
+# act_unsigned dispatch: u4.s4 vs s4.s4 MMA selection
+# =============================================================================
+
+
+class TestActUnsignedDispatch:
+    """Verify act_unsigned flag actually selects the u4.s4 MMA variant at
+    kernel level (as distinct from the signed s4.s4 MMA).
+
+    Construction: pack an activation byte of 0xFF (all 1s) and a weight of 1.
+    Signed interpretation: 0xFF = -1, result = 64 * -1 * 1 = -64.
+    Unsigned interpretation: 0xFF = 15, result = 64 * 15 * 1 = +960.
+    The sign/magnitude split is the cleanest test that the flag routes
+    correctly end-to-end.
+    """
+
+    @pytest.fixture
+    def _cuda_required(self, cuda_available):
+        if not cuda_available:
+            pytest.skip("CUDA required for int4 MMA kernels")
+
+    def _run(self, act_unsigned):
+        M, N, K, R = 16, 8, 64, 16
+        q_act = torch.full((M, K // 2), 0xFF, dtype=torch.uint8, device="cuda").view(torch.int8)
+        q_wgt = torch.full((N, K // 2), 0x11, dtype=torch.int8, device="cuda")  # two s4=1 per byte
+        asc = torch.ones(K // 64, M, dtype=torch.bfloat16, device="cuda")
+        wsc = torch.ones(K // 64, N, dtype=torch.bfloat16, device="cuda")
+        lai = torch.zeros(M, R, dtype=torch.float32, device="cuda")
+        lu = torch.zeros(N, R, dtype=torch.bfloat16, device="cuda")
+        b = torch.zeros(N, dtype=torch.bfloat16, device="cuda")
+        with ck.use_backend("cuda"):
+            return ck.scaled_mm_svdquant_w4a4(
+                act=q_act, wgt=q_wgt, ascales=asc, wscales=wsc,
+                lora_act_in=lai, lora_up=lu, bias=b, act_unsigned=act_unsigned,
+            )
+
+    def test_signed_mma_gives_minus_64(self, _cuda_required, seed):
+        out = self._run(act_unsigned=False)
+        # Allow tiny tolerance for fp16 accumulation rounding
+        assert abs(out[0, 0].item() - (-64.0)) < 1.0
+        assert (out == out[0, 0]).all().item()
+
+    def test_unsigned_mma_gives_plus_960(self, _cuda_required, seed):
+        out = self._run(act_unsigned=True)
+        assert abs(out[0, 0].item() - 960.0) < 5.0
+        assert (out == out[0, 0]).all().item()
+
+
+# =============================================================================
+# lora_x kwarg: LoRA uses raw x when caller pre-shifts main input
+# =============================================================================
+
+
+class TestLoraXSeparation:
+    """SVDQuant defines LoRA-down on the pre-quantization, pre-shift activation
+    regardless of the main-path treatment. The quantize wrapper's lora_x kwarg
+    lets callers pass a separate (un-shifted) tensor for the LoRA matmul.
+
+    These tests verify *routing* (that lora_x actually changes where the LoRA
+    matmul reads its input from) and consistency with a high-precision fp32
+    reference. They deliberately do NOT compare eager and CUDA LoRA outputs
+    bitwise: the CUDA backend takes a bf16 @ bf16 matmul path for memory/launch
+    savings, the eager reference runs in fp32. The tolerances below reflect
+    bf16 matmul precision (~8e-3 abs).
+    """
+
+    @pytest.mark.parametrize("backend", ["eager", "cuda"])
+    def test_lora_x_none_defaults_to_x(self, cuda_available, seed, backend):
+        """Explicit lora_x=x is indistinguishable from lora_x=None (default)."""
+        if backend == "cuda" and not cuda_available:
+            pytest.skip("CUDA backend not available")
+        device = "cuda" if cuda_available else "cpu"
+        if backend == "eager" and device == "cpu":
+            pass  # eager runs on CPU
+        elif device != "cuda":
+            pytest.skip(f"backend {backend} needs cuda")
+
+        K, R = 128, 16
+        x = torch.randn(4, K, dtype=torch.bfloat16, device=device)
+        smooth = torch.ones(K, dtype=torch.bfloat16, device=device)
+        lora_down = torch.randn(K, R, dtype=torch.bfloat16, device=device) * 0.1
+
+        with ck.use_backend(backend):
+            q1, asc1, la1 = ck.quantize_svdquant_w4a4(x, smooth, lora_down, pad_size=16)
+            q2, asc2, la2 = ck.quantize_svdquant_w4a4(
+                x, smooth, lora_down, pad_size=16, lora_x=x,
+            )
+        # Both main-path (quantize) outputs and LoRA outputs must be bit-identical
+        # — same backend, same input, same code path.
+        assert torch.equal(q1, q2)
+        assert torch.equal(asc1, asc2)
+        assert_values_close(la1, la2, rtol=0.0, atol=0.0, name=f"{backend} lora_act")
+
+    @pytest.mark.parametrize("backend", ["eager", "cuda"])
+    def test_lora_x_separate_uses_raw_for_lora(self, cuda_available, seed, backend):
+        """Pass a pre-shifted x as main input + raw x as lora_x. LoRA output
+        must follow the raw lora_x, proving the kwarg is wired through and not
+        silently falling back to the shifted x. Accuracy check uses a fp32
+        reference with bf16-precision tolerance (CUDA backend uses bf16 matmul,
+        not fp32-accumulate — do not interpret this as a cross-backend bit-parity
+        test).
+        """
+        if backend == "cuda" and not cuda_available:
+            pytest.skip("CUDA backend not available")
+        device = "cuda" if cuda_available else "cpu"
+        if backend != "eager" and device != "cuda":
+            pytest.skip(f"backend {backend} needs cuda")
+
+        K, R = 128, 16
+        raw_x = torch.randn(4, K, dtype=torch.bfloat16, device=device) * 0.5
+        shifted_x = raw_x + 0.171875
+        smooth = torch.ones(K, dtype=torch.bfloat16, device=device)
+        lora_down = torch.randn(K, R, dtype=torch.bfloat16, device=device) * 0.1
+
+        with ck.use_backend(backend):
+            # Correct: pre-shifted for main, raw for lora
+            _, _, la_correct = ck.quantize_svdquant_w4a4(
+                shifted_x, smooth, lora_down, pad_size=16, lora_x=raw_x,
+            )
+            # Incorrect baseline: shifted used for both (what happens if caller
+            # forgets lora_x). Used to prove the kwarg is live, not a pass-through.
+            _, _, la_if_shifted = ck.quantize_svdquant_w4a4(
+                shifted_x, smooth, lora_down, pad_size=16,
+            )
+        assert not torch.allclose(la_correct, la_if_shifted), (
+            "lora_x had no effect — LoRA matmul is still using shifted input"
+        )
+
+        # Accuracy check against a fp32 reference. Tolerance is bf16-precision
+        # because the CUDA wrapper uses a bf16 matmul (then upcasts to the fp32
+        # lora_act buffer). Eager uses fp32 internally so it will be tighter,
+        # but we apply the same tolerance to avoid treating eager as a bit-
+        # parity oracle — it is a higher-precision reference, not a backend
+        # parity target.
+        expected = raw_x.float() @ lora_down.float()
+        assert_values_close(
+            la_correct[:4].float(), expected, rtol=5e-3, atol=5e-3,
+            name=f"{backend} lora_act vs fp32 reference (bf16 tolerance)",
+        )
+
+
+# =============================================================================
+# Cross-backend smoke: quantize + scaled_mm round-trip
+# =============================================================================
+
+
+class TestSvdquantSmoke:
+    """Basic end-to-end smoke test that the CUDA and eager paths produce
+    reasonable outputs on matched random data (not a nunchaku bit-parity test —
+    that's an integration concern)."""
+
+    @pytest.mark.parametrize("M,N,K,R", [
+        (16, 8, 64, 16),     # one MMA
+        (64, 32, 128, 16),
+        (256, 128, 512, 32),
+    ])
+    def test_signed_forward_runs(self, cuda_available, seed, M, N, K, R):
+        if not cuda_available:
+            pytest.skip("CUDA required")
+        device = "cuda"
+        x = torch.randn(M, K, dtype=torch.bfloat16, device=device) * 0.3
+        smooth = torch.ones(K, dtype=torch.bfloat16, device=device) * 1.0
+        proj_down = torch.randn(K, R, dtype=torch.bfloat16, device=device) * 0.05
+        proj_up = torch.randn(N, R, dtype=torch.bfloat16, device=device) * 0.05
+        wscales = torch.rand(K // _GROUP, N, dtype=torch.bfloat16, device=device) * 0.5 + 0.1
+        # Signed wgt in [-7, 7]
+        wgt_int = torch.randint(-7, 8, (N, K), dtype=torch.int8, device=device)
+        lo = wgt_int[..., 0::2].to(torch.int32) & 0x0F
+        hi = wgt_int[..., 1::2].to(torch.int32) & 0x0F
+        wgt = (lo | (hi << 4)).to(torch.int8)
+
+        with ck.use_backend("cuda"):
+            q_act, asc, la = ck.quantize_svdquant_w4a4(x, smooth, proj_down, pad_size=256)
+            out = ck.scaled_mm_svdquant_w4a4(
+                act=q_act, wgt=wgt, ascales=asc, wscales=wscales,
+                lora_act_in=la, lora_up=proj_up,
+            )
+        assert out.shape[0] >= M  # padded to pad_size
+        assert out.shape[1] == N
+        assert torch.isfinite(out).all()


### PR DESCRIPTION
Add SVDQuant W4A4 int4 quantization support for Qwen-Image-Edit and similar SVD-LoRA checkpoints. Built as a kitchen-native row-major backend .

Targets sm_80+ (Ampere).                                                                     
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       
  Changes                                                
                                                                                                                                                                                                                                                                                                     
  - comfy_kitchen.quantize_svdquant_w4a4 / scaled_mm_svdquant_w4a4 as torch.library.custom_op entry points with eager pure-PyTorch reference                                                                                                                                                         
  - TensorCoreSVDQuantW4A4Layout dispatching aten.t / aten.mm / aten.addmm / aten.linear over int4 qdata + proj_down / proj_up / smooth_factor + per-group weight_scale
  - CUDA kernels: m16n8k64 int4 MMA GEMM + fused activation quantize over kitchen-native row-major tensors; fp32 accumulator (fp16 overflows at production Qwen scale ≈28 — see kernel header)                                                                                                       
  - act_unsigned end-to-end for post-GELU fc2 layers: u4.s4 MMA variant + +0.171875 shift applied at the layer (kernel API stays shift-free)                                                                                                                                                         
  - Signed quantizer clamp to [-7, 7] (skip -8) to match nunchaku's absmax/7 dequant-symmetric contract                                                                                                                                                                                              
  - LoRA-up + bias applied in Python via bf16 addmm_ (faster than kernel fusion for R=96; see scaled_mm_svdquant_w4a4 docstring for the precision tradeoff and the cuBLASLt upgrade path if needed)                                                                                                  
                                                                                                                                                                                                                                                                                                     
  Tests                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                     
  tests/test_svdquant_w4a4.py — 16 tests: quantizer clamp contract, signed/unsigned MMA dispatch, lora_x separation, cross-shape smoke.                                                                                                                                                              
