### PR TITLE
Nibble Swizzle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ uv.lock
 .idea/
 *.pyd
 *.so
+.*/

--- a/comfy_kitchen/__init__.py
+++ b/comfy_kitchen/__init__.py
@@ -30,9 +30,6 @@ __all__ = [
     # Fused matmul
     "scaled_mm_nvfp4",
     "scaled_mm_mxfp8",
-    # Attention
-    "sage_sdpa",
-    "sage_is_available",
     # Positional encoding
     "apply_rope",
     "apply_rope1",

--- a/comfy_kitchen/__init__.py
+++ b/comfy_kitchen/__init__.py
@@ -12,6 +12,7 @@ from .exceptions import (
     BackendNotImplementedError,
     NoCapableBackendError,
 )
+from .float_utils import from_blocked, swap_nibbles, to_blocked
 
 # Import registry and exceptions
 from .registry import registry
@@ -19,28 +20,37 @@ from .registry import registry
 __version__ = "0.1.0"
 
 __all__ = [
+    # Quantization / dequantization
+    "quantize_per_tensor_fp8",
+    "dequantize_per_tensor_fp8",
+    "quantize_nvfp4",
+    "dequantize_nvfp4",
+    "quantize_mxfp8",
+    "dequantize_mxfp8",
+    # Fused matmul
+    "scaled_mm_nvfp4",
+    "scaled_mm_mxfp8",
+    # Attention
+    "sage_sdpa",
+    "sage_is_available",
+    # Positional encoding
+    "apply_rope",
+    "apply_rope1",
+    # Utilities
+    "swap_nibbles",
+    "to_blocked",
+    "from_blocked",
+    # Backend configuration
+    "list_backends",
+    "set_backend_priority",
+    "enable_backend",
+    "disable_backend",
+    "use_backend",
     # Exceptions
     "BackendError",
     "BackendNotFoundError",
     "BackendNotImplementedError",
     "NoCapableBackendError",
-    # Core functions
-    "apply_rope",
-    "apply_rope1",
-    "dequantize_mxfp8",
-    "dequantize_nvfp4",
-    "dequantize_per_tensor_fp8",
-    # Backend configuration
-    "disable_backend",
-    "enable_backend",
-    "list_backends",
-    "quantize_mxfp8",
-    "quantize_nvfp4",
-    "quantize_per_tensor_fp8",
-    "scaled_mm_mxfp8",
-    "scaled_mm_nvfp4",
-    "set_backend_priority",
-    "use_backend",
 ]
 
 
@@ -92,6 +102,7 @@ def quantize_nvfp4(
     per_tensor_scale: torch.Tensor,
     epsilon: float = 0.0,
     pad_16x: bool = False,
+    hi_first: bool = True,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Quantize tensor to NVFP4 format with block-wise scaling.
 
@@ -100,11 +111,14 @@ def quantize_nvfp4(
         per_tensor_scale: Global scale factor
         epsilon: Epsilon for numerical stability
         pad_16x: If True, implicit zero-padding is applied to make dimensions divisible by 16
+        hi_first: Nibble packing order. If True (default), the even-indexed element
+                  is stored in the high nibble of each packed byte. If False, the
+                  even-indexed element is stored in the low nibble.
 
     Returns:
         Tuple of (quantized_tensor, block_scales)
     """
-    return torch.ops.comfy_kitchen.quantize_nvfp4(x, per_tensor_scale, epsilon, pad_16x)
+    return torch.ops.comfy_kitchen.quantize_nvfp4(x, per_tensor_scale, epsilon, pad_16x, hi_first)
 
 
 def dequantize_nvfp4(
@@ -112,6 +126,7 @@ def dequantize_nvfp4(
     per_tensor_scale: torch.Tensor,
     block_scales: torch.Tensor,
     output_type: torch.dtype = torch.bfloat16,
+    hi_first: bool = True,
 ) -> torch.Tensor:
     """Dequantize tensor from NVFP4 format with block-wise scaling.
 
@@ -120,12 +135,15 @@ def dequantize_nvfp4(
         per_tensor_scale: Global scale factor
         block_scales: Block scales in swizzled layout (float8_e4m3fn)
         output_type: Target output dtype (float32, float16, or bfloat16)
+        hi_first: Nibble packing order. Must match the packing order used
+                  during quantization. If True (default), the even-indexed
+                  element is in the high nibble.
 
     Returns:
         Dequantized tensor in specified output format
     """
     dtype_code = DTYPE_TO_CODE[output_type]
-    return torch.ops.comfy_kitchen.dequantize_nvfp4(qx, per_tensor_scale, block_scales, dtype_code)
+    return torch.ops.comfy_kitchen.dequantize_nvfp4(qx, per_tensor_scale, block_scales, dtype_code, hi_first)
 
 
 def scaled_mm_nvfp4(

--- a/comfy_kitchen/backends/cuda/__init__.py
+++ b/comfy_kitchen/backends/cuda/__init__.py
@@ -192,6 +192,7 @@ def quantize_nvfp4(
     per_tensor_scale: torch.Tensor,
     epsilon: float = 0.0,
     pad_16x: bool = False,
+    hi_first: bool = True,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     # CUDA backend: uses cuBLAS tiled layout for block scales
     assert x.is_contiguous(), "Input tensor must be contiguous"
@@ -229,6 +230,7 @@ def quantize_nvfp4(
         _wrap_for_dlpack(sx_uint8),
         epsilon,
         pad_16x,
+        hi_first,
         stream_ptr,
     )
 
@@ -243,6 +245,7 @@ def dequantize_nvfp4(
     per_tensor_scale: torch.Tensor,
     block_scales: torch.Tensor,
     output_type: torch.dtype = torch.bfloat16,
+    hi_first: bool = True,
 ) -> torch.Tensor:
     assert qx.is_contiguous(), "Input tensor must be contiguous"
 
@@ -265,6 +268,7 @@ def dequantize_nvfp4(
         _wrap_for_dlpack(block_scales_uint8),
         _wrap_for_dlpack(output),
         output_dtype_code,
+        hi_first,
         stream_ptr,
     )
 

--- a/comfy_kitchen/backends/cuda/dlpack_bindings.cpp
+++ b/comfy_kitchen/backends/cuda/dlpack_bindings.cpp
@@ -106,6 +106,7 @@ extern "C" {
         int64_t orig_cols,
         float epsilon,
         int input_dtype_code,
+        bool hi_first,
         cudaStream_t stream);
 
     void launch_dequantize_nvfp4_kernel(
@@ -116,6 +117,7 @@ extern "C" {
         int64_t num_rows,
         int64_t num_cols,
         int output_dtype_code,
+        bool hi_first,
         cudaStream_t stream);
 
     void launch_quantize_mxfp8_kernel(
@@ -248,6 +250,7 @@ void quantize_nvfp4(
     nb::ndarray<nb::device::cuda> block_scales,
     float epsilon,
     bool pad_16x,
+    bool hi_first,
     uintptr_t stream_ptr) {
 
     // Get input dimensions (orig_rows, orig_cols)
@@ -282,6 +285,7 @@ void quantize_nvfp4(
         orig_cols,
         epsilon,
         input_dtype_code,
+        hi_first,
         stream);
 }
 
@@ -292,6 +296,7 @@ void dequantize_nvfp4(
     nb::ndarray<nb::device::cuda> block_scales,
     nb::ndarray<nb::ndim<2>, nb::device::cuda> output,
     int output_dtype_code,
+    bool hi_first,
     uintptr_t stream_ptr) {
 
     // Get output dimensions (should match input logical dimensions)
@@ -312,6 +317,7 @@ void dequantize_nvfp4(
         num_rows,
         num_cols,
         output_dtype_code,
+        hi_first,
         stream);
 }
 
@@ -531,6 +537,7 @@ NB_MODULE(_C, m) {
           nb::arg("block_scales"),
           nb::arg("epsilon"),
           nb::arg("pad_16x") = false,
+          nb::arg("hi_first") = true,
           nb::arg("stream_ptr"));
 
     m.def("dequantize_nvfp4", &dequantize_nvfp4,
@@ -540,6 +547,7 @@ NB_MODULE(_C, m) {
           nb::arg("block_scales"),
           nb::arg("output"),
           nb::arg("output_dtype_code"),
+          nb::arg("hi_first") = true,
           nb::arg("stream_ptr"));
 
     m.def("quantize_mxfp8", &quantize_mxfp8,

--- a/comfy_kitchen/backends/cuda/float_utils.cuh
+++ b/comfy_kitchen/backends/cuda/float_utils.cuh
@@ -81,22 +81,27 @@ template<typename IType>
 #pragma nv_diag_default 1056
 
 // Store 2 FP4 values (1 __nv_fp4x2)
-template<typename OType>
+// hi_first=true: val0 in high nibble, val1 in low nibble (default, matches cuBLAS convention)
+// hi_first=false: val0 in low nibble, val1 in high nibble
+template<typename OType, bool hi_first = true>
 __forceinline__ __device__ void store_fp4x2(OType* output, size_t idx, float val0, float val1) {
+    float2 args = hi_first ? float2{val1, val0} : float2{val0, val1};
     *reinterpret_cast<__nv_fp4x2_storage_t*>(&output[idx]) =
-        __nv_cvt_float2_to_fp4x2(float2{val1, val0}, __NV_E2M1, cudaRoundNearest);
+        __nv_cvt_float2_to_fp4x2(args, __NV_E2M1, cudaRoundNearest);
 }
 
 // Store 4 FP4 values (2 __nv_fp4x2) using single store
-template<typename OType>
+template<typename OType, bool hi_first = true>
 __forceinline__ __device__ void store_fp4x4(OType* output, size_t idx, float val0, float val1, float val2, float val3) {
     union {
         uint16_t u16;
         __nv_fp4x2_storage_t fp4x2[2];
     } packed;
 
-    packed.fp4x2[0] = __nv_cvt_float2_to_fp4x2(float2{val1, val0}, __NV_E2M1, cudaRoundNearest);
-    packed.fp4x2[1] = __nv_cvt_float2_to_fp4x2(float2{val3, val2}, __NV_E2M1, cudaRoundNearest);
+    float2 args0 = hi_first ? float2{val1, val0} : float2{val0, val1};
+    float2 args1 = hi_first ? float2{val3, val2} : float2{val2, val3};
+    packed.fp4x2[0] = __nv_cvt_float2_to_fp4x2(args0, __NV_E2M1, cudaRoundNearest);
+    packed.fp4x2[1] = __nv_cvt_float2_to_fp4x2(args1, __NV_E2M1, cudaRoundNearest);
 
     *reinterpret_cast<uint16_t*>(&output[2*idx]) = packed.u16;
 }

--- a/comfy_kitchen/backends/cuda/ops/quantize_nvfp4.cu
+++ b/comfy_kitchen/backends/cuda/ops/quantize_nvfp4.cu
@@ -61,7 +61,8 @@ template <
     typename IType,
     typename OType=__nv_fp4x2_e2m1,
     typename ScaleType=__nv_fp8_e4m3,
-    bool Misaligned = false>
+    bool Misaligned = false,
+    bool HiFirst = true>
 __global__ void quantize_nvfp4_kernel(
     const IType* const input,
     const float* global_scale, // absmax(input) / (6.0 * 488.0)
@@ -186,10 +187,10 @@ __global__ void quantize_nvfp4_kernel(
     // Store quantized values to output using vectorized stores
     // Both aligned and misaligned paths use the same store since each thread processes kValsPerThread values
     if (kValsPerThread == 2) {
-        store_fp4x2(output, idx, vals_encoded[0], vals_encoded[1]);
+        store_fp4x2<OType, HiFirst>(output, idx, vals_encoded[0], vals_encoded[1]);
     }
     else if (kValsPerThread == 4) {
-        store_fp4x4(output, idx, vals_encoded[0], vals_encoded[1], vals_encoded[2], vals_encoded[3]);
+        store_fp4x4<OType, HiFirst>(output, idx, vals_encoded[0], vals_encoded[1], vals_encoded[2], vals_encoded[3]);
     }
 }
 
@@ -211,7 +212,8 @@ __global__ void quantize_nvfp4_kernel(
 template <
     typename IType=__nv_fp4x2_e2m1,
     typename OType,
-    typename ScaleType=__nv_fp8_e4m3>
+    typename ScaleType=__nv_fp8_e4m3,
+    bool HiFirst = true>
 __global__ void dequantize_nvfp4_kernel(
     const IType* const input,
     const float* global_scale,
@@ -247,18 +249,23 @@ __global__ void dequantize_nvfp4_kernel(
     // Unpack and dequantize
     OType vals_output[kValsPerThread];
     
+    // __nv_cvt_fp4x2_to_halfraw2 returns: .x = low nibble value, .y = high nibble value.
+    // HiFirst=true:  high nibble = even index (val0), low nibble = odd index (val1) → .y=val0, .x=val1
+    // HiFirst=false: high nibble = odd index (val1), low nibble = even index (val0) → .x=val0, .y=val1
     if (kValsPerThread == 2) {
-        // Read 1 packed value (2 FP4 values)
         __half2_raw unpacked_raw = __nv_cvt_fp4x2_to_halfraw2(
             *reinterpret_cast<const __nv_fp4x2_storage_t*>(input_ptr),
             __NV_E2M1);
         float2 unpacked_f2 = __half22float2(*reinterpret_cast<__half2*>(&unpacked_raw));
-        // Note: order is swapped because store_fp4x2 packs as float2{val1, val0}
-        vals_output[0] = static_cast<OType>(unpacked_f2.y * decode_scale);
-        vals_output[1] = static_cast<OType>(unpacked_f2.x * decode_scale);
+        if constexpr (HiFirst) {
+            vals_output[0] = static_cast<OType>(unpacked_f2.y * decode_scale);
+            vals_output[1] = static_cast<OType>(unpacked_f2.x * decode_scale);
+        } else {
+            vals_output[0] = static_cast<OType>(unpacked_f2.x * decode_scale);
+            vals_output[1] = static_cast<OType>(unpacked_f2.y * decode_scale);
+        }
     }
     else if (kValsPerThread == 4) {
-        // Read 2 packed values (4 FP4 values total)
         union {
             uint16_t u16;
             __nv_fp4x2_storage_t fp4x2[2];
@@ -270,11 +277,17 @@ __global__ void dequantize_nvfp4_kernel(
         float2 unpacked_f2_0 = __half22float2(*reinterpret_cast<__half2*>(&unpacked_raw0));
         float2 unpacked_f2_1 = __half22float2(*reinterpret_cast<__half2*>(&unpacked_raw1));
         
-        // Note: order is swapped because store_fp4x4 packs values with reversed order
-        vals_output[0] = static_cast<OType>(unpacked_f2_0.y * decode_scale);
-        vals_output[1] = static_cast<OType>(unpacked_f2_0.x * decode_scale);
-        vals_output[2] = static_cast<OType>(unpacked_f2_1.y * decode_scale);
-        vals_output[3] = static_cast<OType>(unpacked_f2_1.x * decode_scale);
+        if constexpr (HiFirst) {
+            vals_output[0] = static_cast<OType>(unpacked_f2_0.y * decode_scale);
+            vals_output[1] = static_cast<OType>(unpacked_f2_0.x * decode_scale);
+            vals_output[2] = static_cast<OType>(unpacked_f2_1.y * decode_scale);
+            vals_output[3] = static_cast<OType>(unpacked_f2_1.x * decode_scale);
+        } else {
+            vals_output[0] = static_cast<OType>(unpacked_f2_0.x * decode_scale);
+            vals_output[1] = static_cast<OType>(unpacked_f2_0.y * decode_scale);
+            vals_output[2] = static_cast<OType>(unpacked_f2_1.x * decode_scale);
+            vals_output[3] = static_cast<OType>(unpacked_f2_1.y * decode_scale);
+        }
     }
     
     // Store output using vectorized writes
@@ -318,6 +331,7 @@ void launch_quantize_nvfp4_kernel(
     int64_t orig_cols,
     float epsilon,
     int input_dtype_code,
+    bool hi_first,
     cudaStream_t stream) {
     
     if (num_rows == 0 || num_cols == 0) {
@@ -339,38 +353,28 @@ void launch_quantize_nvfp4_kernel(
     constexpr int threads_per_block = 128;  // CUDA block size
     const int64_t total_threads_needed = numel / comfy::kValsPerThread;
     const int blocks = static_cast<int>((total_threads_needed + threads_per_block - 1) / threads_per_block);
-    
-    // Dispatch based on input dtype (only FP16/BF16 supported)
-    // Input dtype codes: 1=float16, 2=bfloat16
+
+    // Macro to reduce duplication across misaligned x hi_first combinations
+    #define LAUNCH_QUANT_KERNEL(MISALIGNED, HI_FIRST) \
+        comfy::quantize_nvfp4_kernel<InputType, __nv_fp4x2_e2m1, __nv_fp8_e4m3, MISALIGNED, HI_FIRST> \
+            <<<blocks, threads_per_block, 0, stream>>>( \
+                static_cast<const InputType*>(input), \
+                scale_f, \
+                static_cast<__nv_fp4x2_e2m1*>(output), \
+                static_cast<__nv_fp8_e4m3*>(block_scales), \
+                num_cols, num_rows, orig_rows, orig_cols, epsilon)
+
     DISPATCH_HALF_DTYPE(input_dtype_code, InputType, [&] {
         if (misaligned) {
-            // Misaligned path: loads values one at a time with bounds checking
-            comfy::quantize_nvfp4_kernel<InputType, __nv_fp4x2_e2m1, __nv_fp8_e4m3, true>
-                <<<blocks, threads_per_block, 0, stream>>>(
-                    static_cast<const InputType*>(input),
-                    scale_f,
-                    static_cast<__nv_fp4x2_e2m1*>(output),
-                    static_cast<__nv_fp8_e4m3*>(block_scales),
-                    num_cols,
-                    num_rows,
-                    orig_rows,
-                    orig_cols,
-                    epsilon);
+            if (hi_first) { LAUNCH_QUANT_KERNEL(true, true); }
+            else          { LAUNCH_QUANT_KERNEL(true, false); }
         } else {
-            // Aligned path: uses vectorized loads
-            comfy::quantize_nvfp4_kernel<InputType, __nv_fp4x2_e2m1, __nv_fp8_e4m3, false>
-                <<<blocks, threads_per_block, 0, stream>>>(
-                    static_cast<const InputType*>(input),
-                    scale_f,
-                    static_cast<__nv_fp4x2_e2m1*>(output),
-                    static_cast<__nv_fp8_e4m3*>(block_scales),
-                    num_cols,
-                    num_rows,
-                    orig_rows,
-                    orig_cols,
-                    epsilon);
+            if (hi_first) { LAUNCH_QUANT_KERNEL(false, true); }
+            else          { LAUNCH_QUANT_KERNEL(false, false); }
         }
     });
+
+    #undef LAUNCH_QUANT_KERNEL
     
     // Check for kernel launch errors
     cudaError_t err = cudaGetLastError();
@@ -387,6 +391,7 @@ void launch_dequantize_nvfp4_kernel(
     int64_t num_rows,
     int64_t num_cols,
     int output_dtype_code,
+    bool hi_first,
     cudaStream_t stream) {
 
     if (num_rows == 0 || num_cols == 0) {
@@ -405,19 +410,22 @@ void launch_dequantize_nvfp4_kernel(
     constexpr int threads_per_block = 128;
     const int64_t total_threads_needed = numel / comfy::kValsPerThread;
     const int blocks = static_cast<int>((total_threads_needed + threads_per_block - 1) / threads_per_block);
-    
-    // Dispatch based on output dtype
-    // Output dtype codes: 0=float32, 1=float16, 2=bfloat16
+
+    #define LAUNCH_DEQUANT_KERNEL(HI_FIRST) \
+        comfy::dequantize_nvfp4_kernel<__nv_fp4x2_e2m1, OutputType, __nv_fp8_e4m3, HI_FIRST> \
+            <<<blocks, threads_per_block, 0, stream>>>( \
+                static_cast<const __nv_fp4x2_e2m1*>(input), \
+                scale_f, \
+                static_cast<const __nv_fp8_e4m3*>(block_scales), \
+                static_cast<OutputType*>(output), \
+                num_cols, num_rows)
+
     DISPATCH_FP_DTYPE(output_dtype_code, OutputType, [&] {
-        comfy::dequantize_nvfp4_kernel<__nv_fp4x2_e2m1, OutputType, __nv_fp8_e4m3>
-            <<<blocks, threads_per_block, 0, stream>>>(
-                static_cast<const __nv_fp4x2_e2m1*>(input),
-                scale_f,
-                static_cast<const __nv_fp8_e4m3*>(block_scales),
-                static_cast<OutputType*>(output),
-                num_cols,
-                num_rows);
+        if (hi_first) { LAUNCH_DEQUANT_KERNEL(true); }
+        else          { LAUNCH_DEQUANT_KERNEL(false); }
     });
+
+    #undef LAUNCH_DEQUANT_KERNEL
     
     // Check for kernel launch errors
     cudaError_t err = cudaGetLastError();

--- a/comfy_kitchen/backends/eager/quantization.py
+++ b/comfy_kitchen/backends/eager/quantization.py
@@ -65,6 +65,7 @@ def quantize_nvfp4(
     per_tensor_scale: torch.Tensor,
     epsilon: float = 0.0,
     pad_16x: bool = False,
+    hi_first: bool = True,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     orig_shape = x.shape
 
@@ -102,7 +103,7 @@ def quantize_nvfp4(
     data_scaled = data_scaled.view(orig_shape)
 
     data_lp = _f32_to_floatx_unpacked(data_scaled, 2, 1)
-    data_lp = pack_uint4(data_lp)
+    data_lp = pack_uint4(data_lp, hi_first=hi_first)
     blocked_scales = to_blocked(out_scales.to(torch.float8_e4m3fn), flatten=False)
     return data_lp, blocked_scales
 
@@ -120,6 +121,7 @@ def dequantize_nvfp4(
     per_tensor_scale: torch.Tensor,
     block_scales: torch.Tensor,
     output_type: torch.dtype = torch.bfloat16,
+    hi_first: bool = True,
 ) -> torch.Tensor:
     lut = E2M1_LUT_CACHE.get((qx.device, output_type))
     if lut is None:
@@ -128,7 +130,10 @@ def dequantize_nvfp4(
 
     lo = qx & 0x0F
     hi = qx >> 4
-    out = torch.stack([hi, lo], dim=-1).view(*qx.shape[:-1], -1)
+    if hi_first:
+        out = torch.stack([hi, lo], dim=-1).view(*qx.shape[:-1], -1)
+    else:
+        out = torch.stack([lo, hi], dim=-1).view(*qx.shape[:-1], -1)
     out = torch.nn.functional.embedding(out.int(), lut).squeeze(-1)
 
     # Get original shape (packed tensor has half the columns)
@@ -417,6 +422,7 @@ def _op_quantize_nvfp4(
     per_tensor_scale: torch.Tensor,
     epsilon: float,
     pad_16x: bool,
+    hi_first: bool,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Quantize tensor to NVFP4 format with block-wise scaling.
 
@@ -425,19 +431,21 @@ def _op_quantize_nvfp4(
         per_tensor_scale: Global scale factor
         epsilon: Epsilon for numerical stability
         pad_16x: If True, pad dimensions to be divisible by 16
+        hi_first: If True, the even-indexed element is packed into the high nibble (default).
+                  If False, the even-indexed element goes into the low nibble.
 
     Returns:
         Tuple of (quantized_tensor, block_scales)
     """
     from comfy_kitchen.registry import registry
 
-    kwargs = {"x": x, "per_tensor_scale": per_tensor_scale, "epsilon": epsilon, "pad_16x": pad_16x}
+    kwargs = {"x": x, "per_tensor_scale": per_tensor_scale, "epsilon": epsilon, "pad_16x": pad_16x, "hi_first": hi_first}
     impl = registry.get_implementation("quantize_nvfp4", kwargs=kwargs)
     return impl(**kwargs)
 
 
 @_op_quantize_nvfp4.register_fake
-def _op_quantize_nvfp4_fake(x, per_tensor_scale, epsilon, pad_16x):
+def _op_quantize_nvfp4_fake(x, per_tensor_scale, epsilon, pad_16x, hi_first):
     rows, cols = x.shape
 
     if pad_16x:
@@ -461,6 +469,7 @@ def _op_dequantize_nvfp4(
     per_tensor_scale: torch.Tensor,
     block_scales: torch.Tensor,
     output_dtype_code: int,
+    hi_first: bool,
 ) -> torch.Tensor:
     """Dequantize tensor from NVFP4 format with block-wise scaling.
 
@@ -469,6 +478,8 @@ def _op_dequantize_nvfp4(
         per_tensor_scale: Global scale factor
         block_scales: Block scales in swizzled layout (float8_e4m3fn)
         output_dtype_code: Target dtype code (0=float32, 1=float16, 2=bfloat16)
+        hi_first: If True, the high nibble is the even-indexed element (default).
+                  If False, the low nibble is the even-indexed element.
 
     Returns:
         Dequantized tensor in specified output format
@@ -476,13 +487,13 @@ def _op_dequantize_nvfp4(
     from comfy_kitchen.registry import registry
 
     output_dtype = DTYPE_CODE_TO_DTYPE[output_dtype_code]
-    kwargs = {"qx": qx, "per_tensor_scale": per_tensor_scale, "block_scales": block_scales, "output_type": output_dtype}
+    kwargs = {"qx": qx, "per_tensor_scale": per_tensor_scale, "block_scales": block_scales, "output_type": output_dtype, "hi_first": hi_first}
     impl = registry.get_implementation("dequantize_nvfp4", kwargs=kwargs)
     return impl(**kwargs)
 
 
 @_op_dequantize_nvfp4.register_fake
-def _op_dequantize_nvfp4_fake(qx, per_tensor_scale, block_scales, output_dtype_code):
+def _op_dequantize_nvfp4_fake(qx, per_tensor_scale, block_scales, output_dtype_code, hi_first):
     output_dtype = DTYPE_CODE_TO_DTYPE[output_dtype_code]
     # Unpacked shape: cols * 2 (since 2 FP4 values per uint8)
     rows, cols_packed = qx.shape

--- a/comfy_kitchen/backends/triton/quantization.py
+++ b/comfy_kitchen/backends/triton/quantization.py
@@ -204,6 +204,7 @@ def quantize_nvfp4_kernel_tl(
     padded_scale_cols,
     block_size: tl.constexpr,
     blocks_per_program: tl.constexpr,
+    hi_first: tl.constexpr,
 ):
     """Single Triton kernel for NVFP4 quantization with packing and scale swizzling.
 
@@ -295,6 +296,12 @@ def quantize_nvfp4_kernel_tl(
             f32_even = tl.sum(tl.where(indices == even_idx[:, None], data_scaled, 0), axis=1)
             f32_odd = tl.sum(tl.where(indices == odd_idx[:, None], data_scaled, 0), axis=1)
 
+            # cvt.rn.satfinite.e2m1x2.f32 packs $1 into the high nibble, $2 into the low nibble.
+            if hi_first:
+                asm_arg_hi, asm_arg_lo = f32_even, f32_odd
+            else:
+                asm_arg_hi, asm_arg_lo = f32_odd, f32_even
+
             packed_bytes_u16 = tl.inline_asm_elementwise(
                 asm="""
                 {
@@ -306,7 +313,7 @@ def quantize_nvfp4_kernel_tl(
                 }
                 """,
                 constraints="=h,f,f",
-                args=[f32_even, f32_odd],
+                args=[asm_arg_hi, asm_arg_lo],
                 dtype=tl.uint16,
                 is_pure=True,
                 pack=1,
@@ -325,6 +332,7 @@ def quantize_nvfp4(
     per_tensor_scale: torch.Tensor,
     epsilon: float = 0.0,
     pad_16x: bool = False,
+    hi_first: bool = True,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     # Note: epsilon is accepted for API compatibility but not currently used
     orig_shape = x.shape
@@ -393,6 +401,7 @@ def quantize_nvfp4(
         padded_scale_cols,
         block_size=block_size,
         blocks_per_program=blocks_per_program,
+        hi_first=hi_first,
     )
 
     # Reshape packed output to original shape (with last dim halved)
@@ -415,6 +424,7 @@ def dequantize_nvfp4_kernel_tl(
     padded_scale_cols,
     block_size: tl.constexpr,
     tile_size: tl.constexpr,
+    hi_first: tl.constexpr,
 ):
     """Dequantizes FP4 packed data using per-block scaling factors.
 
@@ -506,11 +516,15 @@ def dequantize_nvfp4_kernel_tl(
     )
 
     # Apply scaling
-    # Note: Due to packing order ((even << 4) | odd) and PTX cvt.rn.f16x2.e2m1x2:
-    # - val_low (from low nibble) contains odd-indexed values
-    # - val_high (from high nibble) contains even-indexed values
-    result_even = val_high * scale_low.to(tl.float32) * global_scale
-    result_odd = val_low * scale_high.to(tl.float32) * global_scale
+    # PTX cvt.rn.f16x2.e2m1x2 unpacks: high nibble -> val_high, low nibble -> val_low.
+    # hi_first=True: high nibble = even-indexed element, low nibble = odd-indexed element.
+    # hi_first=False: high nibble = odd-indexed element, low nibble = even-indexed element.
+    if hi_first:
+        result_even = val_high * scale_low.to(tl.float32) * global_scale
+        result_odd = val_low * scale_high.to(tl.float32) * global_scale
+    else:
+        result_even = val_low * scale_low.to(tl.float32) * global_scale
+        result_odd = val_high * scale_high.to(tl.float32) * global_scale
 
     # Store results
     out_mask_low = packed_mask & (out_col_low < n)
@@ -525,6 +539,7 @@ def dequantize_nvfp4(
     per_tensor_scale: torch.Tensor,
     block_scales: torch.Tensor,
     output_type: torch.dtype = torch.bfloat16,
+    hi_first: bool = True,
 ) -> torch.Tensor:
     # Triton backend: fused kernel with inline SM100 cvt.rn.f16x2.e2m1x2 instruction
     block_size = 16
@@ -558,6 +573,7 @@ def dequantize_nvfp4(
         padded_scale_cols,
         block_size=block_size,
         tile_size=tile_size,
+        hi_first=hi_first,
     )
 
     return output

--- a/comfy_kitchen/float_utils.py
+++ b/comfy_kitchen/float_utils.py
@@ -250,23 +250,43 @@ def ceil_div(a, b):
     return (a + b - 1) // b
 
 
-def pack_uint4(uint8_data: torch.Tensor) -> torch.Tensor:
-    # converting to uint8 for operations
+def pack_uint4(uint8_data: torch.Tensor, hi_first: bool = True) -> torch.Tensor:
     shape = uint8_data.shape
     assert shape[-1] % 2 == 0
     uint8_data = uint8_data.contiguous().view(-1)
-    return (uint8_data[::2] << 4 | uint8_data[1::2]).view(down_size(shape))
+    if hi_first:
+        return (uint8_data[::2] << 4 | uint8_data[1::2]).view(down_size(shape))
+    else:
+        return (uint8_data[1::2] << 4 | uint8_data[::2]).view(down_size(shape))
 
 
-def unpack_uint4(uint8_data) -> torch.Tensor:
+def unpack_uint4(uint8_data, hi_first: bool = True) -> torch.Tensor:
     """Get the original weight from the normalized float weight format"""
     assert uint8_data.is_contiguous()
     shape = uint8_data.shape
 
-    first_elements = (uint8_data >> 4).to(torch.uint8)
-    second_elements = (uint8_data & 0b1111).to(torch.uint8)
-    unpacked = torch.stack([first_elements, second_elements], dim=-1).view(up_size(shape))
+    hi = (uint8_data >> 4).to(torch.uint8)
+    lo = (uint8_data & 0b1111).to(torch.uint8)
+    if hi_first:
+        unpacked = torch.stack([hi, lo], dim=-1).view(up_size(shape))
+    else:
+        unpacked = torch.stack([lo, hi], dim=-1).view(up_size(shape))
     return unpacked
+
+
+def swap_nibbles(packed: torch.Tensor) -> torch.Tensor:
+    """Exchange the high and low nibbles of each byte in a uint8 tensor.
+
+    This converts between hi_first=True and hi_first=False FP4 packing
+    without re-quantizing: ``0xAB`` becomes ``0xBA``.
+
+    Args:
+        packed: A uint8 tensor of nibble-packed FP4 values.
+
+    Returns:
+        A new uint8 tensor with the nibble order reversed in every byte.
+    """
+    return ((packed << 4) | (packed >> 4)).to(torch.uint8)
 
 
 def to_blocked(input_matrix, flatten: bool = True) -> torch.Tensor:
@@ -332,8 +352,8 @@ def from_blocked(blocked_matrix, num_rows: int, num_cols: int) -> torch.Tensor:
     return unblocked[:num_rows, :num_cols]
 
 
-def fp4_x2_to_f32(a):
-    a_u8 = unpack_uint4(a)
+def fp4_x2_to_f32(a, hi_first: bool = True):
+    a_u8 = unpack_uint4(a, hi_first=hi_first)
     a_f32 = _floatx_unpacked_to_f32(a_u8, 2, 1)
     return a_f32
 

--- a/tests/test_qdq.py
+++ b/tests/test_qdq.py
@@ -6,6 +6,7 @@ from comfy_kitchen.float_utils import (
     F4_E2M1_MAX,
     F8_E4M3_MAX,
     fp4_x2_to_f32,
+    swap_nibbles,
 )
 
 from .conftest import (
@@ -253,8 +254,137 @@ class TestDequantizeNVFP4:
                 ref_result,
                 rtol=1e-3,
                 atol=1e-2,
+                max_mismatch_ratio=0.05,
                 name=f"dequantized output ({backend_name} vs eager)"
             )
+
+
+# =============================================================================
+# NVFP4 Nibble Packing Order Tests
+# =============================================================================
+
+
+class TestNVFP4HiFirst:
+    """Tests for the hi_first nibble packing order switch."""
+
+    @pytest.fixture
+    def capable_backends(self, device):
+        backends = get_capable_backends("quantize_nvfp4", device)
+        if not backends:
+            pytest.skip(f"No backend supports quantize_nvfp4 on {device}")
+        return backends
+
+    def test_hi_first_default_matches_legacy(self, capable_backends, device, seed):
+        """Verify hi_first=True (default) produces the same output as the original code."""
+        x = torch.randn(64, 128, device=device, dtype=torch.bfloat16) * 4
+        scale = (torch.max(torch.abs(x)) / (F8_E4M3_MAX * F4_E2M1_MAX)).to(torch.float32)
+
+        for backend_name in capable_backends:
+            with ck.use_backend(backend_name):
+                qx_default, sx_default = ck.quantize_nvfp4(x, scale)
+                qx_explicit, sx_explicit = ck.quantize_nvfp4(x, scale, hi_first=True)
+
+            assert torch.equal(qx_default, qx_explicit), f"{backend_name}: default != hi_first=True"
+            assert torch.equal(
+                sx_default.view(torch.uint8), sx_explicit.view(torch.uint8)
+            ), f"{backend_name}: scales differ"
+
+    def test_hi_first_false_swaps_nibbles(self, capable_backends, device, seed):
+        """hi_first=False should produce nibble-swapped packed bytes vs hi_first=True."""
+        x = torch.randn(64, 128, device=device, dtype=torch.bfloat16) * 4
+        scale = (torch.max(torch.abs(x)) / (F8_E4M3_MAX * F4_E2M1_MAX)).to(torch.float32)
+
+        for backend_name in capable_backends:
+            with ck.use_backend(backend_name):
+                qx_hi, sx_hi = ck.quantize_nvfp4(x, scale, hi_first=True)
+                qx_lo, sx_lo = ck.quantize_nvfp4(x, scale, hi_first=False)
+
+            # Scales are independent of packing order
+            assert torch.equal(
+                sx_hi.view(torch.uint8), sx_lo.view(torch.uint8)
+            ), f"{backend_name}: scales should be identical"
+
+            # Packed bytes should be nibble-swapped versions of each other
+            assert torch.equal(
+                swap_nibbles(qx_hi), qx_lo
+            ), f"{backend_name}: hi_first=False should be nibble-swapped hi_first=True"
+
+    def test_roundtrip_hi_first_true(self, capable_backends, device, seed):
+        """Quantize then dequantize with hi_first=True recovers original values."""
+        x = torch.randn(64, 128, device=device, dtype=torch.bfloat16) * 4
+        scale = (torch.max(torch.abs(x)) / (F8_E4M3_MAX * F4_E2M1_MAX)).to(torch.float32)
+
+        for backend_name in capable_backends:
+            with ck.use_backend(backend_name):
+                qx, sx = ck.quantize_nvfp4(x, scale, hi_first=True)
+                out = ck.dequantize_nvfp4(qx, scale, sx, output_type=torch.bfloat16, hi_first=True)
+
+            assert_values_close(
+                out.float(), x.float(), rtol=0.5, atol=2.0,
+                name=f"roundtrip hi_first=True ({backend_name})"
+            )
+
+    def test_roundtrip_hi_first_false(self, capable_backends, device, seed):
+        """Quantize then dequantize with hi_first=False recovers original values."""
+        x = torch.randn(64, 128, device=device, dtype=torch.bfloat16) * 4
+        scale = (torch.max(torch.abs(x)) / (F8_E4M3_MAX * F4_E2M1_MAX)).to(torch.float32)
+
+        for backend_name in capable_backends:
+            with ck.use_backend(backend_name):
+                qx, sx = ck.quantize_nvfp4(x, scale, hi_first=False)
+                out = ck.dequantize_nvfp4(qx, scale, sx, output_type=torch.bfloat16, hi_first=False)
+
+            assert_values_close(
+                out.float(), x.float(), rtol=0.5, atol=2.0,
+                name=f"roundtrip hi_first=False ({backend_name})"
+            )
+
+    def test_mismatched_hi_first_produces_wrong_result(self, capable_backends, device, seed):
+        """Using different hi_first for quant vs dequant should produce incorrect output."""
+        x = torch.randn(64, 128, device=device, dtype=torch.bfloat16) * 4
+        scale = (torch.max(torch.abs(x)) / (F8_E4M3_MAX * F4_E2M1_MAX)).to(torch.float32)
+
+        for backend_name in capable_backends:
+            with ck.use_backend(backend_name):
+                qx, sx = ck.quantize_nvfp4(x, scale, hi_first=True)
+                out_correct = ck.dequantize_nvfp4(qx, scale, sx, output_type=torch.bfloat16, hi_first=True)
+                out_wrong = ck.dequantize_nvfp4(qx, scale, sx, output_type=torch.bfloat16, hi_first=False)
+
+            # The wrong packing order should give a meaningfully different result
+            assert not torch.allclose(
+                out_correct.float(), out_wrong.float(), rtol=1e-2, atol=1e-2
+            ), f"{backend_name}: mismatched hi_first should produce different output"
+
+    def test_cross_backend_consistency_hi_first_false(self, capable_backends, device, seed):
+        """All backends should agree when hi_first=False.
+
+        We test dequant-only (same packed input, different dequant backends)
+        to isolate the hi_first logic from pre-existing block-scale
+        quantization differences between eager and GPU backends.
+        """
+        if len(capable_backends) < 2:
+            pytest.skip("Need at least 2 backends for cross-validation")
+
+        x = torch.randn(64, 128, device=device, dtype=torch.bfloat16) * 4
+        scale = (torch.max(torch.abs(x)) / (F8_E4M3_MAX * F4_E2M1_MAX)).to(torch.float32)
+
+        with ck.use_backend(capable_backends[0]):
+            qx, sx = ck.quantize_nvfp4(x, scale, hi_first=False)
+
+        results = {}
+        for backend_name in capable_backends:
+            with ck.use_backend(backend_name):
+                out = ck.dequantize_nvfp4(qx, scale, sx, output_type=torch.bfloat16, hi_first=False)
+                results[backend_name] = out
+
+        ref_name = capable_backends[0]
+        ref = results[ref_name]
+        for name, result in results.items():
+            if name != ref_name:
+                assert_values_close(
+                    result.float(), ref.float(), rtol=1e-3, atol=1e-2,
+                    name=f"hi_first=False cross-backend ({name} vs {ref_name})"
+                )
 
 
 # =============================================================================


### PR DESCRIPTION
NVFP4 requires two 4-bit values to be packed into an 8-bit container. When doing this there is ambiguity on the order of packing two values A,B in physical memory as either [A|B] or [B|A].

This PR adds the functionality to control this behaviour when running the Q/DQ and adds helpers to change the layout. 