### PR TITLE
RDNA-aware autotune configs for the INT8 matmul kernels

### DIFF
--- a/comfy_kitchen/backends/triton/quantization.py
+++ b/comfy_kitchen/backends/triton/quantization.py
@@ -857,11 +857,8 @@ def triton_quantize_and_rotate_rowwise(x: torch.Tensor, h: torch.Tensor, group_s
 
 
 def _int8_autotune_configs():
-    """INT8 matmul autotune configs. AMD RDNA (gfx11/gfx12) prefers shallow software
-    pipelining (num_stages=2) and deeper block_k; the NVIDIA defaults use num_stages=3-4.
-    The RDNA pool spans small tiles (RDNA3) and large tiles (RDNA4) so autotune can pick
-    per shape/arch. Empirically 1.03-1.11x faster than the NVIDIA configs on gfx1100/1201."""
-    nvidia = [
+    """Return the default and RDNA-tuned INT8 matmul config pools."""
+    default_configs = [
         triton.Config({'block_m': 128, 'block_n': 256, 'block_k': 64, 'group_size_m': 8}, num_stages=3, num_warps=8),
         triton.Config({'block_m': 64,  'block_n': 256, 'block_k': 32, 'group_size_m': 8}, num_stages=4, num_warps=4),
         triton.Config({'block_m': 128, 'block_n': 128, 'block_k': 32, 'group_size_m': 8}, num_stages=4, num_warps=4),
@@ -869,30 +866,50 @@ def _int8_autotune_configs():
         triton.Config({'block_m': 64,  'block_n': 128, 'block_k': 32, 'group_size_m': 8}, num_stages=4, num_warps=4),
         triton.Config({'block_m': 128, 'block_n': 32,  'block_k': 32, 'group_size_m': 8}, num_stages=4, num_warps=4),
     ]
-    if getattr(torch.version, 'hip', None) is None:
-        return nvidia
-    return [
+    rdna_configs = [
         triton.Config({'block_m': 128, 'block_n': 256, 'block_k': 64,  'group_size_m': 8}, num_stages=2, num_warps=8),
         triton.Config({'block_m': 128, 'block_n': 128, 'block_k': 128, 'group_size_m': 8}, num_stages=2, num_warps=8),
         triton.Config({'block_m': 128, 'block_n': 128, 'block_k': 64,  'group_size_m': 8}, num_stages=2, num_warps=4),
         triton.Config({'block_m': 64,  'block_n': 128, 'block_k': 64,  'group_size_m': 8}, num_stages=2, num_warps=4),
         triton.Config({'block_m': 128, 'block_n': 64,  'block_k': 64,  'group_size_m': 8}, num_stages=2, num_warps=4),
         triton.Config({'block_m': 64,  'block_n': 64,  'block_k': 64,  'group_size_m': 4}, num_stages=2, num_warps=4),
-        # waves_per_eu variants -- help occupancy on bandwidth-limited RDNA APUs
-        # (gfx1103/gfx1151: up to ~1.15x); dGPUs autotune-select the base configs above. (thanks @LuXuxue)
         triton.Config({'block_m': 128, 'block_n': 256, 'block_k': 64,  'group_size_m': 8, 'waves_per_eu': 4}, num_stages=2, num_warps=8),
         triton.Config({'block_m': 128, 'block_n': 128, 'block_k': 64,  'group_size_m': 8, 'waves_per_eu': 1}, num_stages=2, num_warps=4),
         triton.Config({'block_m': 64,  'block_n': 128, 'block_k': 64,  'group_size_m': 8, 'waves_per_eu': 1}, num_stages=2, num_warps=4),
         triton.Config({'block_m': 64,  'block_n': 64,  'block_k': 64,  'group_size_m': 4, 'waves_per_eu': 1}, num_stages=2, num_warps=4),
     ]
+    return default_configs, rdna_configs
 
 
-_INT8_MATMUL_CONFIGS = _int8_autotune_configs()
+_INT8_DEFAULT_CONFIGS, _INT8_RDNA_CONFIGS = _int8_autotune_configs()
+_INT8_MATMUL_CONFIGS = _INT8_DEFAULT_CONFIGS + _INT8_RDNA_CONFIGS
 
+
+def _prune_int8_autotune_configs(configs, named_args, **kwargs):
+    args = {**named_args, **kwargs}
+    if getattr(torch.version, 'hip', None) is None:
+        return _INT8_DEFAULT_CONFIGS
+
+    try:
+        arch = torch.cuda.get_device_properties(args['device_index']).gcnArchName.split(":")[0]
+    except Exception:
+        return _INT8_DEFAULT_CONFIGS
+    if not arch.startswith(("gfx11", "gfx12")):
+        return _INT8_DEFAULT_CONFIGS
+
+    rdna_configs = _INT8_RDNA_CONFIGS
+    # BK128 was consistently slower for small-M calls on gfx1151.
+    if args['m'] <= 128:
+        rdna_configs = [config for config in rdna_configs if config.kwargs['block_k'] <= 64]
+    return rdna_configs
+
+
+_INT8_PRUNE_CONFIGS_BY = {'early_config_prune': _prune_int8_autotune_configs}
 
 @triton.autotune(
     configs=_INT8_MATMUL_CONFIGS,
-    key=['m', 'n', 'k'],
+    key=['m', 'n', 'k', 'device_index'],
+    prune_configs_by=_INT8_PRUNE_CONFIGS_BY,
 )
 @triton.jit
 def _int8_matmul_dequant_kernel(
@@ -900,7 +917,7 @@ def _int8_matmul_dequant_kernel(
     a_ptr, b_ptr, c_ptr,
     a_scale_ptr, b_scale_ptr, bias_ptr,
     # Matrix Dimensions
-    m, n, k,
+    m, n, k, device_index: tl.constexpr,
     # Strides
     stride_am, stride_ak,
     stride_bk, stride_bn,
@@ -967,7 +984,8 @@ def _int8_matmul_dequant_kernel(
 
 @triton.autotune(
     configs=_INT8_MATMUL_CONFIGS,
-    key=['m', 'n', 'k'],
+    key=['m', 'n', 'k', 'device_index'],
+    prune_configs_by=_INT8_PRUNE_CONFIGS_BY,
 )
 @triton.jit
 def _int8_matmul_dequant_per_row_kernel(
@@ -975,7 +993,7 @@ def _int8_matmul_dequant_per_row_kernel(
     a_ptr, b_ptr, c_ptr,
     a_scale_ptr, b_scale_ptr, bias_ptr,
     # Matrix Dimensions
-    m, n, k,
+    m, n, k, device_index: tl.constexpr,
     # Strides
     stride_am, stride_ak,
     stride_bk, stride_bn,
@@ -1065,6 +1083,7 @@ def int8_linear(
 
     m, k = x_2d.shape
     n = weight.shape[0]
+    device_index = x.device.index if x.device.index is not None else 0
 
     # Quantize input per-row using fused or normal quantization kernel
     if convrot:
@@ -1099,7 +1118,7 @@ def int8_linear(
             a_scale_ptr=x_scale,
             b_scale_ptr=weight_scale,
             bias_ptr=bias_ptr,
-            m=m, n=n, k=k,
+            m=m, n=n, k=k, device_index=device_index,
             stride_am=x_int8.stride(0), stride_ak=x_int8.stride(1),
             stride_bk=weight.stride(1), stride_bn=weight.stride(0),
             stride_cm=output.stride(0), stride_cn=output.stride(1),
@@ -1113,7 +1132,7 @@ def int8_linear(
             a_scale_ptr=x_scale,
             b_scale_ptr=weight_scale,
             bias_ptr=bias_ptr,
-            m=m, n=n, k=k,
+            m=m, n=n, k=k, device_index=device_index,
             stride_am=x_int8.stride(0), stride_ak=x_int8.stride(1),
             stride_bk=weight.stride(1), stride_bn=weight.stride(0),
             stride_cm=output.stride(0), stride_cn=output.stride(1),

--- a/comfy_kitchen/backends/triton/quantization.py
+++ b/comfy_kitchen/backends/triton/quantization.py
@@ -906,11 +906,13 @@ def _prune_int8_autotune_configs(configs, named_args, **kwargs):
 
 _INT8_PRUNE_CONFIGS_BY = {'early_config_prune': _prune_int8_autotune_configs}
 
-@triton.autotune(
-    configs=_INT8_MATMUL_CONFIGS,
-    key=['m', 'n', 'k', 'device_index'],
-    prune_configs_by=_INT8_PRUNE_CONFIGS_BY,
-)
+_INT8_AUTOTUNE_KWARGS = {
+    'configs': _INT8_MATMUL_CONFIGS,
+    'key': ['m', 'n', 'k', 'device_index'],
+    'prune_configs_by': _INT8_PRUNE_CONFIGS_BY,
+}
+
+@triton.autotune(**_INT8_AUTOTUNE_KWARGS)
 @triton.jit
 def _int8_matmul_dequant_kernel(
     # Pointers
@@ -982,11 +984,7 @@ def _int8_matmul_dequant_kernel(
     c_mask = (offs_am[:, None] < m) & (offs_bn[None, :] < n)
     tl.store(c_ptrs, c, mask=c_mask)
 
-@triton.autotune(
-    configs=_INT8_MATMUL_CONFIGS,
-    key=['m', 'n', 'k', 'device_index'],
-    prune_configs_by=_INT8_PRUNE_CONFIGS_BY,
-)
+@triton.autotune(**_INT8_AUTOTUNE_KWARGS)
 @triton.jit
 def _int8_matmul_dequant_per_row_kernel(
     # Pointers

--- a/comfy_kitchen/backends/triton/quantization.py
+++ b/comfy_kitchen/backends/triton/quantization.py
@@ -857,7 +857,7 @@ def triton_quantize_and_rotate_rowwise(x: torch.Tensor, h: torch.Tensor, group_s
 
 
 def _int8_autotune_configs():
-    """Return the default and RDNA-tuned INT8 matmul config pools."""
+    """Return the default and generation-specific RDNA config pools."""
     default_configs = [
         triton.Config({'block_m': 128, 'block_n': 256, 'block_k': 64, 'group_size_m': 8}, num_stages=3, num_warps=8),
         triton.Config({'block_m': 64,  'block_n': 256, 'block_k': 32, 'group_size_m': 8}, num_stages=4, num_warps=4),
@@ -866,7 +866,7 @@ def _int8_autotune_configs():
         triton.Config({'block_m': 64,  'block_n': 128, 'block_k': 32, 'group_size_m': 8}, num_stages=4, num_warps=4),
         triton.Config({'block_m': 128, 'block_n': 32,  'block_k': 32, 'group_size_m': 8}, num_stages=4, num_warps=4),
     ]
-    rdna_configs = [
+    gfx12_configs = [
         triton.Config({'block_m': 128, 'block_n': 256, 'block_k': 64,  'group_size_m': 8}, num_stages=2, num_warps=8),
         triton.Config({'block_m': 128, 'block_n': 128, 'block_k': 128, 'group_size_m': 8}, num_stages=2, num_warps=8),
         triton.Config({'block_m': 128, 'block_n': 128, 'block_k': 64,  'group_size_m': 8}, num_stages=2, num_warps=4),
@@ -878,11 +878,26 @@ def _int8_autotune_configs():
         triton.Config({'block_m': 64,  'block_n': 128, 'block_k': 64,  'group_size_m': 8, 'waves_per_eu': 1}, num_stages=2, num_warps=4),
         triton.Config({'block_m': 64,  'block_n': 64,  'block_k': 64,  'group_size_m': 4, 'waves_per_eu': 1}, num_stages=2, num_warps=4),
     ]
-    return default_configs, rdna_configs
+    gfx11_configs = list(gfx12_configs)
+    gfx11_configs[6] = triton.Config(
+        {'block_m': 64, 'block_n': 64, 'block_k': 128,
+         'group_size_m': 4, 'waves_per_eu': 1},
+        num_stages=2,
+        num_warps=8,
+    )
+    return default_configs, gfx11_configs, gfx12_configs
 
 
-_INT8_DEFAULT_CONFIGS, _INT8_RDNA_CONFIGS = _int8_autotune_configs()
-_INT8_MATMUL_CONFIGS = _INT8_DEFAULT_CONFIGS + _INT8_RDNA_CONFIGS
+(
+    _INT8_DEFAULT_CONFIGS,
+    _INT8_GFX11_CONFIGS,
+    _INT8_GFX12_CONFIGS,
+) = _int8_autotune_configs()
+# Per-device pruning returns ten RDNA candidates. The decorator sees their
+# eleven-config union so no device pays to benchmark the other generation's tile.
+_INT8_MATMUL_CONFIGS = (
+    _INT8_DEFAULT_CONFIGS + _INT8_GFX12_CONFIGS + [_INT8_GFX11_CONFIGS[6]]
+)
 
 
 def _prune_int8_autotune_configs(configs, named_args, **kwargs):
@@ -894,13 +909,23 @@ def _prune_int8_autotune_configs(configs, named_args, **kwargs):
         arch = torch.cuda.get_device_properties(args['device_index']).gcnArchName.split(":")[0]
     except Exception:
         return _INT8_DEFAULT_CONFIGS
-    if not arch.startswith(("gfx11", "gfx12")):
+    if arch.startswith("gfx11"):
+        rdna_configs = _INT8_GFX11_CONFIGS
+    elif arch.startswith("gfx12"):
+        rdna_configs = _INT8_GFX12_CONFIGS
+    else:
         return _INT8_DEFAULT_CONFIGS
 
-    rdna_configs = _INT8_RDNA_CONFIGS
-    # BK128 was consistently slower for small-M calls on gfx1151.
+    # This large tile was unstable for small-M calls on gfx1151.
     if args['m'] <= 128:
-        rdna_configs = [config for config in rdna_configs if config.kwargs['block_k'] <= 64]
+        rdna_configs = [
+            config for config in rdna_configs
+            if not (
+                config.kwargs['block_m'] == 128
+                and config.kwargs['block_n'] == 128
+                and config.kwargs['block_k'] == 128
+            )
+        ]
     return rdna_configs
 
 
@@ -913,13 +938,13 @@ _INT8_AUTOTUNE_KWARGS = {
 }
 
 @triton.autotune(**_INT8_AUTOTUNE_KWARGS)
-@triton.jit
+@triton.jit(do_not_specialize=["device_index"])
 def _int8_matmul_dequant_kernel(
     # Pointers
     a_ptr, b_ptr, c_ptr,
     a_scale_ptr, b_scale_ptr, bias_ptr,
     # Matrix Dimensions
-    m, n, k, device_index: tl.constexpr,
+    m, n, k, device_index,
     # Strides
     stride_am, stride_ak,
     stride_bk, stride_bn,
@@ -985,13 +1010,13 @@ def _int8_matmul_dequant_kernel(
     tl.store(c_ptrs, c, mask=c_mask)
 
 @triton.autotune(**_INT8_AUTOTUNE_KWARGS)
-@triton.jit
+@triton.jit(do_not_specialize=["device_index"])
 def _int8_matmul_dequant_per_row_kernel(
     # Pointers
     a_ptr, b_ptr, c_ptr,
     a_scale_ptr, b_scale_ptr, bias_ptr,
     # Matrix Dimensions
-    m, n, k, device_index: tl.constexpr,
+    m, n, k, device_index,
     # Strides
     stride_am, stride_ak,
     stride_bk, stride_bn,

--- a/comfy_kitchen/backends/triton/quantization.py
+++ b/comfy_kitchen/backends/triton/quantization.py
@@ -878,6 +878,12 @@ def _int8_autotune_configs():
         triton.Config({'block_m': 64,  'block_n': 128, 'block_k': 64,  'group_size_m': 8}, num_stages=2, num_warps=4),
         triton.Config({'block_m': 128, 'block_n': 64,  'block_k': 64,  'group_size_m': 8}, num_stages=2, num_warps=4),
         triton.Config({'block_m': 64,  'block_n': 64,  'block_k': 64,  'group_size_m': 4}, num_stages=2, num_warps=4),
+        # waves_per_eu variants -- help occupancy on bandwidth-limited RDNA APUs
+        # (gfx1103/gfx1151: up to ~1.15x); dGPUs autotune-select the base configs above. (thanks @LuXuxue)
+        triton.Config({'block_m': 128, 'block_n': 256, 'block_k': 64,  'group_size_m': 8, 'waves_per_eu': 4}, num_stages=2, num_warps=8),
+        triton.Config({'block_m': 128, 'block_n': 128, 'block_k': 64,  'group_size_m': 8, 'waves_per_eu': 1}, num_stages=2, num_warps=4),
+        triton.Config({'block_m': 64,  'block_n': 128, 'block_k': 64,  'group_size_m': 8, 'waves_per_eu': 1}, num_stages=2, num_warps=4),
+        triton.Config({'block_m': 64,  'block_n': 64,  'block_k': 64,  'group_size_m': 4, 'waves_per_eu': 1}, num_stages=2, num_warps=4),
     ]
 
 

--- a/comfy_kitchen/backends/triton/quantization.py
+++ b/comfy_kitchen/backends/triton/quantization.py
@@ -856,15 +856,36 @@ def triton_quantize_and_rotate_rowwise(x: torch.Tensor, h: torch.Tensor, group_s
     return triton_quantize_rowwise(rotated_x)
 
 
-@triton.autotune(
-    configs=[
+def _int8_autotune_configs():
+    """INT8 matmul autotune configs. AMD RDNA (gfx11/gfx12) prefers shallow software
+    pipelining (num_stages=2) and deeper block_k; the NVIDIA defaults use num_stages=3-4.
+    The RDNA pool spans small tiles (RDNA3) and large tiles (RDNA4) so autotune can pick
+    per shape/arch. Empirically 1.03-1.11x faster than the NVIDIA configs on gfx1100/1201."""
+    nvidia = [
         triton.Config({'block_m': 128, 'block_n': 256, 'block_k': 64, 'group_size_m': 8}, num_stages=3, num_warps=8),
         triton.Config({'block_m': 64,  'block_n': 256, 'block_k': 32, 'group_size_m': 8}, num_stages=4, num_warps=4),
         triton.Config({'block_m': 128, 'block_n': 128, 'block_k': 32, 'group_size_m': 8}, num_stages=4, num_warps=4),
         triton.Config({'block_m': 128, 'block_n': 64,  'block_k': 32, 'group_size_m': 8}, num_stages=4, num_warps=4),
         triton.Config({'block_m': 64,  'block_n': 128, 'block_k': 32, 'group_size_m': 8}, num_stages=4, num_warps=4),
         triton.Config({'block_m': 128, 'block_n': 32,  'block_k': 32, 'group_size_m': 8}, num_stages=4, num_warps=4),
-    ],
+    ]
+    if getattr(torch.version, 'hip', None) is None:
+        return nvidia
+    return [
+        triton.Config({'block_m': 128, 'block_n': 256, 'block_k': 64,  'group_size_m': 8}, num_stages=2, num_warps=8),
+        triton.Config({'block_m': 128, 'block_n': 128, 'block_k': 128, 'group_size_m': 8}, num_stages=2, num_warps=8),
+        triton.Config({'block_m': 128, 'block_n': 128, 'block_k': 64,  'group_size_m': 8}, num_stages=2, num_warps=4),
+        triton.Config({'block_m': 64,  'block_n': 128, 'block_k': 64,  'group_size_m': 8}, num_stages=2, num_warps=4),
+        triton.Config({'block_m': 128, 'block_n': 64,  'block_k': 64,  'group_size_m': 8}, num_stages=2, num_warps=4),
+        triton.Config({'block_m': 64,  'block_n': 64,  'block_k': 64,  'group_size_m': 4}, num_stages=2, num_warps=4),
+    ]
+
+
+_INT8_MATMUL_CONFIGS = _int8_autotune_configs()
+
+
+@triton.autotune(
+    configs=_INT8_MATMUL_CONFIGS,
     key=['m', 'n', 'k'],
 )
 @triton.jit
@@ -939,14 +960,7 @@ def _int8_matmul_dequant_kernel(
     tl.store(c_ptrs, c, mask=c_mask)
 
 @triton.autotune(
-    configs=[
-        triton.Config({'block_m': 128, 'block_n': 256, 'block_k': 64, 'group_size_m': 8}, num_stages=3, num_warps=8),
-        triton.Config({'block_m': 64,  'block_n': 256, 'block_k': 32, 'group_size_m': 8}, num_stages=4, num_warps=4),
-        triton.Config({'block_m': 128, 'block_n': 128, 'block_k': 32, 'group_size_m': 8}, num_stages=4, num_warps=4),
-        triton.Config({'block_m': 128, 'block_n': 64,  'block_k': 32, 'group_size_m': 8}, num_stages=4, num_warps=4),
-        triton.Config({'block_m': 64,  'block_n': 128, 'block_k': 32, 'group_size_m': 8}, num_stages=4, num_warps=4),
-        triton.Config({'block_m': 128, 'block_n': 32,  'block_k': 32, 'group_size_m': 8}, num_stages=4, num_warps=4),
-    ],
+    configs=_INT8_MATMUL_CONFIGS,
     key=['m', 'n', 'k'],
 )
 @triton.jit

--- a/tests/test_int8.py
+++ b/tests/test_int8.py
@@ -345,6 +345,12 @@ def test_int8_autotune_pool_creation_does_not_probe_devices(monkeypatch):
 def test_int8_autotune_cache_key_includes_device():
     from comfy_kitchen.backends.triton import quantization
 
+    assert quantization._INT8_AUTOTUNE_KWARGS == {
+        "configs": quantization._INT8_MATMUL_CONFIGS,
+        "key": ["m", "n", "k", "device_index"],
+        "prune_configs_by": quantization._INT8_PRUNE_CONFIGS_BY,
+    }
+
     assert "device_index" in quantization._int8_matmul_dequant_kernel.keys
     assert "device_index" in quantization._int8_matmul_dequant_per_row_kernel.keys
 

--- a/tests/test_int8.py
+++ b/tests/test_int8.py
@@ -377,6 +377,65 @@ def test_int8_autotune_cache_key_includes_device():
         assert device_index.do_not_specialize
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="GPU required")
+@pytest.mark.parametrize(
+    "per_channel,expected_kernel",
+    [
+        (False, "tensorwise"),
+        (True, "per_row"),
+    ],
+)
+def test_int8_linear_forwards_device_index_to_kernel(
+    monkeypatch, per_channel, expected_kernel
+):
+    from comfy_kitchen.backends.triton import quantization
+
+    launches = []
+
+    class KernelRecorder:
+        def __init__(self, name):
+            self.name = name
+
+        def __getitem__(self, grid):
+            def launch(**kwargs):
+                launches.append((self.name, kwargs))
+
+            return launch
+
+    device_index = torch.cuda.current_device()
+    device = torch.device("cuda", device_index)
+    x = torch.zeros((2, 4), device=device, dtype=torch.bfloat16)
+    weight = torch.zeros((3, 4), device=device, dtype=torch.int8)
+    scale_size = weight.shape[0] if per_channel else 1
+    weight_scale = torch.ones(scale_size, device=device, dtype=torch.float32)
+
+    monkeypatch.setattr(
+        quantization,
+        "triton_quantize_rowwise",
+        lambda tensor: (
+            torch.zeros_like(tensor, dtype=torch.int8),
+            torch.ones((tensor.shape[0], 1), device=device, dtype=torch.float32),
+        ),
+    )
+    monkeypatch.setattr(
+        quantization,
+        "_int8_matmul_dequant_kernel",
+        KernelRecorder("tensorwise"),
+    )
+    monkeypatch.setattr(
+        quantization,
+        "_int8_matmul_dequant_per_row_kernel",
+        KernelRecorder("per_row"),
+    )
+
+    output = quantization.int8_linear(x, weight, weight_scale)
+
+    assert output.shape == (2, 3)
+    assert [(name, kwargs["device_index"]) for name, kwargs in launches] == [
+        (expected_kernel, x.device.index)
+    ]
+
+
 # =============================================================================
 # INT8 Quantization Tests
 # =============================================================================

--- a/tests/test_int8.py
+++ b/tests/test_int8.py
@@ -230,16 +230,17 @@ def test_int8_linear_routes_turing_to_fused_kernel(seed, monkeypatch):
     "hip_version,arches,device_index,m,expected_pool",
     [
         (None, ["gfx1100"], 0, 1024, "default"),
-        ("7.2", ["gfx1100"], 0, 1024, "rdna"),
-        ("7.2", ["gfx1151"], 0, 1024, "rdna"),
-        ("7.2", ["gfx1201"], 0, 1024, "rdna"),
-        ("7.2", ["gfx1100"], 0, 128, "rdna-small-m"),
-        ("7.2", ["gfx1100"], 0, 129, "rdna"),
+        ("7.2", ["gfx1100"], 0, 1024, "gfx11"),
+        ("7.2", ["gfx1151"], 0, 1024, "gfx11"),
+        ("7.2", ["gfx1201"], 0, 1024, "gfx12"),
+        ("7.2", ["gfx1100"], 0, 128, "gfx11-small-m"),
+        ("7.2", ["gfx1201"], 0, 128, "gfx12-small-m"),
+        ("7.2", ["gfx1100"], 0, 129, "gfx11"),
         ("7.2", ["gfx908"], 0, 1024, "default"),
         ("7.2", ["gfx90a"], 0, 1024, "default"),
         ("7.2", ["gfx942"], 0, 1024, "default"),
         ("7.2", ["gfx950"], 0, 1024, "default"),
-        ("7.2", ["gfx1100", "gfx90a"], 0, 1024, "rdna"),
+        ("7.2", ["gfx1100", "gfx90a"], 0, 1024, "gfx11"),
         ("7.2", ["gfx1100", "gfx90a"], 1, 1024, "default"),
         ("7.2", ["gfx1300"], 0, 1024, "default"),
     ],
@@ -263,12 +264,24 @@ def test_int8_autotune_configs_are_device_scoped(
         m=m,
     )
 
-    if expected_pool == "rdna":
-        assert configs == quantization._INT8_RDNA_CONFIGS
-    elif expected_pool == "rdna-small-m":
+    expected_configs = {
+        "gfx11": quantization._INT8_GFX11_CONFIGS,
+        "gfx12": quantization._INT8_GFX12_CONFIGS,
+    }
+    if expected_pool in expected_configs:
+        assert configs == expected_configs[expected_pool]
+    elif expected_pool.endswith("-small-m"):
+        full_pool = expected_configs[expected_pool.removesuffix("-small-m")]
         assert len(configs) == 9
-        assert all(config in quantization._INT8_RDNA_CONFIGS for config in configs)
-        assert all(config.kwargs["block_k"] <= 64 for config in configs)
+        assert all(config in full_pool for config in configs)
+        if expected_pool.startswith("gfx11"):
+            assert any(config.kwargs["block_k"] == 128 for config in configs)
+        assert not any(
+            config.kwargs["block_m"] == 128
+            and config.kwargs["block_n"] == 128
+            and config.kwargs["block_k"] == 128
+            for config in configs
+        )
     else:
         signatures = [
             (config.kwargs, config.num_stages, config.num_warps)
@@ -302,7 +315,7 @@ def test_int8_autotune_configs_isolate_heterogeneous_devices(monkeypatch):
         quantization._INT8_MATMUL_CONFIGS, {}, device_index=0, m=1024
     )
 
-    assert rdna_configs == quantization._INT8_RDNA_CONFIGS
+    assert rdna_configs == quantization._INT8_GFX11_CONFIGS
     assert cdna_configs == quantization._INT8_DEFAULT_CONFIGS
     assert rdna_configs_again == rdna_configs
 
@@ -336,10 +349,13 @@ def test_int8_autotune_pool_creation_does_not_probe_devices(monkeypatch):
         lambda _: (_ for _ in ()).throw(AssertionError("unexpected device probe")),
     )
 
-    default_configs, rdna_configs = quantization._int8_autotune_configs()
+    default_configs, gfx11_configs, gfx12_configs = quantization._int8_autotune_configs()
 
     assert len(default_configs) == 6
-    assert len(rdna_configs) == 10
+    assert len(gfx11_configs) == 10
+    assert len(gfx12_configs) == 10
+    assert len(quantization._INT8_MATMUL_CONFIGS) == 17
+    assert gfx11_configs[6] != gfx12_configs[6]
 
 
 def test_int8_autotune_cache_key_includes_device():
@@ -351,8 +367,14 @@ def test_int8_autotune_cache_key_includes_device():
         "prune_configs_by": quantization._INT8_PRUNE_CONFIGS_BY,
     }
 
-    assert "device_index" in quantization._int8_matmul_dequant_kernel.keys
-    assert "device_index" in quantization._int8_matmul_dequant_per_row_kernel.keys
+    for kernel in (
+        quantization._int8_matmul_dequant_kernel,
+        quantization._int8_matmul_dequant_per_row_kernel,
+    ):
+        assert "device_index" in kernel.keys
+        device_index = kernel.fn.params[kernel.fn.arg_names.index("device_index")]
+        assert not device_index.is_constexpr
+        assert device_index.do_not_specialize
 
 
 # =============================================================================

--- a/tests/test_int8.py
+++ b/tests/test_int8.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for INT8 block-wise quantization."""
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 
@@ -222,6 +224,129 @@ def test_int8_linear_routes_turing_to_fused_kernel(seed, monkeypatch):
 
     assert output.shape == (128, 128)
     assert calls == [True]
+
+
+@pytest.mark.parametrize(
+    "hip_version,arches,device_index,m,expected_pool",
+    [
+        (None, ["gfx1100"], 0, 1024, "default"),
+        ("7.2", ["gfx1100"], 0, 1024, "rdna"),
+        ("7.2", ["gfx1151"], 0, 1024, "rdna"),
+        ("7.2", ["gfx1201"], 0, 1024, "rdna"),
+        ("7.2", ["gfx1100"], 0, 128, "rdna-small-m"),
+        ("7.2", ["gfx1100"], 0, 129, "rdna"),
+        ("7.2", ["gfx908"], 0, 1024, "default"),
+        ("7.2", ["gfx90a"], 0, 1024, "default"),
+        ("7.2", ["gfx942"], 0, 1024, "default"),
+        ("7.2", ["gfx950"], 0, 1024, "default"),
+        ("7.2", ["gfx1100", "gfx90a"], 0, 1024, "rdna"),
+        ("7.2", ["gfx1100", "gfx90a"], 1, 1024, "default"),
+        ("7.2", ["gfx1300"], 0, 1024, "default"),
+    ],
+)
+def test_int8_autotune_configs_are_device_scoped(
+    monkeypatch, hip_version, arches, device_index, m, expected_pool
+):
+    from comfy_kitchen.backends.triton import quantization
+
+    monkeypatch.setattr(torch.version, "hip", hip_version)
+    monkeypatch.setattr(
+        torch.cuda,
+        "get_device_properties",
+        lambda index: SimpleNamespace(gcnArchName=arches[index]),
+    )
+
+    configs = quantization._prune_int8_autotune_configs(
+        quantization._INT8_MATMUL_CONFIGS,
+        {},
+        device_index=device_index,
+        m=m,
+    )
+
+    if expected_pool == "rdna":
+        assert configs == quantization._INT8_RDNA_CONFIGS
+    elif expected_pool == "rdna-small-m":
+        assert len(configs) == 9
+        assert all(config in quantization._INT8_RDNA_CONFIGS for config in configs)
+        assert all(config.kwargs["block_k"] <= 64 for config in configs)
+    else:
+        signatures = [
+            (config.kwargs, config.num_stages, config.num_warps)
+            for config in configs
+        ]
+        default_signatures = [
+            (config.kwargs, config.num_stages, config.num_warps)
+            for config in quantization._INT8_DEFAULT_CONFIGS
+        ]
+        assert signatures == default_signatures
+
+
+def test_int8_autotune_configs_isolate_heterogeneous_devices(monkeypatch):
+    from comfy_kitchen.backends.triton import quantization
+
+    arches = ["gfx1100", "gfx90a"]
+    monkeypatch.setattr(torch.version, "hip", "7.2")
+    monkeypatch.setattr(
+        torch.cuda,
+        "get_device_properties",
+        lambda index: SimpleNamespace(gcnArchName=arches[index]),
+    )
+
+    rdna_configs = quantization._prune_int8_autotune_configs(
+        quantization._INT8_MATMUL_CONFIGS, {}, device_index=0, m=1024
+    )
+    cdna_configs = quantization._prune_int8_autotune_configs(
+        quantization._INT8_MATMUL_CONFIGS, {}, device_index=1, m=1024
+    )
+    rdna_configs_again = quantization._prune_int8_autotune_configs(
+        quantization._INT8_MATMUL_CONFIGS, {}, device_index=0, m=1024
+    )
+
+    assert rdna_configs == quantization._INT8_RDNA_CONFIGS
+    assert cdna_configs == quantization._INT8_DEFAULT_CONFIGS
+    assert rdna_configs_again == rdna_configs
+
+
+def test_int8_autotune_configs_fall_back_when_device_probe_fails(monkeypatch):
+    from comfy_kitchen.backends.triton import quantization
+
+    monkeypatch.setattr(torch.version, "hip", "7.2")
+    monkeypatch.setattr(
+        torch.cuda,
+        "get_device_properties",
+        lambda _: (_ for _ in ()).throw(RuntimeError("device probe failed")),
+    )
+
+    configs = quantization._prune_int8_autotune_configs(
+        quantization._INT8_MATMUL_CONFIGS,
+        {},
+        device_index=0,
+        m=1024,
+    )
+
+    assert configs == quantization._INT8_DEFAULT_CONFIGS
+
+
+def test_int8_autotune_pool_creation_does_not_probe_devices(monkeypatch):
+    from comfy_kitchen.backends.triton import quantization
+
+    monkeypatch.setattr(
+        torch.cuda,
+        "get_device_properties",
+        lambda _: (_ for _ in ()).throw(AssertionError("unexpected device probe")),
+    )
+
+    default_configs, rdna_configs = quantization._int8_autotune_configs()
+
+    assert len(default_configs) == 6
+    assert len(rdna_configs) == 10
+
+
+def test_int8_autotune_cache_key_includes_device():
+    from comfy_kitchen.backends.triton import quantization
+
+    assert "device_index" in quantization._int8_matmul_dequant_kernel.keys
+    assert "device_index" in quantization._int8_matmul_dequant_per_row_kernel.keys
 
 
 # =============================================================================


### PR DESCRIPTION
# RDNA-aware autotune configs for the INT8 matmul kernels

## What
This keeps the existing CUDA/CDNA behavior and selects a ten-candidate INT8 Triton pool for the RDNA generation serving each call. `gfx11*` gets a small-M `64x64x128`, eight-warp tile; `gfx12*` retains its existing pool. For `M <= 128`, only the unstable `128x128x128` tile is removed.

`device_index` remains in the autotune key so heterogeneous devices tune separately, but is marked non-specializing in both kernels so the scalar value does not create duplicate code variants.

## Why
The original six default configs use `num_stages=3-4`. Shallow `num_stages=2` pools perform better on the tested consumer RDNA devices. Follow-up SDXL testing also showed that one pool should not be shared blindly across RDNA generations: the extra small-M tile helps `gfx11`, while replacing a `gfx12` tile regresses that generation.

## Validation
- Rebased onto current `main` `5a997b17`; cumulative diff is two files (`+236/-21`).
- Focused config/device tests: 18/18 pass.
- Complete `tests/test_int8.py` on gfx1100, gfx1151, and gfx1201: 80 passed / 33 skipped / the same 5 CUDA-extension-only failures as the before arm.
- Fixed-config correctness/performance sweeps use both actual INT8 kernels and real SDXL@1024 projection shapes. Every output is finite and matches across configs.
- Same-base, fresh-process weighted SDXL kernel estimate, before -> after:
  - gfx1100: 67.20 -> 65.63 ms/step (-2.3%)
  - gfx1151: 129.06 -> 122.98 ms/step (-4.7%)
  - gfx1201: 39.24 -> 39.08 ms/step (-0.4%, effectively unchanged)
- Per-device pruning returns ten RDNA candidates on every tested GPU; the 17-config decorator union is pruned before benchmarking.
- Direct JIT-cache probe: changing `device_index` created one extra compiled entry before this update and zero afterward; the output remained finite.
- Ruff, Python syntax, and whitespace checks pass.

## Reporter follow-up
The exact 1.70 vs 1.79 s/it E2E run could not be reproduced without the reporter's private config/model setup. On gfx1151, their six-config pool was not slower than the one-config pool in steady-state kernel time; its first-use autotune cost was much larger. However, their feedback exposed a real selection gap in this PR's prior pool, and the generation-specific update above improves the matching SDXL shapes without regressing gfx1201.

Fixes #68.

AI usage disclosure: this update was prepared with AI assistance. The submitting human remains responsible for reviewing the changes and validation before publication.
