### PR TITLE
build dev/** branches

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - 'dev/**'
     tags:
       - "v*"
   pull_request:


### PR DESCRIPTION
Add a prefix that lets devs target the CI without using the main branch. This is useful for part-time kitchen devs who dont want the overhead of configuring local build and just want to iterate quickly a few times with the CI build flows.

git push <your-fork> HEAD:refs/heads/dev/foo

And you get wheels to download and test.

Minor dev QoL change that doesnt have any release impact on comfy.