### PR TITLE
Add cutlass int8 kernel

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v5
@@ -117,6 +119,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v5
@@ -199,6 +203,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Install CUDA Toolkit 13.0.2
         uses: Jimver/cuda-toolkit@v0.2.29
@@ -371,6 +377,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
@@ -416,6 +424,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5

--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,3 @@ uv.lock
 .idea/
 *.pyd
 *.so
-.*/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "third_party/cutlass"]
+	path = third_party/cutlass
+	url = https://github.com/NVIDIA/cutlass.git

--- a/comfy_kitchen/backends/cuda/CMakeLists.txt
+++ b/comfy_kitchen/backends/cuda/CMakeLists.txt
@@ -106,6 +106,7 @@ set(CUDA_SOURCES
     ops/quantize_mxfp8.cu
     ops/cublas_gemm_nvfp4.cu
     ops/cublas_gemm_int8.cu
+    ops/cutlass_gemm_int8.cu
     ops/int8_linear.cu
     ops/apply_rope.cu
     ops/quantize_svdquant_w4a4.cu
@@ -148,6 +149,20 @@ target_include_directories(_C PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CUDAToolkit_INCLUDE_DIRS}
 )
+
+# CUTLASS (header-only) for the near-peak INT8 GEMM. Vendored at
+# third_party/cutlass (or pass -DCOMFY_CUTLASS_DIR). Optional: without it the
+# CUTLASS op compiles to a stub and int8_linear falls back to cuBLAS.
+if(NOT DEFINED COMFY_CUTLASS_DIR)
+    set(COMFY_CUTLASS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../third_party/cutlass/include")
+endif()
+if(EXISTS "${COMFY_CUTLASS_DIR}/cutlass/version.h")
+    message(STATUS "CUTLASS found: ${COMFY_CUTLASS_DIR}")
+    target_include_directories(_C PRIVATE ${COMFY_CUTLASS_DIR})
+    target_compile_definitions(_C PRIVATE COMFY_HAVE_CUTLASS)
+else()
+    message(STATUS "CUTLASS not found at ${COMFY_CUTLASS_DIR} - int8 GEMM uses cuBLAS only")
+endif()
 
 # Link libraries
 # Note: cuBLASLt is loaded dynamically at runtime via dlopen/LoadLibrary

--- a/comfy_kitchen/backends/cuda/__init__.py
+++ b/comfy_kitchen/backends/cuda/__init__.py
@@ -359,6 +359,39 @@ def quantize_int8_rowwise(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
     return q_2d.reshape(orig_shape), scales_2d.reshape(*orig_shape[:-1], 1)
 
 
+def quantize_int8_rowwise_convrot(x_2d: torch.Tensor, group_size: int) -> tuple[torch.Tensor, torch.Tensor]:
+    """Fused online ConvRot rotation + per-row INT8 quantization (single kernel).
+
+    Avoids materializing the rotated bf16 activation in global memory. Expects a
+    contiguous 2D [M, K] input with K divisible by group_size (256 only).
+    """
+    q_2d = torch.empty_like(x_2d, dtype=torch.int8)
+    scales_2d = torch.empty((x_2d.shape[0], 1), dtype=torch.float32, device=x_2d.device)
+    stream_ptr = torch.cuda.current_stream(x_2d.device).cuda_stream
+
+    _C.quantize_int8_rowwise_convrot(
+        _wrap_for_dlpack(x_2d),
+        _wrap_for_dlpack(q_2d),
+        _wrap_for_dlpack(scales_2d),
+        group_size,
+        stream_ptr,
+    )
+
+    return q_2d, scales_2d
+
+
+# The fused kernel holds the whole rotated row ((K + tmp) * 4 bytes) in shared
+# memory. It uses a narrow 256-thread block for small K and a wide 1024-thread
+# block for large K to keep enough warps resident under the single-block-per-SM
+# regime. Cap K so the shared-memory request stays within the opt-in limit;
+# larger rows fall back to the rotate-matmul + rowwise-quant path.
+_CONVROT_FUSED_MAX_K = 16384
+
+# Set COMFY_KITCHEN_DISABLE_CUTLASS=1 to force the cuBLAS int8 GEMM + separate
+# dequant path (for benchmarking against the CUTLASS fused kernel).
+_DISABLE_CUTLASS_INT8 = os.environ.get("COMFY_KITCHEN_DISABLE_CUTLASS", "0") == "1"
+
+
 def quantize_int8_tensorwise(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
     """Quantize tensor to INT8 with a single tensor-wise scale."""
     return eager_quantize_int8_tensorwise(x)
@@ -546,16 +579,34 @@ def int8_linear(
     convrot: bool = False,
     convrot_groupsize: int = 256,
 ) -> torch.Tensor:
-    if convrot:
-        h = _build_hadamard(convrot_groupsize, device=x.device, dtype=x.dtype)
-        x = _rotate_activation(x, h, convrot_groupsize)
-
     orig_shape = x.shape
     x_2d = x.reshape(-1, x.shape[-1]).contiguous()
     weight = weight.contiguous()
 
     # cuBLAS INT8 GEMM requires row-wise quantized activations and tensor-wise quantized weights.
-    x_qdata, x_scale = quantize_int8_rowwise(x_2d)
+    if convrot:
+        K = x_2d.shape[-1]
+        # Fused wins for small K (narrow block) and large K (wide block); the
+        # 5120 < K < 8192 band loses to the rotate-matmul path on both, so skip
+        # it. (Real model hidden dims avoid that band anyway.)
+        use_fused = (
+            convrot_groupsize == 256 and K % 256 == 0 and K <= _CONVROT_FUSED_MAX_K
+            and (K <= 5120 or K >= 8192)
+        )
+        x_qdata = None
+        if use_fused:
+            try:
+                # Fused single-kernel rotation + row-wise quant (no bf16 HBM round-trip).
+                x_qdata, x_scale = quantize_int8_rowwise_convrot(x_2d, convrot_groupsize)
+            except RuntimeError:
+                x_qdata = None  # e.g. shared-memory request rejected; fall back
+        if x_qdata is None:
+            # Fallback: standalone rotation matmul, then row-wise quant.
+            h = _build_hadamard(convrot_groupsize, device=x_2d.device, dtype=x_2d.dtype)
+            x_rot = _rotate_activation(x_2d, h, convrot_groupsize)
+            x_qdata, x_scale = quantize_int8_rowwise(x_rot)
+    else:
+        x_qdata, x_scale = quantize_int8_rowwise(x_2d)
 
     m, k = x_2d.shape
     n, k_w = weight.shape
@@ -569,26 +620,47 @@ def int8_linear(
         bias_arg = bias.to(device=x.device).contiguous()
     stream_ptr = torch.cuda.current_stream(x.device).cuda_stream
 
-    # cuBLAS INT8 GEMM outputs int32
-    out_int32 = torch.empty((m, n), dtype=torch.int32, device=x.device)
-
-    _C.cublas_gemm_int8(
-        _wrap_for_dlpack(x_qdata),
-        _wrap_for_dlpack(weight),
-        _wrap_for_dlpack(out_int32),
-        _wrap_for_dlpack(get_cublas_workspace()),
-        stream_ptr,
-    )
-
-    _C.dequantize_int8_linear(
-        _wrap_for_dlpack(out_int32),
-        _wrap_for_dlpack(x_scale),
-        _wrap_for_dlpack(weight_scale),
-        _wrap_for_dlpack(bias_arg),
-        _wrap_for_dlpack(out),
-        DTYPE_TO_CODE[out_dtype],
-        stream_ptr,
-    )
+    # Preferred path: CUTLASS int8 GEMM with a FUSED rowwise x colwise dequant +
+    # bias epilogue (one near-peak kernel, no int32 round-trip). Beats cuBLAS
+    # ~1.1-1.8x and Triton ~1.0-1.2x on tall-skinny diffusion shapes. CUTLASS's
+    # epilogue scales are fp32, so pass fp32 scales/bias.
+    x_scale_f = x_scale.reshape(-1).contiguous()
+    # CUTLASS dequant needs a per-output-channel [N] weight scale; broadcast a
+    # tensor-wise (scalar) scale to [N].
+    ws_cutlass = weight_scale if weight_scale.numel() == n else weight_scale.expand(n).contiguous()
+    bias_f32 = (bias_arg.to(torch.float32).contiguous()
+                if bias is not None else torch.empty(0, dtype=torch.float32, device=x.device))
+    used_cutlass = False
+    if not _DISABLE_CUTLASS_INT8:
+        used_cutlass = _C.cutlass_int8_dequant(
+            _wrap_for_dlpack(x_qdata),
+            _wrap_for_dlpack(weight),
+            _wrap_for_dlpack(x_scale_f),
+            _wrap_for_dlpack(ws_cutlass),
+            _wrap_for_dlpack(bias_f32),
+            _wrap_for_dlpack(out),
+            DTYPE_TO_CODE[out_dtype],
+            stream_ptr,
+        )
+    if not used_cutlass:
+        # Fallback: cuBLAS int8 GEMM (int32) + separate dequant kernel.
+        out_int32 = torch.empty((m, n), dtype=torch.int32, device=x.device)
+        _C.cublas_gemm_int8(
+            _wrap_for_dlpack(x_qdata),
+            _wrap_for_dlpack(weight),
+            _wrap_for_dlpack(out_int32),
+            _wrap_for_dlpack(get_cublas_workspace()),
+            stream_ptr,
+        )
+        _C.dequantize_int8_linear(
+            _wrap_for_dlpack(out_int32),
+            _wrap_for_dlpack(x_scale),
+            _wrap_for_dlpack(weight_scale),
+            _wrap_for_dlpack(bias_arg),
+            _wrap_for_dlpack(out),
+            DTYPE_TO_CODE[out_dtype],
+            stream_ptr,
+        )
 
     return out.reshape(*orig_shape[:-1], n)
 

--- a/comfy_kitchen/backends/cuda/__init__.py
+++ b/comfy_kitchen/backends/cuda/__init__.py
@@ -585,13 +585,13 @@ def int8_linear(
 
     # cuBLAS INT8 GEMM requires row-wise quantized activations and tensor-wise quantized weights.
     if convrot:
-        K = x_2d.shape[-1]
+        k = x_2d.shape[-1]
         # Fused wins for small K (narrow block) and large K (wide block); the
         # 5120 < K < 8192 band loses to the rotate-matmul path on both, so skip
         # it. (Real model hidden dims avoid that band anyway.)
         use_fused = (
-            convrot_groupsize == 256 and K % 256 == 0 and K <= _CONVROT_FUSED_MAX_K
-            and (K <= 5120 or K >= 8192)
+            convrot_groupsize == 256 and k % 256 == 0 and k <= _CONVROT_FUSED_MAX_K
+            and (k <= 5120 or k >= 8192)
         )
         x_qdata = None
         if use_fused:

--- a/comfy_kitchen/backends/cuda/dlpack_bindings.cpp
+++ b/comfy_kitchen/backends/cuda/dlpack_bindings.cpp
@@ -748,6 +748,29 @@ extern "C" {
         int input_dtype_code,
         cudaStream_t stream);
 
+    bool launch_cutlass_int8_dequant(
+        const void* A,
+        const void* B,
+        const void* xs,
+        const void* ws,
+        const void* bias,
+        void* D,
+        int64_t M,
+        int64_t N,
+        int64_t K,
+        int out_dtype_code,
+        cudaStream_t stream);
+
+    void launch_quantize_int8_rowwise_convrot_kernel(
+        const void* input,
+        void* output,
+        void* scales,
+        int64_t num_rows,
+        int64_t num_cols,
+        int group_size,
+        int input_dtype_code,
+        cudaStream_t stream);
+
     void launch_dequantize_int8_linear_kernel(
         const void* input,
         const void* x_scales,
@@ -831,6 +854,62 @@ void quantize_int8_rowwise(
         scales.data(),
         M,
         K,
+        input_dtype_code,
+        stream);
+}
+
+// INT8 GEMM + fused dequant (D = acc * xs[m] * ws[n] + bias[n]) via CUTLASS.
+// Returns true on success; false means caller falls back to cuBLAS + dequant.
+bool cutlass_int8_dequant(
+    nb::ndarray<int8_t, nb::ndim<2>, nb::device::cuda> a,   // [M, K]
+    nb::ndarray<int8_t, nb::ndim<2>, nb::device::cuda> b,   // [N, K]
+    nb::ndarray<float, nb::device::cuda> xs,                // [M] per-row act scale
+    nb::ndarray<float, nb::device::cuda> ws,                // [N] per-col weight scale
+    nb::ndarray<nb::device::cuda> bias,                     // [N] float or empty
+    nb::ndarray<nb::ndim<2>, nb::device::cuda> d,           // [M, N] output
+    int out_dtype_code,
+    uintptr_t stream_ptr) {
+    const int64_t M = a.shape(0);
+    const int64_t K = a.shape(1);
+    const int64_t N = b.shape(0);
+    if (b.shape(1) != K) throw std::runtime_error("cutlass_int8_dequant: K mismatch");
+    if (d.shape(0) != M || d.shape(1) != N) throw std::runtime_error("cutlass_int8_dequant: D shape mismatch");
+    cudaStream_t stream = reinterpret_cast<cudaStream_t>(stream_ptr);
+    const void* bias_ptr = bias.size() > 0 ? bias.data() : nullptr;
+    return launch_cutlass_int8_dequant(a.data(), b.data(), xs.data(), ws.data(),
+                                       bias_ptr, d.data(), M, N, K, out_dtype_code, stream);
+}
+
+void quantize_int8_rowwise_convrot(
+    nb::ndarray<nb::ndim<2>, nb::device::cuda> input,
+    nb::ndarray<int8_t, nb::ndim<2>, nb::device::cuda> output,
+    nb::ndarray<float, nb::ndim<2>, nb::device::cuda> scales,
+    int64_t group_size,
+    uintptr_t stream_ptr) {
+
+    const int64_t M = input.shape(0);
+    const int64_t K = input.shape(1);
+
+    if (output.shape(0) != M || output.shape(1) != K) {
+        throw std::runtime_error("INT8 rowwise convrot output shape mismatch");
+    }
+    if (scales.shape(0) != M || scales.shape(1) != 1) {
+        throw std::runtime_error("INT8 rowwise convrot scale shape mismatch");
+    }
+
+    const int input_dtype_code = map_dtype_to_code(input.dtype());
+    if (input_dtype_code < 0 || input_dtype_code > 2) {
+        throw std::runtime_error("Unsupported input dtype for INT8 rowwise convrot quantization");
+    }
+
+    cudaStream_t stream = reinterpret_cast<cudaStream_t>(stream_ptr);
+    launch_quantize_int8_rowwise_convrot_kernel(
+        input.data(),
+        output.data(),
+        scales.data(),
+        M,
+        K,
+        static_cast<int>(group_size),
         input_dtype_code,
         stream);
 }
@@ -943,6 +1022,25 @@ NB_MODULE(_C, m) {
           nb::arg("input"),
           nb::arg("output"),
           nb::arg("scales"),
+          nb::arg("stream_ptr"));
+
+    m.def("cutlass_int8_dequant", &cutlass_int8_dequant,
+          "INT8 GEMM + fused rowwise x colwise dequant + bias via CUTLASS; false -> fall back to cuBLAS",
+          nb::arg("a"),
+          nb::arg("b"),
+          nb::arg("xs"),
+          nb::arg("ws"),
+          nb::arg("bias"),
+          nb::arg("d"),
+          nb::arg("out_dtype_code"),
+          nb::arg("stream_ptr"));
+
+    m.def("quantize_int8_rowwise_convrot", &quantize_int8_rowwise_convrot,
+          "Fused ConvRot Hadamard rotation + rowwise INT8 quantization",
+          nb::arg("input"),
+          nb::arg("output"),
+          nb::arg("scales"),
+          nb::arg("group_size"),
           nb::arg("stream_ptr"));
 
     m.def("dequantize_int8_linear", &dequantize_int8_linear,

--- a/comfy_kitchen/backends/cuda/ops/cutlass_gemm_int8.cu
+++ b/comfy_kitchen/backends/cuda/ops/cutlass_gemm_int8.cu
@@ -1,0 +1,121 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * INT8 GEMM with a FUSED dequant epilogue via CUTLASS (EVT):
+ *   D[m,n] = (sum_k A[m,k]*B[n,k]) * x_scale[m] * w_scale[n] + bias[n]   -> out dtype
+ *
+ * Replaces cuBLAS-GEMM(int32) + separate dequant kernel with one near-peak
+ * kernel. cuBLAS's int8 IMMA is poorly tuned for tall-skinny diffusion shapes
+ * on sm_120; this beats it ~1.1-1.8x and beats Triton ~1.0-1.2x, with no Triton
+ * runtime dependency. Falls back to cuBLAS if CUTLASS is unavailable.
+ */
+#include <cuda_runtime.h>
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cstdint>
+
+#ifdef COMFY_HAVE_CUTLASS
+
+#include "cutlass/cutlass.h"
+#include "cutlass/gemm/device/gemm_universal_adapter.h"
+#include "cutlass/gemm/kernel/default_gemm_universal_with_visitor.h"
+#include "cutlass/epilogue/threadblock/fusion/visitors.hpp"
+
+namespace {
+using namespace cute;
+
+// One fused int8 GEMM specialized on the output element type.
+template <typename ElementOutput>
+struct FusedInt8Gemm {
+    using ElementA = int8_t; using ElementB = int8_t;
+    using ElementC = ElementOutput;
+    using ElementAcc = int32_t; using ElementCompute = float;
+    using LayoutA = cutlass::layout::RowMajor;
+    using LayoutB = cutlass::layout::ColumnMajor;   // B[N,K] row == [K,N] col
+    using LayoutC = cutlass::layout::RowMajor;
+    static constexpr int AlignA = 16, AlignB = 16;
+    static constexpr int AlignC = 128 / cutlass::sizeof_bits<ElementC>::value;
+    using TB   = cutlass::gemm::GemmShape<128, 256, 64>;
+    using Warp = cutlass::gemm::GemmShape<64, 64, 64>;
+    using Inst = cutlass::gemm::GemmShape<16, 8, 32>;
+    static constexpr int NumStages = 3, EVTStages = 1;
+
+    using ThreadMap = cutlass::epilogue::threadblock::OutputTileThreadLayout<TB, Warp, ElementC, AlignC, EVTStages>;
+
+    using Accum  = cutlass::epilogue::threadblock::VisitorAccFetch;
+    using XScale = cutlass::epilogue::threadblock::VisitorColBroadcast<ThreadMap, ElementCompute, cute::Stride<_1, _0, int32_t>>;
+    using WScale = cutlass::epilogue::threadblock::VisitorRowBroadcast<ThreadMap, ElementCompute, cute::Stride<_0, _1, int32_t>>;
+    using Bias   = cutlass::epilogue::threadblock::VisitorRowBroadcast<ThreadMap, ElementCompute, cute::Stride<_0, _1, int32_t>>;
+    using Mul0 = cutlass::epilogue::threadblock::VisitorCompute<cutlass::multiplies, ElementCompute, ElementCompute, cutlass::FloatRoundStyle::round_to_nearest>;
+    using EVT0 = cutlass::epilogue::threadblock::Sm80EVT<Mul0, Accum, XScale>;
+    using Mul1 = cutlass::epilogue::threadblock::VisitorCompute<cutlass::multiplies, ElementCompute, ElementCompute, cutlass::FloatRoundStyle::round_to_nearest>;
+    using EVT1 = cutlass::epilogue::threadblock::Sm80EVT<Mul1, EVT0, WScale>;
+    using Add2 = cutlass::epilogue::threadblock::VisitorCompute<cutlass::plus, ElementOutput, ElementCompute, cutlass::FloatRoundStyle::round_to_nearest>;
+    using EVT2 = cutlass::epilogue::threadblock::Sm80EVT<Add2, EVT1, Bias>;
+    using StoreD = cutlass::epilogue::threadblock::VisitorAuxStore<ThreadMap, ElementOutput, cutlass::FloatRoundStyle::round_to_nearest, cute::Stride<int64_t, _1, int64_t>>;
+    using EVTD = cutlass::epilogue::threadblock::Sm80EVT<StoreD, EVT2>;
+
+    using GemmKernel = typename cutlass::gemm::kernel::DefaultGemmWithVisitor<
+        ElementA, LayoutA, cutlass::ComplexTransform::kNone, AlignA,
+        ElementB, LayoutB, cutlass::ComplexTransform::kNone, AlignB,
+        ElementC, LayoutC, AlignC,
+        ElementAcc, ElementCompute,
+        cutlass::arch::OpClassTensorOp, cutlass::arch::Sm80,
+        TB, Warp, Inst, EVTD,
+        cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>,
+        NumStages, cutlass::arch::OpMultiplyAddSaturate, EVTStages>::GemmKernel;
+    using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+
+    static bool run(const int8_t* A, const int8_t* B, const float* xs, const float* ws,
+                    const float* bias, ElementOutput* D, int M, int N, int K, cudaStream_t stream) {
+        cutlass::gemm::GemmCoord problem(M, N, K);
+        typename EVTD::Arguments cb{
+            { {  { {}, {const_cast<float*>(xs), 0.f, {_1{}, _0{}, M}}, {} },     // acc * xs
+                 {const_cast<float*>(ws), 0.f, {_0{}, _1{}, N}}, {} },           // * ws
+              {const_cast<float*>(bias), 0.f, {_0{}, _1{}, N}}, {} },            // + bias (null ptr -> 0)
+            {D, {N, _1{}, M * N}} };                                            // store
+        typename Gemm::Arguments args(
+            cutlass::gemm::GemmUniversalMode::kGemm, problem, 1, cb,
+            const_cast<int8_t*>(A), const_cast<int8_t*>(B), nullptr, nullptr,
+            (int64_t)M * K, (int64_t)N * K, 0, 0, K, K, 0, 0);
+
+        Gemm gemm;
+        if (gemm.can_implement(args) != cutlass::Status::kSuccess) return false;
+        if (Gemm::get_workspace_size(args) != 0) return false;  // kGemm mode -> 0; bail if not
+        if (gemm.initialize(args, nullptr, stream) != cutlass::Status::kSuccess) return false;
+        return gemm(stream) == cutlass::Status::kSuccess;
+    }
+};
+}  // namespace
+
+extern "C" {
+// out_dtype_code: 0=float32, 1=float16, 2=bfloat16 (DTYPE_TO_CODE).
+bool launch_cutlass_int8_dequant(
+    const void* A, const void* B, const void* xs, const void* ws, const void* bias,
+    void* D, int64_t M, int64_t N, int64_t K, int out_dtype_code, cudaStream_t stream)
+{
+    if (M == 0 || N == 0 || K == 0) return true;
+    const int8_t* a = static_cast<const int8_t*>(A);
+    const int8_t* b = static_cast<const int8_t*>(B);
+    const float* x = static_cast<const float*>(xs);
+    const float* w = static_cast<const float*>(ws);
+    const float* bs = static_cast<const float*>(bias);
+    switch (out_dtype_code) {
+        case 0: return FusedInt8Gemm<float>::run(a, b, x, w, bs, static_cast<float*>(D), M, N, K, stream);
+        case 1: return FusedInt8Gemm<cutlass::half_t>::run(a, b, x, w, bs, static_cast<cutlass::half_t*>(D), M, N, K, stream);
+        case 2: return FusedInt8Gemm<cutlass::bfloat16_t>::run(a, b, x, w, bs, static_cast<cutlass::bfloat16_t*>(D), M, N, K, stream);
+        default: return false;
+    }
+}
+}  // extern "C"
+
+#else  // !COMFY_HAVE_CUTLASS -- stub; caller falls back to cuBLAS + separate dequant.
+
+extern "C" bool launch_cutlass_int8_dequant(
+    const void*, const void*, const void*, const void*, const void*,
+    void*, int64_t, int64_t, int64_t, int, cudaStream_t) {
+    return false;
+}
+
+#endif

--- a/comfy_kitchen/backends/cuda/ops/cutlass_gemm_int8.cu
+++ b/comfy_kitchen/backends/cuda/ops/cutlass_gemm_int8.cu
@@ -5,10 +5,11 @@
  * INT8 GEMM with a FUSED dequant epilogue via CUTLASS (EVT):
  *   D[m,n] = (sum_k A[m,k]*B[n,k]) * x_scale[m] * w_scale[n] + bias[n]   -> out dtype
  *
- * Replaces cuBLAS-GEMM(int32) + separate dequant kernel with one near-peak
- * kernel. cuBLAS's int8 IMMA is poorly tuned for tall-skinny diffusion shapes
- * on sm_120; this beats it ~1.1-1.8x and beats Triton ~1.0-1.2x, with no Triton
- * runtime dependency. Falls back to cuBLAS if CUTLASS is unavailable.
+ * Replaces cuBLAS-GEMM(int32) + separate dequant with one near-peak kernel.
+ * Multiple tile configs are instantiated and the fastest for each (M,N,K) is
+ * picked at runtime and cached (like Triton's autotuner / cuBLAS's heuristic),
+ * so it adapts to the GPU instead of relying on one hand-tuned tile.
+ * Falls back to cuBLAS when CUTLASS is unavailable or no config can run.
  */
 #include <cuda_runtime.h>
 #include <cuda_bf16.h>
@@ -16,6 +17,10 @@
 #include <cstdint>
 
 #ifdef COMFY_HAVE_CUTLASS
+
+#include <map>
+#include <tuple>
+#include <mutex>
 
 #include "cutlass/cutlass.h"
 #include "cutlass/gemm/device/gemm_universal_adapter.h"
@@ -25,8 +30,8 @@
 namespace {
 using namespace cute;
 
-// One fused int8 GEMM specialized on the output element type.
-template <typename ElementOutput>
+// One fused int8 GEMM, parameterized on output type AND tile/warp/stage config.
+template <typename ElementOutput, int TBM, int TBN, int TBK, int WM, int WN, int WK, int NumStages>
 struct FusedInt8Gemm {
     using ElementA = int8_t; using ElementB = int8_t;
     using ElementC = ElementOutput;
@@ -36,13 +41,12 @@ struct FusedInt8Gemm {
     using LayoutC = cutlass::layout::RowMajor;
     static constexpr int AlignA = 16, AlignB = 16;
     static constexpr int AlignC = 128 / cutlass::sizeof_bits<ElementC>::value;
-    using TB   = cutlass::gemm::GemmShape<128, 256, 64>;
-    using Warp = cutlass::gemm::GemmShape<64, 64, 64>;
+    using TB   = cutlass::gemm::GemmShape<TBM, TBN, TBK>;
+    using Warp = cutlass::gemm::GemmShape<WM, WN, WK>;
     using Inst = cutlass::gemm::GemmShape<16, 8, 32>;
-    static constexpr int NumStages = 3, EVTStages = 1;
+    static constexpr int EVTStages = 1;
 
     using ThreadMap = cutlass::epilogue::threadblock::OutputTileThreadLayout<TB, Warp, ElementC, AlignC, EVTStages>;
-
     using Accum  = cutlass::epilogue::threadblock::VisitorAccFetch;
     using XScale = cutlass::epilogue::threadblock::VisitorColBroadcast<ThreadMap, ElementCompute, cute::Stride<_1, _0, int32_t>>;
     using WScale = cutlass::epilogue::threadblock::VisitorRowBroadcast<ThreadMap, ElementCompute, cute::Stride<_0, _1, int32_t>>;
@@ -71,10 +75,10 @@ struct FusedInt8Gemm {
                     const float* bias, ElementOutput* D, int M, int N, int K, cudaStream_t stream) {
         cutlass::gemm::GemmCoord problem(M, N, K);
         typename EVTD::Arguments cb{
-            { {  { {}, {const_cast<float*>(xs), 0.f, {_1{}, _0{}, M}}, {} },     // acc * xs
-                 {const_cast<float*>(ws), 0.f, {_0{}, _1{}, N}}, {} },           // * ws
-              {const_cast<float*>(bias), 0.f, {_0{}, _1{}, N}}, {} },            // + bias (null ptr -> 0)
-            {D, {N, _1{}, M * N}} };                                            // store
+            { {  { {}, {const_cast<float*>(xs), 0.f, {_1{}, _0{}, M}}, {} },
+                 {const_cast<float*>(ws), 0.f, {_0{}, _1{}, N}}, {} },
+              {const_cast<float*>(bias), 0.f, {_0{}, _1{}, N}}, {} },
+            {D, {N, _1{}, M * N}} };
         typename Gemm::Arguments args(
             cutlass::gemm::GemmUniversalMode::kGemm, problem, 1, cb,
             const_cast<int8_t*>(A), const_cast<int8_t*>(B), nullptr, nullptr,
@@ -87,6 +91,51 @@ struct FusedInt8Gemm {
         return gemm(stream) == cutlass::Status::kSuccess;
     }
 };
+
+// Autotuning dispatcher: try each tile config, time it, cache the fastest per
+// (M,N,K). First call for a shape pays the tuning cost; the rest hit the cache.
+template <typename OutT>
+bool dispatch_fused(const int8_t* A, const int8_t* B, const float* xs, const float* ws,
+                    const float* bias, OutT* D, int M, int N, int K, cudaStream_t stream) {
+    using Fn = bool (*)(const int8_t*, const int8_t*, const float*, const float*, const float*, OutT*, int, int, int, cudaStream_t);
+    // Tile configs spanning big-GPU/large-M (wide) to small-GPU/small-M (more CTAs).
+    static const Fn runners[] = {
+        &FusedInt8Gemm<OutT, 128, 256, 64, 64, 64, 64, 3>::run,
+        &FusedInt8Gemm<OutT, 128, 128, 64, 64, 64, 64, 4>::run,
+        &FusedInt8Gemm<OutT,  64, 128, 64, 32, 64, 64, 4>::run,
+    };
+    constexpr int NC = sizeof(runners) / sizeof(runners[0]);
+
+    static std::mutex mtx;
+    static std::map<std::tuple<int, int, int>, int> cache;   // (M,N,K) -> best config (or -1 = none)
+    const std::tuple<int, int, int> key{M, N, K};
+
+    int best;
+    {
+        std::lock_guard<std::mutex> lk(mtx);
+        auto it = cache.find(key);
+        best = (it != cache.end()) ? it->second : -2;
+    }
+    if (best == -2) {  // not tuned yet
+        best = -1;
+        float best_ms = 1e30f;
+        cudaEvent_t s, e; cudaEventCreate(&s); cudaEventCreate(&e);
+        for (int i = 0; i < NC; ++i) {
+            if (!runners[i](A, B, xs, ws, bias, D, M, N, K, stream)) continue;  // can't run / failed
+            cudaStreamSynchronize(stream);
+            cudaEventRecord(s, stream);
+            for (int r = 0; r < 3; ++r) runners[i](A, B, xs, ws, bias, D, M, N, K, stream);
+            cudaEventRecord(e, stream); cudaEventSynchronize(e);
+            float ms = 0.f; cudaEventElapsedTime(&ms, s, e);
+            if (ms < best_ms) { best_ms = ms; best = i; }
+        }
+        cudaEventDestroy(s); cudaEventDestroy(e);
+        std::lock_guard<std::mutex> lk(mtx);
+        cache[key] = best;
+    }
+    if (best < 0) return false;                              // fall back to cuBLAS
+    return runners[best](A, B, xs, ws, bias, D, M, N, K, stream);  // final, correct write with best config
+}
 }  // namespace
 
 extern "C" {
@@ -102,9 +151,9 @@ bool launch_cutlass_int8_dequant(
     const float* w = static_cast<const float*>(ws);
     const float* bs = static_cast<const float*>(bias);
     switch (out_dtype_code) {
-        case 0: return FusedInt8Gemm<float>::run(a, b, x, w, bs, static_cast<float*>(D), M, N, K, stream);
-        case 1: return FusedInt8Gemm<cutlass::half_t>::run(a, b, x, w, bs, static_cast<cutlass::half_t*>(D), M, N, K, stream);
-        case 2: return FusedInt8Gemm<cutlass::bfloat16_t>::run(a, b, x, w, bs, static_cast<cutlass::bfloat16_t*>(D), M, N, K, stream);
+        case 0: return dispatch_fused<float>(a, b, x, w, bs, static_cast<float*>(D), M, N, K, stream);
+        case 1: return dispatch_fused<cutlass::half_t>(a, b, x, w, bs, static_cast<cutlass::half_t*>(D), M, N, K, stream);
+        case 2: return dispatch_fused<cutlass::bfloat16_t>(a, b, x, w, bs, static_cast<cutlass::bfloat16_t*>(D), M, N, K, stream);
         default: return false;
     }
 }

--- a/comfy_kitchen/backends/cuda/ops/int8_linear.cu
+++ b/comfy_kitchen/backends/cuda/ops/int8_linear.cu
@@ -93,6 +93,137 @@ __global__ void quantize_int8_rowwise_kernel(
     }
 }
 
+// Fused ConvRot (online Hadamard rotation) + row-wise INT8 quantization.
+//
+// The rotation group is fixed to 256 = 4^4 and uses the symmetric "regular"
+// Hadamard block H4:
+//     [  1  1  1 -1 ]
+//     [  1  1 -1  1 ]
+//     [  1 -1  1  1 ]
+//     [ -1  1  1  1 ]
+// The full normalized matrix is H256 = (1/16) * (H4 (x) H4 (x) H4 (x) H4).
+// Because it is a Kronecker power, the matvec H256 @ x factors into 4 radix-4
+// "butterfly" stages (strides 1, 4, 16, 64) with a 1/2 scale per stage, i.e. a
+// Fast Hadamard Transform: O(256*4) work per group instead of O(256*256).
+//
+// The whole row is rotated in shared memory and quantized in place, so the
+// rotated bf16 activation is never written to / read back from global memory
+// (the unfused path's main cost).
+//
+// One block per row. The block holds BLOCK_THREADS / 256 groups "in flight" at
+// once: for large K the row's shared-memory footprint forces a single block per
+// SM, so we want a wide block (many warps) to hide latency rather than a narrow
+// 256-thread block. Each thread owns local element `i = tid % 256` of group
+// slot `sub = tid / 256`.
+constexpr int kConvRotGroup = 256;
+
+__device__ __forceinline__ float h4_row_dot(int d, float x0, float x1, float x2, float x3) {
+    // Row d of H4 dotted with (x0, x1, x2, x3).
+    switch (d) {
+        case 0:  return  x0 + x1 + x2 - x3;
+        case 1:  return  x0 + x1 - x2 + x3;
+        case 2:  return  x0 - x1 + x2 + x3;
+        default: return -x0 + x1 + x2 + x3;
+    }
+}
+
+template<int NUM_WARPS>
+__device__ __forceinline__ float block_reduce_max_t(float v, float* warp_smem, float* block_smem) {
+    const int lane = threadIdx.x & (kThreadsPerWarp - 1);
+    const int wid = threadIdx.x >> 5;
+    v = warp_reduce_max(v);
+    if (lane == 0) {
+        warp_smem[wid] = v;
+    }
+    __syncthreads();
+    if (wid == 0) {
+        float total = lane < NUM_WARPS ? warp_smem[lane] : 0.0f;
+        total = warp_reduce_max(total);
+        if (lane == 0) {
+            *block_smem = total;
+        }
+    }
+    __syncthreads();
+    return *block_smem;
+}
+
+template<typename InputType, int BLOCK_THREADS>
+__global__ void quantize_int8_rowwise_convrot_kernel(
+    const InputType* __restrict__ x,
+    int8_t* __restrict__ q,
+    float* __restrict__ scales,
+    int K)
+{
+    constexpr int kGroupsInFlight = BLOCK_THREADS / kConvRotGroup;
+    constexpr int kWarps = BLOCK_THREADS / kThreadsPerWarp;
+
+    extern __shared__ float smem[];
+    float* row_buf = smem;                         // K floats: rotated row, in place
+    float* tmp = smem + K;                          // kGroupsInFlight * 2 * 256 floats
+
+    __shared__ float warp_smem[kWarps];
+    __shared__ float block_smem;
+
+    const int row = static_cast<int>(blockIdx.x);
+    const int tid = threadIdx.x;
+    const int64_t row_offset = static_cast<int64_t>(row) * K;
+
+    // Load the row into shared memory as float.
+    for (int col = tid; col < K; col += BLOCK_THREADS) {
+        row_buf[col] = to_float(x[row_offset + col]);
+    }
+    __syncthreads();
+
+    // Fast Hadamard transform, kGroupsInFlight groups at a time.
+    const int n_groups = K / kConvRotGroup;
+    const int sub = tid / kConvRotGroup;
+    const int i = tid % kConvRotGroup;
+    // Each slot gets a private double buffer so inactive lanes (when n_groups is
+    // not a multiple of kGroupsInFlight) can keep hitting __syncthreads without
+    // touching the live row data.
+    float* buf0 = tmp + sub * (2 * kConvRotGroup);
+    float* buf1 = buf0 + kConvRotGroup;
+    const int iters = (n_groups + kGroupsInFlight - 1) / kGroupsInFlight;
+
+    for (int it = 0; it < iters; ++it) {
+        const int g = it * kGroupsInFlight + sub;
+        const bool active = (g < n_groups);
+        // active: ping-pong between the row region and buf0, ending in the row
+        // region after 4 swaps. inactive: ping-pong privately in buf0/buf1.
+        float* src = active ? (row_buf + g * kConvRotGroup) : buf0;
+        float* dst = active ? buf0 : buf1;
+        #pragma unroll
+        for (int stage = 0; stage < 4; ++stage) {
+            const int s = (stage == 0) ? 1 : (stage == 1) ? 4 : (stage == 2) ? 16 : 64;
+            const int d = (i / s) & 3;
+            const int base = i - d * s;
+            const float v = 0.5f * h4_row_dot(
+                d, src[base], src[base + s], src[base + 2 * s], src[base + 3 * s]);
+            dst[i] = v;
+            __syncthreads();
+            float* t = src; src = dst; dst = t;
+        }
+    }
+
+    // Row absmax over the rotated values -> per-row scale.
+    float abs_max = 0.0f;
+    for (int col = tid; col < K; col += BLOCK_THREADS) {
+        abs_max = fmaxf(abs_max, fabsf(row_buf[col]));
+    }
+    abs_max = block_reduce_max_t<kWarps>(abs_max, warp_smem, &block_smem);
+    const float scale = fmaxf(abs_max * (1.0f / 127.0f), 1.0e-30f);
+    const float inv_scale = 1.0f / scale;
+    if (tid == 0) {
+        scales[row] = scale;
+    }
+
+    for (int col = tid; col < K; col += BLOCK_THREADS) {
+        float quantized = nearbyintf(row_buf[col] * inv_scale);
+        quantized = fminf(127.0f, fmaxf(-128.0f, quantized));
+        q[row_offset + col] = static_cast<int8_t>(quantized);
+    }
+}
+
 template<typename OutputType, typename BiasType>
 __global__ void dequantize_int8_linear_kernel(
     const int32_t* __restrict__ input,
@@ -154,6 +285,68 @@ void launch_quantize_int8_rowwise_kernel(
     cudaError_t err = cudaGetLastError();
     if (err != cudaSuccess) {
         throw std::runtime_error(std::string("CUDA INT8 rowwise quantization failed: ") + cudaGetErrorString(err));
+    }
+}
+
+void launch_quantize_int8_rowwise_convrot_kernel(
+    const void* input,
+    void* output,
+    void* scales,
+    int64_t num_rows,
+    int64_t num_cols,
+    int group_size,
+    int input_dtype_code,
+    cudaStream_t stream)
+{
+    if (num_rows == 0 || num_cols == 0) {
+        return;
+    }
+    if (group_size != comfy::kConvRotGroup) {
+        throw std::runtime_error("convrot fused kernel only supports group_size 256");
+    }
+    if (num_cols % comfy::kConvRotGroup != 0) {
+        throw std::runtime_error("convrot fused kernel requires K divisible by 256");
+    }
+    if (num_cols > static_cast<int64_t>(std::numeric_limits<int>::max())) {
+        throw std::runtime_error("convrot fused kernel only supports K <= INT_MAX");
+    }
+
+    // Narrow block for small K (high occupancy via many small blocks); wide
+    // block for large K (single smem-bound block per SM needs many warps to
+    // hide latency). 256 threads -> 1 group/iter; 1024 threads -> 4 groups/iter.
+    const bool wide = num_cols > 5120;
+    const int block_threads = wide ? 1024 : comfy::kInt8Threads;  // 1024 or 256
+    const int groups_in_flight = block_threads / comfy::kConvRotGroup;
+    const size_t smem_bytes =
+        (static_cast<size_t>(num_cols) + groups_in_flight * 2 * comfy::kConvRotGroup) * sizeof(float);
+
+    DISPATCH_FP_DTYPE(input_dtype_code, InputType, [&] {
+        auto launch = [&](auto kernel) {
+            cudaError_t attr_err = cudaFuncSetAttribute(
+                kernel, cudaFuncAttributeMaxDynamicSharedMemorySize,
+                static_cast<int>(smem_bytes));
+            if (attr_err != cudaSuccess) {
+                throw std::runtime_error(
+                    std::string("convrot fused kernel shared memory request (") +
+                    std::to_string(smem_bytes) + " bytes) failed: " +
+                    cudaGetErrorString(attr_err));
+            }
+            kernel<<<static_cast<unsigned int>(num_rows), block_threads, smem_bytes, stream>>>(
+                static_cast<const InputType*>(input),
+                static_cast<int8_t*>(output),
+                static_cast<float*>(scales),
+                static_cast<int>(num_cols));
+        };
+        if (wide) {
+            launch(comfy::quantize_int8_rowwise_convrot_kernel<InputType, 1024>);
+        } else {
+            launch(comfy::quantize_int8_rowwise_convrot_kernel<InputType, 256>);
+        }
+    });
+
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        throw std::runtime_error(std::string("CUDA INT8 rowwise convrot quantization failed: ") + cudaGetErrorString(err));
     }
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ exclude = [
     "dist",
     "*.egg-info",
     ".pytest_cache",
+    "third_party",
 ]
 
 [tool.ruff.lint]


### PR DESCRIPTION
Based on quick initial testing, this is faster than both the existing cublast and triton paths on my 5090 at least

Krea2, 1024x1024, 5090, Linux:

cublast 2.82it/s
triton  3.10it/s
cutlass 3.25it/s

Needs further testing on other hardware.