### PR TITLE
int4_tensorwise: W4A4 layout (+ConvRot) with fused CUDA kernels

### DIFF
--- a/comfy_kitchen/backends/cuda/CMakeLists.txt
+++ b/comfy_kitchen/backends/cuda/CMakeLists.txt
@@ -111,6 +111,7 @@ set(CUDA_SOURCES
     ops/apply_rope.cu
     ops/quantize_svdquant_w4a4.cu
     ops/scaled_mm_svdquant_w4a4.cu
+    ops/int4_tensorwise.cu
     ops/awq_w4a16.cu
     ops/adaln.cu
 )

--- a/comfy_kitchen/backends/cuda/__init__.py
+++ b/comfy_kitchen/backends/cuda/__init__.py
@@ -1442,6 +1442,14 @@ def scaled_mm_svdquant_w4a4(
 
 
 _INT4_TENSORWISE_EMPTY_LORA_CACHE: dict = {}
+# Last-activation quantize memo: attention q/k (and txt-stream add_q/add_k)
+# projections receive the SAME activation tensor object back to back, so the
+# rotated+quantized activation can be reused. Guarded by object identity plus
+# torch's in-place version counter — a capacity-1 memo, overwritten every miss.
+_INT4_TENSORWISE_QUANT_MEMO: list = [None]
+_INT4_TENSORWISE_QUANT_MEMO_ENABLED = os.getenv(
+    "COMFY_KITCHEN_INT4_QUANT_MEMO", "1"
+).lower() not in {"0", "false", "no", "off"}
 
 
 def int4_linear(
@@ -1478,25 +1486,40 @@ def int4_linear(
         raise ValueError(f"ConvRot group size 256 does not divide input features {K}")
 
     orig_shape = x.shape
-    x2d = x.reshape(-1, K).contiguous()
-    M = x2d.shape[0]
-    M_pad = roundup(max(M, 1), 256)
+    try:
+        x_version = x._version
+    except RuntimeError:
+        # Inference-mode tensors track no version counter. Fall back to an
+        # identity-only guard: the memo has capacity 1, so it only ever serves
+        # back-to-back projections of the same activation object (q/k pattern) —
+        # any interleaved int4_linear call evicts it.
+        x_version = -1
+    memo_tag = (x_version, K, bool(convrot), int(convrot_groupsize), x.device, x.dtype)
+    memo = _INT4_TENSORWISE_QUANT_MEMO[0]
+    if memo is not None and memo[0] is x and memo[1] == memo_tag:
+        q_x, ascales, M, M_pad = memo[2], memo[3], memo[4], memo[5]
+    else:
+        x2d = x.reshape(-1, K).contiguous()
+        M = x2d.shape[0]
+        M_pad = roundup(max(M, 1), 256)
 
-    q_x = torch.empty(M_pad, k_half, dtype=torch.int8, device=x.device)
-    # Rank-1 GEMM path reads only the first scale-group row, so a single-group
-    # ascales buffer suffices (the quantize kernel writes ascales.shape[0] groups).
-    ascales = torch.empty(1, M_pad, dtype=x2d.dtype, device=x.device)
-    stream_ptr = torch.cuda.current_stream(x.device).cuda_stream
-    _C.int4_tensorwise_quantize(
-        _wrap_for_dlpack(x2d),
-        _wrap_for_dlpack(q_x),
-        _wrap_for_dlpack(ascales),
-        bool(convrot),
-        stream_ptr,
-    )
+        q_x = torch.empty(M_pad, k_half, dtype=torch.int8, device=x.device)
+        # Rank-1 GEMM path reads only the first scale-group row, so a single-group
+        # ascales buffer suffices (the quantize kernel writes ascales.shape[0] groups).
+        ascales = torch.empty(1, M_pad, dtype=x2d.dtype, device=x.device)
+        stream_ptr = torch.cuda.current_stream(x.device).cuda_stream
+        _C.int4_tensorwise_quantize(
+            _wrap_for_dlpack(x2d),
+            _wrap_for_dlpack(q_x),
+            _wrap_for_dlpack(ascales),
+            bool(convrot),
+            stream_ptr,
+        )
+        if _INT4_TENSORWISE_QUANT_MEMO_ENABLED:
+            _INT4_TENSORWISE_QUANT_MEMO[0] = (x, memo_tag, q_x, ascales, M, M_pad)
 
     # Rank-1 GEMM path reads only the first wscales row: no per-group broadcast.
-    wscales = weight_scale.reshape(1, N).to(device=weight.device, dtype=x2d.dtype).contiguous()
+    wscales = weight_scale.reshape(1, N).to(device=weight.device, dtype=x.dtype).contiguous()
 
     lkey = (x.device.index, out_dtype, N)
     lora = _INT4_TENSORWISE_EMPTY_LORA_CACHE.get(lkey)

--- a/comfy_kitchen/backends/cuda/__init__.py
+++ b/comfy_kitchen/backends/cuda/__init__.py
@@ -1473,17 +1473,17 @@ def int4_linear(
       out          (..., N)   out_dtype
     """
     k_half = weight.shape[-1]
-    K = k_half * 2
-    N = weight.shape[0]
-    if x.shape[-1] != K:
+    k = k_half * 2
+    n = weight.shape[0]
+    if x.shape[-1] != k:
         raise ValueError(
-            f"Input and weight inner dimensions must match, got {x.shape[-1]} and {K} "
+            f"Input and weight inner dimensions must match, got {x.shape[-1]} and {k} "
             f"(packed weight {tuple(weight.shape)})"
         )
     if convrot and convrot_groupsize != 256:
         raise ValueError("int4_tensorwise fused kernel only supports convrot_groupsize 256")
-    if convrot and K % 256 != 0:
-        raise ValueError(f"ConvRot group size 256 does not divide input features {K}")
+    if convrot and k % 256 != 0:
+        raise ValueError(f"ConvRot group size 256 does not divide input features {k}")
 
     orig_shape = x.shape
     try:
@@ -1494,19 +1494,19 @@ def int4_linear(
         # back-to-back projections of the same activation object (q/k pattern) —
         # any interleaved int4_linear call evicts it.
         x_version = -1
-    memo_tag = (x_version, K, bool(convrot), int(convrot_groupsize), x.device, x.dtype)
+    memo_tag = (x_version, k, bool(convrot), int(convrot_groupsize), x.device, x.dtype)
     memo = _INT4_TENSORWISE_QUANT_MEMO[0]
     if memo is not None and memo[0] is x and memo[1] == memo_tag:
-        q_x, ascales, M, M_pad = memo[2], memo[3], memo[4], memo[5]
+        q_x, ascales, m, m_pad = memo[2], memo[3], memo[4], memo[5]
     else:
-        x2d = x.reshape(-1, K).contiguous()
-        M = x2d.shape[0]
-        M_pad = roundup(max(M, 1), 256)
+        x2d = x.reshape(-1, k).contiguous()
+        m = x2d.shape[0]
+        m_pad = roundup(max(m, 1), 256)
 
-        q_x = torch.empty(M_pad, k_half, dtype=torch.int8, device=x.device)
+        q_x = torch.empty(m_pad, k_half, dtype=torch.int8, device=x.device)
         # Rank-1 GEMM path reads only the first scale-group row, so a single-group
         # ascales buffer suffices (the quantize kernel writes ascales.shape[0] groups).
-        ascales = torch.empty(1, M_pad, dtype=x2d.dtype, device=x.device)
+        ascales = torch.empty(1, m_pad, dtype=x2d.dtype, device=x.device)
         stream_ptr = torch.cuda.current_stream(x.device).cuda_stream
         _C.int4_tensorwise_quantize(
             _wrap_for_dlpack(x2d),
@@ -1516,17 +1516,17 @@ def int4_linear(
             stream_ptr,
         )
         if _INT4_TENSORWISE_QUANT_MEMO_ENABLED:
-            _INT4_TENSORWISE_QUANT_MEMO[0] = (x, memo_tag, q_x, ascales, M, M_pad)
+            _INT4_TENSORWISE_QUANT_MEMO[0] = (x, memo_tag, q_x, ascales, m, m_pad)
 
     # Rank-1 GEMM path reads only the first wscales row: no per-group broadcast.
-    wscales = weight_scale.reshape(1, N).to(device=weight.device, dtype=x.dtype).contiguous()
+    wscales = weight_scale.reshape(1, n).to(device=weight.device, dtype=x.dtype).contiguous()
 
-    lkey = (x.device.index, out_dtype, N)
+    lkey = (x.device.index, out_dtype, n)
     lora = _INT4_TENSORWISE_EMPTY_LORA_CACHE.get(lkey)
     if lora is None:
-        lora = torch.empty(N, 0, dtype=out_dtype, device=x.device)
+        lora = torch.empty(n, 0, dtype=out_dtype, device=x.device)
         _INT4_TENSORWISE_EMPTY_LORA_CACHE[lkey] = lora
-    lora_act = torch.empty(M_pad, 0, dtype=out_dtype, device=x.device)
+    lora_act = torch.empty(m_pad, 0, dtype=out_dtype, device=x.device)
 
     if bias is not None and bias.dtype != out_dtype:
         bias = bias.to(out_dtype)
@@ -1542,14 +1542,14 @@ def int4_linear(
         act_unsigned=False,
         rank_one=True,
     )
-    return out[:M].reshape(*orig_shape[:-1], N)
+    return out[:m].reshape(*orig_shape[:-1], n)
 
 
-# Above this M the fused MMA kernel falls behind cuBLAS bf16 GEMM on Blackwell
-# (cuBLAS approaches peak; the kernel here is single-thread-per-N-row in the
+# Above this m the fused MMA kernel falls behind cuBLAS bf16 GEMM on Blackwell
+# (cuBLAS approaches peak; the kernel here is single-thread-per-n-row in the
 # dequant pass and lacks cp.async pipelining). Empirically the crossover sits
-# near M=256 on RTX 5090 / Qwen-Image-Edit shapes (M=256: 1.6x vs eager,
-# M=512: 0.88x). Above the limit we route to a CUDA-side dequant +
+# near m=256 on RTX 5090 / Qwen-Image-Edit shapes (m=256: 1.6x vs eager,
+# m=512: 0.88x). Above the limit we route to a CUDA-side dequant +
 # torch.matmul (cuBLAS) path. Future tuning of the MMA kernel will raise
 # this limit and eventually remove the fallback.
 _AWQ_W4A16_MMA_M_LIMIT = 256

--- a/comfy_kitchen/backends/cuda/__init__.py
+++ b/comfy_kitchen/backends/cuda/__init__.py
@@ -33,6 +33,7 @@ __all__ = [
     "dequantize_int8_convrot_weight",
     "dequantize_int8_convrot_weight_dtype",
     "int8_linear",
+    "int4_linear",
     "quantize_int8_tensorwise",
     "quantize_int8_rowwise",
     "quantize_int8_convrot_weight",
@@ -1438,6 +1439,91 @@ def scaled_mm_svdquant_w4a4(
     return out
 
 
+_INT4_TENSORWISE_EMPTY_LORA_CACHE: dict = {}
+
+
+def int4_linear(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    out_dtype: torch.dtype = torch.bfloat16,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+) -> torch.Tensor:
+    """int4_tensorwise W4A4 linear (CUDA): fused ConvRot + per-row int4 activation
+    quantize, then the SVDQuant s4 MMA GEMM with rank-1 scales broadcast into the
+    per-group layout (exact special case; no LoRA branch).
+
+    Layouts:
+      x            (..., K)   bf16/fp16
+      weight       (N, K/2)   int8, two signed int4/byte low-nibble-first, natural row-major
+      weight_scale (N,)/(N,1) fp32 per-output-channel
+      bias         (N,)       optional
+      out          (..., N)   out_dtype
+    """
+    k_half = weight.shape[-1]
+    K = k_half * 2
+    N = weight.shape[0]
+    if x.shape[-1] != K:
+        raise ValueError(
+            f"Input and weight inner dimensions must match, got {x.shape[-1]} and {K} "
+            f"(packed weight {tuple(weight.shape)})"
+        )
+    if convrot and convrot_groupsize != 256:
+        raise ValueError("int4_tensorwise fused kernel only supports convrot_groupsize 256")
+    if convrot and K % 256 != 0:
+        raise ValueError(f"ConvRot group size 256 does not divide input features {K}")
+
+    orig_shape = x.shape
+    x2d = x.reshape(-1, K).contiguous()
+    M = x2d.shape[0]
+    M_pad = roundup(max(M, 1), 256)
+
+    q_x = torch.empty(M_pad, k_half, dtype=torch.int8, device=x.device)
+    ascales = torch.empty(K // 64, M_pad, dtype=x2d.dtype, device=x.device)
+    stream_ptr = torch.cuda.current_stream(x.device).cuda_stream
+    _C.int4_tensorwise_quantize(
+        _wrap_for_dlpack(x2d),
+        _wrap_for_dlpack(q_x),
+        _wrap_for_dlpack(ascales),
+        bool(convrot),
+        stream_ptr,
+    )
+
+    # Rank-1 weight scale broadcast into the (K/64, N) per-group layout. Computed
+    # per call: a data_ptr-keyed cache is unsafe (the allocator reuses freed
+    # addresses) and the broadcast costs ~microseconds per layer.
+    wscales = (
+        weight_scale.reshape(1, N)
+        .to(device=weight.device, dtype=x2d.dtype)
+        .expand(K // 64, N)
+        .contiguous()
+    )
+
+    lkey = (x.device.index, out_dtype, N)
+    lora = _INT4_TENSORWISE_EMPTY_LORA_CACHE.get(lkey)
+    if lora is None:
+        lora = torch.empty(N, 0, dtype=out_dtype, device=x.device)
+        _INT4_TENSORWISE_EMPTY_LORA_CACHE[lkey] = lora
+    lora_act = torch.empty(M_pad, 0, dtype=out_dtype, device=x.device)
+
+    if bias is not None and bias.dtype != out_dtype:
+        bias = bias.to(out_dtype)
+
+    out = scaled_mm_svdquant_w4a4(
+        q_x,
+        weight,
+        ascales,
+        wscales,
+        lora_act,
+        lora,
+        bias=bias,
+        act_unsigned=False,
+    )
+    return out[:M].reshape(*orig_shape[:-1], N)
+
+
 # Above this M the fused MMA kernel falls behind cuBLAS bf16 GEMM on Blackwell
 # (cuBLAS approaches peak; the kernel here is single-thread-per-N-row in the
 # dequant pass and lacks cp.async pipelining). Empirically the crossover sits
@@ -1817,6 +1903,18 @@ def _build_constraints() -> dict:
                     dtypes=frozenset({torch.float32, torch.float16, torch.bfloat16})
                 ),
                 "lora_up": ParamConstraint(dtypes=frozenset({torch.float16, torch.bfloat16})),
+            },
+            default_devices=cuda_devices,
+            min_compute_capability=(8, 0),
+        ),
+        "int4_linear": FunctionConstraints(
+            params={
+                "x": ParamConstraint(dtypes=frozenset({torch.float16, torch.bfloat16})),
+                "weight": ParamConstraint(dtypes=frozenset({torch.int8}), shape_rules=(ExactDims(2),)),
+                "weight_scale": ParamConstraint(dtypes=frozenset({torch.float32, torch.float16, torch.bfloat16})),
+                "bias": ParamConstraint(dtypes=frozenset({torch.float16, torch.bfloat16})),
+                "convrot": ParamConstraint(dtypes=frozenset({bool})),
+                "convrot_groupsize": ParamConstraint(dtypes=frozenset({int})),
             },
             default_devices=cuda_devices,
             min_compute_capability=(8, 0),

--- a/comfy_kitchen/backends/cuda/__init__.py
+++ b/comfy_kitchen/backends/cuda/__init__.py
@@ -1518,8 +1518,12 @@ def int4_linear(
         if _INT4_TENSORWISE_QUANT_MEMO_ENABLED:
             _INT4_TENSORWISE_QUANT_MEMO[0] = (x, memo_tag, q_x, ascales, m, m_pad)
 
+    # The GEMM launcher reinterprets both scale buffers as out_dtype, so keep
+    # them in that lane (the quantize kernel writes ascales in x.dtype).
+    if ascales.dtype != out_dtype:
+        ascales = ascales.to(out_dtype)
     # Rank-1 GEMM path reads only the first wscales row: no per-group broadcast.
-    wscales = weight_scale.reshape(1, n).to(device=weight.device, dtype=x.dtype).contiguous()
+    wscales = weight_scale.reshape(1, n).to(device=weight.device, dtype=out_dtype).contiguous()
 
     lkey = (x.device.index, out_dtype, n)
     lora = _INT4_TENSORWISE_EMPTY_LORA_CACHE.get(lkey)

--- a/comfy_kitchen/backends/cuda/__init__.py
+++ b/comfy_kitchen/backends/cuda/__init__.py
@@ -1366,6 +1366,7 @@ def scaled_mm_svdquant_w4a4(
     lora_up: torch.Tensor,
     bias: torch.Tensor | None = None,
     act_unsigned: bool = False,
+    rank_one: bool = False,
 ) -> torch.Tensor:
     """SVDQuant W4A4 int4 GEMM + LoRA-up + bias (CUDA).
 
@@ -1427,6 +1428,7 @@ def scaled_mm_svdquant_w4a4(
         fast_accum,
         shared_scale,
         fuse_lora,
+        rank_one,
         stream_ptr,
     )
 
@@ -1481,7 +1483,9 @@ def int4_linear(
     M_pad = roundup(max(M, 1), 256)
 
     q_x = torch.empty(M_pad, k_half, dtype=torch.int8, device=x.device)
-    ascales = torch.empty(K // 64, M_pad, dtype=x2d.dtype, device=x.device)
+    # Rank-1 GEMM path reads only the first scale-group row, so a single-group
+    # ascales buffer suffices (the quantize kernel writes ascales.shape[0] groups).
+    ascales = torch.empty(1, M_pad, dtype=x2d.dtype, device=x.device)
     stream_ptr = torch.cuda.current_stream(x.device).cuda_stream
     _C.int4_tensorwise_quantize(
         _wrap_for_dlpack(x2d),
@@ -1491,15 +1495,8 @@ def int4_linear(
         stream_ptr,
     )
 
-    # Rank-1 weight scale broadcast into the (K/64, N) per-group layout. Computed
-    # per call: a data_ptr-keyed cache is unsafe (the allocator reuses freed
-    # addresses) and the broadcast costs ~microseconds per layer.
-    wscales = (
-        weight_scale.reshape(1, N)
-        .to(device=weight.device, dtype=x2d.dtype)
-        .expand(K // 64, N)
-        .contiguous()
-    )
+    # Rank-1 GEMM path reads only the first wscales row: no per-group broadcast.
+    wscales = weight_scale.reshape(1, N).to(device=weight.device, dtype=x2d.dtype).contiguous()
 
     lkey = (x.device.index, out_dtype, N)
     lora = _INT4_TENSORWISE_EMPTY_LORA_CACHE.get(lkey)
@@ -1520,6 +1517,7 @@ def int4_linear(
         lora,
         bias=bias,
         act_unsigned=False,
+        rank_one=True,
     )
     return out[:M].reshape(*orig_shape[:-1], N)
 

--- a/comfy_kitchen/backends/cuda/dlpack_bindings.cpp
+++ b/comfy_kitchen/backends/cuda/dlpack_bindings.cpp
@@ -140,6 +140,18 @@ extern "C" {
         int input_dtype_code,
         cudaStream_t stream);
 
+    // int4_tensorwise W4A4 — see ops/int4_tensorwise.cu
+    void launch_int4_tensorwise_quantize_kernel(
+        const void* x,
+        void* q,
+        void* ascales,
+        int64_t M,
+        int64_t M_pad,
+        int64_t K,
+        int input_dtype_code,
+        bool rotate,
+        cudaStream_t stream);
+
     // SVDQuant W4A4 — see ops/quantize_svdquant_w4a4.cu
     void launch_svdquant_quantize_w4a4_kernel(
         const void* x,
@@ -601,6 +613,24 @@ static int svdquant_dtype_code(const nb::dlpack::dtype& dt) {
     int c = map_dtype_to_code(dt);
     if (c < 0) throw std::runtime_error("svdquant: unsupported dtype");
     return c;
+}
+
+void int4_tensorwise_quantize(
+    nb::ndarray<nb::device::cuda> x,           // (M, K) bf16/fp16
+    nb::ndarray<nb::device::cuda> q_x,         // (M_pad, K/2) int8
+    nb::ndarray<nb::device::cuda> ascales,     // (K/64, M_pad) same dtype as x
+    bool rotate,
+    uintptr_t stream_ptr)
+{
+    int64_t M = static_cast<int64_t>(x.shape(0));
+    int64_t K = static_cast<int64_t>(x.shape(1));
+    int64_t M_pad = static_cast<int64_t>(q_x.shape(0));
+    int input_code = svdquant_dtype_code(x.dtype());
+
+    cudaStream_t stream = reinterpret_cast<cudaStream_t>(stream_ptr);
+    launch_int4_tensorwise_quantize_kernel(
+        x.data(), q_x.data(), ascales.data(),
+        M, M_pad, K, input_code, rotate, stream);
 }
 
 void svdquant_quantize_w4a4(
@@ -1588,6 +1618,16 @@ NB_MODULE(_C, m) {
           nb::arg("output"),
           nb::arg("block_scales"),
           nb::arg("pad_32x") = false,
+          nb::arg("stream_ptr"));
+
+    m.def("int4_tensorwise_quantize", &int4_tensorwise_quantize,
+          "int4_tensorwise W4A4: optional fused ConvRot (group-256 FHT) + per-row "
+          "symmetric int4 quantize (absmax/7, [-7,7]) packed low-nibble-first; "
+          "per-row scale broadcast into the (K/64, M_pad) svdquant ascales layout.",
+          nb::arg("x"),
+          nb::arg("q_x"),
+          nb::arg("ascales"),
+          nb::arg("rotate"),
           nb::arg("stream_ptr"));
 
     m.def("svdquant_quantize_w4a4", &svdquant_quantize_w4a4,

--- a/comfy_kitchen/backends/cuda/dlpack_bindings.cpp
+++ b/comfy_kitchen/backends/cuda/dlpack_bindings.cpp
@@ -148,6 +148,7 @@ extern "C" {
         int64_t M,
         int64_t M_pad,
         int64_t K,
+        int64_t n_scale_groups,
         int input_dtype_code,
         bool rotate,
         cudaStream_t stream);
@@ -188,6 +189,7 @@ extern "C" {
         int fast_accum,
         int shared_scale,
         int fuse_lora,
+        int rank_one,
         cudaStream_t stream);
 
     // AWQ W4A16 — see ops/awq_w4a16.cu. Internal M-routing picks
@@ -625,12 +627,13 @@ void int4_tensorwise_quantize(
     int64_t M = static_cast<int64_t>(x.shape(0));
     int64_t K = static_cast<int64_t>(x.shape(1));
     int64_t M_pad = static_cast<int64_t>(q_x.shape(0));
+    int64_t n_scale_groups = static_cast<int64_t>(ascales.shape(0));
     int input_code = svdquant_dtype_code(x.dtype());
 
     cudaStream_t stream = reinterpret_cast<cudaStream_t>(stream_ptr);
     launch_int4_tensorwise_quantize_kernel(
         x.data(), q_x.data(), ascales.data(),
-        M, M_pad, K, input_code, rotate, stream);
+        M, M_pad, K, n_scale_groups, input_code, rotate, stream);
 }
 
 void svdquant_quantize_w4a4(
@@ -670,6 +673,7 @@ void svdquant_scaled_mm_w4a4(
     bool fast_accum,
     bool shared_scale,
     bool fuse_lora,
+    bool rank_one,
     uintptr_t stream_ptr)
 {
     int M = static_cast<int>(act.shape(0));
@@ -708,7 +712,8 @@ void svdquant_scaled_mm_w4a4(
         M, N, K, R,
         static_cast<int>(act_unsigned), out_code,
         static_cast<int>(tile_packed), static_cast<int>(fast_accum),
-        static_cast<int>(shared_scale), static_cast<int>(fuse_lora), stream);
+        static_cast<int>(shared_scale), static_cast<int>(fuse_lora),
+        static_cast<int>(rank_one), stream);
 }
 
 // ---------------------------------------------------------------------------
@@ -1657,6 +1662,7 @@ NB_MODULE(_C, m) {
           nb::arg("fast_accum"),
           nb::arg("shared_scale"),
           nb::arg("fuse_lora"),
+          nb::arg("rank_one"),
           nb::arg("stream_ptr"));
 
     m.def("awq_w4a16", &awq_w4a16,

--- a/comfy_kitchen/backends/cuda/ops/int4_tensorwise.cu
+++ b/comfy_kitchen/backends/cuda/ops/int4_tensorwise.cu
@@ -1,0 +1,283 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Comfy Org. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * int4_tensorwise (W4A4 + ConvRot) fused activation quantize.
+ *
+ * Produces the operands the SVDQuant W4A4 MMA kernel consumes, but with the
+ * int4_tensorwise semantics: optional fused ConvRot rotation (group-256 regular
+ * Hadamard, FHT — same butterfly as ops/int8_linear.cu) followed by PER-ROW
+ * symmetric int4 quantization (scale = absmax/7, emission [-7, 7], packed two
+ * codes per byte LOW nibble first). The per-row scale is broadcast into the
+ * (K/64, M_pad) per-group ascales layout expected by scaled_mm_svdquant_w4a4 —
+ * a rank-1 scale is an exact special case of the per-group layout, so the
+ * existing s4 MMA GEMM computes the int4_tensorwise linear exactly.
+ *
+ *   in : x        (M, K)       bf16/fp16/fp32
+ *   out: q_x      (M_pad, K/2) int8   two signed int4 per byte, low nibble first
+ *        ascales  (K/64, M_pad) same dtype as x  (per-row scale, broadcast)
+ *
+ * Rows in [M, M_pad) are zero-filled (q = 0, scale = 0) so the GEMM's padding
+ * rows are benign; callers slice the output back to M rows.
+ */
+
+#include "utils.cuh"
+#include "dtype_dispatch.cuh"
+
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+#include <string>
+
+namespace comfy {
+
+namespace {
+
+constexpr int kInt4ConvRotGroup = 256;
+constexpr int kInt4ScaleGroup = 64;   // ascales group expected by the svdquant MMA
+constexpr float kInt4Max = 7.0f;
+
+template<typename T>
+__device__ __forceinline__ float i4_to_float(T val);
+template<> __device__ __forceinline__ float i4_to_float<float>(float val) { return val; }
+template<> __device__ __forceinline__ float i4_to_float<half>(half val) { return __half2float(val); }
+template<> __device__ __forceinline__ float i4_to_float<nv_bfloat16>(nv_bfloat16 val) { return __bfloat162float(val); }
+
+template<typename T>
+__device__ __forceinline__ T i4_from_float(float val);
+template<> __device__ __forceinline__ float i4_from_float<float>(float val) { return val; }
+template<> __device__ __forceinline__ half i4_from_float<half>(float val) { return __float2half_rn(val); }
+template<> __device__ __forceinline__ nv_bfloat16 i4_from_float<nv_bfloat16>(float val) { return __float2bfloat16_rn(val); }
+
+// Emulates the eager recipe's division at the source dtype: value and scale are
+// both rounded through T before the divide (matches quantize_int4_rowwise).
+template<typename T>
+__device__ __forceinline__ float i4_quant_div(float val, float scale) {
+    const float scale_t = i4_to_float(i4_from_float<T>(scale));
+    return i4_to_float(i4_from_float<T>(i4_to_float(i4_from_float<T>(val)) / scale_t));
+}
+
+__device__ __forceinline__ float i4_warp_reduce_max(float v) {
+    for (int offset = kThreadsPerWarp / 2; offset > 0; offset >>= 1) {
+        v = fmaxf(v, __shfl_down_sync(0xffffffff, v, offset));
+    }
+    return v;
+}
+
+template<int NUM_WARPS>
+__device__ __forceinline__ float i4_block_reduce_max(float v, float* warp_smem, float* block_smem) {
+    const int lane = threadIdx.x & (kThreadsPerWarp - 1);
+    const int wid = threadIdx.x >> 5;
+    v = i4_warp_reduce_max(v);
+    if (lane == 0) {
+        warp_smem[wid] = v;
+    }
+    __syncthreads();
+    if (wid == 0) {
+        float total = lane < NUM_WARPS ? warp_smem[lane] : 0.0f;
+        total = i4_warp_reduce_max(total);
+        if (lane == 0) {
+            *block_smem = total;
+        }
+    }
+    __syncthreads();
+    return *block_smem;
+}
+
+__device__ __forceinline__ float i4_h4_row_dot(int d, float x0, float x1, float x2, float x3) {
+    switch (d) {
+        case 0:  return  x0 + x1 + x2 - x3;
+        case 1:  return  x0 + x1 - x2 + x3;
+        case 2:  return  x0 - x1 + x2 + x3;
+        default: return -x0 + x1 + x2 + x3;
+    }
+}
+
+__device__ __forceinline__ int8_t i4_pack_pair(float c0, float c1) {
+    const int i0 = static_cast<int>(c0);
+    const int i1 = static_cast<int>(c1);
+    return static_cast<int8_t>((i0 & 0xF) | ((i1 & 0xF) << 4));
+}
+
+// One block per output row (grid = M_pad). ROTATE=true runs the group-256 FHT
+// in shared memory first (structure identical to int8_linear.cu's fused
+// ConvRot kernel); ROTATE=false quantizes straight from global memory.
+template<typename InputType, int BLOCK_THREADS, bool ROTATE>
+__global__ void quantize_int4_tensorwise_kernel(
+    const InputType* __restrict__ x,
+    int8_t* __restrict__ q,
+    InputType* __restrict__ ascales,
+    int M,
+    int M_pad,
+    int K)
+{
+    constexpr int kWarps = BLOCK_THREADS / kThreadsPerWarp;
+    const int row = static_cast<int>(blockIdx.x);
+    const int tid = threadIdx.x;
+    const int k_half = K / 2;
+    const int n_scale_groups = K / kInt4ScaleGroup;
+
+    if (row >= M) {
+        // Padding row: benign zeros (the GEMM output rows are discarded).
+        for (int p = tid; p < k_half; p += BLOCK_THREADS) {
+            q[static_cast<int64_t>(row) * k_half + p] = 0;
+        }
+        for (int g = tid; g < n_scale_groups; g += BLOCK_THREADS) {
+            ascales[static_cast<int64_t>(g) * M_pad + row] = i4_from_float<InputType>(0.0f);
+        }
+        return;
+    }
+
+    extern __shared__ float smem[];
+    float* row_buf = smem;      // ROTATE: K floats (rotated row, in place)
+    float* tmp = smem + K;      // ROTATE: kGroupsInFlight * 2 * 256 floats
+    __shared__ float warp_smem[kWarps];
+    __shared__ float block_smem;
+
+    const int64_t row_offset = static_cast<int64_t>(row) * K;
+
+    if constexpr (ROTATE) {
+        for (int col = tid; col < K; col += BLOCK_THREADS) {
+            row_buf[col] = i4_to_float(x[row_offset + col]);
+        }
+        __syncthreads();
+
+        constexpr int kGroupsInFlight = BLOCK_THREADS / kInt4ConvRotGroup;
+        const int n_groups = K / kInt4ConvRotGroup;
+        const int sub = tid / kInt4ConvRotGroup;
+        const int i = tid % kInt4ConvRotGroup;
+        float* buf0 = tmp + sub * (2 * kInt4ConvRotGroup);
+        float* buf1 = buf0 + kInt4ConvRotGroup;
+        const int iters = (n_groups + kGroupsInFlight - 1) / kGroupsInFlight;
+
+        for (int it = 0; it < iters; ++it) {
+            const int g = it * kGroupsInFlight + sub;
+            const bool active = (g < n_groups);
+            float* src = active ? (row_buf + g * kInt4ConvRotGroup) : buf0;
+            float* dst = active ? buf0 : buf1;
+            #pragma unroll
+            for (int stage = 0; stage < 4; ++stage) {
+                const int s = (stage == 0) ? 1 : (stage == 1) ? 4 : (stage == 2) ? 16 : 64;
+                const int d = (i / s) & 3;
+                const int base = i - d * s;
+                const float v = 0.5f * i4_h4_row_dot(
+                    d, src[base], src[base + s], src[base + 2 * s], src[base + 3 * s]);
+                dst[i] = v;
+                __syncthreads();
+                float* t = src; src = dst; dst = t;
+            }
+        }
+
+        // Match the eager reference bit-for-bit: eager rotates via one
+        // fp32-accumulated matmul whose OUTPUT is rounded to the source dtype
+        // once. The FHT above is the same fp32 linear map, so a single
+        // round-through-InputType here reproduces eager's rotated values.
+        for (int col = tid; col < K; col += BLOCK_THREADS) {
+            row_buf[col] = i4_to_float(i4_from_float<InputType>(row_buf[col]));
+        }
+        __syncthreads();
+    }
+
+    // Per-row absmax over the (rotated) values -> scale = absmax / 7.
+    float abs_max = 0.0f;
+    if constexpr (ROTATE) {
+        for (int col = tid; col < K; col += BLOCK_THREADS) {
+            abs_max = fmaxf(abs_max, fabsf(row_buf[col]));
+        }
+    } else {
+        for (int col = tid; col < K; col += BLOCK_THREADS) {
+            abs_max = fmaxf(abs_max, fabsf(i4_to_float(x[row_offset + col])));
+        }
+    }
+    abs_max = i4_block_reduce_max<kWarps>(abs_max, warp_smem, &block_smem);
+    const float scale = fmaxf(abs_max * (1.0f / kInt4Max), 1.0e-30f);
+
+    for (int g = tid; g < n_scale_groups; g += BLOCK_THREADS) {
+        ascales[static_cast<int64_t>(g) * M_pad + row] = i4_from_float<InputType>(scale);
+    }
+
+    // Quantize + pack two codes per byte, LOW nibble first.
+    for (int p = tid; p < k_half; p += BLOCK_THREADS) {
+        const int col = 2 * p;
+        float v0, v1;
+        if constexpr (ROTATE) {
+            v0 = i4_quant_div<InputType>(row_buf[col], scale);
+            v1 = i4_quant_div<InputType>(row_buf[col + 1], scale);
+        } else {
+            v0 = i4_quant_div<InputType>(i4_to_float(x[row_offset + col]), scale);
+            v1 = i4_quant_div<InputType>(i4_to_float(x[row_offset + col + 1]), scale);
+        }
+        const float c0 = fminf(kInt4Max, fmaxf(-kInt4Max, nearbyintf(v0)));
+        const float c1 = fminf(kInt4Max, fmaxf(-kInt4Max, nearbyintf(v1)));
+        q[static_cast<int64_t>(row) * k_half + p] = i4_pack_pair(c0, c1);
+    }
+}
+
+}  // namespace
+
+}  // namespace comfy
+
+extern "C" {
+
+void launch_int4_tensorwise_quantize_kernel(
+    const void* x,
+    void* q,
+    void* ascales,
+    int64_t M,
+    int64_t M_pad,
+    int64_t K,
+    int input_dtype_code,
+    bool rotate,
+    cudaStream_t stream)
+{
+    if (M_pad == 0 || K == 0) {
+        return;
+    }
+    if (K % (2 * comfy::kInt4ScaleGroup) != 0) {
+        throw std::runtime_error("int4_tensorwise quantize requires K divisible by 128");
+    }
+    if (rotate && K % comfy::kInt4ConvRotGroup != 0) {
+        throw std::runtime_error("int4_tensorwise ConvRot requires K divisible by 256");
+    }
+    if (K > static_cast<int64_t>(std::numeric_limits<int>::max())) {
+        throw std::runtime_error("int4_tensorwise quantize only supports K <= INT_MAX");
+    }
+
+    DISPATCH_FP_DTYPE(input_dtype_code, InputType, [&] {
+        if (rotate) {
+            constexpr int kBlockThreads = 1024;
+            constexpr int kGroupsInFlight = kBlockThreads / comfy::kInt4ConvRotGroup;
+            auto kernel = comfy::quantize_int4_tensorwise_kernel<InputType, kBlockThreads, true>;
+            const size_t smem_bytes =
+                (static_cast<size_t>(K) + kGroupsInFlight * 2 * comfy::kInt4ConvRotGroup) * sizeof(float);
+            cudaError_t attr_err = cudaFuncSetAttribute(
+                kernel, cudaFuncAttributeMaxDynamicSharedMemorySize,
+                static_cast<int>(smem_bytes));
+            if (attr_err != cudaSuccess) {
+                throw std::runtime_error(
+                    std::string("int4_tensorwise quantize shared memory request (") +
+                    std::to_string(smem_bytes) + " bytes) failed: " +
+                    cudaGetErrorString(attr_err));
+            }
+            kernel<<<static_cast<unsigned int>(M_pad), kBlockThreads, smem_bytes, stream>>>(
+                static_cast<const InputType*>(x),
+                static_cast<int8_t*>(q),
+                static_cast<InputType*>(ascales),
+                static_cast<int>(M),
+                static_cast<int>(M_pad),
+                static_cast<int>(K));
+        } else {
+            constexpr int kBlockThreads = 256;
+            auto kernel = comfy::quantize_int4_tensorwise_kernel<InputType, kBlockThreads, false>;
+            kernel<<<static_cast<unsigned int>(M_pad), kBlockThreads, 0, stream>>>(
+                static_cast<const InputType*>(x),
+                static_cast<int8_t*>(q),
+                static_cast<InputType*>(ascales),
+                static_cast<int>(M),
+                static_cast<int>(M_pad),
+                static_cast<int>(K));
+        }
+    });
+}
+
+}  // extern "C"

--- a/comfy_kitchen/backends/cuda/ops/int4_tensorwise.cu
+++ b/comfy_kitchen/backends/cuda/ops/int4_tensorwise.cu
@@ -109,13 +109,13 @@ __global__ void quantize_int4_tensorwise_kernel(
     InputType* __restrict__ ascales,
     int M,
     int M_pad,
-    int K)
+    int K,
+    int n_scale_groups)
 {
     constexpr int kWarps = BLOCK_THREADS / kThreadsPerWarp;
     const int row = static_cast<int>(blockIdx.x);
     const int tid = threadIdx.x;
     const int k_half = K / 2;
-    const int n_scale_groups = K / kInt4ScaleGroup;
 
     if (row >= M) {
         // Padding row: benign zeros (the GEMM output rows are discarded).
@@ -137,8 +137,23 @@ __global__ void quantize_int4_tensorwise_kernel(
     const int64_t row_offset = static_cast<int64_t>(row) * K;
 
     if constexpr (ROTATE) {
-        for (int col = tid; col < K; col += BLOCK_THREADS) {
-            row_buf[col] = i4_to_float(x[row_offset + col]);
+        if constexpr (sizeof(InputType) == 2) {
+            // 16-byte vectorized loads: 8 elements per iteration per thread.
+            const uint4* x4 = reinterpret_cast<const uint4*>(x + row_offset);
+            const int n_vec = K / 8;
+            for (int v = tid; v < n_vec; v += BLOCK_THREADS) {
+                const uint4 raw = x4[v];
+                const InputType* e = reinterpret_cast<const InputType*>(&raw);
+                const int base = v * 8;
+                #pragma unroll
+                for (int j = 0; j < 8; ++j) {
+                    row_buf[base + j] = i4_to_float(e[j]);
+                }
+            }
+        } else {
+            for (int col = tid; col < K; col += BLOCK_THREADS) {
+                row_buf[col] = i4_to_float(x[row_offset + col]);
+            }
         }
         __syncthreads();
 
@@ -197,19 +212,33 @@ __global__ void quantize_int4_tensorwise_kernel(
     }
 
     // Quantize + pack two codes per byte, LOW nibble first.
-    for (int p = tid; p < k_half; p += BLOCK_THREADS) {
-        const int col = 2 * p;
-        float v0, v1;
-        if constexpr (ROTATE) {
-            v0 = i4_quant_div<InputType>(row_buf[col], scale);
-            v1 = i4_quant_div<InputType>(row_buf[col + 1], scale);
-        } else {
-            v0 = i4_quant_div<InputType>(i4_to_float(x[row_offset + col]), scale);
-            v1 = i4_quant_div<InputType>(i4_to_float(x[row_offset + col + 1]), scale);
+    if constexpr (ROTATE) {
+        // Vectorized: each thread packs 8 rotated values into 4 bytes (uchar4).
+        uchar4* q4 = reinterpret_cast<uchar4*>(q + static_cast<int64_t>(row) * k_half);
+        const int n_vec = k_half / 4;
+        for (int v = tid; v < n_vec; v += BLOCK_THREADS) {
+            const int col = v * 8;
+            uchar4 packed;
+            unsigned char* pb = reinterpret_cast<unsigned char*>(&packed);
+            #pragma unroll
+            for (int j = 0; j < 4; ++j) {
+                const float a = i4_quant_div<InputType>(row_buf[col + 2 * j], scale);
+                const float b = i4_quant_div<InputType>(row_buf[col + 2 * j + 1], scale);
+                const float c0 = fminf(kInt4Max, fmaxf(-kInt4Max, nearbyintf(a)));
+                const float c1 = fminf(kInt4Max, fmaxf(-kInt4Max, nearbyintf(b)));
+                pb[j] = static_cast<unsigned char>(i4_pack_pair(c0, c1));
+            }
+            q4[v] = packed;
         }
-        const float c0 = fminf(kInt4Max, fmaxf(-kInt4Max, nearbyintf(v0)));
-        const float c1 = fminf(kInt4Max, fmaxf(-kInt4Max, nearbyintf(v1)));
-        q[static_cast<int64_t>(row) * k_half + p] = i4_pack_pair(c0, c1);
+    } else {
+        for (int p = tid; p < k_half; p += BLOCK_THREADS) {
+            const int col = 2 * p;
+            const float v0 = i4_quant_div<InputType>(i4_to_float(x[row_offset + col]), scale);
+            const float v1 = i4_quant_div<InputType>(i4_to_float(x[row_offset + col + 1]), scale);
+            const float c0 = fminf(kInt4Max, fmaxf(-kInt4Max, nearbyintf(v0)));
+            const float c1 = fminf(kInt4Max, fmaxf(-kInt4Max, nearbyintf(v1)));
+            q[static_cast<int64_t>(row) * k_half + p] = i4_pack_pair(c0, c1);
+        }
     }
 }
 
@@ -226,6 +255,7 @@ void launch_int4_tensorwise_quantize_kernel(
     int64_t M,
     int64_t M_pad,
     int64_t K,
+    int64_t n_scale_groups,
     int input_dtype_code,
     bool rotate,
     cudaStream_t stream)
@@ -265,7 +295,8 @@ void launch_int4_tensorwise_quantize_kernel(
                 static_cast<InputType*>(ascales),
                 static_cast<int>(M),
                 static_cast<int>(M_pad),
-                static_cast<int>(K));
+                static_cast<int>(K),
+                static_cast<int>(n_scale_groups));
         } else {
             constexpr int kBlockThreads = 256;
             auto kernel = comfy::quantize_int4_tensorwise_kernel<InputType, kBlockThreads, false>;
@@ -275,7 +306,8 @@ void launch_int4_tensorwise_quantize_kernel(
                 static_cast<InputType*>(ascales),
                 static_cast<int>(M),
                 static_cast<int>(M_pad),
-                static_cast<int>(K));
+                static_cast<int>(K),
+                static_cast<int>(n_scale_groups));
         }
     });
 }

--- a/comfy_kitchen/backends/cuda/ops/scaled_mm_svdquant_w4a4.cu
+++ b/comfy_kitchen/backends/cuda/ops/scaled_mm_svdquant_w4a4.cu
@@ -58,6 +58,7 @@
 #include <cuda_bf16.h>
 #include <cuda_fp16.h>
 #include <cstdint>
+#include <cstdlib>
 #include <type_traits>
 
 namespace {
@@ -223,7 +224,9 @@ template<
     bool kSharedScale,
     bool kFuseLora,
     bool kRankOne,
-    int kMUnrollT = kMUnroll>
+    int kMUnrollT = kMUnroll,
+    int kWarpsMT = kWarpsM,
+    int kStagesT = kStages>
 __global__ void svdquant_scaled_mm_w4a4_kernel(
     const int8_t* __restrict__ act,          // (M, K/2)
     const int8_t* __restrict__ wgt,          // (N, K/2)
@@ -239,11 +242,19 @@ __global__ void svdquant_scaled_mm_w4a4_kernel(
         (void)lora_act_in; (void)lora_up; (void)R;
     }
 
-    // M-tile geometry may be widened per instantiation (rank-one uses a taller
-    // CTA to cut B-tile rereads); these shadow the file-scope defaults.
+    // Tile geometry / pipeline depth may be widened per instantiation (rank-one
+    // uses a taller CTA to cut B-tile rereads); these shadow the file-scope
+    // defaults, and every derived constant is recomputed from them.
     constexpr int kMUnroll = kMUnrollT;
     constexpr int kWarpM   = kMUnroll * 16;
+    constexpr int kWarpsM  = kWarpsMT;
     constexpr int kBlockM  = kWarpM * kWarpsM;
+    constexpr int kNumWarps = kWarpsM * kWarpsN;
+    constexpr int kThreadsPerBlock = kNumWarps * 32;
+    constexpr int kStages = kStagesT;
+    constexpr int kBLoadSweeps = (kBlockN * 2 + kThreadsPerBlock - 1) / kThreadsPerBlock;
+    constexpr int kALoadSweeps = (kBlockM * 2 + kThreadsPerBlock - 1) / kThreadsPerBlock;
+    static_assert((kWarpsM & (kWarpsM - 1)) == 0, "kWarpsM must be a power of two");
 
     // CTA coordinates
     const int cta_m = blockIdx.y * kBlockM;
@@ -375,17 +386,20 @@ __global__ void svdquant_scaled_mm_w4a4_kernel(
     // ---------- Helper: issue async cp for A tile at group `g` into stage ----------
     auto issue_A_load = [&](int g, int stage) {
         if (g >= num_groups) return;
-        const int t = threadIdx.x;
-        if (t < kBlockM * 2) {
-            const int m_row = t >> 1;
-            const int half  = t & 1;
-            const int m_global = cta_m + m_row;
-            int8_t* dst = &smem_A[stage][m_row * kBlockKBytes + half * 16];
-            if (m_global < M) {
-                const int8_t* src = act + m_global * K_half + g * kBlockKBytes + half * 16;
-                cp_async_16b(dst, src);
-            } else {
-                reinterpret_cast<uint4*>(dst)[0] = {0, 0, 0, 0};
+        #pragma unroll
+        for (int sweep = 0; sweep < kALoadSweeps; ++sweep) {
+            const int t = threadIdx.x + sweep * kThreadsPerBlock;
+            if (t < kBlockM * 2) {
+                const int m_row = t >> 1;
+                const int half  = t & 1;
+                const int m_global = cta_m + m_row;
+                int8_t* dst = &smem_A[stage][m_row * kBlockKBytes + half * 16];
+                if (m_global < M) {
+                    const int8_t* src = act + m_global * K_half + g * kBlockKBytes + half * 16;
+                    cp_async_16b(dst, src);
+                } else {
+                    reinterpret_cast<uint4*>(dst)[0] = {0, 0, 0, 0};
+                }
             }
         }
     };
@@ -756,29 +770,50 @@ void launch_svdquant_scaled_mm_w4a4_kernel(
 
     if (rank_one) {
         // int4_tensorwise path: natural layout, signed, robust accumulator, no LoRA.
-        // Taller M tile (kMUnroll=4 -> 128 M/CTA) quarters B-tile rereads vs the
-        // default geometry; the freed per-group scale registers pay for it.
-        constexpr int kMUnrollR1 = 4;
-        constexpr int kBlockM_R1 = kMUnrollR1 * 16 * kWarpsM;
-        const dim3 grid_r1((N + kBlockN - 1) / kBlockN, (M + kBlockM_R1 - 1) / kBlockM_R1);
-        #define LAUNCH_GEMM_R1(OutType)                                                     \
-            svdquant_scaled_mm_w4a4_kernel<OutType, false, false, false, false, false, true,\
-                                           kMUnrollR1>                                      \
-                <<<grid_r1, block, 0, stream>>>(                                            \
-                reinterpret_cast<const int8_t*>(act),                                       \
-                reinterpret_cast<const int8_t*>(wgt),                                       \
-                reinterpret_cast<const OutType*>(ascales),                                  \
-                reinterpret_cast<const OutType*>(wscales),                                  \
-                reinterpret_cast<const OutType*>(lora_act_in),                              \
-                reinterpret_cast<const OutType*>(lora_up),                                  \
-                reinterpret_cast<const OutType*>(bias),                                     \
-                reinterpret_cast<OutType*>(out),                                            \
-                M, N, K, R)
-        if (out_dtype_code == 2 /* bf16 */) {
-            LAUNCH_GEMM_R1(__nv_bfloat16);
-        } else if (out_dtype_code == 1 /* fp16 */) {
-            LAUNCH_GEMM_R1(__half);
+        // Taller M tiles cut B-tile rereads (the freed per-group scale registers /
+        // extra warps pay for them). Config selectable for tuning via
+        // COMFY_KITCHEN_INT4_R1_CONFIG (0: 128M/8w/3st, 1: 128M/8w/4st,
+        // 2: 64M/8w/3st, 3: 96M/8w/3st); default 0. Register-file trade: kMUnroll=4
+        // costs 128 regs -> 2 CTAs/SM (33% occupancy); smaller M-tiles raise
+        // occupancy at the price of more (L2-resident) B rereads.
+        int r1_config = 0;
+        if (const char* cfg = std::getenv("COMFY_KITCHEN_INT4_R1_CONFIG")) {
+            r1_config = std::atoi(cfg);
         }
+        #define LAUNCH_GEMM_R1(OutType, MU, WM, ST)                                         \
+            do {                                                                            \
+                constexpr int kBlockM_R1 = (MU) * 16 * (WM);                                \
+                const dim3 grid_r1((N + kBlockN - 1) / kBlockN,                             \
+                                   (M + kBlockM_R1 - 1) / kBlockM_R1);                      \
+                const dim3 block_r1((WM) * kWarpsN * 32);                                   \
+                svdquant_scaled_mm_w4a4_kernel<OutType, false, false, false, false, false,  \
+                                               true, (MU), (WM), (ST)>                      \
+                    <<<grid_r1, block_r1, 0, stream>>>(                                     \
+                    reinterpret_cast<const int8_t*>(act),                                   \
+                    reinterpret_cast<const int8_t*>(wgt),                                   \
+                    reinterpret_cast<const OutType*>(ascales),                              \
+                    reinterpret_cast<const OutType*>(wscales),                              \
+                    reinterpret_cast<const OutType*>(lora_act_in),                          \
+                    reinterpret_cast<const OutType*>(lora_up),                              \
+                    reinterpret_cast<const OutType*>(bias),                                 \
+                    reinterpret_cast<OutType*>(out),                                        \
+                    M, N, K, R);                                                            \
+            } while (0)
+        #define DISPATCH_R1(OutType)                                                        \
+            do {                                                                            \
+                switch (r1_config) {                                                        \
+                    case 1:  LAUNCH_GEMM_R1(OutType, 4, 2, 4); break;                       \
+                    case 2:  LAUNCH_GEMM_R1(OutType, 2, 2, 3); break;                       \
+                    case 3:  LAUNCH_GEMM_R1(OutType, 3, 2, 3); break;                       \
+                    default: LAUNCH_GEMM_R1(OutType, 4, 2, 3); break;                       \
+                }                                                                           \
+            } while (0)
+        if (out_dtype_code == 2 /* bf16 */) {
+            DISPATCH_R1(__nv_bfloat16);
+        } else if (out_dtype_code == 1 /* fp16 */) {
+            DISPATCH_R1(__half);
+        }
+        #undef DISPATCH_R1
         #undef LAUNCH_GEMM_R1
         return;
     }

--- a/comfy_kitchen/backends/cuda/ops/scaled_mm_svdquant_w4a4.cu
+++ b/comfy_kitchen/backends/cuda/ops/scaled_mm_svdquant_w4a4.cu
@@ -222,7 +222,8 @@ template<
     bool kFastAccum,
     bool kSharedScale,
     bool kFuseLora,
-    bool kRankOne>
+    bool kRankOne,
+    int kMUnrollT = kMUnroll>
 __global__ void svdquant_scaled_mm_w4a4_kernel(
     const int8_t* __restrict__ act,          // (M, K/2)
     const int8_t* __restrict__ wgt,          // (N, K/2)
@@ -237,6 +238,12 @@ __global__ void svdquant_scaled_mm_w4a4_kernel(
     if constexpr (!kFuseLora) {
         (void)lora_act_in; (void)lora_up; (void)R;
     }
+
+    // M-tile geometry may be widened per instantiation (rank-one uses a taller
+    // CTA to cut B-tile rereads); these shadow the file-scope defaults.
+    constexpr int kMUnroll = kMUnrollT;
+    constexpr int kWarpM   = kMUnroll * 16;
+    constexpr int kBlockM  = kWarpM * kWarpsM;
 
     // CTA coordinates
     const int cta_m = blockIdx.y * kBlockM;
@@ -749,9 +756,15 @@ void launch_svdquant_scaled_mm_w4a4_kernel(
 
     if (rank_one) {
         // int4_tensorwise path: natural layout, signed, robust accumulator, no LoRA.
+        // Taller M tile (kMUnroll=4 -> 128 M/CTA) quarters B-tile rereads vs the
+        // default geometry; the freed per-group scale registers pay for it.
+        constexpr int kMUnrollR1 = 4;
+        constexpr int kBlockM_R1 = kMUnrollR1 * 16 * kWarpsM;
+        const dim3 grid_r1((N + kBlockN - 1) / kBlockN, (M + kBlockM_R1 - 1) / kBlockM_R1);
         #define LAUNCH_GEMM_R1(OutType)                                                     \
-            svdquant_scaled_mm_w4a4_kernel<OutType, false, false, false, false, false, true>\
-                <<<grid, block, 0, stream>>>(                                               \
+            svdquant_scaled_mm_w4a4_kernel<OutType, false, false, false, false, false, true,\
+                                           kMUnrollR1>                                      \
+                <<<grid_r1, block, 0, stream>>>(                                            \
                 reinterpret_cast<const int8_t*>(act),                                       \
                 reinterpret_cast<const int8_t*>(wgt),                                       \
                 reinterpret_cast<const OutType*>(ascales),                                  \

--- a/comfy_kitchen/backends/cuda/ops/scaled_mm_svdquant_w4a4.cu
+++ b/comfy_kitchen/backends/cuda/ops/scaled_mm_svdquant_w4a4.cu
@@ -221,7 +221,8 @@ template<
     bool kTilePacked,
     bool kFastAccum,
     bool kSharedScale,
-    bool kFuseLora>
+    bool kFuseLora,
+    bool kRankOne>
 __global__ void svdquant_scaled_mm_w4a4_kernel(
     const int8_t* __restrict__ act,          // (M, K/2)
     const int8_t* __restrict__ wgt,          // (N, K/2)
@@ -267,6 +268,21 @@ __global__ void svdquant_scaled_mm_w4a4_kernel(
     using Pair = typename Vec2::Pair;
     float out_f[kMUnroll][kNUnroll][4];
     Pair out_h[kMUnroll][kNUnroll][2];
+    // kRankOne: per-row x per-col scales factor out of the K loop entirely, so the
+    // MMA carries raw int32 accumulators across ALL K groups (|acc| <= 49*K << 2^31)
+    // and dequantization collapses into the epilogue — no per-group scale loads, no
+    // per-group fp conversion (the QServe W4A4 main-loop critique does not apply).
+    int32_t acc_i[kMUnroll][kNUnroll][4];
+    if constexpr (kRankOne) {
+        #pragma unroll
+        for (int mi = 0; mi < kMUnroll; ++mi) {
+            #pragma unroll
+            for (int c = 0; c < kNUnroll; ++c) {
+                #pragma unroll
+                for (int i = 0; i < 4; ++i) acc_i[mi][c][i] = 0;
+            }
+        }
+    }
     if constexpr (kFastAccum) {
         #pragma unroll
         for (int mi = 0; mi < kMUnroll; ++mi) {
@@ -445,15 +461,17 @@ __global__ void svdquant_scaled_mm_w4a4_kernel(
                 a_reg[mi][1] = *reinterpret_cast<const uint32_t*>(rb + tid_in_group * 8);
                 a_reg[mi][3] = *reinterpret_cast<const uint32_t*>(rb + tid_in_group * 8 + 4);
             }
-            as_row0_arr[mi] = (row0_m < M) ? load_scale<OutType>(&ascales[g * M + row0_m]) : 0.f;
-            as_row1_arr[mi] = (row1_m < M) ? load_scale<OutType>(&ascales[g * M + row1_m]) : 0.f;
+            if constexpr (!kRankOne) {
+                as_row0_arr[mi] = (row0_m < M) ? load_scale<OutType>(&ascales[g * M + row0_m]) : 0.f;
+                as_row1_arr[mi] = (row1_m < M) ? load_scale<OutType>(&ascales[g * M + row1_m]) : 0.f;
+            }
         }
 
         // Pre-load this K-iter's wscales into per-lane registers, hoisted out of
         // the inner MMA loop so the compiler can schedule the loads ahead of MMAs.
         float ws_regs[kNUnroll][2];
         #pragma unroll
-        for (int cc = 0; cc < kNUnroll; ++cc) {
+        for (int cc = 0; cc < kNUnroll && !kRankOne; ++cc) {
             const int col0 = warp_n_base + cc * 8 + tid_in_group * 2 + 0;
             const int col1 = warp_n_base + cc * 8 + tid_in_group * 2 + 1;
             if constexpr (kSharedScale) {
@@ -504,6 +522,15 @@ __global__ void svdquant_scaled_mm_w4a4_kernel(
             // Reuse b_reg for each M-tile
             #pragma unroll
             for (int mi = 0; mi < kMUnroll; ++mi) {
+                if constexpr (kRankOne) {
+                    // Accumulate raw int32 across the whole K loop; dequant in epilogue.
+                    if constexpr (kActUnsigned) {
+                        mma_m16n8k64_u4s4s32(a_reg[mi], b_reg, acc_i[mi][c], acc_i[mi][c]);
+                    } else {
+                        mma_m16n8k64_s4s4s32(a_reg[mi], b_reg, acc_i[mi][c], acc_i[mi][c]);
+                    }
+                    continue;
+                }
                 int32_t c_reg[4] = {0, 0, 0, 0};
                 int32_t d_reg[4];
                 if constexpr (kActUnsigned) {
@@ -536,6 +563,30 @@ __global__ void svdquant_scaled_mm_w4a4_kernel(
         }
     }
     cp_async_wait_group<0>();  // drain pipeline
+
+    if constexpr (kRankOne) {
+        // Rank-1 dequant: one per-row and one per-col scale (read from the first
+        // group row of the (possibly 1-group) ascales/wscales buffers).
+        #pragma unroll
+        for (int mi = 0; mi < kMUnroll; ++mi) {
+            const int m_tile_base = warp_m_base + mi * 16;
+            const int row0_m = m_tile_base + groupID;
+            const int row1_m = m_tile_base + groupID + 8;
+            const float as0 = (row0_m < M) ? load_scale<OutType>(&ascales[row0_m]) : 0.f;
+            const float as1 = (row1_m < M) ? load_scale<OutType>(&ascales[row1_m]) : 0.f;
+            #pragma unroll
+            for (int c = 0; c < kNUnroll; ++c) {
+                const int col0 = warp_n_base + c * 8 + tid_in_group * 2 + 0;
+                const int col1 = col0 + 1;
+                const float ws0 = (col0 < N) ? load_scale<OutType>(&wscales[col0]) : 0.f;
+                const float ws1 = (col1 < N) ? load_scale<OutType>(&wscales[col1]) : 0.f;
+                out_f[mi][c][0] = static_cast<float>(acc_i[mi][c][0]) * as0 * ws0;
+                out_f[mi][c][1] = static_cast<float>(acc_i[mi][c][1]) * as0 * ws1;
+                out_f[mi][c][2] = static_cast<float>(acc_i[mi][c][2]) * as1 * ws0;
+                out_f[mi][c][3] = static_cast<float>(acc_i[mi][c][3]) * as1 * ws1;
+            }
+        }
+    }
 
     if constexpr (kFuseLora) {
         // LoRA-up epilogue: out += lora_act_in @ lora_up.T.
@@ -688,6 +739,7 @@ void launch_svdquant_scaled_mm_w4a4_kernel(
     int fast_accum,
     int shared_scale,
     int fuse_lora,
+    int rank_one,
     cudaStream_t stream)
 {
     if (K % comfy::svdquant::kGroupSize != 0) return;
@@ -695,9 +747,32 @@ void launch_svdquant_scaled_mm_w4a4_kernel(
     const dim3 grid((N + kBlockN - 1) / kBlockN, (M + kBlockM - 1) / kBlockM);
     const dim3 block(kNumWarps * 32);
 
+    if (rank_one) {
+        // int4_tensorwise path: natural layout, signed, robust accumulator, no LoRA.
+        #define LAUNCH_GEMM_R1(OutType)                                                     \
+            svdquant_scaled_mm_w4a4_kernel<OutType, false, false, false, false, false, true>\
+                <<<grid, block, 0, stream>>>(                                               \
+                reinterpret_cast<const int8_t*>(act),                                       \
+                reinterpret_cast<const int8_t*>(wgt),                                       \
+                reinterpret_cast<const OutType*>(ascales),                                  \
+                reinterpret_cast<const OutType*>(wscales),                                  \
+                reinterpret_cast<const OutType*>(lora_act_in),                              \
+                reinterpret_cast<const OutType*>(lora_up),                                  \
+                reinterpret_cast<const OutType*>(bias),                                     \
+                reinterpret_cast<OutType*>(out),                                            \
+                M, N, K, R)
+        if (out_dtype_code == 2 /* bf16 */) {
+            LAUNCH_GEMM_R1(__nv_bfloat16);
+        } else if (out_dtype_code == 1 /* fp16 */) {
+            LAUNCH_GEMM_R1(__half);
+        }
+        #undef LAUNCH_GEMM_R1
+        return;
+    }
+
     #define LAUNCH_GEMM(OutType, Unsigned, TilePacked, FastAccum, SharedScale, FuseLora) \
         svdquant_scaled_mm_w4a4_kernel<                                                     \
-            OutType, Unsigned, TilePacked, FastAccum, SharedScale, FuseLora>                \
+            OutType, Unsigned, TilePacked, FastAccum, SharedScale, FuseLora, false>         \
             <<<grid, block, 0, stream>>>(                                                   \
             reinterpret_cast<const int8_t*>(act),                                           \
             reinterpret_cast<const int8_t*>(wgt),                                           \

--- a/comfy_kitchen/backends/cuda/ops/scaled_mm_svdquant_w4a4.cu
+++ b/comfy_kitchen/backends/cuda/ops/scaled_mm_svdquant_w4a4.cu
@@ -67,6 +67,7 @@ using comfy::svdquant::kGroupSize;
 using comfy::svdquant::mma_m16n8k64_s4s4s32;
 using comfy::svdquant::mma_m16n8k64_u4s4s32;
 using comfy::svdquant::cvta_smem_u32;
+using comfy::svdquant::ldmatrix_x2;
 using comfy::svdquant::ldmatrix_x4;
 using comfy::svdquant::mma_m16n8k16_f32;
 using comfy::svdquant::cp_async_16b;
@@ -254,6 +255,10 @@ __global__ void svdquant_scaled_mm_w4a4_kernel(
     constexpr int kStages = kStagesT;
     constexpr int kBLoadSweeps = (kBlockN * 2 + kThreadsPerBlock - 1) / kThreadsPerBlock;
     constexpr int kALoadSweeps = (kBlockM * 2 + kThreadsPerBlock - 1) / kThreadsPerBlock;
+    // Rank-one loads fragments with ldmatrix; a 48-byte smem row stride staggers the
+    // 8 row addresses of each ldmatrix phase across distinct bank groups (32-byte
+    // stride would alias rows r and r+4). Non-rank-one keeps the packed 32B stride.
+    constexpr int kSmemRowBytes = kRankOne ? (kBlockKBytes + 16) : kBlockKBytes;
     static_assert((kWarpsM & (kWarpsM - 1)) == 0, "kWarpsM must be a power of two");
 
     // CTA coordinates
@@ -331,8 +336,8 @@ __global__ void svdquant_scaled_mm_w4a4_kernel(
     // Shared memory: triple-buffered A and B tiles.
     // B stage: kBlockN rows × kBlockKBytes bytes = 128 * 32 = 4 KB
     // A stage: kBlockM rows × kBlockKBytes bytes =  32 * 32 = 1 KB
-    __shared__ alignas(16) int8_t smem_B[kStages][kBlockN * kBlockKBytes];
-    __shared__ alignas(16) int8_t smem_A[kStages][kBlockM * kBlockKBytes];
+    __shared__ alignas(16) int8_t smem_B[kStages][kBlockN * kSmemRowBytes];
+    __shared__ alignas(16) int8_t smem_A[kStages][kBlockM * kSmemRowBytes];
     __shared__ alignas(16) int8_t smem_WS[kSharedScale ? kStages : 1][kBlockN * sizeof(OutType)];
     __shared__ alignas(16) OutType smem_LoraA[kFuseLora ? (kBlockM * kLoraRankTile) : 1];
     __shared__ alignas(16) OutType smem_LoraB[kFuseLora ? (kBlockN * kLoraRankTile) : 1];
@@ -349,7 +354,7 @@ __global__ void svdquant_scaled_mm_w4a4_kernel(
                 const int n_row = t >> 1;
                 const int half  = t & 1;
                 const int n_global = cta_n + n_row;
-                int8_t* dst = &smem_B[stage][n_row * kBlockKBytes + half * 16];
+                int8_t* dst = &smem_B[stage][n_row * kSmemRowBytes + half * 16];
                 if (n_global < N) {
                     const int8_t* src;
                     if constexpr (kTilePacked) {
@@ -372,12 +377,22 @@ __global__ void svdquant_scaled_mm_w4a4_kernel(
     };
 
     auto load_B_fragment = [&](int stage, int c, uint32_t (&b_reg)[2]) {
+        if constexpr (kRankOne) {
+            // ldmatrix.x2: lanes 0..15 address the 8 n-rows x two 16B k-chunks of
+            // this N-chunk's tile (staging zero-pads OOB rows, so no guard needed).
+            const int r = lane & 7;
+            const int h = (lane >> 3) & 1;
+            const int row_local = (warp_n * kWarpN) + c * 8 + r;
+            const int8_t* addr = &smem_B[stage][row_local * kSmemRowBytes + h * 16];
+            ldmatrix_x2(b_reg, cvta_smem_u32(addr));
+            return;
+        }
         const int b_col_local = (warp_n * kWarpN) + c * 8 + groupID;
         const int b_col_global = cta_n + b_col_local;
         b_reg[0] = b_reg[1] = 0;
         if (b_col_local < kBlockN && b_col_global < N) {
             const int byte0 = tid_in_group * 8;
-            const int8_t* row_base = &smem_B[stage][b_col_local * kBlockKBytes];
+            const int8_t* row_base = &smem_B[stage][b_col_local * kSmemRowBytes];
             b_reg[0] = *reinterpret_cast<const uint32_t*>(row_base + byte0);
             b_reg[1] = *reinterpret_cast<const uint32_t*>(row_base + byte0 + 4);
         }
@@ -393,7 +408,7 @@ __global__ void svdquant_scaled_mm_w4a4_kernel(
                 const int m_row = t >> 1;
                 const int half  = t & 1;
                 const int m_global = cta_m + m_row;
-                int8_t* dst = &smem_A[stage][m_row * kBlockKBytes + half * 16];
+                int8_t* dst = &smem_A[stage][m_row * kSmemRowBytes + half * 16];
                 if (m_global < M) {
                     const int8_t* src = act + m_global * K_half + g * kBlockKBytes + half * 16;
                     cp_async_16b(dst, src);
@@ -466,6 +481,17 @@ __global__ void svdquant_scaled_mm_w4a4_kernel(
         float as_row0_arr[kMUnroll], as_row1_arr[kMUnroll];
         #pragma unroll
         for (int mi = 0; mi < kMUnroll; ++mi) {
+            if constexpr (kRankOne) {
+                // ldmatrix.x4 over the 16-row x 32B A tile: matrices land as
+                // {r0k0, r1k0, r0k1, r1k1} — the exact s4 MMA A-fragment order.
+                // Both operands use the same ldmatrix k-permutation, so the MMA
+                // dot product is unchanged; staging zero-pads rows >= M.
+                const int row_local = warp_m * kWarpM + mi * 16 + (lane & 15);
+                const int8_t* addr =
+                    &smem_A[cur_stage][row_local * kSmemRowBytes + ((lane >> 4) & 1) * 16];
+                ldmatrix_x4(a_reg[mi], cvta_smem_u32(addr));
+                continue;
+            }
             const int m_tile_base = warp_m_base + mi * 16;
             const int row0_m = m_tile_base + groupID;
             const int row1_m = m_tile_base + groupID + 8;
@@ -473,12 +499,12 @@ __global__ void svdquant_scaled_mm_w4a4_kernel(
             const int row1_local = warp_m * kWarpM + mi * 16 + groupID + 8;
             a_reg[mi][0] = a_reg[mi][1] = a_reg[mi][2] = a_reg[mi][3] = 0;
             if (row0_m < M) {
-                const int8_t* rb = &smem_A[cur_stage][row0_local * kBlockKBytes];
+                const int8_t* rb = &smem_A[cur_stage][row0_local * kSmemRowBytes];
                 a_reg[mi][0] = *reinterpret_cast<const uint32_t*>(rb + tid_in_group * 8);
                 a_reg[mi][2] = *reinterpret_cast<const uint32_t*>(rb + tid_in_group * 8 + 4);
             }
             if (row1_m < M) {
-                const int8_t* rb = &smem_A[cur_stage][row1_local * kBlockKBytes];
+                const int8_t* rb = &smem_A[cur_stage][row1_local * kSmemRowBytes];
                 a_reg[mi][1] = *reinterpret_cast<const uint32_t*>(rb + tid_in_group * 8);
                 a_reg[mi][3] = *reinterpret_cast<const uint32_t*>(rb + tid_in_group * 8 + 4);
             }

--- a/comfy_kitchen/backends/cuda/ops/svdquant_utils.cuh
+++ b/comfy_kitchen/backends/cuda/ops/svdquant_utils.cuh
@@ -169,6 +169,18 @@ __forceinline__ __device__ uint32_t cvta_smem_u32(const void* ptr) {
     return s;
 }
 
+__forceinline__ __device__ void ldmatrix_x2(uint32_t (&dst)[2], uint32_t addr) {
+#if __CUDA_ARCH__ >= 800
+    asm volatile("ldmatrix.sync.aligned.m8n8.x2.shared.b16 "
+                 "{%0, %1}, [%2];\n"
+                 : "=r"(dst[0]), "=r"(dst[1])
+                 : "r"(addr));
+#else
+    dst[0] = dst[1] = 0;
+    (void)addr;
+#endif
+}
+
 __forceinline__ __device__ void ldmatrix_x4(uint32_t (&dst)[4], uint32_t addr) {
 #if __CUDA_ARCH__ >= 800
     asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 "

--- a/comfy_kitchen/backends/eager/__init__.py
+++ b/comfy_kitchen/backends/eager/__init__.py
@@ -11,6 +11,10 @@ __all__ = [
     "dequantize_int8_simple_dtype",
     "dequantize_int8_convrot_weight",
     "dequantize_int8_convrot_weight_dtype",
+    "dequantize_int4_simple",
+    "dequantize_int4_simple_dtype",
+    "dequantize_int4_convrot_weight",
+    "dequantize_int4_convrot_weight_dtype",
     "gemv_awq_w4a16",
     "quantize_mxfp8",
     "quantize_nvfp4",
@@ -19,12 +23,15 @@ __all__ = [
     "quantize_int8_convrot_weight",
     "quantize_and_rotate_rowwise",
     "quantize_int8_tensorwise",
+    "quantize_int4_rowwise",
+    "quantize_int4_convrot_weight",
     "quantize_svdquant_w4a4",
     "scaled_mm_mxfp8",
     "scaled_mm_nvfp4",
     "scaled_mm_svdquant_w4a4",
     "stochastic_rounding_fp8",
     "int8_linear",
+    "int4_linear",
 ]
 
 import torch
@@ -39,6 +46,10 @@ from comfy_kitchen.registry import registry
 from .adaln import adaln
 from .awq import gemv_awq_w4a16
 from .quantization import (
+    dequantize_int4_convrot_weight,
+    dequantize_int4_convrot_weight_dtype,
+    dequantize_int4_simple,
+    dequantize_int4_simple_dtype,
     dequantize_int8_convrot_weight,
     dequantize_int8_convrot_weight_dtype,
     dequantize_int8_simple,
@@ -46,8 +57,11 @@ from .quantization import (
     dequantize_mxfp8,
     dequantize_nvfp4,
     dequantize_per_tensor_fp8,
+    int4_linear,
     int8_linear,
     quantize_and_rotate_rowwise,
+    quantize_int4_convrot_weight,
+    quantize_int4_rowwise,
     quantize_int8_convrot_weight,
     quantize_int8_rowwise,
     quantize_int8_tensorwise,
@@ -290,6 +304,64 @@ def _build_constraints() -> dict:
         default_devices=all_devices,
     )
     out["int8_linear"] = FunctionConstraints(
+        params={
+            "x": ParamConstraint(dtypes=standard_floats),
+            "weight": ParamConstraint(dtypes=frozenset({torch.int8})),
+            "weight_scale": ParamConstraint(dtypes=standard_floats),
+            "bias": ParamConstraint(dtypes=standard_floats),
+            "convrot": ParamConstraint(dtypes=frozenset({bool})),
+            "convrot_groupsize": ParamConstraint(dtypes=frozenset({int})),
+        },
+        default_devices=all_devices,
+    )
+    out["quantize_int4_rowwise"] = FunctionConstraints(
+        params={
+            "x": ParamConstraint(dtypes=standard_floats),
+            "stochastic_rounding": ParamConstraint(dtypes=frozenset({int})),
+        },
+        default_devices=all_devices,
+    )
+    out["quantize_int4_convrot_weight"] = FunctionConstraints(
+        params={
+            "weight": ParamConstraint(dtypes=standard_floats, shape_rules=(ExactDims(2),)),
+            "group_size": ParamConstraint(dtypes=frozenset({int})),
+            "stochastic_rounding": ParamConstraint(dtypes=frozenset({int})),
+        },
+        default_devices=all_devices,
+    )
+    out["dequantize_int4_simple"] = FunctionConstraints(
+        params={
+            "q": ParamConstraint(dtypes=frozenset({torch.int8})),
+            "scale": ParamConstraint(dtypes=standard_floats),
+        },
+        default_devices=all_devices,
+    )
+    out["dequantize_int4_simple_dtype"] = FunctionConstraints(
+        params={
+            "q": ParamConstraint(dtypes=frozenset({torch.int8})),
+            "scale": ParamConstraint(dtypes=standard_floats),
+            "output_dtype_code": ParamConstraint(dtypes=frozenset({int})),
+        },
+        default_devices=all_devices,
+    )
+    out["dequantize_int4_convrot_weight"] = FunctionConstraints(
+        params={
+            "q": ParamConstraint(dtypes=frozenset({torch.int8}), shape_rules=(ExactDims(2),)),
+            "scale": ParamConstraint(dtypes=standard_floats),
+            "group_size": ParamConstraint(dtypes=frozenset({int})),
+        },
+        default_devices=all_devices,
+    )
+    out["dequantize_int4_convrot_weight_dtype"] = FunctionConstraints(
+        params={
+            "q": ParamConstraint(dtypes=frozenset({torch.int8}), shape_rules=(ExactDims(2),)),
+            "scale": ParamConstraint(dtypes=standard_floats),
+            "group_size": ParamConstraint(dtypes=frozenset({int})),
+            "output_dtype_code": ParamConstraint(dtypes=frozenset({int})),
+        },
+        default_devices=all_devices,
+    )
+    out["int4_linear"] = FunctionConstraints(
         params={
             "x": ParamConstraint(dtypes=standard_floats),
             "weight": ParamConstraint(dtypes=frozenset({torch.int8})),

--- a/comfy_kitchen/backends/eager/quantization.py
+++ b/comfy_kitchen/backends/eager/quantization.py
@@ -1168,3 +1168,339 @@ def _op_int8_linear(
 def _op_int8_linear_fake(x, weight, weight_scale, bias, output_dtype_code, convrot=False, convrot_groupsize=256):
     out_dtype = DTYPE_CODE_TO_DTYPE[output_dtype_code]
     return torch.empty(*x.shape[:-1], weight.shape[0], dtype=out_dtype, device=x.device)
+
+
+# =============================================================================
+# INT4 Tensor-wise (int4_tensorwise): per-row signed INT4, packed 2/byte,
+# optional ConvRot. Downward extension of the int8_tensorwise protocol:
+# same per-row fp32 scale shape, same source-dtype DIVISION recipe, same
+# regular-Hadamard rotation — with the int4 emission contract shared with the
+# svdquant kernels: symmetric [-7, 7], scale = absmax / 7 (no -8).
+# Weights are stored PACKED low-nibble-first in an int8 container [N, K/2]
+# (K must be even; ConvRot additionally requires K % group_size == 0).
+# =============================================================================
+
+INT4_QMAX = 7.0
+
+
+def _round_int4(scaled: torch.Tensor, stochastic_rounding: int | None = 0) -> torch.Tensor:
+    if stochastic_rounding is not None and stochastic_rounding > 0:
+        rng = _int8_stochastic_rng(scaled, stochastic_rounding)
+        scaled.add_(rng)
+        return scaled.floor_().clamp_(-INT4_QMAX, INT4_QMAX).to(torch.int8)
+    return scaled.round_().clamp_(-INT4_QMAX, INT4_QMAX).to(torch.int8)
+
+
+def _int4_pack_rowwise(q: torch.Tensor) -> torch.Tensor:
+    """Pack signed int4 codes ([-7, 7] stored as int8) 2-per-byte, LOW nibble first.
+
+    [..., K] int8 -> [..., K/2] int8 container. Matches the svdquant/kitchen int4
+    nibble order (and comfy-quants ``formats/int4_common.py``); the NVFP4 pack is
+    high-nibble-first — do not mix the two.
+    """
+    if q.shape[-1] % 2 != 0:
+        raise ValueError(f"int4 pack requires an even last dim, got {q.shape[-1]}")
+    u = q.to(torch.int8).contiguous().view(torch.uint8)
+    lo = u[..., 0::2] & 0x0F
+    hi = u[..., 1::2] & 0x0F
+    return (lo | (hi << 4)).contiguous().view(torch.int8)
+
+
+def _int4_unpack_rowwise(packed: torch.Tensor) -> torch.Tensor:
+    """Inverse of :func:`_int4_pack_rowwise`: [..., K/2] int8 -> [..., K] int8 codes."""
+    u = packed.contiguous().view(torch.uint8)
+    lo = (u & 0x0F).to(torch.int16)
+    hi = (u >> 4).to(torch.int16)
+    lo = torch.where(lo >= 8, lo - 16, lo)
+    hi = torch.where(hi >= 8, hi - 16, hi)
+    out = torch.stack((lo, hi), dim=-1)
+    return out.reshape(*packed.shape[:-1], packed.shape[-1] * 2).to(torch.int8)
+
+
+def _quantize_int4_codes_rowwise(
+    x: torch.Tensor,
+    stochastic_rounding: int | None = 0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Per-row signed INT4 quantization returning UNPACKED codes (internal).
+
+    Same recipe shape as :func:`quantize_int8_rowwise`: fp32 scale =
+    absmax / 7 clamped to >= 1e-30, DIVISION with the scale cast to the source
+    dtype (zeros -> dtype tiny), round-half-even (or stochastic), clamp [-7, 7].
+    """
+    abs_max = x.abs().amax(dim=-1, keepdim=True)
+    scale = (abs_max.float() / INT4_QMAX).clamp(min=1e-30)
+    q = _round_int4(x / _int8_scale_for_math(scale, x), stochastic_rounding=stochastic_rounding)
+    return q, scale
+
+
+def quantize_int4_rowwise(
+    x: torch.Tensor,
+    stochastic_rounding: int | None = 0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize tensor to packed per-row INT4 (storage form).
+
+    Args:
+        x: Input tensor [..., K], K even.
+        stochastic_rounding: Seed for stochastic rounding. Disabled when <= 0.
+
+    Returns:
+        Tuple of (packed_int4, scales):
+            - packed_int4: int8 container [..., K/2], 2 codes/byte low-nibble-first
+            - scales: float32 tensor [..., 1] with per-row scales (absmax / 7)
+    """
+    if x.shape[-1] % 2 != 0:
+        raise ValueError(f"int4 quantization requires an even last dim, got {x.shape[-1]}")
+    q, scale = _quantize_int4_codes_rowwise(x, stochastic_rounding=stochastic_rounding)
+    return _int4_pack_rowwise(q), scale
+
+
+def quantize_int4_convrot_weight(
+    weight: torch.Tensor,
+    group_size: int,
+    stochastic_rounding: int | None = 0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Offline ConvRot weight rotation followed by row-wise packed INT4 quantization.
+
+    The Hadamard is built and applied at the SOURCE weight dtype, exactly like
+    :func:`quantize_int8_convrot_weight`.
+    """
+    h = _build_hadamard(group_size, device=weight.device, dtype=weight.dtype)
+    weight_rot = _rotate_weight(weight, h, group_size)
+    return quantize_int4_rowwise(weight_rot, stochastic_rounding=stochastic_rounding)
+
+
+def dequantize_int4_simple(q: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
+    """Dequantize packed INT4 tensor with scale to float32."""
+    return _int4_unpack_rowwise(q).float() * scale
+
+
+def dequantize_int4_simple_dtype(q: torch.Tensor, scale: torch.Tensor, output_dtype_code: int) -> torch.Tensor:
+    """Dequantize packed INT4 tensor with scale into a requested floating dtype."""
+    return dequantize_int4_simple(q, scale).to(DTYPE_CODE_TO_DTYPE[output_dtype_code])
+
+
+def dequantize_int4_convrot_weight(q: torch.Tensor, scale: torch.Tensor, group_size: int) -> torch.Tensor:
+    """Dequantize packed INT4 ConvRot weights and rotate them back to the original basis."""
+    h = _build_hadamard(group_size, device=q.device, dtype=torch.float32)
+    return _rotate_weight(dequantize_int4_simple(q, scale), h, group_size)
+
+
+def dequantize_int4_convrot_weight_dtype(
+    q: torch.Tensor, scale: torch.Tensor, group_size: int, output_dtype_code: int
+) -> torch.Tensor:
+    """Dequantize packed INT4 ConvRot weights into a requested floating dtype."""
+    return dequantize_int4_convrot_weight(q, scale, group_size).to(DTYPE_CODE_TO_DTYPE[output_dtype_code])
+
+
+def int4_linear(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    out_dtype: torch.dtype = torch.bfloat16,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+) -> torch.Tensor:
+    """INT4 W4A4 linear layer (eager reference).
+
+    Weights arrive packed [N, K/2] with per-row fp32 scales; activations are
+    rotated online (when ``convrot``) and dynamically quantized per-token to
+    signed INT4 codes with the same absmax/7 recipe. Both operands stay 4-bit
+    valued, so the int8 matmul accumulates them exactly in INT32; because the
+    scales are rank-1 (per-token x per-row), dequantization happens entirely in
+    the epilogue — no per-group rescaling in the K loop.
+
+    Args:
+        x: Input tensor [..., K].
+        weight: Packed INT4 weight, int8 container [N, K/2], low-nibble-first.
+        weight_scale: Per-output-channel scale [N] / [N, 1] (or scalar).
+        bias: Optional bias [N].
+        out_dtype: Output dtype.
+        convrot: If True, apply online activation rotation.
+        convrot_groupsize: Group size for Hadamard rotation.
+
+    Returns:
+        Result tensor [..., N].
+    """
+    w_codes = _int4_unpack_rowwise(weight.to(device=x.device).contiguous())
+    if x.shape[-1] != w_codes.shape[-1]:
+        raise ValueError(
+            f"Input and weight inner dimensions must match, got {x.shape[-1]} and {w_codes.shape[-1]} "
+            f"(packed weight {tuple(weight.shape)})"
+        )
+
+    weight_scale = weight_scale.to(device=x.device, dtype=torch.float32).reshape(-1)
+    if weight_scale.numel() not in (1, w_codes.shape[0]):
+        raise ValueError(
+            f"INT4 weight scale must be scalar or per-output-channel, got {tuple(weight_scale.shape)} "
+            f"for packed weight shape {tuple(weight.shape)}"
+        )
+
+    if convrot:
+        if x.shape[-1] % convrot_groupsize != 0:
+            raise ValueError(
+                f"ConvRot group size {convrot_groupsize} does not divide input features {x.shape[-1]}"
+            )
+        h = _build_hadamard(convrot_groupsize, device=x.device, dtype=x.dtype)
+        x = _rotate_activation(x, h, convrot_groupsize)
+
+    orig_shape = x.shape
+    x_2d = x.reshape(-1, x.shape[-1])
+
+    x_codes, x_scale = _quantize_int4_codes_rowwise(x_2d)
+
+    result = _int8_matmul_accumulate(x_codes, w_codes.T.contiguous())
+
+    m, n = result.shape
+    chunk_size = max(1, min(m, 256 * 1024 * 1024 // (n * 4)))
+
+    weight_scale = weight_scale.reshape(1, -1)
+    scaled_parts = []
+    for i in range(0, m, chunk_size):
+        end_i = min(i + chunk_size, m)
+        chunk = result[i:end_i].float()
+        chunk_scales = x_scale[i:end_i].to(device=chunk.device, dtype=torch.float32) * weight_scale
+        chunk_scaled = chunk * chunk_scales
+        chunk_scaled = chunk_scaled.to(out_dtype)
+        scaled_parts.append(chunk_scaled)
+
+    result = torch.cat(scaled_parts, dim=0)
+
+    if bias is not None:
+        result = result + bias.to(device=result.device, dtype=result.dtype).reshape(1, -1)
+
+    return result.reshape(*orig_shape[:-1], w_codes.shape[0])
+
+
+# =============================================================================
+# torch.library Custom Op Definitions — INT4 Tensor-wise
+# =============================================================================
+
+
+@torch.library.custom_op("comfy_kitchen::quantize_int4_rowwise", mutates_args=())
+def _op_quantize_int4_rowwise(
+    x: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    kwargs = {"x": x}
+    impl = registry.get_implementation("quantize_int4_rowwise", kwargs=kwargs)
+    return impl(**kwargs)
+
+
+@_op_quantize_int4_rowwise.register_fake
+def _op_quantize_int4_rowwise_fake(x):
+    q = torch.empty(*x.shape[:-1], x.shape[-1] // 2, dtype=torch.int8, device=x.device)
+    scale = torch.empty(*x.shape[:-1], 1, dtype=torch.float32, device=x.device)
+    return q, scale
+
+
+@torch.library.custom_op("comfy_kitchen::quantize_int4_convrot_weight", mutates_args=())
+def _op_quantize_int4_convrot_weight(
+    weight: torch.Tensor,
+    group_size: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    kwargs = {"weight": weight, "group_size": group_size}
+    impl = registry.get_implementation("quantize_int4_convrot_weight", kwargs=kwargs)
+    return impl(**kwargs)
+
+
+@_op_quantize_int4_convrot_weight.register_fake
+def _op_quantize_int4_convrot_weight_fake(weight, group_size):
+    q = torch.empty(*weight.shape[:-1], weight.shape[-1] // 2, dtype=torch.int8, device=weight.device)
+    scale = torch.empty(*weight.shape[:-1], 1, dtype=torch.float32, device=weight.device)
+    return q, scale
+
+
+@torch.library.custom_op("comfy_kitchen::dequantize_int4_simple", mutates_args=())
+def _op_dequantize_int4_simple(
+    q: torch.Tensor,
+    scale: torch.Tensor,
+) -> torch.Tensor:
+    kwargs = {"q": q, "scale": scale}
+    impl = registry.get_implementation("dequantize_int4_simple", kwargs=kwargs)
+    return impl(**kwargs)
+
+
+@_op_dequantize_int4_simple.register_fake
+def _op_dequantize_int4_simple_fake(q, scale):
+    return torch.empty(*q.shape[:-1], q.shape[-1] * 2, dtype=torch.float32, device=q.device)
+
+
+@torch.library.custom_op("comfy_kitchen::dequantize_int4_simple_dtype", mutates_args=())
+def _op_dequantize_int4_simple_dtype(
+    q: torch.Tensor,
+    scale: torch.Tensor,
+    output_dtype_code: int,
+) -> torch.Tensor:
+    kwargs = {"q": q, "scale": scale, "output_dtype_code": output_dtype_code}
+    impl = registry.get_implementation("dequantize_int4_simple_dtype", kwargs=kwargs)
+    return impl(**kwargs)
+
+
+@_op_dequantize_int4_simple_dtype.register_fake
+def _op_dequantize_int4_simple_dtype_fake(q, scale, output_dtype_code):
+    return torch.empty(*q.shape[:-1], q.shape[-1] * 2, dtype=DTYPE_CODE_TO_DTYPE[output_dtype_code], device=q.device)
+
+
+@torch.library.custom_op("comfy_kitchen::dequantize_int4_convrot_weight", mutates_args=())
+def _op_dequantize_int4_convrot_weight(
+    q: torch.Tensor,
+    scale: torch.Tensor,
+    group_size: int,
+) -> torch.Tensor:
+    kwargs = {"q": q, "scale": scale, "group_size": group_size}
+    impl = registry.get_implementation("dequantize_int4_convrot_weight", kwargs=kwargs)
+    return impl(**kwargs)
+
+
+@_op_dequantize_int4_convrot_weight.register_fake
+def _op_dequantize_int4_convrot_weight_fake(q, scale, group_size):
+    return torch.empty(*q.shape[:-1], q.shape[-1] * 2, dtype=torch.float32, device=q.device)
+
+
+@torch.library.custom_op("comfy_kitchen::dequantize_int4_convrot_weight_dtype", mutates_args=())
+def _op_dequantize_int4_convrot_weight_dtype(
+    q: torch.Tensor,
+    scale: torch.Tensor,
+    group_size: int,
+    output_dtype_code: int,
+) -> torch.Tensor:
+    kwargs = {"q": q, "scale": scale, "group_size": group_size, "output_dtype_code": output_dtype_code}
+    impl = registry.get_implementation("dequantize_int4_convrot_weight_dtype", kwargs=kwargs)
+    return impl(**kwargs)
+
+
+@_op_dequantize_int4_convrot_weight_dtype.register_fake
+def _op_dequantize_int4_convrot_weight_dtype_fake(q, scale, group_size, output_dtype_code):
+    return torch.empty(
+        *q.shape[:-1], q.shape[-1] * 2, dtype=DTYPE_CODE_TO_DTYPE[output_dtype_code], device=q.device
+    )
+
+
+@torch.library.custom_op("comfy_kitchen::int4_linear", mutates_args=())
+def _op_int4_linear(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    bias: torch.Tensor | None,
+    output_dtype_code: int,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+) -> torch.Tensor:
+    out_dtype = DTYPE_CODE_TO_DTYPE[output_dtype_code]
+    kwargs = {
+        "x": x,
+        "weight": weight,
+        "weight_scale": weight_scale,
+        "bias": bias,
+        "out_dtype": out_dtype,
+        "convrot": convrot,
+        "convrot_groupsize": convrot_groupsize,
+    }
+    impl = registry.get_implementation("int4_linear", kwargs=kwargs)
+    return impl(**kwargs)
+
+
+@_op_int4_linear.register_fake
+def _op_int4_linear_fake(x, weight, weight_scale, bias, output_dtype_code, convrot=False, convrot_groupsize=256):
+    out_dtype = DTYPE_CODE_TO_DTYPE[output_dtype_code]
+    return torch.empty(*x.shape[:-1], weight.shape[0], dtype=out_dtype, device=x.device)

--- a/comfy_kitchen/backends/eager/quantization.py
+++ b/comfy_kitchen/backends/eager/quantization.py
@@ -1292,6 +1292,9 @@ def dequantize_int4_convrot_weight_dtype(
     return dequantize_int4_convrot_weight(q, scale, group_size).to(DTYPE_CODE_TO_DTYPE[output_dtype_code])
 
 
+_int4_eager_cuda_warned = False
+
+
 def int4_linear(
     x: torch.Tensor,
     weight: torch.Tensor,
@@ -1322,6 +1325,30 @@ def int4_linear(
     Returns:
         Result tensor [..., N].
     """
+    global _int4_eager_cuda_warned
+    if x.is_cuda and not _int4_eager_cuda_warned:
+        _int4_eager_cuda_warned = True
+        import logging
+        try:
+            from comfy_kitchen.backends.cuda import _C as _CUDA_EXT
+            _has_kernels = hasattr(_CUDA_EXT, "int4_tensorwise_quantize")
+        except Exception:
+            _has_kernels = False
+        if _has_kernels:
+            reason = (
+                "the compiled kernels are present but this call does not meet the "
+                "fused path's constraints (SM >= 8.0, K % 64 == 0)"
+            )
+        else:
+            reason = (
+                "the compiled comfy_kitchen CUDA extension with the int4 kernels was "
+                "not found — build it from this checkout "
+                "(python setup.py build_ext --inplace) or install a wheel that ships it"
+            )
+        logging.warning(
+            "int4_tensorwise is running on the SLOW eager reference path on a CUDA "
+            "device (roughly 4x slower than the int8 kernels): %s.", reason
+        )
     w_codes = _int4_unpack_rowwise(weight.to(device=x.device).contiguous())
     if x.shape[-1] != w_codes.shape[-1]:
         raise ValueError(

--- a/comfy_kitchen/tensor/__init__.py
+++ b/comfy_kitchen/tensor/__init__.py
@@ -11,6 +11,7 @@ from .base import (
     register_layout_op,
 )
 from .fp8 import TensorCoreFP8Layout
+from .int4 import TensorWiseINT4Layout
 from .int8 import TensorWiseINT8Layout
 from .mxfp8 import TensorCoreMXFP8Layout
 from .nvfp4 import TensorCoreNVFP4Layout
@@ -30,6 +31,7 @@ __all__ = [
     "TensorCoreFP8Layout",
     "TensorCoreMXFP8Layout",
     "TensorCoreNVFP4Layout",
+    "TensorWiseINT4Layout",
     "TensorWiseINT8Layout",
     "TensorCoreSVDQuantW4A4Layout",
     "dequantize_args",
@@ -47,5 +49,6 @@ register_layout_class("TensorCoreAWQW4A16Layout", TensorCoreAWQW4A16Layout)
 register_layout_class("TensorCoreFP8Layout", TensorCoreFP8Layout)
 register_layout_class("TensorCoreMXFP8Layout", TensorCoreMXFP8Layout)
 register_layout_class("TensorCoreNVFP4Layout", TensorCoreNVFP4Layout)
+register_layout_class("TensorWiseINT4Layout", TensorWiseINT4Layout)
 register_layout_class("TensorWiseINT8Layout", TensorWiseINT8Layout)
 register_layout_class("TensorCoreSVDQuantW4A4Layout", TensorCoreSVDQuantW4A4Layout)

--- a/comfy_kitchen/tensor/int4.py
+++ b/comfy_kitchen/tensor/int4.py
@@ -1,0 +1,295 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 Comfy Org. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tensor-wise INT4 quantization layout (int4_tensorwise, W4A4 + optional ConvRot).
+
+Downward extension of :mod:`comfy_kitchen.tensor.int8` (``TensorWiseINT8Layout``):
+per-output-channel signed INT4 weights packed 2-per-byte (low nibble first, int8
+container ``[N, K/2]``) with a per-row float32 scale ``[N, 1]``; activations are
+rotated online (when ConvRot) and dynamically quantized per-token to INT4 inside
+``int4_linear``. Emission contract is shared with the svdquant kernels: symmetric
+``[-7, 7]``, ``scale = absmax / 7``.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+from dataclasses import dataclass
+
+import torch
+
+from comfy_kitchen.registry import registry
+
+from .base import (
+    BaseLayoutParams,
+    QuantizedLayout,
+    QuantizedTensor,
+    dequantize_args,
+    get_cuda_capability,
+    register_layout_op,
+)
+
+logger = logging.getLogger(__name__)
+
+_INT4_DEQUANT_DTYPE_TO_CODE = {
+    torch.float32: 0,
+    torch.float16: 1,
+    torch.bfloat16: 2,
+}
+
+
+def _dtype_code(dtype: torch.dtype) -> int:
+    code = _INT4_DEQUANT_DTYPE_TO_CODE.get(dtype)
+    if code is None:
+        raise ValueError(f"Unsupported INT4 output dtype: {dtype}")
+    return code
+
+
+class TensorWiseINT4Layout(QuantizedLayout):
+    """Per-row INT4 quantization (W4A4), packed storage, optional ConvRot.
+
+    - Weights: per-output-channel fp32 scale, packed int8 container [N, K/2]
+    - Activations: per-token scales + online rotation, dynamic inside int4_linear
+
+    Uses the int8 tensor-core matmul path (INT4 codes are valid INT8 operands,
+    INT32 accumulation is exact). Native INT4 tensor cores exist only on
+    SM 7.5-8.9; newer architectures execute the same math via the INT8 pipeline.
+
+    Note:
+        Requires SM >= 7.5 (Turing) like the INT8 layout; there is no additional
+        upper gate — correctness is preserved everywhere, speed varies by arch.
+    """
+
+    MIN_SM_VERSION = (7, 5)
+
+    @dataclass(frozen=True)
+    class Params(BaseLayoutParams):
+        """Tensor-wise INT4 layout parameters.
+
+        Inherits scale, orig_dtype, orig_shape from BaseLayoutParams.
+        ``orig_shape`` is the LOGICAL [N, K] shape; qdata is packed [N, K/2].
+        """
+
+        is_weight: bool = True
+        convrot: bool = False
+        convrot_groupsize: int = 256
+        transposed: bool = False
+
+        def _tensor_fields(self) -> list[str]:
+            return ["scale"]
+
+        def _validate_tensor_fields(self):
+            pass
+
+    @classmethod
+    def quantize(
+        cls,
+        tensor: torch.Tensor,
+        scale: torch.Tensor | float | str | None = None,
+        stochastic_rounding: int | None = 0,
+        inplace_ops: bool = False,
+        is_weight: bool = True,
+        per_channel: bool = True,
+        convrot: bool = False,
+        convrot_groupsize: int = 256,
+        **kwargs,
+    ) -> tuple[torch.Tensor, Params]:
+        """Quantize a tensor to packed per-row INT4.
+
+        Args:
+            tensor: Input tensor to quantize (last dim even; ConvRot additionally
+                requires last dim % convrot_groupsize == 0).
+            scale: Ignored (scales are always recomputed per-row, absmax/7).
+            stochastic_rounding: Seed for stochastic rounding. Disabled when <= 0.
+            inplace_ops: Kept for ComfyUI compatibility; quantization does not mutate input.
+            is_weight: If True this is a weight (ConvRot eligible).
+            per_channel: Kept for interface compatibility; INT4 is always per-row.
+            convrot: If True, apply orthogonal group-wise Hadamard rotation to weight.
+            convrot_groupsize: Group size for Hadamard rotation.
+            **kwargs: Additional arguments (ignored).
+
+        Returns:
+            Tuple of (packed_int4_data, params).
+        """
+        orig_dtype = tensor.dtype
+        orig_shape = tuple(tensor.shape)
+
+        if convrot and not is_weight:
+            raise ValueError("convrot is only supported when is_weight is True")
+
+        if convrot:
+            impl = registry.get_implementation(
+                "quantize_int4_convrot_weight",
+                kwargs={"weight": tensor, "group_size": convrot_groupsize, "stochastic_rounding": stochastic_rounding},
+            )
+            qdata, qscale = impl(tensor, convrot_groupsize, stochastic_rounding=stochastic_rounding)
+        else:
+            impl = registry.get_implementation(
+                "quantize_int4_rowwise",
+                kwargs={"x": tensor, "stochastic_rounding": stochastic_rounding},
+            )
+            qdata, qscale = impl(tensor, stochastic_rounding=stochastic_rounding)
+
+        params = cls.Params(
+            scale=qscale,
+            orig_dtype=orig_dtype,
+            orig_shape=orig_shape,
+            is_weight=is_weight,
+            convrot=convrot,
+            convrot_groupsize=convrot_groupsize,
+        )
+        return qdata, params
+
+    @classmethod
+    def dequantize(cls, qdata: torch.Tensor, params: Params) -> torch.Tensor:
+        """Dequantize packed INT4 data back to original dtype (un-rotating ConvRot)."""
+        output_dtype_code = _INT4_DEQUANT_DTYPE_TO_CODE.get(params.orig_dtype, 0)
+        if getattr(params, "convrot", False):
+            result = torch.ops.comfy_kitchen.dequantize_int4_convrot_weight_dtype(
+                qdata, params.scale, params.convrot_groupsize, output_dtype_code
+            )
+        else:
+            result = torch.ops.comfy_kitchen.dequantize_int4_simple_dtype(qdata, params.scale, output_dtype_code)
+        return result.to(params.orig_dtype)
+
+    @classmethod
+    def get_plain_tensors(cls, qtensor: QuantizedTensor) -> tuple[torch.Tensor, torch.Tensor]:
+        """Extract raw tensors for computation: (packed_qdata, scale)."""
+        return qtensor._qdata, qtensor._params.scale
+
+    @classmethod
+    def state_dict_tensors(cls, qdata: torch.Tensor, params: Params) -> dict[str, torch.Tensor]:
+        """Return key suffix → tensor mapping for serialization."""
+        return {
+            "": qdata,
+            "_scale": params.scale,
+        }
+
+    @classmethod
+    def requantize_kwargs(cls, qtensor: QuantizedTensor) -> dict[str, object]:
+        """Return INT4 quantization options needed to preserve this layout.
+
+        Critical for the LoRA-offload requantize path: a ConvRot weight must be
+        re-rotated before requantization (see the int8 convrot lesson,
+        ComfyUI #14642).
+        """
+        params = qtensor._params
+        return {
+            "is_weight": getattr(params, "is_weight", True),
+            "per_channel": True,
+            "convrot": getattr(params, "convrot", False),
+            "convrot_groupsize": getattr(params, "convrot_groupsize", 256),
+        }
+
+    @classmethod
+    def get_logical_shape_from_storage(cls, storage_shape: tuple[int, ...]) -> tuple[int, ...]:
+        """Compute the logical shape from packed storage by reversing 2-per-byte packing.
+
+        int4_tensorwise never pads (K must be even), so ``padded_shape`` equals the
+        logical [N, K] and ``is_padded`` stays False — same hook as the NVFP4 layout.
+        """
+        return (storage_shape[0], storage_shape[1] * 2)
+
+    @classmethod
+    def supports_fast_matmul(cls) -> bool:
+        """Check if the int8-pipeline matmul used by int4_linear is available."""
+        capability = get_cuda_capability()
+        if capability is None:
+            return False
+        return capability >= cls.MIN_SM_VERSION
+
+
+# =============================================================================
+# INT4 Tensor-wise Operations
+# =============================================================================
+
+
+@register_layout_op(torch.ops.aten.t.default, TensorWiseINT4Layout)
+def _handle_int4_transpose(qt, args, kwargs):
+    """Handle transpose as a logical flag flip for INT4 tensors."""
+    input_tensor = args[0]
+    if not isinstance(input_tensor, QuantizedTensor):
+        return torch.ops.aten.t.default(*args, **kwargs)
+
+    old = input_tensor._params
+    new_params = dataclasses.replace(
+        old,
+        orig_shape=(old.orig_shape[1], old.orig_shape[0]),
+        transposed=not old.transposed,
+    )
+    return QuantizedTensor(input_tensor._qdata, "TensorWiseINT4Layout", new_params)
+
+
+def _int4_weight_linear(input_tensor, weight, bias, out_dtype):
+    weight_qdata, weight_scale = TensorWiseINT4Layout.get_plain_tensors(weight)
+    convrot = getattr(weight._params, "convrot", False)
+    convrot_groupsize = getattr(weight._params, "convrot_groupsize", 256)
+    return torch.ops.comfy_kitchen.int4_linear(
+        input_tensor.contiguous(),
+        weight_qdata.contiguous(),
+        weight_scale,
+        bias,
+        _dtype_code(out_dtype),
+        convrot,
+        convrot_groupsize,
+    )
+
+
+@register_layout_op(torch.ops.aten.linear.default, TensorWiseINT4Layout)
+def _handle_int4_linear_tensorwise(qt, args, kwargs):
+    """INT4 linear for tensor-wise layout: output = input @ weight.T + bias."""
+    input_tensor = args[0]
+    weight = args[1]
+    bias = args[2] if len(args) > 2 else None
+
+    if not isinstance(weight, QuantizedTensor) or weight._layout_cls != "TensorWiseINT4Layout":
+        return torch.nn.functional.linear(*dequantize_args(args), **dequantize_args(kwargs))
+    if getattr(weight._params, "transposed", False):
+        return torch.nn.functional.linear(*dequantize_args(args), **dequantize_args(kwargs))
+
+    if isinstance(input_tensor, QuantizedTensor):
+        input_tensor = input_tensor.dequantize()
+
+    out_dtype = kwargs.get("out_dtype", input_tensor.dtype)
+    return _int4_weight_linear(input_tensor, weight, bias, out_dtype)
+
+
+@register_layout_op(torch.ops.aten.mm.default, TensorWiseINT4Layout)
+def _handle_int4_mm_tensorwise(qt, args, kwargs):
+    """INT4 matrix multiplication for tensor-wise layout: output = a @ b."""
+    input_tensor = args[0]
+    weight = args[1]
+
+    if not isinstance(weight, QuantizedTensor) or weight._layout_cls != "TensorWiseINT4Layout":
+        return torch.mm(*dequantize_args(args), **dequantize_args(kwargs))
+
+    if isinstance(input_tensor, QuantizedTensor):
+        input_tensor = input_tensor.dequantize()
+
+    if not getattr(weight._params, "transposed", False):
+        # Per-row scales belong to the rows of the logical RHS, not output
+        # columns, so a directly-quantized RHS cannot ride int4_linear.
+        return torch.mm(*dequantize_args(args), **dequantize_args(kwargs))
+
+    out_dtype = kwargs.get("out_dtype", input_tensor.dtype)
+    return _int4_weight_linear(input_tensor, weight, None, out_dtype)
+
+
+@register_layout_op(torch.ops.aten.addmm.default, TensorWiseINT4Layout)
+def _handle_int4_addmm_tensorwise(qt, args, kwargs):
+    """INT4 addmm for tensor-wise layout: output = bias + input @ weight."""
+    bias = args[0]
+    input_tensor = args[1]
+    weight = args[2]
+
+    if not isinstance(weight, QuantizedTensor) or weight._layout_cls != "TensorWiseINT4Layout":
+        return torch.addmm(*dequantize_args(args), **dequantize_args(kwargs))
+
+    if isinstance(input_tensor, QuantizedTensor):
+        input_tensor = input_tensor.dequantize()
+
+    if not getattr(weight._params, "transposed", False):
+        return torch.addmm(*dequantize_args(args), **dequantize_args(kwargs))
+
+    out_dtype = kwargs.get("out_dtype", input_tensor.dtype)
+    return _int4_weight_linear(input_tensor, weight, bias, out_dtype)

--- a/comfy_kitchen/tensor/int4.py
+++ b/comfy_kitchen/tensor/int4.py
@@ -56,11 +56,12 @@ class TensorWiseINT4Layout(QuantizedLayout):
     SM 7.5-8.9; newer architectures execute the same math via the INT8 pipeline.
 
     Note:
-        Requires SM >= 7.5 (Turing) like the INT8 layout; there is no additional
-        upper gate — correctness is preserved everywhere, speed varies by arch.
+        Requires SM >= 8.0: the fused CUDA path is built on cp.async, which
+        Turing lacks. Native INT4 tensor cores exist on SM 7.5-8.9; SM >= 9.0
+        executes the same math via the INT8 pipeline (correct, int8-class speed).
     """
 
-    MIN_SM_VERSION = (7, 5)
+    MIN_SM_VERSION = (8, 0)
 
     @dataclass(frozen=True)
     class Params(BaseLayoutParams):

--- a/tests/test_int4_tensorwise.py
+++ b/tests/test_int4_tensorwise.py
@@ -197,10 +197,10 @@ class TestInt4LinearCudaParity:
     def test_matches_eager(self, seed, dtype, convrot, shape):
         from comfy_kitchen.backends.cuda import int4_linear as cuda_int4_linear
 
-        M, K, N = shape
-        x = torch.randn(M, K, dtype=dtype, device="cuda")
-        w = torch.randn(N, K, dtype=dtype, device="cuda")
-        bias = torch.randn(N, dtype=dtype, device="cuda")
+        m, k, n = shape
+        x = torch.randn(m, k, dtype=dtype, device="cuda")
+        w = torch.randn(n, k, dtype=dtype, device="cuda")
+        bias = torch.randn(n, dtype=dtype, device="cuda")
         if convrot:
             wq, ws = quantize_int4_convrot_weight(w, 256)
         else:

--- a/tests/test_int4_tensorwise.py
+++ b/tests/test_int4_tensorwise.py
@@ -1,0 +1,353 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 Comfy Org. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for INT4 tensor-wise (int4_tensorwise, W4A4 + optional ConvRot) quantization."""
+
+import pytest
+import torch
+
+from comfy_kitchen.backends.eager.quantization import (
+    _build_hadamard,
+    _int4_pack_rowwise,
+    _int4_unpack_rowwise,
+    _rotate_activation,
+    _rotate_weight,
+    dequantize_int4_convrot_weight,
+    dequantize_int4_simple,
+    int4_linear,
+    quantize_int4_convrot_weight,
+    quantize_int4_rowwise,
+)
+
+
+def test_int4_pack_unpack_roundtrip(seed):
+    codes = torch.randint(-8, 8, (16, 64), dtype=torch.int8)
+    packed = _int4_pack_rowwise(codes)
+    assert packed.dtype == torch.int8
+    assert packed.shape == (16, 32)
+    assert torch.equal(_int4_unpack_rowwise(packed), codes)
+
+
+def test_int4_pack_low_nibble_first():
+    packed = _int4_pack_rowwise(torch.tensor([[1, -2]], dtype=torch.int8))
+    # low nibble = element 0 (0x1), high nibble = element 1 (-2 -> 0xE)
+    assert packed.contiguous().view(torch.uint8).item() == (0x1 | (0xE << 4))
+
+
+def test_int4_pack_rejects_odd_last_dim():
+    with pytest.raises(ValueError, match="even last dim"):
+        _int4_pack_rowwise(torch.zeros(4, 7, dtype=torch.int8))
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16, torch.float16])
+def test_quantize_int4_rowwise_recipe(seed, dtype):
+    """Recipe parity with the int8_tensorwise convention at 4-bit: fp32 scale =
+    absmax/7 clamped 1e-30, DIVISION with the scale cast to the source dtype,
+    round-half-even, clamp [-7, 7]."""
+    x = torch.randn(8, 128, dtype=dtype)
+    q, scale = quantize_int4_rowwise(x)
+    assert q.shape == (8, 64)
+    assert q.dtype == torch.int8
+    assert scale.shape == (8, 1)
+    assert scale.dtype == torch.float32
+
+    expected_scale = (x.abs().amax(dim=-1, keepdim=True).float() / 7.0).clamp(min=1e-30)
+    assert torch.equal(scale, expected_scale)
+
+    codes = _int4_unpack_rowwise(q)
+    assert codes.min().item() >= -7
+    assert codes.max().item() <= 7
+    expected = (x / expected_scale.to(dtype)).round().clamp(-7, 7).to(torch.int8)
+    assert torch.equal(codes, expected)
+
+
+def test_quantize_int4_rowwise_rejects_odd_k():
+    with pytest.raises(ValueError, match="even last dim"):
+        quantize_int4_rowwise(torch.randn(4, 7))
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_convrot_weight_matches_rotate_then_rowwise(seed, dtype):
+    """quantize_int4_convrot_weight == Hadamard at the SOURCE dtype, then rowwise."""
+    w = torch.randn(8, 128, dtype=dtype)
+    q, scale = quantize_int4_convrot_weight(w, 64)
+    h = _build_hadamard(64, device=w.device, dtype=w.dtype)
+    q_ref, scale_ref = quantize_int4_rowwise(_rotate_weight(w, h, 64))
+    assert torch.equal(q, q_ref)
+    assert torch.equal(scale, scale_ref)
+
+
+def test_convrot_weight_group_must_divide():
+    with pytest.raises((ValueError, RuntimeError)):
+        quantize_int4_convrot_weight(torch.randn(8, 96), 64)
+
+
+def test_dequant_roundtrip_error_bound(seed):
+    """|W - dequant(quant(W))| <= scale/2 per element (fp32, deterministic rounding)."""
+    w = torch.randn(16, 128, dtype=torch.float32)
+    q, scale = quantize_int4_rowwise(w)
+    deq = dequantize_int4_simple(q, scale)
+    assert deq.dtype == torch.float32
+    assert deq.shape == w.shape
+    assert ((w - deq).abs() <= scale * 0.5 + 1e-6).all()
+
+
+def test_convrot_dequant_returns_original_basis(seed):
+    """dequantize_int4_convrot_weight rotates back: result approximates W, not rot(W)."""
+    w = torch.randn(16, 128, dtype=torch.float32)
+    q, scale = quantize_int4_convrot_weight(w, 64)
+    deq = dequantize_int4_convrot_weight(q, scale, 64)
+    rel = (w - deq).norm() / w.norm()
+    assert rel.item() < 0.2, f"relative error too high: {rel:.4f}"
+    # and it must NOT be the rotated-basis reconstruction
+    h = _build_hadamard(64, device=w.device, dtype=torch.float32)
+    rel_rot = (_rotate_weight(w, h, 64) - deq).norm() / w.norm()
+    assert rel_rot > rel
+
+
+def test_int4_linear_exact_integer_case(seed):
+    """With exactly-representable codes/scales the whole W4A4 path is exact."""
+    w_codes = torch.randint(-7, 8, (16, 64), dtype=torch.int8)
+    w_codes[:, 0] = 7  # pin per-row absmax so scale is exactly 0.5
+    w = w_codes.float() * 0.5
+    x_codes = torch.randint(-7, 8, (4, 64), dtype=torch.int8)
+    x_codes[:, 0] = 7  # pin per-row absmax so scale is exactly 0.25
+    x = x_codes.float() * 0.25
+
+    wq, ws = quantize_int4_rowwise(w)
+    assert torch.equal(_int4_unpack_rowwise(wq), w_codes)
+
+    y = int4_linear(x, wq, ws, None, torch.float32)
+    assert torch.equal(y, x @ w.T)
+
+    bias = torch.arange(16, dtype=torch.float32)
+    y_bias = int4_linear(x, wq, ws, bias, torch.float32)
+    assert torch.equal(y_bias, x @ w.T + bias)
+
+
+def test_int4_linear_convrot_matches_eager_composition(seed):
+    """int4_linear(convrot=True) == rotate act -> rowwise quant -> exact int mm ->
+    rank-1 scale epilogue, composed from the public pieces."""
+    w = torch.randn(16, 128, dtype=torch.float32)
+    x = torch.randn(4, 128, dtype=torch.float32)
+    wq, ws = quantize_int4_convrot_weight(w, 64)
+
+    y = int4_linear(x, wq, ws, None, torch.float32, convrot=True, convrot_groupsize=64)
+
+    h = _build_hadamard(64, device=x.device, dtype=x.dtype)
+    x_rot = _rotate_activation(x, h, 64)
+    xq, xs = quantize_int4_rowwise(x_rot)
+    y_ref = (_int4_unpack_rowwise(xq).float() * xs) @ (_int4_unpack_rowwise(wq).float() * ws).T
+    torch.testing.assert_close(y, y_ref, rtol=1e-5, atol=1e-5)
+
+
+@pytest.mark.parametrize("convrot", [False, True])
+def test_int4_linear_close_to_dense(seed, convrot):
+    """W4A4 output stays within coarse-4-bit tolerance of the dense linear."""
+    w = torch.randn(32, 256, dtype=torch.float32)
+    x = torch.randn(8, 256, dtype=torch.float32)
+    if convrot:
+        wq, ws = quantize_int4_convrot_weight(w, 64)
+    else:
+        wq, ws = quantize_int4_rowwise(w)
+    y = int4_linear(x, wq, ws, None, torch.float32, convrot=convrot, convrot_groupsize=64)
+    y_ref = x @ w.T
+    rel = (y - y_ref).norm() / y_ref.norm()
+    assert rel.item() < 0.25, f"relative error too high (convrot={convrot}): {rel:.4f}"
+
+
+def test_int4_linear_batch_dims(seed):
+    w = torch.randn(16, 64, dtype=torch.float32)
+    x = torch.randn(2, 3, 64, dtype=torch.float32)
+    wq, ws = quantize_int4_rowwise(w)
+    y = int4_linear(x, wq, ws, None, torch.float32)
+    assert y.shape == (2, 3, 16)
+    y_2d = int4_linear(x.reshape(6, 64), wq, ws, None, torch.float32)
+    torch.testing.assert_close(y, y_2d.reshape(2, 3, 16))
+
+
+def test_int4_linear_shape_mismatch_raises():
+    wq, ws = quantize_int4_rowwise(torch.randn(16, 64))
+    with pytest.raises(ValueError, match="inner dimensions"):
+        int4_linear(torch.randn(4, 128), wq, ws, None, torch.float32)
+
+
+def test_int4_linear_convrot_group_must_divide():
+    wq, ws = quantize_int4_rowwise(torch.randn(16, 96))
+    with pytest.raises(ValueError, match="does not divide"):
+        int4_linear(torch.randn(4, 96), wq, ws, None, torch.float32, convrot=True, convrot_groupsize=64)
+
+
+class TestTensorWiseINT4Layout:
+    """Tests for the TensorWiseINT4Layout quantized tensor format."""
+
+    @pytest.fixture(autouse=True)
+    def cuda_only(self):
+        if not torch.cuda.is_available():
+            pytest.skip("CUDA required for TensorWiseINT4Layout tests")
+
+    def test_weight_quantize_shape_dtype(self, seed):
+        from comfy_kitchen.tensor import QuantizedTensor
+
+        w = torch.randn(256, 512, device="cuda", dtype=torch.bfloat16)
+        qt = QuantizedTensor.from_float(w, "TensorWiseINT4Layout")
+
+        assert qt._qdata.dtype == torch.int8
+        assert qt._qdata.shape == (256, 256)  # packed [N, K/2]
+        assert qt._params.scale.shape == (256, 1)
+        assert qt._params.scale.dtype == torch.float32
+        assert qt._params.orig_shape == (256, 512)
+
+    def test_convrot_quantize_params(self, seed):
+        from comfy_kitchen.tensor import TensorWiseINT4Layout
+
+        w = torch.randn(64, 512, device="cuda", dtype=torch.bfloat16)
+        qdata, params = TensorWiseINT4Layout.quantize(w, convrot=True, convrot_groupsize=256)
+        assert qdata.shape == (64, 256)
+        assert params.convrot is True
+        assert params.convrot_groupsize == 256
+
+    def test_weight_dequantize_dtype_and_logical_shape(self, seed):
+        from comfy_kitchen.tensor import QuantizedTensor
+
+        for dtype in (torch.float16, torch.bfloat16):
+            w = torch.randn(64, 128, device="cuda", dtype=dtype)
+            qt = QuantizedTensor.from_float(w, "TensorWiseINT4Layout")
+            dq = qt.dequantize()
+            assert dq.dtype == dtype
+            assert dq.shape == w.shape
+
+    @pytest.mark.parametrize("convrot", [False, True])
+    def test_weight_roundtrip_error(self, seed, convrot):
+        from comfy_kitchen.tensor import QuantizedTensor
+
+        w = torch.randn(128, 256, device="cuda", dtype=torch.bfloat16)
+        qt = QuantizedTensor.from_float(w, "TensorWiseINT4Layout", convrot=convrot)
+        dq = qt.dequantize()
+
+        rel = (w.float() - dq.float()).norm() / w.float().norm()
+        assert rel.item() < 0.2, f"relative roundtrip error too high: {rel:.4f}"
+
+    def test_state_dict_tensors_keys(self, seed):
+        from comfy_kitchen.tensor import QuantizedTensor, TensorWiseINT4Layout
+
+        w = torch.randn(64, 64, device="cuda", dtype=torch.bfloat16)
+        qt = QuantizedTensor.from_float(w, "TensorWiseINT4Layout")
+        sd = TensorWiseINT4Layout.state_dict_tensors(qt._qdata, qt._params)
+
+        assert set(sd.keys()) == {"", "_scale"}
+        assert sd[""].dtype == torch.int8
+        assert sd[""].shape == (64, 32)
+        assert sd["_scale"].shape == (64, 1)
+
+    def test_requantize_kwargs_preserve_convrot(self, seed):
+        from comfy_kitchen.tensor import QuantizedTensor, TensorWiseINT4Layout
+
+        w = torch.randn(64, 512, device="cuda", dtype=torch.bfloat16)
+        qt = QuantizedTensor.from_float(w, "TensorWiseINT4Layout", convrot=True, convrot_groupsize=256)
+        kwargs = TensorWiseINT4Layout.requantize_kwargs(qt)
+        assert kwargs["convrot"] is True
+        assert kwargs["convrot_groupsize"] == 256
+        assert kwargs["per_channel"] is True
+
+    def test_transpose_flips_flags(self, seed):
+        from comfy_kitchen.tensor import QuantizedTensor
+
+        w = torch.randn(64, 128, device="cuda", dtype=torch.bfloat16)
+        qt = QuantizedTensor.from_float(w, "TensorWiseINT4Layout")
+        qt_t = torch.ops.aten.t.default(qt)
+        assert qt_t._params.transposed is True
+        assert qt_t._params.orig_shape == (128, 64)
+
+    @pytest.mark.parametrize("convrot", [False, True])
+    def test_linear_dispatch(self, seed, convrot):
+        from comfy_kitchen.tensor import QuantizedTensor
+
+        x = torch.randn(4, 256, device="cuda", dtype=torch.bfloat16)
+        w = torch.randn(64, 256, device="cuda", dtype=torch.bfloat16)
+        qt_w = QuantizedTensor.from_float(w, "TensorWiseINT4Layout", convrot=convrot)
+
+        out = torch.nn.functional.linear(x, qt_w)
+
+        assert out.shape == (4, 64)
+        assert out.dtype == torch.bfloat16
+        rel = (out.float() - (x.float() @ w.float().T)).norm() / (x.float() @ w.float().T).norm()
+        assert rel.item() < 0.3, f"linear dispatch error too high (convrot={convrot}): {rel:.4f}"
+
+    def test_linear_dispatch_with_bias(self, seed):
+        from comfy_kitchen.tensor import QuantizedTensor
+
+        x = torch.randn(4, 128, device="cuda", dtype=torch.bfloat16)
+        w = torch.randn(64, 128, device="cuda", dtype=torch.bfloat16)
+        bias = torch.randn(64, device="cuda", dtype=torch.bfloat16)
+        qt_w = QuantizedTensor.from_float(w, "TensorWiseINT4Layout")
+
+        out = torch.nn.functional.linear(x, qt_w, bias)
+        assert out.shape == (4, 64)
+        assert out.dtype == torch.bfloat16
+
+    def test_logical_shape_and_no_padding(self, seed):
+        """padded_shape reverses the 2-per-byte packing; int4 never pads."""
+        from comfy_kitchen.tensor import QuantizedTensor
+
+        w = torch.randn(64, 128, device="cuda", dtype=torch.bfloat16)
+        qt = QuantizedTensor.from_float(w, "TensorWiseINT4Layout")
+        assert qt._qdata.shape == (64, 64)  # packed storage
+        assert qt.padded_shape == (64, 128)  # logical, unpacked
+        assert qt.is_padded is False
+        assert qt.shape == (64, 128)
+
+    def test_mm_dispatch_transposed_and_fallback(self, seed):
+        """mm(x, qt.t()) rides int4_linear; non-transposed mm falls back to dequant."""
+        from comfy_kitchen.tensor import QuantizedTensor
+
+        x = torch.randn(4, 128, device="cuda", dtype=torch.bfloat16)
+        w = torch.randn(64, 128, device="cuda", dtype=torch.bfloat16)
+        qt_w = QuantizedTensor.from_float(w, "TensorWiseINT4Layout")
+
+        out = torch.mm(x, qt_w.t())
+        assert out.shape == (4, 64)
+        ref = x.float() @ w.float().T
+        rel = (out.float() - ref).norm() / ref.norm()
+        assert rel.item() < 0.3, f"transposed mm error too high: {rel:.4f}"
+
+        # Non-transposed: per-row scales cannot ride int4_linear -> dequant fallback.
+        w_sq = torch.randn(128, 128, device="cuda", dtype=torch.bfloat16)
+        qt_sq = QuantizedTensor.from_float(w_sq, "TensorWiseINT4Layout")
+        out_sq = torch.mm(x, qt_sq)
+        ref_sq = x.float() @ qt_sq.dequantize().float()
+        rel_sq = (out_sq.float() - ref_sq).norm() / ref_sq.norm()
+        assert rel_sq.item() < 0.05, f"non-transposed mm fallback error too high: {rel_sq:.4f}"
+
+    def test_addmm_dispatch_transposed_and_fallback(self, seed):
+        from comfy_kitchen.tensor import QuantizedTensor
+
+        x = torch.randn(4, 128, device="cuda", dtype=torch.bfloat16)
+        w = torch.randn(64, 128, device="cuda", dtype=torch.bfloat16)
+        bias = torch.randn(64, device="cuda", dtype=torch.bfloat16)
+        qt_w = QuantizedTensor.from_float(w, "TensorWiseINT4Layout")
+
+        out = torch.addmm(bias, x, qt_w.t())
+        assert out.shape == (4, 64)
+        ref = bias.float() + x.float() @ w.float().T
+        rel = (out.float() - ref).norm() / ref.norm()
+        assert rel.item() < 0.3, f"transposed addmm error too high: {rel:.4f}"
+
+        w_sq = torch.randn(128, 128, device="cuda", dtype=torch.bfloat16)
+        qt_sq = QuantizedTensor.from_float(w_sq, "TensorWiseINT4Layout")
+        bias_sq = torch.randn(128, device="cuda", dtype=torch.bfloat16)
+        out_sq = torch.addmm(bias_sq, x, qt_sq)
+        ref_sq = bias_sq.float() + x.float() @ qt_sq.dequantize().float()
+        rel_sq = (out_sq.float() - ref_sq).norm() / ref_sq.norm()
+        assert rel_sq.item() < 0.05, f"non-transposed addmm fallback error too high: {rel_sq:.4f}"
+
+    @pytest.mark.parametrize("convrot", [False, True])
+    def test_mm_dispatch_convrot(self, seed, convrot):
+        from comfy_kitchen.tensor import QuantizedTensor
+
+        x = torch.randn(4, 256, device="cuda", dtype=torch.bfloat16)
+        w = torch.randn(64, 256, device="cuda", dtype=torch.bfloat16)
+        qt_w = QuantizedTensor.from_float(w, "TensorWiseINT4Layout", convrot=convrot)
+        out = torch.mm(x, qt_w.t())
+        ref = x.float() @ w.float().T
+        rel = (out.float() - ref).norm() / ref.norm()
+        assert rel.item() < 0.3, f"mm convrot={convrot} error too high: {rel:.4f}"

--- a/tests/test_int4_tensorwise.py
+++ b/tests/test_int4_tensorwise.py
@@ -214,6 +214,19 @@ class TestInt4LinearCudaParity:
         rel = (y_cuda - y_ref).norm() / y_ref.norm().clamp(min=1e-9)
         assert rel.item() < 0.02, f"cuda/eager divergence {rel:.5f} (convrot={convrot}, {shape})"
 
+    def test_out_dtype_mismatch_matches_eager(self, seed):
+        # The GEMM reads ascales/wscales as out_dtype; a bf16 activation with
+        # fp16 output must not misread the scale bytes.
+        from comfy_kitchen.backends.cuda import int4_linear as cuda_int4_linear
+
+        x = torch.randn(37, 3072, dtype=torch.bfloat16, device="cuda")
+        w = torch.randn(1024, 3072, dtype=torch.bfloat16, device="cuda")
+        wq, ws = quantize_int4_convrot_weight(w, 256)
+        y_ref = int4_linear(x, wq, ws, None, torch.float16, True, 256).float()
+        y_cuda = cuda_int4_linear(x, wq, ws, None, torch.float16, True, 256).float()
+        rel = (y_cuda - y_ref).norm() / y_ref.norm().clamp(min=1e-9)
+        assert rel.item() < 0.02, f"out-dtype-mismatch divergence {rel:.5f}"
+
     def test_batch_dims_and_dispatch(self, seed):
         from comfy_kitchen.tensor import QuantizedTensor
 

--- a/tests/test_int4_tensorwise.py
+++ b/tests/test_int4_tensorwise.py
@@ -177,6 +177,56 @@ def test_int4_linear_convrot_group_must_divide():
         int4_linear(torch.randn(4, 96), wq, ws, None, torch.float32, convrot=True, convrot_groupsize=64)
 
 
+class TestInt4LinearCudaParity:
+    """CUDA int4_linear (fused ConvRot + s4 MMA via the svdquant GEMM) vs eager."""
+
+    @pytest.fixture(autouse=True)
+    def cuda_kernel_only(self):
+        if not torch.cuda.is_available():
+            pytest.skip("CUDA required")
+        try:
+            from comfy_kitchen.backends.cuda import _C  # noqa: F401
+        except Exception:
+            pytest.skip("compiled comfy_kitchen CUDA extension required")
+        if torch.cuda.get_device_capability() < (8, 0):
+            pytest.skip("int4 MMA path requires SM >= 8.0")
+
+    @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+    @pytest.mark.parametrize("convrot", [False, True])
+    @pytest.mark.parametrize("shape", [(1, 512, 256), (37, 3072, 1024), (300, 12288, 512)])
+    def test_matches_eager(self, seed, dtype, convrot, shape):
+        from comfy_kitchen.backends.cuda import int4_linear as cuda_int4_linear
+
+        M, K, N = shape
+        x = torch.randn(M, K, dtype=dtype, device="cuda")
+        w = torch.randn(N, K, dtype=dtype, device="cuda")
+        bias = torch.randn(N, dtype=dtype, device="cuda")
+        if convrot:
+            wq, ws = quantize_int4_convrot_weight(w, 256)
+        else:
+            wq, ws = quantize_int4_rowwise(w)
+        y_ref = int4_linear(x, wq, ws, bias, dtype, convrot, 256).float()
+        y_cuda = cuda_int4_linear(x, wq, ws, bias, dtype, convrot, 256).float()
+        # The GEMM epilogue uses 16-bit (a/w)scales vs eager's fp32; the ConvRot
+        # path additionally rounds the fp32 FHT output through the source dtype
+        # to reproduce eager's rotated values. Residual divergence is boundary
+        # code flips at ~1e-3 relative.
+        rel = (y_cuda - y_ref).norm() / y_ref.norm().clamp(min=1e-9)
+        assert rel.item() < 0.02, f"cuda/eager divergence {rel:.5f} (convrot={convrot}, {shape})"
+
+    def test_batch_dims_and_dispatch(self, seed):
+        from comfy_kitchen.tensor import QuantizedTensor
+
+        x = torch.randn(2, 3, 512, dtype=torch.bfloat16, device="cuda")
+        w = torch.randn(256, 512, dtype=torch.bfloat16, device="cuda")
+        qt_w = QuantizedTensor.from_float(w, "TensorWiseINT4Layout", convrot=True)
+        out = torch.nn.functional.linear(x, qt_w)
+        assert out.shape == (2, 3, 256)
+        ref = x.float() @ w.float().transpose(0, 1)
+        rel = (out.float() - ref).norm() / ref.norm()
+        assert rel.item() < 0.3
+
+
 class TestTensorWiseINT4Layout:
     """Tests for the TensorWiseINT4Layout quantized tensor format."""
 


### PR DESCRIPTION

Adds `TensorWiseINT4Layout` — a 4-bit downward extension of int8_tensorwise. Weights are packed signed int4 pairs (low-nibble-first, `[N, K/2]` int8 container) with fp32 `[N, 1]` per-row scales; activations are rotated + quantized to int4 dynamically inside the kernel. 

**Eager**: `quantize_int4_rowwise` / `quantize_int4_convrot_weight` / `int4_linear` reference path, exact pack/unpack roundtrip, works on CPU.

**CUDA** (SM >= 8.0 for the MMA path, layout MIN_SM (7,5)):
- fused activation kernel: FHT rotation (smem, radix-4) + rowwise int4 quantize + pack in one pass
- s4·s4 MMA GEMM with rank-one epilogue dequant: per-row/per-col scales factor out of the K loop, so the main loop is pure `cp.async` + `mma.m16n8k64.s4` with carried int32 accumulators (`|acc| <= 49·K << 2^31`) — no in-loop CUDA-core dequant
- `ldmatrix.x4`/`x2` fragment loads over a 48-byte-stride smem layout (bank-conflict-free); both operands share the ldmatrix k-permutation so the dot product is unchanged
- capacity-1 activation-quantize memo: q/k (and add_q/add_k) projections receive the same activation object, so the second layer reuses the rotated+quantized activation (object identity + `_version` guarded, inference-mode safe)

Per-layer, L4 (SM 8.9, native int4 tensor cores), M=4608, vs the compiled int8 path:

```
 3072x3072    0.54 ms   (int8: 1.18)
 3072->12288  2.60 ms   (int8: 4.54)
12288->3072   2.30 ms   (int8: 4.04)
```

E2E Qwen-Image-Edit-2511 mixed checkpoint (80% int4 / 20% int8 layers, 20 steps, 1024², L4, same session): 4.22 s/it vs 4.29 s/it for full int8, at 75% of the file size (14.9 GB vs 20 GB, bf16 is 40 GB). Krea-2 Turbo/Raw: 1.33×/1.22× vs bf16. Published checkpoints for testing:

- https://huggingface.co/LAXMAYDAY/Qwen-Image-Edit-2511-int4-tensorwise-mixed
- https://huggingface.co/LAXMAYDAY/Krea-2-Turbo-int4-tensorwise-mixed
- https://huggingface.co/LAXMAYDAY/Krea-2-Raw-int4-tensorwise-mixed

To test them, use ComfyUI from the companion loader branch: [HK416-TYPED/ComfyUI `feat/int4-tensorwise-loader`](https://github.com/HK416-TYPED/ComfyUI/tree/feat/int4-tensorwise-loader) with this branch 