### PR TITLE
Change rounding method in quantization process (triton backend fix for amd gpus)

### DIFF
--- a/comfy_kitchen/backends/triton/quantization.py
+++ b/comfy_kitchen/backends/triton/quantization.py
@@ -801,7 +801,7 @@ def _quantize_rowwise_kernel(
     q_f = x / scale
 
     # Round and Clamp
-    q_i = libdevice.rint(q_f).to(tl.int32)
+    q_i = tl.floor(q_f + 0.5).to(tl.int32)
     q_i = tl.clamp(q_i, -128.0, 127.0)
 
     # 4. Store


### PR DESCRIPTION
fails on ROCm:
AttributeError("module 'triton.language.extra.hip.libdevice' has no attribute 'rint'") The generic from triton.language.extra import libdevice import resolves to triton.language.extra.hip.libdevice on AMD GPUs, which doesn't expose rint. This is the same gap as triton-lang#7135, where libdevice.round is declared but throws the same AttributeError when actually compiled on HIP — the documented workaround there is the same swap used below. Repro: Load an INT8/ConvRot-quantized checkpoint with the native UNETLoader on an AMD GPU with the triton backend enabled (COMFY_KITCHEN_BACKEND=triton or equivalent). Fails on first call into int8_linear → triton_quantize_rowwise.

tl.floor(x + 0.5) is portable across both CUDA and HIP backends (no branching needed), and the rounding difference vs. rint's round-half-to-even is negligible for INT8 quantization scales. Confirmed against current main (v0.2.12) — this is the only occurrence of libdevice.rint/libdevice.round in the codebase, so this single-line change should resolve ROCm compatibility for this path.