### PR TITLE
[docs] Fix QuantizedTensor.from_float examples to use layout name strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ The library provides `QuantizedTensor`, a `torch.Tensor` subclass that transpare
 | `TensorCoreMXFP8Layout`| MXFP8 E4M3   | SM ≥ 10.0 (Blackwell) | Block quantization with 32-element blocks, E8M0 scales |
 
 ```python
-from comfy_kitchen.tensor import QuantizedTensor, TensorCoreFP8Layout, TensorCoreNVFP4Layout
+from comfy_kitchen.tensor import QuantizedTensor
 
 # Quantize a tensor
 x = torch.randn(128, 256, device="cuda", dtype=torch.bfloat16)
-qt = QuantizedTensor.from_float(x, TensorCoreFP8Layout)
+qt = QuantizedTensor.from_float(x, "TensorCoreFP8Layout")
 
 # Operations dispatch to optimized kernels automatically
 output = torch.nn.functional.linear(qt, weight_qt)

--- a/comfy_kitchen/tensor/fp8.py
+++ b/comfy_kitchen/tensor/fp8.py
@@ -23,7 +23,7 @@ class TensorCoreFP8Layout(QuantizedLayout):
 
     Example:
         >>> x = torch.randn(128, 256, device="cuda", dtype=torch.bfloat16)
-        >>> qt = QuantizedTensor.from_float(x, TensorCoreFP8Layout)
+        >>> qt = QuantizedTensor.from_float(x, "TensorCoreFP8Layout")
         >>> qt.shape
         torch.Size([128, 256])
         >>> dq = qt.dequantize()


### PR DESCRIPTION
## Summary

This PR updates the `QuantizedTensor.from_float(...)` examples to match the current API.

## What changed

- Fixed the README example to pass the registered layout name string
- Fixed the `TensorCoreFP8Layout` docstring example to do the same

## Why

`QuantizedTensor.from_float(...)` currently expects `layout_cls` to be the registered layout name string, not the layout class object itself. Internally, the implementation resolves that string through the `LAYOUTS` registry in `comfy_kitchen.tensor.base`. While the codebase and test suite correctly pass this string, the README examples and docstrings pass the layout class object.

As a result, passing `TensorCoreFP8Layout` directly raises a lookup error, while passing `"TensorCoreFP8Layout"` works as intended. This PR updates the examples to reflect the behavior implemented by the current API.

## Scope

Documentation only; no implementation changes.