### PR TITLE
Fix INT8 quantization Triton kernel for HIP/ROCm

### DIFF
--- a/comfy_kitchen/backends/triton/quantization.py
+++ b/comfy_kitchen/backends/triton/quantization.py
@@ -800,14 +800,24 @@ def _quantize_rowwise_kernel(
     # 3. Quantize
     q_f = x / scale
 
-    # Round and Clamp
-    rounding_bias = tl.where(q_f >= 0, 0.5, -0.5)
-    q_i = q_f + rounding_bias
-
-    # Clamp in float (HIP only supports float clamp)
-    q_i = tl.clamp(q_i, -128.0, 127.0)
+    # Round half-to-even (emulates libdevice.rint for HIP compat)
+    # Triton 3.6.0 HIP backend lacks rint, math.round, and integer clamp
+    floor_val = tl.floor(q_f)
+    frac = q_f - floor_val
+    
+    # Standard round: floor(x + 0.5)
+    standard = tl.floor(q_f + 0.5)
+    
+    # For exactly .5: round to nearest even
+    # floor_val % 2.0 == 1.0 means odd floor, so add 1 to round up to even
+    q_i = tl.where(
+        frac == 0.5,
+        floor_val + (floor_val % 2.0),  # odd->+1 (round up), even->+0 (stay)
+        standard
+    )
 
     # Convert to int for storage
+    q_i = tl.clamp(q_i, -128.0, 127.0)
     q_i = q_i.to(tl.int32)
 
     # 4. Store

--- a/comfy_kitchen/backends/triton/quantization.py
+++ b/comfy_kitchen/backends/triton/quantization.py
@@ -810,6 +810,7 @@ def _quantize_rowwise_kernel(
     
     # For exactly .5: round to nearest even
     # floor_val % 2.0 == 1.0 means odd floor, so add 1 to round up to even
+    is_odd = tl.abs(floor_val) % 2.0 == 1.0
     q_i = tl.where(
         frac == 0.5,
         floor_val + is_odd,

--- a/comfy_kitchen/backends/triton/quantization.py
+++ b/comfy_kitchen/backends/triton/quantization.py
@@ -71,6 +71,7 @@ def quantize_per_tensor_fp8(
 
     output = torch.empty_like(x_flat, dtype=output_type)
 
+
     if n_elements < 32768:  # < 32K elements
         block_size = 128
     elif n_elements < 131072:  # < 128K elements
@@ -371,7 +372,9 @@ def quantize_nvfp4(
     packed_output = torch.empty((m, n // 2), dtype=torch.uint8, device=x.device)
     # Use zeros for scales to avoid garbage in padded regions
     swizzled_scales = torch.zeros(
-        (padded_scale_rows, padded_scale_cols), dtype=torch.float8_e4m3fn, device=x.device
+        (padded_scale_rows, padded_scale_cols),
+        dtype=torch.float8_e4m3fn,
+        device=x.device
     )
 
     # Determine blocks per program based on tensor size for better occupancy
@@ -577,7 +580,6 @@ def dequantize_nvfp4(
 
     return output
 
-
 @triton.jit
 def quantize_mxfp8_kernel_tl(
     x_ptr,
@@ -643,7 +645,7 @@ def quantize_mxfp8_kernel_tl(
             scale_ratio = max_abs / fp8_max
             # Clamp to avoid log2(0) and ensure valid E8M0 range
             scale_ratio = tl.maximum(scale_ratio, 2.0 ** (-127))  # min E8M0 value
-            scale_ratio = tl.minimum(scale_ratio, 2.0**127)  # max E8M0 value
+            scale_ratio = tl.minimum(scale_ratio, 2.0 ** 127)     # max E8M0 value
 
             # Compute exponent: round up to next power of 2
             log2_ratio = tl.log2(scale_ratio)
@@ -725,7 +727,7 @@ def quantize_mxfp8(
     swizzled_scales = torch.zeros(
         (padded_scale_rows, padded_scale_cols),
         dtype=torch.uint8,  # E8M0 stored as uint8
-        device=x.device,
+        device=x.device
     )
 
     # Determine blocks per program
@@ -758,21 +760,18 @@ def quantize_mxfp8(
     swizzled_scales = swizzled_scales.view(torch.float8_e8m0fnu)
 
     return output, swizzled_scales
-
-
 # =============================================================================
 # INT8 Tensor-wise Quantization (from dxqb/OneTrainer & ComfyUI-Flux2-INT8)
 # =============================================================================
 # Single scale per tensor + per-row activation scaling.
 # Fuses dequantization and bias addition.
 
-
 @triton.jit
 def _quantize_rowwise_kernel(
-    x_ptr,  # Input pointer (FP16/BF16)
-    y_ptr,  # Output pointer (INT8)
-    s_ptr,  # Scale pointer (FP32)
-    n_elements,  # Number of columns
+    x_ptr,      # Input pointer (FP16/BF16)
+    y_ptr,      # Output pointer (INT8)
+    s_ptr,      # Scale pointer (FP32)
+    n_elements, # Number of columns
     block_size: tl.constexpr,
 ):
     # Row index we are processing
@@ -815,7 +814,6 @@ def _quantize_rowwise_kernel(
     tl.store(y_row_ptr + offsets, q_i.to(tl.int8), mask=mask)
     tl.store(s_ptr + row_idx, scale.to(tl.float32))
 
-
 def triton_quantize_rowwise(x: torch.Tensor):
     """
     Input: [Batch, Dim] (float16/bfloat16/float32)
@@ -835,9 +833,7 @@ def triton_quantize_rowwise(x: torch.Tensor):
     return y, s
 
 
-def triton_quantize_and_rotate_rowwise(
-    x: torch.Tensor, h: torch.Tensor, group_size: int
-) -> tuple[torch.Tensor, torch.Tensor]:
+def triton_quantize_and_rotate_rowwise(x: torch.Tensor, h: torch.Tensor, group_size: int) -> tuple[torch.Tensor, torch.Tensor]:
     """Decoupled online activation rotation + row-wise quantization.
 
     Args:
@@ -854,65 +850,30 @@ def triton_quantize_and_rotate_rowwise(
 
 @triton.autotune(
     configs=[
-        triton.Config(
-            {"block_m": 128, "block_n": 256, "block_k": 64, "group_size_m": 8},
-            num_stages=3,
-            num_warps=8,
-        ),
-        triton.Config(
-            {"block_m": 64, "block_n": 256, "block_k": 32, "group_size_m": 8},
-            num_stages=4,
-            num_warps=4,
-        ),
-        triton.Config(
-            {"block_m": 128, "block_n": 128, "block_k": 32, "group_size_m": 8},
-            num_stages=4,
-            num_warps=4,
-        ),
-        triton.Config(
-            {"block_m": 128, "block_n": 64, "block_k": 32, "group_size_m": 8},
-            num_stages=4,
-            num_warps=4,
-        ),
-        triton.Config(
-            {"block_m": 64, "block_n": 128, "block_k": 32, "group_size_m": 8},
-            num_stages=4,
-            num_warps=4,
-        ),
-        triton.Config(
-            {"block_m": 128, "block_n": 32, "block_k": 32, "group_size_m": 8},
-            num_stages=4,
-            num_warps=4,
-        ),
+        triton.Config({'block_m': 128, 'block_n': 256, 'block_k': 64, 'group_size_m': 8}, num_stages=3, num_warps=8),
+        triton.Config({'block_m': 64,  'block_n': 256, 'block_k': 32, 'group_size_m': 8}, num_stages=4, num_warps=4),
+        triton.Config({'block_m': 128, 'block_n': 128, 'block_k': 32, 'group_size_m': 8}, num_stages=4, num_warps=4),
+        triton.Config({'block_m': 128, 'block_n': 64,  'block_k': 32, 'group_size_m': 8}, num_stages=4, num_warps=4),
+        triton.Config({'block_m': 64,  'block_n': 128, 'block_k': 32, 'group_size_m': 8}, num_stages=4, num_warps=4),
+        triton.Config({'block_m': 128, 'block_n': 32,  'block_k': 32, 'group_size_m': 8}, num_stages=4, num_warps=4),
     ],
-    key=["m", "n", "k"],
+    key=['m', 'n', 'k'],
 )
 @triton.jit
 def _int8_matmul_dequant_kernel(
     # Pointers
-    a_ptr,
-    b_ptr,
-    c_ptr,
-    a_scale_ptr,
-    b_scale_ptr,
-    bias_ptr,
+    a_ptr, b_ptr, c_ptr,
+    a_scale_ptr, b_scale_ptr, bias_ptr,
     # Matrix Dimensions
-    m,
-    n,
-    k,
+    m, n, k,
     # Strides
-    stride_am,
-    stride_ak,
-    stride_bk,
-    stride_bn,
-    stride_cm,
-    stride_cn,
+    stride_am, stride_ak,
+    stride_bk, stride_bn,
+    stride_cm, stride_cn,
     # Meta-parameters
-    block_m: tl.constexpr,
-    block_n: tl.constexpr,
-    block_k: tl.constexpr,
+    block_m: tl.constexpr, block_n: tl.constexpr, block_k: tl.constexpr,
     group_size_m: tl.constexpr,
-    has_bias: tl.constexpr,
+    has_bias: tl.constexpr
 ):
     """
     Computes: C = ((A * B) * (scale_a * scale_b)) + bias
@@ -953,7 +914,7 @@ def _int8_matmul_dequant_kernel(
         b_ptrs += block_k * stride_bk
 
     # 3. Fused Epilogue (Dequantize & Bias)
-    scale_a = tl.load(a_scale_ptr + offs_am)  # Vector [BLOCK_M]
+    scale_a = tl.load(a_scale_ptr + offs_am) # Vector [BLOCK_M]
     scale_b = tl.load(b_scale_ptr)
 
     c = accumulator.to(tl.float32)
@@ -961,7 +922,7 @@ def _int8_matmul_dequant_kernel(
     c = c * total_scale
 
     if has_bias:
-        bias = tl.load(bias_ptr + offs_bn)  # Vector [BLOCK_N]
+        bias = tl.load(bias_ptr + offs_bn) # Vector [BLOCK_N]
         c = c + bias[None, :]
 
     # 4. Store Result
@@ -969,68 +930,32 @@ def _int8_matmul_dequant_kernel(
     c_mask = (offs_am[:, None] < m) & (offs_bn[None, :] < n)
     tl.store(c_ptrs, c, mask=c_mask)
 
-
 @triton.autotune(
     configs=[
-        triton.Config(
-            {"block_m": 128, "block_n": 256, "block_k": 64, "group_size_m": 8},
-            num_stages=3,
-            num_warps=8,
-        ),
-        triton.Config(
-            {"block_m": 64, "block_n": 256, "block_k": 32, "group_size_m": 8},
-            num_stages=4,
-            num_warps=4,
-        ),
-        triton.Config(
-            {"block_m": 128, "block_n": 128, "block_k": 32, "group_size_m": 8},
-            num_stages=4,
-            num_warps=4,
-        ),
-        triton.Config(
-            {"block_m": 128, "block_n": 64, "block_k": 32, "group_size_m": 8},
-            num_stages=4,
-            num_warps=4,
-        ),
-        triton.Config(
-            {"block_m": 64, "block_n": 128, "block_k": 32, "group_size_m": 8},
-            num_stages=4,
-            num_warps=4,
-        ),
-        triton.Config(
-            {"block_m": 128, "block_n": 32, "block_k": 32, "group_size_m": 8},
-            num_stages=4,
-            num_warps=4,
-        ),
+        triton.Config({'block_m': 128, 'block_n': 256, 'block_k': 64, 'group_size_m': 8}, num_stages=3, num_warps=8),
+        triton.Config({'block_m': 64,  'block_n': 256, 'block_k': 32, 'group_size_m': 8}, num_stages=4, num_warps=4),
+        triton.Config({'block_m': 128, 'block_n': 128, 'block_k': 32, 'group_size_m': 8}, num_stages=4, num_warps=4),
+        triton.Config({'block_m': 128, 'block_n': 64,  'block_k': 32, 'group_size_m': 8}, num_stages=4, num_warps=4),
+        triton.Config({'block_m': 64,  'block_n': 128, 'block_k': 32, 'group_size_m': 8}, num_stages=4, num_warps=4),
+        triton.Config({'block_m': 128, 'block_n': 32,  'block_k': 32, 'group_size_m': 8}, num_stages=4, num_warps=4),
     ],
-    key=["m", "n", "k"],
+    key=['m', 'n', 'k'],
 )
 @triton.jit
 def _int8_matmul_dequant_per_row_kernel(
     # Pointers
-    a_ptr,
-    b_ptr,
-    c_ptr,
-    a_scale_ptr,
-    b_scale_ptr,
-    bias_ptr,
+    a_ptr, b_ptr, c_ptr,
+    a_scale_ptr, b_scale_ptr, bias_ptr,
     # Matrix Dimensions
-    m,
-    n,
-    k,
+    m, n, k,
     # Strides
-    stride_am,
-    stride_ak,
-    stride_bk,
-    stride_bn,
-    stride_cm,
-    stride_cn,
+    stride_am, stride_ak,
+    stride_bk, stride_bn,
+    stride_cm, stride_cn,
     # Meta-parameters
-    block_m: tl.constexpr,
-    block_n: tl.constexpr,
-    block_k: tl.constexpr,
+    block_m: tl.constexpr, block_n: tl.constexpr, block_k: tl.constexpr,
     group_size_m: tl.constexpr,
-    has_bias: tl.constexpr,
+    has_bias: tl.constexpr
 ):
     """
     Computes: C = ((A * B) * (scale_a[:, None] * scale_b[None, :])) + bias
@@ -1081,7 +1006,6 @@ def _int8_matmul_dequant_per_row_kernel(
     c_ptrs = c_ptr + stride_cm * offs_am[:, None] + stride_cn * offs_bn[None, :]
     c_mask = (offs_am[:, None] < m) & (offs_bn[None, :] < n)
     tl.store(c_ptrs, c, mask=c_mask)
-
 
 def int8_linear(
     x: torch.Tensor,
@@ -1147,16 +1071,11 @@ def int8_linear(
             a_scale_ptr=x_scale,
             b_scale_ptr=weight_scale,
             bias_ptr=bias_ptr,
-            m=m,
-            n=n,
-            k=k,
-            stride_am=x_int8.stride(0),
-            stride_ak=x_int8.stride(1),
-            stride_bk=weight.stride(1),
-            stride_bn=weight.stride(0),
-            stride_cm=output.stride(0),
-            stride_cn=output.stride(1),
-            has_bias=has_bias,
+            m=m, n=n, k=k,
+            stride_am=x_int8.stride(0), stride_ak=x_int8.stride(1),
+            stride_bk=weight.stride(1), stride_bn=weight.stride(0),
+            stride_cm=output.stride(0), stride_cn=output.stride(1),
+            has_bias=has_bias
         )
     else:
         _int8_matmul_dequant_kernel[grid](
@@ -1166,16 +1085,11 @@ def int8_linear(
             a_scale_ptr=x_scale,
             b_scale_ptr=weight_scale,
             bias_ptr=bias_ptr,
-            m=m,
-            n=n,
-            k=k,
-            stride_am=x_int8.stride(0),
-            stride_ak=x_int8.stride(1),
-            stride_bk=weight.stride(1),
-            stride_bn=weight.stride(0),
-            stride_cm=output.stride(0),
-            stride_cn=output.stride(1),
-            has_bias=has_bias,
+            m=m, n=n, k=k,
+            stride_am=x_int8.stride(0), stride_ak=x_int8.stride(1),
+            stride_bk=weight.stride(1), stride_bn=weight.stride(0),
+            stride_cm=output.stride(0), stride_cn=output.stride(1),
+            has_bias=has_bias
         )
 
     return output.reshape(*orig_shape[:-1], n)

--- a/comfy_kitchen/backends/triton/quantization.py
+++ b/comfy_kitchen/backends/triton/quantization.py
@@ -812,7 +812,7 @@ def _quantize_rowwise_kernel(
     # floor_val % 2.0 == 1.0 means odd floor, so add 1 to round up to even
     q_i = tl.where(
         frac == 0.5,
-        floor_val + (floor_val % 2.0),  # odd->+1 (round up), even->+0 (stay)
+        floor_val + is_odd,
         standard
     )
 

--- a/comfy_kitchen/backends/triton/quantization.py
+++ b/comfy_kitchen/backends/triton/quantization.py
@@ -71,7 +71,6 @@ def quantize_per_tensor_fp8(
 
     output = torch.empty_like(x_flat, dtype=output_type)
 
-
     if n_elements < 32768:  # < 32K elements
         block_size = 128
     elif n_elements < 131072:  # < 128K elements
@@ -372,9 +371,7 @@ def quantize_nvfp4(
     packed_output = torch.empty((m, n // 2), dtype=torch.uint8, device=x.device)
     # Use zeros for scales to avoid garbage in padded regions
     swizzled_scales = torch.zeros(
-        (padded_scale_rows, padded_scale_cols),
-        dtype=torch.float8_e4m3fn,
-        device=x.device
+        (padded_scale_rows, padded_scale_cols), dtype=torch.float8_e4m3fn, device=x.device
     )
 
     # Determine blocks per program based on tensor size for better occupancy
@@ -580,6 +577,7 @@ def dequantize_nvfp4(
 
     return output
 
+
 @triton.jit
 def quantize_mxfp8_kernel_tl(
     x_ptr,
@@ -645,7 +643,7 @@ def quantize_mxfp8_kernel_tl(
             scale_ratio = max_abs / fp8_max
             # Clamp to avoid log2(0) and ensure valid E8M0 range
             scale_ratio = tl.maximum(scale_ratio, 2.0 ** (-127))  # min E8M0 value
-            scale_ratio = tl.minimum(scale_ratio, 2.0 ** 127)     # max E8M0 value
+            scale_ratio = tl.minimum(scale_ratio, 2.0**127)  # max E8M0 value
 
             # Compute exponent: round up to next power of 2
             log2_ratio = tl.log2(scale_ratio)
@@ -727,7 +725,7 @@ def quantize_mxfp8(
     swizzled_scales = torch.zeros(
         (padded_scale_rows, padded_scale_cols),
         dtype=torch.uint8,  # E8M0 stored as uint8
-        device=x.device
+        device=x.device,
     )
 
     # Determine blocks per program
@@ -760,18 +758,21 @@ def quantize_mxfp8(
     swizzled_scales = swizzled_scales.view(torch.float8_e8m0fnu)
 
     return output, swizzled_scales
+
+
 # =============================================================================
 # INT8 Tensor-wise Quantization (from dxqb/OneTrainer & ComfyUI-Flux2-INT8)
 # =============================================================================
 # Single scale per tensor + per-row activation scaling.
 # Fuses dequantization and bias addition.
 
+
 @triton.jit
 def _quantize_rowwise_kernel(
-    x_ptr,      # Input pointer (FP16/BF16)
-    y_ptr,      # Output pointer (INT8)
-    s_ptr,      # Scale pointer (FP32)
-    n_elements, # Number of columns
+    x_ptr,  # Input pointer (FP16/BF16)
+    y_ptr,  # Output pointer (INT8)
+    s_ptr,  # Scale pointer (FP32)
+    n_elements,  # Number of columns
     block_size: tl.constexpr,
 ):
     # Row index we are processing
@@ -801,12 +802,19 @@ def _quantize_rowwise_kernel(
     q_f = x / scale
 
     # Round and Clamp
-    q_i = libdevice.rint(q_f).to(tl.int32)
+    rounding_bias = tl.where(q_f >= 0, 0.5, -0.5)
+    q_i = q_f + rounding_bias
+
+    # Clamp in float (HIP only supports float clamp)
     q_i = tl.clamp(q_i, -128.0, 127.0)
+
+    # Convert to int for storage
+    q_i = q_i.to(tl.int32)
 
     # 4. Store
     tl.store(y_row_ptr + offsets, q_i.to(tl.int8), mask=mask)
     tl.store(s_ptr + row_idx, scale.to(tl.float32))
+
 
 def triton_quantize_rowwise(x: torch.Tensor):
     """
@@ -827,7 +835,9 @@ def triton_quantize_rowwise(x: torch.Tensor):
     return y, s
 
 
-def triton_quantize_and_rotate_rowwise(x: torch.Tensor, h: torch.Tensor, group_size: int) -> tuple[torch.Tensor, torch.Tensor]:
+def triton_quantize_and_rotate_rowwise(
+    x: torch.Tensor, h: torch.Tensor, group_size: int
+) -> tuple[torch.Tensor, torch.Tensor]:
     """Decoupled online activation rotation + row-wise quantization.
 
     Args:
@@ -844,30 +854,65 @@ def triton_quantize_and_rotate_rowwise(x: torch.Tensor, h: torch.Tensor, group_s
 
 @triton.autotune(
     configs=[
-        triton.Config({'block_m': 128, 'block_n': 256, 'block_k': 64, 'group_size_m': 8}, num_stages=3, num_warps=8),
-        triton.Config({'block_m': 64,  'block_n': 256, 'block_k': 32, 'group_size_m': 8}, num_stages=4, num_warps=4),
-        triton.Config({'block_m': 128, 'block_n': 128, 'block_k': 32, 'group_size_m': 8}, num_stages=4, num_warps=4),
-        triton.Config({'block_m': 128, 'block_n': 64,  'block_k': 32, 'group_size_m': 8}, num_stages=4, num_warps=4),
-        triton.Config({'block_m': 64,  'block_n': 128, 'block_k': 32, 'group_size_m': 8}, num_stages=4, num_warps=4),
-        triton.Config({'block_m': 128, 'block_n': 32,  'block_k': 32, 'group_size_m': 8}, num_stages=4, num_warps=4),
+        triton.Config(
+            {"block_m": 128, "block_n": 256, "block_k": 64, "group_size_m": 8},
+            num_stages=3,
+            num_warps=8,
+        ),
+        triton.Config(
+            {"block_m": 64, "block_n": 256, "block_k": 32, "group_size_m": 8},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"block_m": 128, "block_n": 128, "block_k": 32, "group_size_m": 8},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"block_m": 128, "block_n": 64, "block_k": 32, "group_size_m": 8},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"block_m": 64, "block_n": 128, "block_k": 32, "group_size_m": 8},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"block_m": 128, "block_n": 32, "block_k": 32, "group_size_m": 8},
+            num_stages=4,
+            num_warps=4,
+        ),
     ],
-    key=['m', 'n', 'k'],
+    key=["m", "n", "k"],
 )
 @triton.jit
 def _int8_matmul_dequant_kernel(
     # Pointers
-    a_ptr, b_ptr, c_ptr,
-    a_scale_ptr, b_scale_ptr, bias_ptr,
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    a_scale_ptr,
+    b_scale_ptr,
+    bias_ptr,
     # Matrix Dimensions
-    m, n, k,
+    m,
+    n,
+    k,
     # Strides
-    stride_am, stride_ak,
-    stride_bk, stride_bn,
-    stride_cm, stride_cn,
+    stride_am,
+    stride_ak,
+    stride_bk,
+    stride_bn,
+    stride_cm,
+    stride_cn,
     # Meta-parameters
-    block_m: tl.constexpr, block_n: tl.constexpr, block_k: tl.constexpr,
+    block_m: tl.constexpr,
+    block_n: tl.constexpr,
+    block_k: tl.constexpr,
     group_size_m: tl.constexpr,
-    has_bias: tl.constexpr
+    has_bias: tl.constexpr,
 ):
     """
     Computes: C = ((A * B) * (scale_a * scale_b)) + bias
@@ -908,7 +953,7 @@ def _int8_matmul_dequant_kernel(
         b_ptrs += block_k * stride_bk
 
     # 3. Fused Epilogue (Dequantize & Bias)
-    scale_a = tl.load(a_scale_ptr + offs_am) # Vector [BLOCK_M]
+    scale_a = tl.load(a_scale_ptr + offs_am)  # Vector [BLOCK_M]
     scale_b = tl.load(b_scale_ptr)
 
     c = accumulator.to(tl.float32)
@@ -916,7 +961,7 @@ def _int8_matmul_dequant_kernel(
     c = c * total_scale
 
     if has_bias:
-        bias = tl.load(bias_ptr + offs_bn) # Vector [BLOCK_N]
+        bias = tl.load(bias_ptr + offs_bn)  # Vector [BLOCK_N]
         c = c + bias[None, :]
 
     # 4. Store Result
@@ -924,32 +969,68 @@ def _int8_matmul_dequant_kernel(
     c_mask = (offs_am[:, None] < m) & (offs_bn[None, :] < n)
     tl.store(c_ptrs, c, mask=c_mask)
 
+
 @triton.autotune(
     configs=[
-        triton.Config({'block_m': 128, 'block_n': 256, 'block_k': 64, 'group_size_m': 8}, num_stages=3, num_warps=8),
-        triton.Config({'block_m': 64,  'block_n': 256, 'block_k': 32, 'group_size_m': 8}, num_stages=4, num_warps=4),
-        triton.Config({'block_m': 128, 'block_n': 128, 'block_k': 32, 'group_size_m': 8}, num_stages=4, num_warps=4),
-        triton.Config({'block_m': 128, 'block_n': 64,  'block_k': 32, 'group_size_m': 8}, num_stages=4, num_warps=4),
-        triton.Config({'block_m': 64,  'block_n': 128, 'block_k': 32, 'group_size_m': 8}, num_stages=4, num_warps=4),
-        triton.Config({'block_m': 128, 'block_n': 32,  'block_k': 32, 'group_size_m': 8}, num_stages=4, num_warps=4),
+        triton.Config(
+            {"block_m": 128, "block_n": 256, "block_k": 64, "group_size_m": 8},
+            num_stages=3,
+            num_warps=8,
+        ),
+        triton.Config(
+            {"block_m": 64, "block_n": 256, "block_k": 32, "group_size_m": 8},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"block_m": 128, "block_n": 128, "block_k": 32, "group_size_m": 8},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"block_m": 128, "block_n": 64, "block_k": 32, "group_size_m": 8},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"block_m": 64, "block_n": 128, "block_k": 32, "group_size_m": 8},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"block_m": 128, "block_n": 32, "block_k": 32, "group_size_m": 8},
+            num_stages=4,
+            num_warps=4,
+        ),
     ],
-    key=['m', 'n', 'k'],
+    key=["m", "n", "k"],
 )
 @triton.jit
 def _int8_matmul_dequant_per_row_kernel(
     # Pointers
-    a_ptr, b_ptr, c_ptr,
-    a_scale_ptr, b_scale_ptr, bias_ptr,
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    a_scale_ptr,
+    b_scale_ptr,
+    bias_ptr,
     # Matrix Dimensions
-    m, n, k,
+    m,
+    n,
+    k,
     # Strides
-    stride_am, stride_ak,
-    stride_bk, stride_bn,
-    stride_cm, stride_cn,
+    stride_am,
+    stride_ak,
+    stride_bk,
+    stride_bn,
+    stride_cm,
+    stride_cn,
     # Meta-parameters
-    block_m: tl.constexpr, block_n: tl.constexpr, block_k: tl.constexpr,
+    block_m: tl.constexpr,
+    block_n: tl.constexpr,
+    block_k: tl.constexpr,
     group_size_m: tl.constexpr,
-    has_bias: tl.constexpr
+    has_bias: tl.constexpr,
 ):
     """
     Computes: C = ((A * B) * (scale_a[:, None] * scale_b[None, :])) + bias
@@ -1000,6 +1081,7 @@ def _int8_matmul_dequant_per_row_kernel(
     c_ptrs = c_ptr + stride_cm * offs_am[:, None] + stride_cn * offs_bn[None, :]
     c_mask = (offs_am[:, None] < m) & (offs_bn[None, :] < n)
     tl.store(c_ptrs, c, mask=c_mask)
+
 
 def int8_linear(
     x: torch.Tensor,
@@ -1065,11 +1147,16 @@ def int8_linear(
             a_scale_ptr=x_scale,
             b_scale_ptr=weight_scale,
             bias_ptr=bias_ptr,
-            m=m, n=n, k=k,
-            stride_am=x_int8.stride(0), stride_ak=x_int8.stride(1),
-            stride_bk=weight.stride(1), stride_bn=weight.stride(0),
-            stride_cm=output.stride(0), stride_cn=output.stride(1),
-            has_bias=has_bias
+            m=m,
+            n=n,
+            k=k,
+            stride_am=x_int8.stride(0),
+            stride_ak=x_int8.stride(1),
+            stride_bk=weight.stride(1),
+            stride_bn=weight.stride(0),
+            stride_cm=output.stride(0),
+            stride_cn=output.stride(1),
+            has_bias=has_bias,
         )
     else:
         _int8_matmul_dequant_kernel[grid](
@@ -1079,11 +1166,16 @@ def int8_linear(
             a_scale_ptr=x_scale,
             b_scale_ptr=weight_scale,
             bias_ptr=bias_ptr,
-            m=m, n=n, k=k,
-            stride_am=x_int8.stride(0), stride_ak=x_int8.stride(1),
-            stride_bk=weight.stride(1), stride_bn=weight.stride(0),
-            stride_cm=output.stride(0), stride_cn=output.stride(1),
-            has_bias=has_bias
+            m=m,
+            n=n,
+            k=k,
+            stride_am=x_int8.stride(0),
+            stride_ak=x_int8.stride(1),
+            stride_bk=weight.stride(1),
+            stride_bn=weight.stride(0),
+            stride_cm=output.stride(0),
+            stride_cn=output.stride(1),
+            has_bias=has_bias,
         )
 
     return output.reshape(*orig_shape[:-1], n)


### PR DESCRIPTION
Replace libdevice.rint() with manual sign-aware rounding since Triton 3.6.0 HIP backend lacks rint, math.round, and int clamp. All 33 INT8 tests pass on gfx1100 (RDNA 3 / RX 7900 XT).


```
⬢ [jnolck@toolbx tests]$ python -m pytest test_int8.py -v
========================================================== test session starts ==========================================================
platform linux -- Python 3.12.13, pytest-7.4.4, pluggy-1.6.0 -- /home/jnolck/Documents/src/ai/.venv/bin/python
cachedir: .pytest_cache
rootdir: /var/home/jnolck/Documents/src/ai/comfy-kitchen
configfile: pytest.ini
plugins: anyio-4.13.0, dash-4.2.0, hydra-core-1.3.3
collected 33 items                                                                                                                      

test_int8.py::test_cuda_int8_cublas_turing_n_alignment PASSED                                                                     [  3%]
test_int8.py::test_eager_int8_matmul_turing_n_alignment PASSED                                                                    [  6%]
test_int8.py::TestTensorWiseINT8Layout::test_weight_quantize_shape_dtype PASSED                                                   [  9%]
test_int8.py::TestTensorWiseINT8Layout::test_activation_quantize_shape_dtype PASSED                                               [ 12%]
test_int8.py::TestTensorWiseINT8Layout::test_weight_dequantize_dtype PASSED                                                       [ 15%]
test_int8.py::TestTensorWiseINT8Layout::test_weight_roundtrip_error PASSED                                                        [ 18%]
test_int8.py::TestTensorWiseINT8Layout::test_state_dict_tensors_keys PASSED                                                       [ 21%]
test_int8.py::TestTensorWiseINT8Layout::test_supports_fast_matmul PASSED                                                          [ 24%]
test_int8.py::TestTensorWiseINT8Layout::test_linear_dispatch PASSED                                                               [ 27%]
test_int8.py::TestTensorWiseINT8Layout::test_linear_dispatch_uses_activation_dtype PASSED                                         [ 30%]
test_int8.py::TestTensorWiseINT8Layout::test_mm_dispatch PASSED                                                                   [ 33%]
test_int8.py::TestTensorWiseINT8Layout::test_mm_dispatch_uses_activation_dtype PASSED                                             [ 36%]
test_int8.py::TestTensorWiseINT8Layout::test_addmm_dispatch PASSED                                                                [ 39%]
test_int8.py::TestTensorWiseINT8Layout::test_addmm_dispatch_uses_activation_dtype PASSED                                          [ 42%]
test_int8.py::TestTensorWiseINT8Layout::test_int8_linear_correctness[triton] PASSED                                               [ 45%]
test_int8.py::TestTensorWiseINT8Layout::test_int8_linear_correctness[eager] PASSED                                                [ 48%]
test_int8.py::TestTensorWiseINT8Layout::test_public_api_quantize_tensorwise PASSED                                                [ 51%]
test_int8.py::TestTensorWiseINT8Layout::test_public_api_quantize_rowwise PASSED                                                   [ 54%]
test_int8.py::TestTensorWiseINT8Layout::test_public_api_dequantize_simple PASSED                                                  [ 57%]
test_int8.py::TestTensorWiseINT8Layout::test_public_api_int8_linear PASSED                                                        [ 60%]
test_int8.py::TestTensorWiseINT8Layout::test_convrot_hadamard_properties PASSED                                                   [ 63%]
test_int8.py::TestTensorWiseINT8Layout::test_convrot_param_validation PASSED                                                      [ 66%]
test_int8.py::TestTensorWiseINT8Layout::test_convrot_weight_roundtrip PASSED                                                      [ 69%]
test_int8.py::TestTensorWiseINT8Layout::test_convrot_divisibility PASSED                                                          [ 72%]
test_int8.py::TestTensorWiseINT8Layout::test_convrot_linear_mm_addmm_dispatch PASSED                                              [ 75%]
test_int8.py::TestTensorWiseINT8Layout::test_convrot_triton_fused_correctness PASSED                                              [ 78%]
test_int8.py::TestTensorWisePublicAPI::test_public_api_quantize_tensorwise PASSED                                                 [ 81%]
test_int8.py::TestTensorWisePublicAPI::test_public_api_quantize_rowwise PASSED                                                    [ 84%]
test_int8.py::TestTensorWisePublicAPI::test_public_api_dequantize_simple PASSED                                                   [ 87%]
test_int8.py::TestTensorWisePublicAPI::test_public_api_int8_linear PASSED                                                         [ 90%]
test_int8.py::TestTensorWisePublicAPI::test_eager_int8_linear_single_row PASSED                                                   [ 93%]
test_int8.py::TestTensorWisePublicAPI::test_eager_int8_linear_pads_k_to_int8_mm_tile PASSED                                       [ 96%]
test_int8.py::TestTensorWisePublicAPI::test_eager_int8_linear_pads_n_to_int8_mm_tile PASSED                                       [100%]

========================================================== 33 passed in 13.94s ==========================================================
```
A lot of them were failing before and I was getting seg faults when trying to run workflows and started comfy with --enable-triton-backend. 