### PR TITLE
Add HIP backend with WMMA kernels for AMD RDNA4 (gfx12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,104 @@ Fast kernel library for Diffusion inference with multiple compute backends.
 
 ## Backend Capabilities Matrix
 
-| Function                    | eager | cuda | triton |
-|-----------------------------|-------|------|--------|
-| `quantize_per_tensor_fp8`   | ✓     | ✓    | ✓      |
-| `dequantize_per_tensor_fp8` | ✓     | ✓    | ✓      |
-| `quantize_nvfp4`            | ✓     | ✓    | ✓      |
-| `dequantize_nvfp4`          | ✓     | ✓    |        |
-| `scaled_mm_nvfp4`           | ✓     | ✓    |        |
-| `quantize_mxfp8`            | ✓     | ✓    | ✓      |
-| `dequantize_mxfp8`          | ✓     |      |        |
-| `scaled_mm_mxfp8`           | ✓     |      |        |
-| `apply_rope`                | ✓     | ✓    | ✓      |
-| `apply_rope1`               | ✓     | ✓    | ✓      |
+| Function                    | eager | cuda | triton | hip |
+|-----------------------------|-------|------|--------|-----|
+| `quantize_per_tensor_fp8`   | ✓     | ✓    | ✓      | ✓   |
+| `dequantize_per_tensor_fp8` | ✓     | ✓    | ✓      | ✓   |
+| `stochastic_rounding_fp8`   | ✓     | ✓    |        | ✓   |
+| `quantize_nvfp4`            | ✓     | ✓    | ✓      |     |
+| `dequantize_nvfp4`          | ✓     | ✓    | ✓      |     |
+| `scaled_mm_nvfp4`           | ✓     | ✓    |        |     |
+| `quantize_mxfp8`            | ✓     | ✓    | ✓      |     |
+| `dequantize_mxfp8`          | ✓     |      |        |     |
+| `scaled_mm_mxfp8`           | ✓     |      |        |     |
+| `adaln`                     | ✓     | ✓    | ✓      | ✓   |
+| `apply_rope`                | ✓     | ✓    | ✓      | ✓   |
+| `apply_rope1`               | ✓     | ✓    | ✓      | ✓   |
+| `apply_rope_split_half`     | ✓     | ✓    | ✓      | ✓   |
+| `apply_rope_split_half1`    | ✓     | ✓    | ✓      | ✓   |
+| `quantize_int8_rowwise`     | ✓     | ✓    | ✓      | ✓   |
+| `quantize_int8_tensorwise`  | ✓     | ✓    |        | ✓   |
+| `quantize_and_rotate_rowwise` | ✓   | ✓    | ✓      | ✓   |
+| `quantize_int8_convrot_weight` | ✓  | ✓    |        | ✓   |
+| `int8_linear`               | ✓     |      | ✓      | ✓   |
+| `gemv_awq_w4a16`            | ✓     | ✓    |        | ✓   |
+| `quantize_svdquant_w4a4`    | ✓     | ✓    |        | ✓   |
+| `scaled_mm_svdquant_w4a4`   | ✓     | ✓    |        | ✓   |
+| `convrot_w4a4_linear`       | ✓     | ✓    |        | ✓   |
+| `quantize_convrot_w4a4_weight` | ✓  | ✓    |        | ✓   |
+| `dequantize_convrot_w4a4_weight` | ✓ | ✓   |        | ✓   |
+
+## HIP backend (AMD RDNA4 / gfx12)
+
+The `hip` backend implements the quantized paths with WMMA kernels written
+against the `v_wmma_*_w32_gfx12` intrinsics. It does not link or call
+hipBLAS/hipBLASLt; every matmul is compiled from the sources in
+`comfy_kitchen/backends/hip/`.
+
+These intrinsics are gfx12-only, so the backend does not register on any other
+architecture (including RDNA3/gfx11) and dispatch falls through to triton/eager
+there.
+
+| Op | Instruction |
+|----|-------------|
+| fp8 `scaled_mm`           | `v_wmma_f32_16x16x16_fp8_fp8` |
+| `int8_linear`             | `v_wmma_i32_16x16x16_iu8` |
+| `convrot_w4a4_linear`     | `v_wmma_i32_16x16x32_iu4` |
+| `scaled_mm_svdquant_w4a4` | `v_wmma_i32_16x16x32_iu4`, group-scaled, fused LoRA-up |
+| `gemv_awq_w4a16`          | scalar; bandwidth bound, no operand reuse for a tile |
+
+fp8, int8 and int4 share one tile kernel (`gemm_wmma.h`): all three hold 8 bytes
+per lane per WMMA, so a K-step is 16 bytes of a row regardless of element type,
+and the tile loop is byte-addressed.
+
+`torch._scaled_mm` and `torch._int_mm`, the calls that route to hipBLASLt, are
+not reached for any request the backend accepts; `tests/test_hip_wmma.py` traps
+both and exercises the fp8, int8, int4, AWQ and SVDQuant paths. A request outside
+a kernel's domain still falls back to torch or eager, as described below. NVFP4
+and MXFP8 remain on eager throughout: RDNA4 has neither fp4 WMMA nor microscaling
+hardware.
+
+ROCm's fp8 `scaled_mm` is competitive on RDNA4 and is faster than the WMMA kernel
+on square, deep-K and small-M shapes, while the WMMA kernel is faster at large N.
+fp8 is nevertheless routed to WMMA on every call the kernel supports, with no
+shape gate, to keep the backend free of BLAS calls. Calls outside its domain
+(swizzled operands, scaling other than tensor-wise, a K that is not a multiple of
+16) fall back to torch. Set `COMFY_KITCHEN_DISABLE_HIP=1` to remove the backend
+from dispatch.
+
+### Building
+
+The backend is built whenever a ROCm toolchain is found. Both a system ROCm
+install and the pip `rocm-sdk` layout (which a ROCm PyTorch build already pulls
+in) are detected automatically, so on Linux and Windows alike the build is:
+
+```bash
+pip install .
+```
+
+No environment variables, no `CC`/`CXX` override and no Visual Studio developer
+shell are required: the ROCm clang is used for C, C++ and HIP alike, and it
+locates the MSVC toolchain by itself. CMake >= 3.21 is required, and Ninja is
+used for the HIP extension because CMake's default Visual Studio generator on
+Windows does not support the HIP language (both are declared as build
+dependencies). On Windows the Microsoft C++ build tools and Windows SDK must be
+installed, since clang links against them.
+
+The target architectures default to the gfx12 GPUs the build machine can see.
+When it cannot see any -- a CI or cross-build box -- they default to
+`gfx1200;gfx1201`. To select them explicitly, set `COMFY_HIP_ARCHS`
+(`PYTORCH_ROCM_ARCH` and `GPU_ARCHS` are also honoured):
+
+```bash
+COMFY_HIP_ARCHS=gfx1201 pip install .
+```
+
+The kernels are gfx12-only, so the extension is skipped rather than built when
+the visible AMD GPUs are all of another architecture. Two more environment
+variables control that: `COMFY_KITCHEN_BUILD_HIP=1` turns a missing ROCm
+toolchain (or a non-gfx12 GPU) into an error instead of a skip, and
+`COMFY_KITCHEN_BUILD_NO_HIP=1` suppresses the backend entirely.
 
 
 ## Quantized Tensors
@@ -107,7 +193,7 @@ python setup.py build_ext --debug-build --lineinfo bdist_wheel
   - Pre-built wheels require NVIDIA Driver r580+
   - Building from source requires CUDA Toolkit ≥12.8 and `CUDA_HOME` environment variable
 - **nanobind**: ≥2.0.0 (for building from source)
-- **CMake**: ≥3.18 (for building from source)
+- **CMake**: ≥3.18 (for building from source; ≥3.21 for the HIP backend)
 
 ## Quick Start
 
@@ -115,7 +201,7 @@ python setup.py build_ext --debug-build --lineinfo bdist_wheel
 import comfy_kitchen as ck
 import torch
 
-# Automatic backend selection (triton -> cuda -> eager)
+# Automatic backend selection (hip -> cuda -> triton -> eager)
 x = torch.randn(100, 100, device="cuda")
 scale = torch.tensor([1.0], device="cuda")
 result = ck.quantize_per_tensor_fp8(x, scale)
@@ -136,11 +222,12 @@ with ck.use_backend("triton"):
 The library supports multiple backends:
 - **eager**: Pure PyTorch implementation
 - **cuda**: Custom CUDA C kernels (CUDA only)
+- **hip**: Custom HIP WMMA kernels (AMD RDNA4 / gfx12 only)
 - **triton**: Triton JIT-compiled kernels
 
 ### Automatic Backend Selection
 
-When you call a function, the registry selects the best backend by checking **constraints** in priority order (`cuda` → `triton` → `eager`):
+When you call a function, the registry selects the best backend by checking **constraints** in priority order (`hip` → `cuda` → `triton` → `eager`):
 
 ```python
 # Backend is selected automatically based on input constraints

--- a/comfy_kitchen/__init__.py
+++ b/comfy_kitchen/__init__.py
@@ -4,6 +4,7 @@ from .backends import cuda as _cuda_backend  # noqa: F401
 
 # Import backends to trigger auto-registration
 from .backends import eager as _eager_backend  # noqa: F401
+from .backends import hip as _hip_backend  # noqa: F401
 from .backends import triton as _triton_backend  # noqa: F401
 from .backends.eager.quantization import DTYPE_TO_CODE
 from .backends.eager.quantization import mm_int8 as _mm_int8
@@ -24,6 +25,10 @@ from .tensor.convrot_w4a4 import (
 )
 
 __version__ = "0.1.0"
+
+# The HIP backend only registers on gfx12; prefer it there.
+if registry.is_available("hip"):
+    registry.set_priority(["hip", "cuda", "triton", "eager"])
 
 __all__ = [
     # Normalization

--- a/comfy_kitchen/backends/hip/CMakeLists.txt
+++ b/comfy_kitchen/backends/hip/CMakeLists.txt
@@ -1,0 +1,113 @@
+cmake_minimum_required(VERSION 3.21)
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_HIP_STANDARD 20)
+set(CMAKE_HIP_STANDARD_REQUIRED ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+# The WMMA kernels are gfx12-only (v_wmma_*_w32_gfx12 has no gfx11 encoding).
+# Override with --hip-archs / COMFY_HIP_ARCHS. Must precede project(), which
+# fails HIP compiler detection when CMAKE_HIP_ARCHITECTURES is unset.
+if(NOT DEFINED COMFY_HIP_ARCHS OR COMFY_HIP_ARCHS STREQUAL "")
+    set(COMFY_HIP_ARCHS "gfx1200;gfx1201")
+endif()
+set(CMAKE_HIP_ARCHITECTURES "${COMFY_HIP_ARCHS}")
+
+# A pip-installed rocm-sdk places the device bitcode under
+# lib/llvm/amdgcn/bitcode rather than the <root>/amdgcn/bitcode clang probes for.
+# Must precede project(), which compiles a test program with these flags.
+if(DEFINED CMAKE_HIP_COMPILER_ROCM_ROOT)
+    set(_ck_devlib "${CMAKE_HIP_COMPILER_ROCM_ROOT}/lib/llvm/amdgcn/bitcode")
+    if(EXISTS "${_ck_devlib}" AND NOT EXISTS "${CMAKE_HIP_COMPILER_ROCM_ROOT}/amdgcn/bitcode")
+        set(CMAKE_HIP_FLAGS "${CMAKE_HIP_FLAGS} --rocm-device-lib-path=${_ck_devlib}")
+    endif()
+endif()
+
+project(comfy_kitchen_hip LANGUAGES CXX HIP)
+
+message(STATUS "HIP architectures: ${CMAKE_HIP_ARCHITECTURES}")
+
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release)
+endif()
+
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -O0")
+else()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3")
+endif()
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden -fdiagnostics-color=always")
+
+find_package(Python COMPONENTS Interpreter Development.Module REQUIRED)
+
+execute_process(
+    COMMAND "${Python_EXECUTABLE}" -c "import nanobind; print(nanobind.cmake_dir())"
+    OUTPUT_VARIABLE NB_DIR
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    RESULT_VARIABLE NB_RESULT
+)
+
+if(NOT NB_RESULT EQUAL 0)
+    message(FATAL_ERROR "nanobind not found. Install with: pip install nanobind")
+endif()
+
+list(APPEND CMAKE_PREFIX_PATH "${NB_DIR}")
+find_package(nanobind CONFIG REQUIRED)
+
+find_package(hip REQUIRED CONFIG)
+
+set(HIP_SOURCES
+    ops/per_tensor_fp8.hip
+    ops/stochastic_round_fp8.hip
+    ops/quantize_int8.hip
+    ops/gemm_fp8.hip
+    ops/gemm_int8.hip
+    ops/convrot_w4a4.hip
+    ops/adaln.hip
+    ops/apply_rope.hip
+    ops/gemv_awq.hip
+    ops/svdquant_w4a4.hip
+)
+
+set(CPP_SOURCES
+    dlpack_bindings.cpp
+)
+
+# NOMINSIZE: nanobind_add_module() otherwise puts -Os on the whole target, which the
+# -O3 below would have to override by flag order alone. The kernels are the point of
+# this module, so opt out rather than rely on which -O wins.
+nanobind_add_module(_C NB_STATIC LTO NOMINSIZE ${CPP_SOURCES} ${HIP_SOURCES})
+
+target_compile_definitions(_C PRIVATE NB_STATIC)
+
+target_compile_options(_C PRIVATE
+    $<$<COMPILE_LANGUAGE:HIP>:-O3>
+    $<$<COMPILE_LANGUAGE:HIP>:-ffast-math>
+)
+
+if(COMFY_ENABLE_LINEINFO OR CMAKE_BUILD_TYPE STREQUAL "Debug")
+    target_compile_options(_C PRIVATE $<$<COMPILE_LANGUAGE:HIP>:-gline-tables-only>)
+endif()
+
+target_include_directories(_C PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+target_link_libraries(_C PRIVATE hip::host)
+
+if(CMAKE_CONFIGURATION_TYPES)
+    set_target_properties(_C PROPERTIES
+        LIBRARY_OUTPUT_DIRECTORY_DEBUG "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}"
+        LIBRARY_OUTPUT_DIRECTORY_RELEASE "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}"
+        LIBRARY_OUTPUT_DIRECTORY_RELWITHDEBINFO "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}"
+        LIBRARY_OUTPUT_DIRECTORY_MINSIZEREL "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}"
+        RUNTIME_OUTPUT_DIRECTORY_DEBUG "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}"
+        RUNTIME_OUTPUT_DIRECTORY_RELEASE "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}"
+        RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}"
+        RUNTIME_OUTPUT_DIRECTORY_MINSIZEREL "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}"
+    )
+endif()
+
+install(TARGETS _C
+    LIBRARY DESTINATION .
+    RUNTIME DESTINATION .
+)

--- a/comfy_kitchen/backends/hip/__init__.py
+++ b/comfy_kitchen/backends/hip/__init__.py
@@ -1,0 +1,970 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""HIP backend for AMD RDNA4 (gfx12), built on WMMA intrinsics.
+
+Every matmul is a WMMA kernel compiled from the sources in this directory; the
+backend does not link or call hipBLAS/hipBLASLt.
+
+The WMMA builtins used (v_wmma_*_w32_gfx12) are gfx12-only, so the backend does
+not register on any other architecture, including RDNA3 (gfx11).
+"""
+import importlib.util
+import logging
+import os
+import sys
+
+import torch
+
+from comfy_kitchen.backends import eager as _eager
+from comfy_kitchen.backends.eager.quantization import DTYPE_TO_CODE
+
+logger = logging.getLogger("comfy_kitchen.hip")
+
+__all__ = [
+    "adaln",
+    "gemv_awq_w4a16",
+    "quantize_svdquant_w4a4",
+    "scaled_mm_svdquant_w4a4",
+    "apply_rope",
+    "apply_rope1",
+    "apply_rope_split_half",
+    "apply_rope_split_half1",
+    "convrot_w4a4_linear",
+    "dequantize_convrot_w4a4_weight",
+    "dequantize_per_tensor_fp8",
+    "int8_linear",
+    "is_available",
+    "quantize_and_rotate_rowwise",
+    "quantize_convrot_w4a4_weight",
+    "quantize_int8_convrot_weight",
+    "quantize_int8_rowwise",
+    "quantize_int8_tensorwise",
+    "quantize_per_tensor_fp8",
+    "scaled_mm_fp8",
+    "stochastic_rounding_fp8",
+]
+
+_C = None
+_EXT_AVAILABLE = False
+_EXT_ERROR = None
+
+try:
+    _dir = os.path.dirname(__file__)
+    _module_path = None
+    for _fn in os.listdir(_dir):
+        if _fn.startswith("_C.") and _fn.endswith((".so", ".pyd")):
+            _module_path = os.path.join(_dir, _fn)
+            break
+
+    if _module_path is None:
+        _EXT_ERROR = "HIP extension not built (no _C module in backends/hip)"
+    else:
+        _spec = importlib.util.spec_from_file_location("comfy_kitchen.backends.hip._C", _module_path)
+        _C = importlib.util.module_from_spec(_spec)
+        sys.modules["comfy_kitchen.backends.hip._C"] = _C
+        _spec.loader.exec_module(_C)
+        _EXT_AVAILABLE = True
+except Exception as e:  # noqa: BLE001 - a broken extension must not break import
+    _EXT_ERROR = f"Failed to load HIP extension: {e}"
+    _C = None
+
+
+def _gfx_arch(device: torch.device | int | None = None) -> str | None:
+    """gfx architecture of ``device``, e.g. "gfx1201". Defaults to the current device."""
+    if not torch.cuda.is_available() or not getattr(torch.version, "hip", None):
+        return None
+    try:
+        return torch.cuda.get_device_properties(device).gcnArchName.split(":")[0]
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _visible_gfx_arches() -> list[str | None]:
+    """One entry per visible device; None where the architecture could not be read."""
+    if not torch.cuda.is_available() or not getattr(torch.version, "hip", None):
+        return []
+    return [_gfx_arch(i) for i in range(torch.cuda.device_count())]
+
+
+def _unsupported_arch_reason(arches: list[str | None]) -> str | None:
+    """Why the backend must not register for this set of devices, or None if it may.
+
+    Registration is per-process while kernels launch on the tensor's own device,
+    so a single non-gfx12 device in the process makes any registration unsafe. A
+    device whose architecture cannot be read counts against it: it cannot be
+    shown to be gfx12.
+    """
+    if not arches:
+        return "no HIP device available"
+    if any(a is None for a in arches):
+        return "could not read the architecture of every visible device"
+    unsupported = sorted({a for a in arches if not a.startswith("gfx12")})
+    if unsupported:
+        return f"WMMA kernels require RDNA4 (gfx12), found {', '.join(unsupported)}"
+    return None
+
+
+def is_available() -> bool:
+    return _EXT_AVAILABLE and _unsupported_arch_reason(_visible_gfx_arches()) is None
+
+
+def _stream(t: torch.Tensor) -> int:
+    return torch.cuda.current_stream(t.device).cuda_stream
+
+
+# The epilogues read a scalar per element with one dtype code.
+_EPILOGUE_DTYPES = (torch.float32, torch.float16, torch.bfloat16)
+
+
+def _operand(t: torch.Tensor, device: torch.device, name: str, shape=None) -> torch.Tensor:
+    """A contiguous view of ``t`` on ``device``, since the kernels take raw pointers.
+
+    Every launch uses one stream and one set of extents, so an operand left on
+    another device would be dereferenced there, and a mis-shaped one read past its
+    end.
+    """
+    if shape is not None and tuple(t.shape) != tuple(shape):
+        raise ValueError(f"{name} must have shape {tuple(shape)}, got {tuple(t.shape)}")
+    return t.to(device=device).contiguous()
+
+
+def _scale_operand(scale: torch.Tensor, device: torch.device) -> torch.Tensor:
+    """The fp8 kernels read one float scale off a raw pointer on the launch stream."""
+    scale = scale.reshape(-1)
+    if scale.numel() != 1:
+        raise ValueError(f"expected a single per-tensor scale, got {scale.numel()} elements")
+    return scale.to(device=device, dtype=torch.float32).contiguous()
+
+
+def _bias_operand(bias: torch.Tensor, n: int, device: torch.device) -> torch.Tensor:
+    """The epilogue indexes bias[col], so it must be 1D of length N and decodable."""
+    if bias.dim() != 1 or bias.numel() != n:
+        raise ValueError(f"bias must be 1D of length {n}, got {tuple(bias.shape)}")
+    if bias.dtype not in _EPILOGUE_DTYPES:
+        raise ValueError(f"bias dtype {bias.dtype} is not supported, expected one of "
+                         f"{[str(d) for d in _EPILOGUE_DTYPES]}")
+    return bias.to(device=device).contiguous()
+
+
+def _dl(t: torch.Tensor):
+    # stream=-1 tells PyTorch to skip synchronization (DLPack spec)
+    return t.__dlpack__(stream=-1)
+
+
+# ---------------------------------------------------------------------------
+# FP8 elementwise
+# ---------------------------------------------------------------------------
+
+def quantize_per_tensor_fp8(
+    x: torch.Tensor,
+    scale: torch.Tensor,
+    output_type: torch.dtype = torch.float8_e4m3fn,
+) -> torch.Tensor:
+    x = x.contiguous()
+    scale = _scale_operand(scale, x.device)
+
+    out = torch.empty(x.shape, dtype=torch.uint8, device=x.device)
+    _C.quantize_per_tensor_fp8(
+        _dl(x), _dl(scale), _dl(out),
+        DTYPE_TO_CODE[x.dtype], DTYPE_TO_CODE[output_type], x.numel(), _stream(x),
+    )
+    return out.view(output_type)
+
+
+def dequantize_per_tensor_fp8(
+    x: torch.Tensor,
+    scale: torch.Tensor,
+    output_type: torch.dtype = torch.bfloat16,
+) -> torch.Tensor:
+    x = x.contiguous()
+    scale = _scale_operand(scale, x.device)
+
+    out = torch.empty(x.shape, dtype=output_type, device=x.device)
+    _C.dequantize_per_tensor_fp8(
+        _dl(x.view(torch.uint8)), _dl(scale), _dl(out),
+        DTYPE_TO_CODE[x.dtype], DTYPE_TO_CODE[output_type], x.numel(), _stream(x),
+    )
+    return out
+
+
+def stochastic_rounding_fp8(
+    x: torch.Tensor,
+    rng: torch.Tensor,
+    output_type: torch.dtype = torch.float8_e4m3fn,
+) -> torch.Tensor:
+    """Quantize x to fp8 with stochastic rounding, consuming rng as the random source.
+
+    The kernel writes the fp8 result into rng's storage, so the caller's rng
+    tensor is overwritten and the returned tensor is a view of it.
+    """
+    if rng.device != x.device:
+        raise ValueError("rng must be on the same device as x")
+    if rng.shape != x.shape:
+        raise ValueError("rng must have the same shape as x")
+    # .contiguous() would hand the kernel a copy, leaving the caller's rng
+    # untouched and the returned view backed by the wrong storage.
+    if not rng.is_contiguous():
+        raise ValueError("rng must be contiguous: the kernel writes the result into it")
+
+    x = x.contiguous()
+    _C.stochastic_round_fp8(
+        _dl(rng), _dl(x), DTYPE_TO_CODE[output_type], x.numel(), _stream(x),
+    )
+    return rng.view(output_type)
+
+
+# ---------------------------------------------------------------------------
+# FP8 GEMM (v_wmma_f32_16x16x16_fp8_fp8)
+# ---------------------------------------------------------------------------
+
+def _weight_as_nk(b: torch.Tensor) -> torch.Tensor:
+    """Return the weight as a contiguous (N, K) tensor.
+
+    The B operand of ``a @ b`` arrives with shape (K, N). When it is a transposed
+    view of a contiguous (N, K) weight, as it is for linear, the transpose is
+    free; otherwise it costs a copy.
+    """
+    if b.dim() != 2:
+        raise ValueError(f"expected a 2D weight, got {tuple(b.shape)}")
+    bt = b.t()
+    return bt if bt.is_contiguous() else bt.contiguous()
+
+
+def scaled_mm_fp8(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    scale_a: torch.Tensor,
+    scale_b: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    out_dtype: torch.dtype = torch.bfloat16,
+) -> torch.Tensor:
+    """out = (a @ b) * scale_a * scale_b + bias, with a (M, K) and b (K, N) fp8."""
+    a = a.contiguous()
+    b_nk = _weight_as_nk(b).to(device=a.device)
+
+    M, K = a.shape
+    N = b_nk.shape[0]
+    if b_nk.shape[1] != K:
+        raise ValueError(f"inner dimension mismatch: a K={K}, b K={b_nk.shape[1]}")
+
+    # The WMMA K-step and the small-M GEMV both read a row 16 bytes at a time.
+    if K % 16 != 0:
+        raise ValueError(f"scaled_mm_fp8 requires K divisible by 16, got {K}")
+    # The kernel takes raw pointers on a's stream, so the scales and bias have to
+    # live on a's device, and the epilogue indexes bias[col].
+    scale_a = _scale_operand(scale_a, a.device)
+    scale_b = _scale_operand(scale_b, a.device)
+    if bias is not None:
+        bias = _bias_operand(bias, N, a.device)
+
+    out = torch.empty((M, N), dtype=out_dtype, device=a.device)
+    _C.scaled_mm_fp8(
+        _dl(a.view(torch.uint8)), _dl(b_nk.view(torch.uint8)), _dl(out),
+        _dl(scale_a), _dl(scale_b), None if bias is None else _dl(bias),
+        M, N, K, DTYPE_TO_CODE[out_dtype], _stream(a),
+    )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# INT8 quantization + GEMM (v_wmma_i32_16x16x16_iu8)
+# ---------------------------------------------------------------------------
+
+def quantize_int8_rowwise(
+    x: torch.Tensor,
+    stochastic_rounding: int | None = 0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if stochastic_rounding:
+        return _eager.quantize_int8_rowwise(x, stochastic_rounding=stochastic_rounding)
+
+    x2d = x.reshape(-1, x.shape[-1]).contiguous()
+    M, K = x2d.shape
+    q = torch.empty((M, K), dtype=torch.int8, device=x.device)
+    scales = torch.empty((M,), dtype=torch.float32, device=x.device)
+    _C.quantize_int8_rowwise(_dl(x2d), _dl(q), _dl(scales), M, K, _stream(x))
+    return q.reshape(x.shape), scales.reshape(*x.shape[:-1], 1)
+
+
+def quantize_int8_tensorwise(
+    x: torch.Tensor,
+    scale: torch.Tensor | float | str | None = None,
+    stochastic_rounding: int | None = 0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    # A caller-supplied scale reduces to an elementwise quantize; only the
+    # absmax-derived scale needs the fused reduction kernel.
+    if stochastic_rounding or (scale is not None and not isinstance(scale, str)):
+        return _eager.quantize_int8_tensorwise(x, scale=scale, stochastic_rounding=stochastic_rounding)
+
+    xc = x.contiguous()
+    q = torch.empty(xc.shape, dtype=torch.int8, device=x.device)
+    out_scale = torch.empty((), dtype=torch.float32, device=x.device)
+    scratch = torch.zeros((), dtype=torch.int32, device=x.device)
+    _C.quantize_int8_tensorwise(
+        _dl(xc), _dl(q), _dl(out_scale.reshape(1)), _dl(scratch.reshape(1)), xc.numel(), _stream(x)
+    )
+    return q, out_scale
+
+
+_convrot_max_k: int | None = None
+
+
+def _convrot_supported(k: int, group_size: int) -> bool:
+    """Whether the fused rotation can take a row of this width.
+
+    It stages the whole row in LDS, which bounds K per device, and it rotates K/G
+    whole groups while reading back all K entries, so a partial trailing group
+    would quantize uninitialized LDS.
+    """
+    global _convrot_max_k
+    if group_size not in (16, 64, 256) or k % group_size != 0:
+        return False
+    if _convrot_max_k is None:
+        _convrot_max_k = _C.convrot_max_k()
+    return _convrot_max_k > 0 and k <= _convrot_max_k
+
+
+def _rotate_quant_int8(x2d: torch.Tensor, group_size: int) -> tuple[torch.Tensor, torch.Tensor]:
+    M, K = x2d.shape
+    q = torch.empty((M, K), dtype=torch.int8, device=x2d.device)
+    scales = torch.empty((M,), dtype=torch.float32, device=x2d.device)
+    _C.quantize_int8_convrot(_dl(x2d), _dl(q), _dl(scales), M, K, group_size, _stream(x2d))
+    return q, scales
+
+
+def quantize_and_rotate_rowwise(
+    x: torch.Tensor,
+    h: torch.Tensor,
+    group_size: int,
+    stochastic_rounding: int | None = 0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Fused ConvRot rotation + rowwise int8 quantize.
+
+    ``h`` is the pre-built Hadamard matrix the eager path multiplies by. The
+    fused kernel synthesizes the same transform from radix-4 butterflies, so the
+    argument is accepted and unused.
+    """
+    if stochastic_rounding or not _convrot_supported(x.shape[-1], group_size):
+        return _eager.quantize_and_rotate_rowwise(
+            x, h, group_size, stochastic_rounding=stochastic_rounding
+        )
+
+    x2d = x.reshape(-1, x.shape[-1]).contiguous()
+    q, scales = _rotate_quant_int8(x2d, group_size)
+    return q.reshape(x.shape), scales.reshape(*x.shape[:-1], 1)
+
+
+def quantize_int8_convrot_weight(
+    weight: torch.Tensor,
+    group_size: int,
+    stochastic_rounding: int | None = 0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Offline ConvRot weight rotation + rowwise int8 quantize.
+
+    Uses the same fused kernel as the activation path.
+    """
+    if stochastic_rounding or not _convrot_supported(weight.shape[-1], group_size):
+        return _eager.quantize_int8_convrot_weight(
+            weight, group_size, stochastic_rounding=stochastic_rounding
+        )
+
+    w2d = weight.reshape(-1, weight.shape[-1]).contiguous()
+    q, scales = _rotate_quant_int8(w2d, group_size)
+    return q.reshape(weight.shape), scales.reshape(*weight.shape[:-1], 1)
+
+
+def int8_linear(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    out_dtype: torch.dtype = torch.bfloat16,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+) -> torch.Tensor:
+    """INT8 linear with dynamic row-wise activation quantization, on WMMA."""
+    if x.shape[-1] != weight.shape[-1]:
+        raise ValueError(
+            f"Input and weight inner dimensions must match, got {x.shape[-1]} and {weight.shape[-1]}"
+        )
+
+    weight = weight.to(device=x.device).contiguous()
+    weight_scale = weight_scale.to(device=x.device, dtype=torch.float32).reshape(-1)
+    if weight_scale.numel() not in (1, weight.shape[0]):
+        raise ValueError(
+            f"INT8 weight scale must be scalar or per-output-channel, got {tuple(weight_scale.shape)}"
+        )
+
+    orig_shape = x.shape
+    x2d = x.reshape(-1, orig_shape[-1]).contiguous()
+    M, K = x2d.shape
+    N = weight.shape[0]
+
+    # The WMMA K-step and the small-M GEMV both read a row 16 bytes at a time.
+    if K % 16 != 0:
+        raise ValueError(f"int8_linear requires K divisible by 16, got {K}")
+
+    if convrot:
+        if K % convrot_groupsize != 0:
+            raise ValueError(
+                f"ConvRot group size {convrot_groupsize} does not divide input features {K}"
+            )
+        if convrot_groupsize not in (16, 64, 256):
+            raise ValueError(f"ConvRot group size must be 16, 64 or 256, got {convrot_groupsize}")
+        if not _convrot_supported(K, convrot_groupsize):
+            return _eager.int8_linear(
+                x, weight, weight_scale, bias, out_dtype, convrot, convrot_groupsize
+            )
+        q, x_scale = _rotate_quant_int8(x2d, convrot_groupsize)
+    else:
+        q = torch.empty((M, K), dtype=torch.int8, device=x.device)
+        x_scale = torch.empty((M,), dtype=torch.float32, device=x.device)
+        _C.quantize_int8_rowwise(_dl(x2d), _dl(q), _dl(x_scale), M, K, _stream(x))
+
+    x_scale = x_scale.reshape(-1).contiguous()
+    if bias is not None:
+        bias = _bias_operand(bias, N, x.device)
+
+    out = torch.empty((M, N), dtype=out_dtype, device=x.device)
+    _C.int8_gemm(
+        _dl(q), _dl(weight), _dl(out),
+        _dl(x_scale), _dl(weight_scale), 0 if weight_scale.numel() == 1 else 1,
+        None if bias is None else _dl(bias),
+        M, N, K, DTYPE_TO_CODE[out_dtype], _stream(x),
+    )
+    return out.reshape(*orig_shape[:-1], N)
+
+
+# ---------------------------------------------------------------------------
+# ConvRot W4A4 (v_wmma_i32_16x16x32_iu4)
+# ---------------------------------------------------------------------------
+
+_INT4_GROUP_SIZE = 64
+
+
+def quantize_convrot_w4a4_weight(
+    weight: torch.Tensor,
+    convrot_groupsize: int = 256,
+    quant_group_size: int = _INT4_GROUP_SIZE,
+    stochastic_rounding: int | None = 0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if quant_group_size != _INT4_GROUP_SIZE:
+        raise ValueError(f"int4 MMA kernel requires quant_group_size {_INT4_GROUP_SIZE}")
+    if stochastic_rounding or not _convrot_supported(weight.shape[-1], convrot_groupsize):
+        return _eager.quantize_convrot_w4a4_weight(
+            weight, convrot_groupsize, quant_group_size, stochastic_rounding
+        )
+
+    w = weight.reshape(-1, weight.shape[-1]).contiguous()
+    N, K = w.shape
+    q = torch.empty((N, K // 2), dtype=torch.int8, device=w.device)
+    scales = torch.empty((N,), dtype=torch.float32, device=w.device)
+    _C.convrot_quant_int4(_dl(w), _dl(q), _dl(scales), N, K, convrot_groupsize, _stream(w))
+    return q, scales
+
+
+def dequantize_convrot_w4a4_weight(
+    qdata: torch.Tensor,
+    scales: torch.Tensor,
+    convrot_groupsize: int = 256,
+    quant_group_size: int = _INT4_GROUP_SIZE,
+    output_dtype: torch.dtype = torch.float32,
+) -> torch.Tensor:
+    # Only the nibble unpack runs on device; the inverse rotation reuses the
+    # eager Hadamard.
+    from comfy_kitchen.backends.eager.convrot_w4a4 import _build_hadamard, _rotate_weight
+
+    if quant_group_size != _INT4_GROUP_SIZE:
+        raise ValueError(f"int4 MMA kernel requires quant_group_size {_INT4_GROUP_SIZE}")
+
+    N, Kp = qdata.shape
+    unpacked = torch.empty((N, Kp * 2), dtype=torch.int8, device=qdata.device)
+    _C.unpack_int4(_dl(qdata.contiguous()), _dl(unpacked), N * Kp, _stream(qdata))
+
+    w_rot = unpacked.float() * scales.to(device=qdata.device, dtype=torch.float32).reshape(-1, 1)
+    h = _build_hadamard(convrot_groupsize, device=qdata.device, dtype=torch.float32)
+    return _rotate_weight(w_rot, h, convrot_groupsize).to(output_dtype)
+
+
+def convrot_w4a4_linear(
+    x: torch.Tensor,
+    qweight: torch.Tensor,
+    wscales: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    convrot_groupsize: int = 256,
+    quant_group_size: int = _INT4_GROUP_SIZE,
+    linear_dtype: str = "int4",
+) -> torch.Tensor:
+    if linear_dtype not in {"int4", "int8"}:
+        raise ValueError(f"ConvRot W4A4 linear_dtype must be 'int4' or 'int8', got {linear_dtype!r}")
+    if quant_group_size != _INT4_GROUP_SIZE:
+        raise ValueError(f"int4 MMA kernel requires quant_group_size {_INT4_GROUP_SIZE}")
+    if x.shape[-1] != qweight.shape[-1] * 2:
+        raise ValueError(f"Input K={x.shape[-1]} does not match qweight K={qweight.shape[-1] * 2}")
+    # The tile loader reads the packed row (K/2 bytes) in 16-byte chunks. A group
+    # size of 16 alone would allow a K that packs to a partial chunk.
+    if x.shape[-1] % 32 != 0:
+        raise ValueError(f"convrot_w4a4_linear requires K divisible by 32, got {x.shape[-1]}")
+    if x.shape[-1] % convrot_groupsize != 0:
+        raise ValueError(
+            f"Input K={x.shape[-1]} not divisible by convrot_groupsize {convrot_groupsize}"
+        )
+    if not _convrot_supported(x.shape[-1], convrot_groupsize):
+        return _eager.convrot_w4a4_linear(
+            x, qweight, wscales, bias, convrot_groupsize, quant_group_size, linear_dtype
+        )
+
+    if linear_dtype == "int8":
+        # As on CUDA: the int4 weight is unpacked to int8 values and the whole
+        # linear runs on the int8 WMMA kernel with int8 activations.
+        qw = _operand(qweight, x.device, "qweight")
+        w_int8 = torch.empty((qw.shape[0], qw.shape[1] * 2), dtype=torch.int8, device=x.device)
+        _C.unpack_int4(_dl(qw), _dl(w_int8), qw.numel(), _stream(x))
+        return int8_linear(
+            x, w_int8, wscales, bias, x.dtype,
+            convrot=True, convrot_groupsize=convrot_groupsize,
+        )
+
+    orig_shape = x.shape
+    x2d = x.reshape(-1, orig_shape[-1]).contiguous()
+    M, K = x2d.shape
+    N = qweight.shape[0]
+
+    qact = torch.empty((M, K // 2), dtype=torch.int8, device=x.device)
+    x_scale = torch.empty((M,), dtype=torch.float32, device=x.device)
+    _C.convrot_quant_int4(_dl(x2d), _dl(qact), _dl(x_scale), M, K, convrot_groupsize, _stream(x))
+
+    wscales = wscales.to(device=x.device, dtype=torch.float32).reshape(-1)
+    if wscales.numel() != N:
+        raise ValueError(f"wscales must have {N} entries, got {wscales.numel()}")
+    if bias is not None:
+        bias = _bias_operand(bias, N, x.device)
+    qw = _operand(qweight, x.device, "qweight", shape=(N, K // 2))
+
+    out = torch.empty((M, N), dtype=x.dtype, device=x.device)
+    _C.convrot_w4a4_gemm(
+        _dl(qact), _dl(qw), _dl(out),
+        _dl(x_scale), _dl(wscales), None if bias is None else _dl(bias),
+        M, N, K, DTYPE_TO_CODE[x.dtype], _stream(x),
+    )
+    return out.reshape(*orig_shape[:-1], N)
+
+
+# ---------------------------------------------------------------------------
+# AWQ W4A16 and SVDQuant W4A4
+# ---------------------------------------------------------------------------
+
+def gemv_awq_w4a16(
+    x: torch.Tensor,
+    qweight: torch.Tensor,
+    wscales: torch.Tensor,
+    wzeros: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    group_size: int = 64,
+) -> torch.Tensor:
+    orig_shape = x.shape
+    x2d = x.reshape(-1, orig_shape[-1]).contiguous()
+    M, K = x2d.shape
+    N = qweight.shape[0]
+
+    # The inner loop decodes eight weights at a time and rescales the chunk once,
+    # so a chunk must not straddle a group boundary.
+    if group_size <= 0 or group_size % 8 != 0:
+        raise ValueError(f"group_size must be a positive multiple of 8, got {group_size}")
+    if K % group_size != 0:
+        raise ValueError(f"K={K} not divisible by group_size={group_size}")
+    if qweight.shape[1] * 2 != K:
+        raise ValueError(f"qweight K//2={qweight.shape[1]} inconsistent with x K={K}")
+
+    # The kernel decodes scales and zeros with a single dtype code, taken from
+    # wscales; a wzeros of another dtype would be read as that one.
+    wscales = _operand(wscales, x.device, "wscales", shape=(K // group_size, N))
+    if wscales.dtype not in _EPILOGUE_DTYPES:
+        raise ValueError(f"wscales dtype {wscales.dtype} is not supported")
+    wzeros = _operand(wzeros, x.device, "wzeros", shape=(K // group_size, N)).to(wscales.dtype)
+    qw = _operand(qweight, x.device, "qweight", shape=(N, K // 2))
+    if bias is not None:
+        bias = _bias_operand(bias, N, x.device)
+
+    out_dtype = wscales.dtype
+    out = torch.empty((M, N), dtype=out_dtype, device=x.device)
+    _C.gemv_awq_w4a16(
+        _dl(x2d), _dl(qw), _dl(wscales), _dl(wzeros),
+        None if bias is None else _dl(bias), _dl(out),
+        M, N, K, group_size, _stream(x),
+    )
+    return out.reshape(*orig_shape[:-1], N)
+
+
+_SVD_GROUP = 64
+
+
+def quantize_svdquant_w4a4(
+    x: torch.Tensor,
+    smooth: torch.Tensor,
+    lora_down: torch.Tensor,
+    pad_size: int = 256,
+    act_unsigned: bool = False,
+    lora_x: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    if x.dim() != 2:
+        raise ValueError(f"expected 2D input, got shape {tuple(x.shape)}")
+    M, K = x.shape
+    if K % _SVD_GROUP != 0:
+        raise ValueError(f"K={K} not divisible by group_size={_SVD_GROUP}")
+
+    if pad_size <= 0:
+        raise ValueError(f"pad_size must be positive, got {pad_size}")
+    if lora_down.dim() != 2:
+        raise ValueError(f"lora_down must be 2D, got {tuple(lora_down.shape)}")
+
+    R = lora_down.shape[1]
+    m_pad = -(-M // pad_size) * pad_size
+
+    # The kernels take M, K and R with no bounds of their own, so every operand
+    # has to match those extents and sit on x's device.
+    xc = x.contiguous()
+    smooth = _operand(smooth.reshape(-1), x.device, "smooth", shape=(K,))
+    lora_down = _operand(lora_down, x.device, "lora_down", shape=(K, R))
+    # The LoRA branch is defined on the un-shifted, un-smoothed activation.
+    lora_src = _operand(lora_x if lora_x is not None else x, x.device, "lora_x", shape=(M, K))
+
+    # Padded rows stay zero: q = 0 and scale = 0 contribute nothing downstream.
+    q = torch.zeros((m_pad, K // 2), dtype=torch.int8, device=x.device)
+    ascales = torch.zeros((K // _SVD_GROUP, m_pad), dtype=x.dtype, device=x.device)
+    lora_act = torch.zeros((m_pad, R), dtype=torch.float32, device=x.device)
+
+    _C.svdquant_quantize(
+        _dl(xc), _dl(smooth), _dl(q), _dl(ascales),
+        M, m_pad, K, act_unsigned, _stream(x),
+    )
+    _C.svdquant_lora_down(
+        _dl(lora_src), _dl(lora_down), _dl(lora_act[:M]), M, K, R, _stream(x)
+    )
+    return q, ascales, lora_act
+
+
+def scaled_mm_svdquant_w4a4(
+    act: torch.Tensor,
+    wgt: torch.Tensor,
+    ascales: torch.Tensor,
+    wscales: torch.Tensor,
+    lora_act_in: torch.Tensor,
+    lora_up: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    act_unsigned: bool = False,
+) -> torch.Tensor:
+    # act is the padded output of quantize_svdquant_w4a4, so M here is m_pad, which
+    # is also the row stride of ascales. The kernel indexes ascales as g * M + row.
+    if act.dim() != 2 or wgt.dim() != 2 or lora_up.dim() != 2:
+        raise ValueError("act, wgt and lora_up must be 2D")
+
+    M, k_half = act.shape
+    N = wgt.shape[0]
+    K = k_half * 2
+    R = lora_up.shape[1]
+
+    # One scale per 64-element group: a partial trailing group has no scale, and the
+    # (K // 64, ...) scale shapes below would silently truncate it away.
+    if K % _SVD_GROUP != 0:
+        raise ValueError(f"K={K} not divisible by group_size={_SVD_GROUP}")
+
+    # The kernel gets M, N, K and R but no tensor bounds, so each operand has to
+    # match those extents and share act's device.
+    dev = act.device
+    act = _operand(act, dev, "act")
+    wgt = _operand(wgt, dev, "wgt", shape=(N, k_half))
+    ascales = _operand(ascales, dev, "ascales", shape=(K // _SVD_GROUP, M))
+    wscales = _operand(wscales, dev, "wscales", shape=(K // _SVD_GROUP, N))
+    if wscales.dtype not in _EPILOGUE_DTYPES:
+        raise ValueError(f"wscales dtype {wscales.dtype} is not supported")
+    lora_act_in = _operand(lora_act_in, dev, "lora_act_in", shape=(M, R))
+    lora_up = _operand(lora_up, dev, "lora_up", shape=(N, R))
+    if bias is not None:
+        bias = _bias_operand(bias, N, dev)
+
+    out = torch.empty((M, N), dtype=wscales.dtype, device=dev)
+    _C.svdquant_gemm(
+        _dl(act), _dl(wgt), _dl(out),
+        _dl(ascales), _dl(wscales),
+        _dl(lora_act_in), _dl(lora_up),
+        None if bias is None else _dl(bias),
+        M, N, K, R, act_unsigned, _stream(act),
+    )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Normalization and positional encoding
+# ---------------------------------------------------------------------------
+
+def adaln(
+    x: torch.Tensor,
+    scale: torch.Tensor,
+    shift: torch.Tensor,
+    eps: float = 1e-6,
+) -> torch.Tensor:
+    from comfy_kitchen.backends._modulation import adaln_prep_modulation
+
+    orig_shape = x.shape
+    d = x.shape[-1]
+    n = x.numel() // d
+
+    x_flat = x.reshape(n, d).contiguous()
+    scale_flat, scale_group = adaln_prep_modulation(scale, x, n, d)
+    shift_flat, shift_group = adaln_prep_modulation(shift, x, n, d)
+
+    out = torch.empty_like(x_flat)
+    _C.adaln(
+        _dl(x_flat), _dl(scale_flat), _dl(shift_flat), _dl(out),
+        n, d, scale_group, shift_group, eps, _stream(x),
+    )
+    return out.reshape(orig_shape)
+
+
+def _rope(xq, xk, freqs_cis, split_half):
+    # One dtype code and one stream are passed for the whole launch, so every
+    # buffer has to agree on device, and xq/xk on dtype.
+    if freqs_cis.device != xq.device:
+        raise ValueError("freqs_cis must be on the same device as the input")
+    if xk is not None:
+        if xk.device != xq.device:
+            raise ValueError("xq and xk must be on the same device")
+        if xk.dtype != xq.dtype:
+            raise ValueError("xq and xk must have the same dtype")
+
+    xq = xq.contiguous()
+    freqs_cis = freqs_cis.contiguous()
+    xq_out = torch.empty_like(xq)
+
+    xk_c = xk_out = None
+    if xk is not None:
+        xk_c = xk.contiguous()
+        xk_out = torch.empty_like(xk_c)
+
+    _C.apply_rope(
+        _dl(xq), None if xk_c is None else _dl(xk_c), _dl(freqs_cis),
+        _dl(xq_out), None if xk_out is None else _dl(xk_out),
+        split_half, _stream(xq),
+    )
+    return xq_out, xk_out
+
+
+def apply_rope1(x: torch.Tensor, freqs_cis: torch.Tensor) -> torch.Tensor:
+    return _rope(x, None, freqs_cis, False)[0]
+
+
+def apply_rope(
+    xq: torch.Tensor, xk: torch.Tensor, freqs_cis: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    # The kernel indexes one set of strides and reads both tensors with one dtype
+    # code, so a difference in either is done one at a time.
+    if xq.shape != xk.shape or xq.dtype != xk.dtype:
+        return apply_rope1(xq, freqs_cis), apply_rope1(xk, freqs_cis)
+    q, k = _rope(xq, xk, freqs_cis, False)
+    return q, k
+
+
+def apply_rope_split_half1(x: torch.Tensor, freqs_cis: torch.Tensor) -> torch.Tensor:
+    return _rope(x, None, freqs_cis, True)[0]
+
+
+def apply_rope_split_half(
+    xq: torch.Tensor, xk: torch.Tensor, freqs_cis: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if xq.shape != xk.shape or xq.dtype != xk.dtype:
+        return apply_rope_split_half1(xq, freqs_cis), apply_rope_split_half1(xk, freqs_cis)
+    q, k = _rope(xq, xk, freqs_cis, True)
+    return q, k
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+def _build_constraints() -> dict:
+    from comfy_kitchen.constraints import (
+        DivisibleBy,
+        ExactDims,
+        FunctionConstraints,
+        ParamConstraint,
+    )
+
+    # PyTorch exposes ROCm tensors with device type "cuda".
+    dev = frozenset({"cuda", "hip"})
+    floats = frozenset({torch.float32, torch.float16, torch.bfloat16})
+    fp8s = frozenset({torch.float8_e4m3fn, torch.float8_e5m2})
+    out_floats = frozenset({torch.float32, torch.float16, torch.bfloat16})
+
+    return {
+        "quantize_per_tensor_fp8": FunctionConstraints(
+            params={
+                "x": ParamConstraint(dtypes=floats),
+                "scale": ParamConstraint(dtypes=frozenset({torch.float32})),
+                "output_type": ParamConstraint(dtypes=fp8s),
+            },
+            default_devices=dev,
+        ),
+        "dequantize_per_tensor_fp8": FunctionConstraints(
+            params={
+                "x": ParamConstraint(dtypes=fp8s),
+                "scale": ParamConstraint(dtypes=frozenset({torch.float32})),
+                "output_type": ParamConstraint(dtypes=out_floats),
+            },
+            default_devices=dev,
+        ),
+        "stochastic_rounding_fp8": FunctionConstraints(
+            params={
+                "x": ParamConstraint(dtypes=floats),
+                "rng": ParamConstraint(dtypes=frozenset({torch.uint8})),
+                "output_type": ParamConstraint(dtypes=fp8s),
+            },
+            default_devices=dev,
+        ),
+        "quantize_int8_rowwise": FunctionConstraints(
+            params={"x": ParamConstraint(dtypes=floats)},
+            default_devices=dev,
+        ),
+        "quantize_int8_tensorwise": FunctionConstraints(
+            params={"x": ParamConstraint(dtypes=floats)},
+            default_devices=dev,
+        ),
+        "quantize_and_rotate_rowwise": FunctionConstraints(
+            params={"x": ParamConstraint(dtypes=floats)},
+            default_devices=dev,
+        ),
+        "quantize_int8_convrot_weight": FunctionConstraints(
+            params={"weight": ParamConstraint(dtypes=floats)},
+            default_devices=dev,
+        ),
+        # K must be a multiple of 16 so a WMMA K-step never straddles a row end.
+        "int8_linear": FunctionConstraints(
+            params={
+                "x": ParamConstraint(dtypes=floats, shape_rules=(DivisibleBy(-1, 16),)),
+                "weight": ParamConstraint(dtypes=frozenset({torch.int8})),
+                "out_dtype": ParamConstraint(dtypes=out_floats),
+            },
+            default_devices=dev,
+        ),
+        "quantize_convrot_w4a4_weight": FunctionConstraints(
+            params={"weight": ParamConstraint(dtypes=floats, shape_rules=(DivisibleBy(-1, 32),))},
+            default_devices=dev,
+        ),
+        "dequantize_convrot_w4a4_weight": FunctionConstraints(
+            params={"qdata": ParamConstraint(dtypes=frozenset({torch.int8}))},
+            default_devices=dev,
+        ),
+        "convrot_w4a4_linear": FunctionConstraints(
+            params={
+                "x": ParamConstraint(dtypes=floats, shape_rules=(DivisibleBy(-1, 32),)),
+                "qweight": ParamConstraint(dtypes=frozenset({torch.int8})),
+            },
+            default_devices=dev,
+        ),
+        # 2D only: the tile-packed weight/scale variants have no HIP kernel and
+        # fall through to eager.
+        "gemv_awq_w4a16": FunctionConstraints(
+            params={
+                "x": ParamConstraint(dtypes=floats),
+                "qweight": ParamConstraint(
+                    dtypes=frozenset({torch.int8}), shape_rules=(ExactDims(2),)
+                ),
+            },
+            default_devices=dev,
+        ),
+        "quantize_svdquant_w4a4": FunctionConstraints(
+            params={
+                "x": ParamConstraint(
+                    dtypes=floats, shape_rules=(ExactDims(2), DivisibleBy(-1, 64))
+                ),
+                "smooth": ParamConstraint(dtypes=floats),
+                "lora_down": ParamConstraint(dtypes=floats, shape_rules=(ExactDims(2),)),
+            },
+            default_devices=dev,
+        ),
+        "scaled_mm_svdquant_w4a4": FunctionConstraints(
+            params={
+                "act": ParamConstraint(
+                    dtypes=frozenset({torch.int8}), shape_rules=(ExactDims(2),)
+                ),
+                "wgt": ParamConstraint(
+                    dtypes=frozenset({torch.int8}), shape_rules=(ExactDims(2),)
+                ),
+                "wscales": ParamConstraint(dtypes=floats, shape_rules=(ExactDims(2),)),
+                "lora_up": ParamConstraint(dtypes=floats, shape_rules=(ExactDims(2),)),
+            },
+            default_devices=dev,
+        ),
+        "adaln": FunctionConstraints(
+            params={
+                "x": ParamConstraint(dtypes=floats),
+                "scale": ParamConstraint(dtypes=floats),
+                "shift": ParamConstraint(dtypes=floats),
+            },
+            default_devices=dev,
+        ),
+        # The rope kernel indexes x as 4D and freqs_cis as 6D.
+        "apply_rope": FunctionConstraints(
+            params={
+                "xq": ParamConstraint(dtypes=floats, shape_rules=(ExactDims(4),)),
+                "xk": ParamConstraint(dtypes=floats, shape_rules=(ExactDims(4),)),
+                "freqs_cis": ParamConstraint(dtypes=floats, shape_rules=(ExactDims(6),)),
+            },
+            default_devices=dev,
+        ),
+        "apply_rope1": FunctionConstraints(
+            params={
+                "x": ParamConstraint(dtypes=floats, shape_rules=(ExactDims(4),)),
+                "freqs_cis": ParamConstraint(dtypes=floats, shape_rules=(ExactDims(6),)),
+            },
+            default_devices=dev,
+        ),
+        "apply_rope_split_half": FunctionConstraints(
+            params={
+                "xq": ParamConstraint(dtypes=floats, shape_rules=(ExactDims(4),)),
+                "xk": ParamConstraint(dtypes=floats, shape_rules=(ExactDims(4),)),
+                "freqs_cis": ParamConstraint(dtypes=floats, shape_rules=(ExactDims(6),)),
+            },
+            default_devices=dev,
+        ),
+        "apply_rope_split_half1": FunctionConstraints(
+            params={
+                "x": ParamConstraint(dtypes=floats, shape_rules=(ExactDims(4),)),
+                "freqs_cis": ParamConstraint(dtypes=floats, shape_rules=(ExactDims(6),)),
+            },
+            default_devices=dev,
+        ),
+    }
+
+
+def _register():
+    from comfy_kitchen.registry import registry
+
+    # COMFY_KITCHEN_DISABLE_HIP=1 removes the backend from dispatch, leaving
+    # triton/eager to handle every op.
+    if os.getenv("COMFY_KITCHEN_DISABLE_HIP") == "1":
+        registry.mark_unavailable("hip", "disabled by COMFY_KITCHEN_DISABLE_HIP=1")
+        return
+
+    if not _EXT_AVAILABLE:
+        registry.mark_unavailable("hip", _EXT_ERROR or "HIP extension not built")
+        return
+
+    if not getattr(torch.version, "hip", None):
+        registry.mark_unavailable("hip", "PyTorch ROCm/HIP runtime not available")
+        return
+
+    arches = _visible_gfx_arches()
+    reason = _unsupported_arch_reason(arches)
+    if reason is not None:
+        registry.mark_unavailable("hip", reason)
+        return
+
+    registry.register(
+        name="hip",
+        module=sys.modules[__name__],
+        capabilities=_build_constraints(),
+    )
+    logger.debug("registered HIP backend for %s", ", ".join(sorted(set(arches))))
+
+
+_register()

--- a/comfy_kitchen/backends/hip/dlpack_bindings.cpp
+++ b/comfy_kitchen/backends/hip/dlpack_bindings.cpp
@@ -1,0 +1,324 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+#include <cstring>
+#include <optional>
+#include <stdexcept>
+
+#include <hip/hip_runtime.h>
+#include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
+#include <nanobind/stl/optional.h>
+
+namespace nb = nanobind;
+
+// Matches comfy_kitchen.backends.eager.quantization.DTYPE_TO_CODE:
+// 0=float32, 1=float16, 2=bfloat16, 3=uint8, 4=int8, 5=float8_e4m3fn, 6=float8_e5m2
+int map_dtype_to_code(const nb::dlpack::dtype& dtype) {
+    if (dtype.code == static_cast<uint8_t>(nb::dlpack::dtype_code::Float)) {
+        if (dtype.bits == 32) return 0;
+        if (dtype.bits == 16) return 1;
+        if (dtype.bits == 8) return 5;
+    } else if (dtype.code == static_cast<uint8_t>(nb::dlpack::dtype_code::Bfloat) && dtype.bits == 16) {
+        return 2;
+    } else if (dtype.code == static_cast<uint8_t>(nb::dlpack::dtype_code::UInt) && dtype.bits == 8) {
+        return 3;
+    } else if (dtype.code == static_cast<uint8_t>(nb::dlpack::dtype_code::Int) && dtype.bits == 8) {
+        return 4;
+    }
+    return -1;
+}
+
+extern "C" {
+void launch_quantize_per_tensor_fp8_kernel(const void*, const void*, void*, int64_t, int, int,
+                                           hipStream_t);
+void launch_dequantize_per_tensor_fp8_kernel(const void*, const void*, void*, int64_t, int, int,
+                                             hipStream_t);
+void launch_stochastic_round_fp8_kernel(void*, const void*, int64_t, int, int, int, hipStream_t);
+
+void launch_scaled_mm_fp8_kernel(const void*, const void*, void*, const void*, const void*,
+                                 const void*, int, int, int, int, int, hipStream_t);
+void launch_int8_gemm_kernel(const void*, const void*, void*, const void*, const void*, int,
+                             const void*, int, int, int, int, int, hipStream_t);
+void launch_convrot_w4a4_gemm_kernel(const void*, const void*, void*, const void*, const void*,
+                                     const void*, int, int, int, int, int, hipStream_t);
+
+void launch_quantize_int8_rowwise_kernel(const void*, int, void*, void*, int, int, hipStream_t);
+void launch_quantize_int8_convrot_kernel(const void*, int, void*, void*, int, int, int,
+                                         hipStream_t);
+void launch_quantize_int8_tensorwise_kernel(const void*, int, void*, void*, void*, int64_t,
+                                            hipStream_t);
+void launch_convrot_quant_int4_kernel(const void*, int, void*, void*, int, int, int, hipStream_t);
+void launch_unpack_int4_kernel(const void*, void*, int64_t, hipStream_t);
+int convrot_max_k_host();
+
+void launch_adaln_kernel(const void*, const void*, const void*, void*, int, int, int, int, float,
+                         int, int, int, hipStream_t);
+void launch_gemv_awq_kernel(const void*, const void*, const void*, const void*, const void*, void*,
+                            int, int, int, int, int, int, int, int, hipStream_t);
+void launch_svdquant_lora_down_kernel(const void*, const void*, void*, int, int, int, int, int,
+                                      hipStream_t);
+void launch_svdquant_quant_kernel(const void*, const void*, void*, void*, int, int, int, int, int,
+                                  bool, hipStream_t);
+void launch_svdquant_gemm_kernel(const void*, const void*, void*, const void*, const void*,
+                                 const void*, const void*, const void*, int, int, int, int, int,
+                                 int, int, int, int, int, bool, hipStream_t);
+void launch_apply_rope_kernel(const void*, const void*, const void*, void*, void*, int64_t, int64_t,
+                              int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t,
+                              int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, int, int,
+                              bool, hipStream_t);
+}
+
+static void check_hip_launch() {
+    hipError_t err = hipGetLastError();
+    if (err != hipSuccess) {
+        throw std::runtime_error(std::string("HIP kernel launch failed: ") + hipGetErrorString(err));
+    }
+}
+
+using OptArray = std::optional<nb::ndarray<>>;
+
+static const void* opt_data(const OptArray& t) {
+    return t.has_value() ? t->data() : nullptr;
+}
+
+static int opt_code(const OptArray& t) {
+    return t.has_value() ? map_dtype_to_code(t->dtype()) : 0;
+}
+
+void quantize_per_tensor_fp8(nb::ndarray<> input, nb::ndarray<> scale, nb::ndarray<> output,
+                             int input_dtype_code, int output_dtype_code, int64_t numel,
+                             uintptr_t stream_ptr) {
+    launch_quantize_per_tensor_fp8_kernel(input.data(), scale.data(), output.data(), numel,
+                                          input_dtype_code, output_dtype_code,
+                                          reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+void dequantize_per_tensor_fp8(nb::ndarray<> input, nb::ndarray<> scale, nb::ndarray<> output,
+                               int input_dtype_code, int output_dtype_code, int64_t numel,
+                               uintptr_t stream_ptr) {
+    launch_dequantize_per_tensor_fp8_kernel(input.data(), scale.data(), output.data(), numel,
+                                            input_dtype_code, output_dtype_code,
+                                            reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+void stochastic_round_fp8(nb::ndarray<> rng_and_output, nb::ndarray<> input, int output_dtype_code,
+                          int64_t numel, uintptr_t stream_ptr) {
+    int rng_dtype_code = map_dtype_to_code(rng_and_output.dtype());
+    if (rng_dtype_code != 3) {
+        throw std::runtime_error("stochastic_round_fp8 requires uint8 RNG storage");
+    }
+    int input_dtype_code = map_dtype_to_code(input.dtype());
+    if (input_dtype_code < 0 || input_dtype_code > 2) {
+        throw std::runtime_error("Unsupported input dtype for stochastic_round_fp8");
+    }
+    if (output_dtype_code < 5 || output_dtype_code > 6) {
+        throw std::runtime_error("Unsupported output dtype for stochastic_round_fp8");
+    }
+    launch_stochastic_round_fp8_kernel(rng_and_output.data(), input.data(), numel, rng_dtype_code,
+                                       input_dtype_code, output_dtype_code,
+                                       reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+void scaled_mm_fp8(nb::ndarray<> a, nb::ndarray<> b, nb::ndarray<> c, nb::ndarray<> scale_a,
+                   nb::ndarray<> scale_b, OptArray bias, int M, int N, int K, int out_code,
+                   uintptr_t stream_ptr) {
+    launch_scaled_mm_fp8_kernel(a.data(), b.data(), c.data(), scale_a.data(), scale_b.data(),
+                                opt_data(bias), opt_code(bias), M, N, K, out_code,
+                                reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+void int8_gemm(nb::ndarray<> a, nb::ndarray<> b, nb::ndarray<> c, nb::ndarray<> scale_a,
+               nb::ndarray<> scale_b, int scale_b_stride, OptArray bias, int M, int N, int K,
+               int out_code, uintptr_t stream_ptr) {
+    launch_int8_gemm_kernel(a.data(), b.data(), c.data(), scale_a.data(), scale_b.data(),
+                            scale_b_stride, opt_data(bias), opt_code(bias), M, N, K, out_code,
+                            reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+void convrot_w4a4_gemm(nb::ndarray<> a, nb::ndarray<> b, nb::ndarray<> c, nb::ndarray<> x_scale,
+                       nb::ndarray<> w_scale, OptArray bias, int M, int N, int K, int out_code,
+                       uintptr_t stream_ptr) {
+    launch_convrot_w4a4_gemm_kernel(a.data(), b.data(), c.data(), x_scale.data(), w_scale.data(),
+                                    opt_data(bias), opt_code(bias), M, N, K, out_code,
+                                    reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+void quantize_int8_rowwise(nb::ndarray<> x, nb::ndarray<> q, nb::ndarray<> scales, int M, int K,
+                           uintptr_t stream_ptr) {
+    launch_quantize_int8_rowwise_kernel(x.data(), map_dtype_to_code(x.dtype()), q.data(),
+                                        scales.data(), M, K,
+                                        reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+void quantize_int8_convrot(nb::ndarray<> x, nb::ndarray<> q, nb::ndarray<> scales, int M, int K,
+                           int group_size, uintptr_t stream_ptr) {
+    launch_quantize_int8_convrot_kernel(x.data(), map_dtype_to_code(x.dtype()), q.data(),
+                                        scales.data(), M, K, group_size,
+                                        reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+void quantize_int8_tensorwise(nb::ndarray<> x, nb::ndarray<> q, nb::ndarray<> scale,
+                              nb::ndarray<> scratch, int64_t numel, uintptr_t stream_ptr) {
+    launch_quantize_int8_tensorwise_kernel(x.data(), map_dtype_to_code(x.dtype()), q.data(),
+                                           scale.data(), scratch.data(), numel,
+                                           reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+void convrot_quant_int4(nb::ndarray<> x, nb::ndarray<> q, nb::ndarray<> scales, int M, int K,
+                        int group_size, uintptr_t stream_ptr) {
+    launch_convrot_quant_int4_kernel(x.data(), map_dtype_to_code(x.dtype()), q.data(),
+                                     scales.data(), M, K, group_size,
+                                     reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+void unpack_int4(nb::ndarray<> q, nb::ndarray<> out, int64_t nbytes, uintptr_t stream_ptr) {
+    launch_unpack_int4_kernel(q.data(), out.data(), nbytes,
+                              reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+void adaln(nb::ndarray<> x, nb::ndarray<> scale, nb::ndarray<> shift, nb::ndarray<> out, int N,
+           int D, int scale_group, int shift_group, float eps, uintptr_t stream_ptr) {
+    launch_adaln_kernel(x.data(), scale.data(), shift.data(), out.data(), N, D, scale_group,
+                        shift_group, eps, map_dtype_to_code(x.dtype()),
+                        map_dtype_to_code(scale.dtype()), map_dtype_to_code(shift.dtype()),
+                        reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+// xq is (batch, dim1, dim2, head_dim); freqs is (fb, fd1, fd2, head_dim/2, 2, 2).
+// Shapes and strides are read off the arrays so the broadcast rules stay in one
+// place rather than being recomputed on the Python side.
+void apply_rope(nb::ndarray<> xq, OptArray xk, nb::ndarray<> freqs, nb::ndarray<> xq_out,
+                OptArray xk_out, bool split_half, uintptr_t stream_ptr) {
+    if (xq.ndim() != 4) throw std::runtime_error("apply_rope expects a 4D input");
+    if (freqs.ndim() != 6) throw std::runtime_error("apply_rope expects a 6D freqs_cis");
+    if (xq.shape(3) % 2 != 0) throw std::runtime_error("apply_rope expects an even head_dim");
+
+    // The kernel indexes freqs as (fb, fd1, fd2, head_dim/2, 2, 2), broadcasting a
+    // leading dim only when it is 1. Anything else walks off the end of the array.
+    if (freqs.shape(3) != xq.shape(3) / 2 || freqs.shape(4) != 2 || freqs.shape(5) != 2) {
+        throw std::runtime_error("apply_rope expects freqs_cis trailing dims (head_dim/2, 2, 2)");
+    }
+    for (size_t i = 0; i < 3; ++i) {
+        if (freqs.shape(i) != 1 && freqs.shape(i) != xq.shape(i)) {
+            throw std::runtime_error(
+                "apply_rope expects each leading freqs_cis dim to be 1 or match the input");
+        }
+    }
+
+    // The kernel addresses xk and both outputs with xq's strides and dtype code, and
+    // writes xk_out whenever xk is present. Anything that does not share xq's layout
+    // has to be launched on its own.
+    auto same_layout_as_xq = [&xq](const nb::ndarray<>& t, const char* name) {
+        if (t.ndim() != 4 || t.dtype() != xq.dtype()) {
+            throw std::runtime_error(std::string("apply_rope expects ") + name +
+                                     " to be 4D with xq's dtype");
+        }
+        for (size_t i = 0; i < 4; ++i) {
+            if (t.shape(i) != xq.shape(i) || t.stride(i) != xq.stride(i)) {
+                throw std::runtime_error(std::string("apply_rope expects ") + name +
+                                         " to have xq's shape and strides");
+            }
+        }
+    };
+
+    if (xk.has_value() != xk_out.has_value()) {
+        throw std::runtime_error("apply_rope expects xk and xk_out together or not at all");
+    }
+    same_layout_as_xq(xq_out, "xq_out");
+    if (xk.has_value()) {
+        same_layout_as_xq(*xk, "xk");
+        same_layout_as_xq(*xk_out, "xk_out");
+    }
+
+    launch_apply_rope_kernel(
+        xq.data(), xk.has_value() ? xk->data() : nullptr, freqs.data(), xq_out.data(),
+        xk_out.has_value() ? xk_out->data() : nullptr,
+        static_cast<int64_t>(xq.shape(0)), static_cast<int64_t>(xq.shape(1)),
+        static_cast<int64_t>(xq.shape(2)), static_cast<int64_t>(xq.shape(3)),
+        static_cast<int64_t>(freqs.shape(0)), static_cast<int64_t>(freqs.shape(1)),
+        static_cast<int64_t>(freqs.shape(2)),
+        static_cast<int64_t>(xq.stride(0)), static_cast<int64_t>(xq.stride(1)),
+        static_cast<int64_t>(xq.stride(2)), static_cast<int64_t>(xq.stride(3)),
+        static_cast<int64_t>(freqs.stride(0)), static_cast<int64_t>(freqs.stride(1)),
+        static_cast<int64_t>(freqs.stride(2)), static_cast<int64_t>(freqs.stride(3)),
+        static_cast<int64_t>(freqs.stride(4)), static_cast<int64_t>(freqs.stride(5)),
+        map_dtype_to_code(xq.dtype()), map_dtype_to_code(freqs.dtype()), split_half,
+        reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+void gemv_awq_w4a16(nb::ndarray<> x, nb::ndarray<> qweight, nb::ndarray<> wscales,
+                    nb::ndarray<> wzeros, OptArray bias, nb::ndarray<> out, int M, int N, int K,
+                    int group_size, uintptr_t stream_ptr) {
+    launch_gemv_awq_kernel(x.data(), qweight.data(), wscales.data(), wzeros.data(), opt_data(bias),
+                           out.data(), M, N, K, group_size, map_dtype_to_code(x.dtype()),
+                           map_dtype_to_code(wscales.dtype()), opt_code(bias),
+                           map_dtype_to_code(out.dtype()),
+                           reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+void svdquant_lora_down(nb::ndarray<> x, nb::ndarray<> lora_down, nb::ndarray<> lora_act, int M,
+                        int K, int R, uintptr_t stream_ptr) {
+    launch_svdquant_lora_down_kernel(x.data(), lora_down.data(), lora_act.data(), M, K, R,
+                                     map_dtype_to_code(x.dtype()),
+                                     map_dtype_to_code(lora_down.dtype()),
+                                     reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+void svdquant_quantize(nb::ndarray<> x, nb::ndarray<> smooth, nb::ndarray<> q,
+                       nb::ndarray<> ascales, int M, int M_pad, int K, bool act_unsigned,
+                       uintptr_t stream_ptr) {
+    launch_svdquant_quant_kernel(x.data(), smooth.data(), q.data(), ascales.data(), M, M_pad, K,
+                                 map_dtype_to_code(x.dtype()), map_dtype_to_code(ascales.dtype()),
+                                 act_unsigned, reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+void svdquant_gemm(nb::ndarray<> a, nb::ndarray<> b, nb::ndarray<> c, nb::ndarray<> ascales,
+                   nb::ndarray<> wscales, nb::ndarray<> lora_act, nb::ndarray<> lora_up,
+                   OptArray bias, int M, int N, int K, int R, bool act_unsigned,
+                   uintptr_t stream_ptr) {
+    launch_svdquant_gemm_kernel(
+        a.data(), b.data(), c.data(), ascales.data(), wscales.data(), lora_act.data(),
+        lora_up.data(), opt_data(bias), M, N, K, R, map_dtype_to_code(ascales.dtype()),
+        map_dtype_to_code(wscales.dtype()), map_dtype_to_code(lora_act.dtype()),
+        map_dtype_to_code(lora_up.dtype()), opt_code(bias), map_dtype_to_code(c.dtype()),
+        act_unsigned, reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+NB_MODULE(_C, m) {
+    m.doc() = "ComfyKitchen HIP backend native operations (gfx12 WMMA)";
+    m.def("quantize_per_tensor_fp8", &quantize_per_tensor_fp8);
+    m.def("dequantize_per_tensor_fp8", &dequantize_per_tensor_fp8);
+    m.def("stochastic_round_fp8", &stochastic_round_fp8);
+    m.def("scaled_mm_fp8", &scaled_mm_fp8);
+    m.def("int8_gemm", &int8_gemm);
+    m.def("convrot_w4a4_gemm", &convrot_w4a4_gemm);
+    m.def("quantize_int8_rowwise", &quantize_int8_rowwise);
+    m.def("quantize_int8_convrot", &quantize_int8_convrot);
+    m.def("quantize_int8_tensorwise", &quantize_int8_tensorwise);
+    m.def("convrot_quant_int4", &convrot_quant_int4);
+    m.def("convrot_max_k", &convrot_max_k_host);
+    m.def("unpack_int4", &unpack_int4);
+    m.def("adaln", &adaln);
+    m.def("apply_rope", &apply_rope);
+    m.def("gemv_awq_w4a16", &gemv_awq_w4a16);
+    m.def("svdquant_lora_down", &svdquant_lora_down);
+    m.def("svdquant_quantize", &svdquant_quantize);
+    m.def("svdquant_gemm", &svdquant_gemm);
+}

--- a/comfy_kitchen/backends/hip/epilogue.h
+++ b/comfy_kitchen/backends/hip/epilogue.h
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// GEMM epilogues. Each holds device pointers only and is passed to the tile
+// kernel by value. init() runs once per thread before the writeback loop, so
+// scalar scales are loaded once rather than per output element.
+#pragma once
+
+#include <hip/hip_fp16.h>
+#include <hip/hip_runtime.h>
+
+namespace comfy::hip_backend {
+
+// dtype codes match comfy_kitchen.backends.eager.quantization.DTYPE_TO_CODE
+constexpr int kF32 = 0;
+constexpr int kF16 = 1;
+constexpr int kBF16 = 2;
+
+__forceinline__ __device__ float load_scalar(const void* p, int code, int64_t i) {
+    if (code == kF32) return static_cast<const float*>(p)[i];
+    if (code == kF16) return __half2float(static_cast<const __half*>(p)[i]);
+    return static_cast<float>(static_cast<const __bf16*>(p)[i]);
+}
+
+__forceinline__ __device__ void store_scalar(void* p, int code, int64_t i, float v) {
+    if (code == kF32) {
+        static_cast<float*>(p)[i] = v;
+    } else if (code == kF16) {
+        static_cast<__half*>(p)[i] = __float2half(v);
+    } else {
+        static_cast<__bf16*>(p)[i] = static_cast<__bf16>(v);
+    }
+}
+
+// out = acc * (scale_a * scale_b) + bias[col]
+struct EpiTensorwise {
+    const float* scale_a;
+    const float* scale_b;
+    const void* bias;
+    int bias_code;
+    float alpha;
+
+    __forceinline__ __device__ void init() { alpha = scale_a[0] * scale_b[0]; }
+
+    __forceinline__ __device__ float operator()(int, int col, float acc) const {
+        float v = acc * alpha;
+        if (bias) v += load_scalar(bias, bias_code, col);
+        return v;
+    }
+};
+
+// out = acc * scale_a[row] * scale_b[col * scale_b_stride] + bias[col]
+// scale_b_stride is 1 for a per-output-channel weight scale, 0 for a scalar.
+struct EpiRowwise {
+    const float* scale_a;
+    const float* scale_b;
+    int scale_b_stride;
+    const void* bias;
+    int bias_code;
+
+    __forceinline__ __device__ void init() {}
+
+    __forceinline__ __device__ float operator()(int row, int col, float acc) const {
+        float v = acc * scale_a[row] * scale_b[col * scale_b_stride];
+        if (bias) v += load_scalar(bias, bias_code, col);
+        return v;
+    }
+};
+
+}  // namespace comfy::hip_backend

--- a/comfy_kitchen/backends/hip/fp8_utils.h
+++ b/comfy_kitchen/backends/hip/fp8_utils.h
@@ -1,0 +1,150 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// OCP FP8 encode/decode shared by the elementwise quantization kernels and the
+// scalar small-M GEMV path. The WMMA path consumes fp8 as raw bytes and needs
+// none of this.
+#pragma once
+
+#include <hip/hip_bfloat16.h>
+#include <hip/hip_fp16.h>
+#include <hip/hip_runtime.h>
+
+#include <cmath>
+#include <cstdint>
+
+namespace comfy::hip_backend {
+
+// dtype codes match comfy_kitchen.backends.eager.quantization.DTYPE_TO_CODE
+constexpr int kFp8E4M3Code = 5;
+
+__forceinline__ __device__ float fp8_clamp(float v, float lo, float hi) {
+    return fminf(hi, fmaxf(lo, v));
+}
+
+// The kernels are compiled with -ffast-math, which implies -ffinite-math-only:
+// isnan() folds to false there, and fp8_clamp() drops a NaN operand outright.
+// Test the bits instead, so a NaN input still encodes as a NaN.
+__forceinline__ __device__ bool fp8_is_nan(float v) {
+    return (__float_as_uint(v) & 0x7fffffffu) > 0x7f800000u;
+}
+
+template <typename T>
+__forceinline__ __device__ float to_float(T value) {
+    return static_cast<float>(value);
+}
+
+template <>
+__forceinline__ __device__ float to_float<__half>(__half value) {
+    return __half2float(value);
+}
+
+template <>
+__forceinline__ __device__ float to_float<hip_bfloat16>(hip_bfloat16 value) {
+    return static_cast<float>(value);
+}
+
+// e4m3fn: 1-4-3, bias 7, no infinities. e5m2: 1-5-2, bias 15.
+__forceinline__ __device__ uint8_t pack_fp8(float value, int dtype_code) {
+    const bool e4m3 = dtype_code == kFp8E4M3Code;
+    const int mantissa_bits = e4m3 ? 3 : 2;
+    const int exponent_bias = e4m3 ? 7 : 15;
+    const int mantissa_levels = 1 << mantissa_bits;
+    const int max_exponent_field = e4m3 ? 15 : 30;
+    const int max_mantissa_field = e4m3 ? 6 : (mantissa_levels - 1);
+    const float fp8_max = e4m3 ? 448.0f : 57344.0f;
+
+    const uint8_t sign_bit = (__float_as_uint(value) >> 31) ? 0x80 : 0x00;
+    float abs_value = fabsf(value);
+    // Exponent all ones, mantissa all ones: the NaN torch encodes for both formats.
+    if (fp8_is_nan(value)) {
+        return static_cast<uint8_t>(sign_bit | 0x7f);
+    }
+
+    abs_value = fp8_clamp(abs_value, 0.0f, fp8_max);
+    if (abs_value == 0.0f) {
+        return sign_bit;
+    }
+
+    const float min_normal = exp2f(1 - exponent_bias);
+    int exponent_field = 0;
+    int mantissa_field = 0;
+    if (abs_value < min_normal) {
+        const float subnormal_scale = exp2f(1 - exponent_bias - mantissa_bits);
+        mantissa_field = static_cast<int>(floorf(abs_value / subnormal_scale + 0.5f));
+        if (mantissa_field >= mantissa_levels) {
+            exponent_field = 1;
+            mantissa_field = 0;
+        }
+    } else {
+        exponent_field = static_cast<int>(floorf(log2f(abs_value))) + exponent_bias;
+        const float exponent_scale = exp2f(exponent_field - exponent_bias);
+        mantissa_field =
+            static_cast<int>(floorf((abs_value / exponent_scale - 1.0f) * mantissa_levels + 0.5f));
+        if (mantissa_field >= mantissa_levels) {
+            mantissa_field = 0;
+            exponent_field += 1;
+        }
+    }
+
+    if (exponent_field > max_exponent_field ||
+        (exponent_field == max_exponent_field && mantissa_field > max_mantissa_field)) {
+        exponent_field = max_exponent_field;
+        mantissa_field = max_mantissa_field;
+    }
+
+    return static_cast<uint8_t>(sign_bit | (exponent_field << mantissa_bits) | mantissa_field);
+}
+
+__forceinline__ __device__ float unpack_fp8(uint8_t value, int dtype_code = kFp8E4M3Code) {
+    const bool e4m3 = dtype_code == kFp8E4M3Code;
+    const int mantissa_bits = e4m3 ? 3 : 2;
+    const int exponent_bits = e4m3 ? 4 : 5;
+    const int exponent_bias = e4m3 ? 7 : 15;
+    const int mantissa_mask = (1 << mantissa_bits) - 1;
+    const int exponent_mask = (1 << exponent_bits) - 1;
+
+    const float sign = (value & 0x80) ? -1.0f : 1.0f;
+    const int exponent = (value >> mantissa_bits) & exponent_mask;
+    const int mantissa = value & mantissa_mask;
+
+    // e4m3fn has no infinities: an all-ones exponent with an all-ones mantissa is
+    // its only NaN. e5m2 follows IEEE: all-ones exponent is inf, or NaN when the
+    // mantissa is non-zero. pack_fp8 emits these, so decode them back. The result
+    // is assembled from bits, not float literals: -ffast-math assumes no NaN and
+    // would fold a branch that only ever returns one.
+    if (exponent == exponent_mask && (!e4m3 || mantissa == mantissa_mask)) {
+        const uint32_t sign_bits = (value & 0x80) ? 0x80000000u : 0u;
+        const uint32_t payload = (!e4m3 && mantissa == 0) ? 0x7f800000u   // e5m2 inf
+                                                          : 0x7fc00000u;  // quiet NaN
+        return __uint_as_float(sign_bits | payload);
+    }
+
+    if (exponent == 0) {
+        if (mantissa == 0) {
+            return sign * 0.0f;
+        }
+        return sign * exp2f(1 - exponent_bias) *
+               (static_cast<float>(mantissa) / (1 << mantissa_bits));
+    }
+    return sign * exp2f(exponent - exponent_bias) *
+           (1.0f + static_cast<float>(mantissa) / (1 << mantissa_bits));
+}
+
+// Branch-free e4m3fn decode for the GEMV inner loop. Unlike unpack_fp8 it does
+// not decode the 0x7f/0xff NaN, which becomes 480.0: the AWQ weights it reads
+// are produced by a quantizer that never emits NaN, and the branch costs more
+// than the case is worth.
+__forceinline__ __device__ float fp8_to_float(uint8_t b) {
+    const int exp = (b >> 3) & 0xF;
+    const int man = b & 0x7;
+    const float sign = (b & 0x80) ? -1.0f : 1.0f;
+
+    if (exp == 0) return sign * man * 0.001953125f;  // subnormal step: 2^-9
+
+    const uint32_t bits = (static_cast<uint32_t>(exp - 7 + 127) << 23) |
+                          (static_cast<uint32_t>(man) << 20);
+    return sign * __uint_as_float(bits);
+}
+
+}  // namespace comfy::hip_backend

--- a/comfy_kitchen/backends/hip/gemm_wmma.h
+++ b/comfy_kitchen/backends/hip/gemm_wmma.h
@@ -1,0 +1,238 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Tiled WMMA GEMM core for gfx12, shared by the fp8, int8 and int4 paths.
+//
+// Computes C[M, N] = epilogue(A[M, K] @ B[N, K]^T). The B operand is the weight
+// in its natural (N, K) row-major form, matching torch linear.
+//
+// All supported element types hold 8 bytes per lane per WMMA, so one K-step is
+// 16 bytes of a row whether those bytes hold 16 fp8/int8 values or 32 int4
+// nibbles. The tile loop is byte-addressed and the element type appears only in
+// the Mma policy.
+//
+// The K loop is software-pipelined: the next tile's global loads are issued into
+// registers before the current tile's math.
+#pragma once
+
+#include "wmma_gfx12.h"
+
+namespace comfy::hip_backend {
+
+// LDS row padding, in bytes. 8 spreads the 16 lanes of a fragment read across
+// distinct banks. 16 would preserve 128-bit LDS access but aliases rows
+// 0/4/8/... onto the same bank.
+constexpr int kLdsPad = 8;
+
+struct MmaFp8 {
+    using Acc = v8f;
+    static __forceinline__ __device__ Acc zero() { return Acc{0, 0, 0, 0, 0, 0, 0, 0}; }
+    static __forceinline__ __device__ Acc mma(v2i a, v2i b, Acc c) { return wmma_fp8(a, b, c); }
+    static __forceinline__ __device__ float get(Acc c, int e) { return c[e]; }
+};
+
+struct MmaBf8 {
+    using Acc = v8f;
+    static __forceinline__ __device__ Acc zero() { return Acc{0, 0, 0, 0, 0, 0, 0, 0}; }
+    static __forceinline__ __device__ Acc mma(v2i a, v2i b, Acc c) { return wmma_bf8(a, b, c); }
+    static __forceinline__ __device__ float get(Acc c, int e) { return c[e]; }
+};
+
+struct MmaInt8 {
+    using Acc = v8i;
+    static __forceinline__ __device__ Acc zero() { return Acc{0, 0, 0, 0, 0, 0, 0, 0}; }
+    static __forceinline__ __device__ Acc mma(v2i a, v2i b, Acc c) { return wmma_iu8(a, b, c); }
+    static __forceinline__ __device__ float get(Acc c, int e) { return static_cast<float>(c[e]); }
+};
+
+struct MmaInt4 {
+    using Acc = v8i;
+    static __forceinline__ __device__ Acc zero() { return Acc{0, 0, 0, 0, 0, 0, 0, 0}; }
+    static __forceinline__ __device__ Acc mma(v2i a, v2i b, Acc c) { return wmma_iu4(a, b, c); }
+    static __forceinline__ __device__ float get(Acc c, int e) { return static_cast<float>(c[e]); }
+};
+
+// Staging for one ROWS x BKB byte tile. load() issues only the global reads, so
+// the caller can place the tile's math between load() and store().
+//
+// kbytes is the source row length in bytes (K for 8-bit types, K/2 for int4) and
+// is a multiple of 16, so a 16-byte chunk starting inside a row also ends inside
+// it. Out-of-range rows and the K tail are zero-filled.
+template <int ROWS, int BKB, int THREADS>
+struct TileStager {
+    static constexpr int kChunksPerRow = BKB / 16;
+    static constexpr int kChunks = ROWS * kChunksPerRow;
+    static constexpr int kPerThread = kChunks / THREADS;
+    static constexpr int kStride = BKB + kLdsPad;
+    // Both divisions truncate, and either remainder would leave part of the tile
+    // unwritten in LDS for the math to then read as stale.
+    static_assert(BKB % 16 == 0, "BKB must be a whole number of 16-byte chunks");
+    static_assert(kChunks % THREADS == 0, "THREADS must divide the tile's 16-byte chunks");
+
+    uint4 regs[kPerThread];
+
+    __forceinline__ __device__ void load(const uint8_t* __restrict__ src, int row0, int rows_total,
+                                         int kbyte0, int kbytes) {
+        const int tid = threadIdx.x;
+        #pragma unroll
+        for (int i = 0; i < kPerThread; ++i) {
+            const int c = tid * kPerThread + i;
+            const int grow = row0 + c / kChunksPerRow;
+            const int gk = kbyte0 + (c % kChunksPerRow) * 16;
+
+            regs[i] = (grow < rows_total && gk < kbytes)
+                          ? *reinterpret_cast<const uint4*>(
+                                src + static_cast<int64_t>(grow) * kbytes + gk)
+                          : make_uint4(0, 0, 0, 0);
+        }
+    }
+
+    __forceinline__ __device__ void store(uint8_t* __restrict__ lds) const {
+        const int tid = threadIdx.x;
+        #pragma unroll
+        for (int i = 0; i < kPerThread; ++i) {
+            const int c = tid * kPerThread + i;
+            uint8_t* dst = lds + (c / kChunksPerRow) * kStride + (c % kChunksPerRow) * 16;
+            // 8-byte stores: kLdsPad breaks 16-byte LDS alignment.
+            *reinterpret_cast<uint2*>(dst) = make_uint2(regs[i].x, regs[i].y);
+            *reinterpret_cast<uint2*>(dst + 8) = make_uint2(regs[i].z, regs[i].w);
+        }
+    }
+};
+
+// Epi is a functor: float operator()(int row, int col, float acc) const.
+template <typename Mma, typename Epi, typename OutT,
+          int BM, int BN, int BKB, int WARPS_M, int WARPS_N, int TM, int TN>
+__global__ __launch_bounds__(WARPS_M* WARPS_N* kWave) void gemm_wmma_kernel(
+    const uint8_t* __restrict__ A, const uint8_t* __restrict__ B, OutT* __restrict__ C,
+    int M, int N, int kbytes, Epi epi) {
+
+    constexpr int kThreads = WARPS_M * WARPS_N * kWave;
+    constexpr int kStride = BKB + kLdsPad;
+
+    // The fragment reads below index As by wm * (TM * 16) + i * 16 + row, which
+    // reaches WARPS_M * TM * 16 - 1, and Bs likewise. The warp grid has to tile the
+    // block exactly: a smaller product leaves part of the tile unread, a larger one
+    // walks off the end of the LDS array.
+    static_assert(BM == WARPS_M * TM * 16, "the M warp grid must tile BM exactly");
+    static_assert(BN == WARPS_N * TN * 16, "the N warp grid must tile BN exactly");
+
+    __shared__ uint8_t As[BM * kStride];
+    __shared__ uint8_t Bs[BN * kStride];
+
+    const int tid = threadIdx.x;
+    const int lane = tid % kWave;
+    const int warp = tid / kWave;
+    const int wm = warp / WARPS_N;
+    const int wn = warp % WARPS_N;
+
+    // Grouped block ordering for L2 locality: consecutive blocks advance along M
+    // within a group of kGroupM block-rows, so concurrently resident blocks share
+    // the same B columns.
+    constexpr int kGroupM = 4;
+    const int blocks_n = gridDim.x;
+    const int blocks_m = gridDim.y;
+    const int bid = blockIdx.y * blocks_n + blockIdx.x;
+    const int per_group = kGroupM * blocks_n;
+    const int group = bid / per_group;
+    const int idx_in_group = bid - group * per_group;
+    const int group_rows = min(kGroupM, blocks_m - group * kGroupM);
+    const int bm = group * kGroupM + idx_in_group % group_rows;
+    const int bn = idx_in_group / group_rows;
+
+    const int m0 = bm * BM;
+    const int n0 = bn * BN;
+
+    typename Mma::Acc acc[TM][TN];
+    #pragma unroll
+    for (int i = 0; i < TM; ++i)
+        #pragma unroll
+        for (int j = 0; j < TN; ++j) acc[i][j] = Mma::zero();
+
+    const int row = frag_row(lane);
+    const int khalf = frag_khalf(lane);
+
+    TileStager<BM, BKB, kThreads> sa;
+    TileStager<BN, BKB, kThreads> sb;
+
+    sa.load(A, m0, M, 0, kbytes);
+    sb.load(B, n0, N, 0, kbytes);
+    sa.store(As);
+    sb.store(Bs);
+    __syncthreads();
+
+    for (int kb0 = 0; kb0 < kbytes; kb0 += BKB) {
+        const int knext = kb0 + BKB;
+        const bool has_next = knext < kbytes;
+
+        // Prefetch the next tile's global reads ahead of the current tile's math.
+        if (has_next) {
+            sa.load(A, m0, M, knext, kbytes);
+            sb.load(B, n0, N, knext, kbytes);
+        }
+
+        // Register-level pipeline over K-steps: the LDS reads for step kk+1 are
+        // issued before the MMAs of step kk.
+        v2i af[2][TM];
+        v2i bf[2][TN];
+
+        #pragma unroll
+        for (int i = 0; i < TM; ++i)
+            af[0][i] = load_frag_b64(As, wm * (TM * 16) + i * 16 + row, 8 * khalf, kStride);
+        #pragma unroll
+        for (int j = 0; j < TN; ++j)
+            bf[0][j] = load_frag_b64(Bs, wn * (TN * 16) + j * 16 + row, 8 * khalf, kStride);
+
+        #pragma unroll
+        for (int kk = 0; kk < BKB / 16; ++kk) {
+            const int cur = kk & 1;
+            const int nxt = cur ^ 1;
+
+            if (kk + 1 < BKB / 16) {
+                const int kbyte = (kk + 1) * 16 + 8 * khalf;
+                #pragma unroll
+                for (int i = 0; i < TM; ++i)
+                    af[nxt][i] = load_frag_b64(As, wm * (TM * 16) + i * 16 + row, kbyte, kStride);
+                #pragma unroll
+                for (int j = 0; j < TN; ++j)
+                    bf[nxt][j] = load_frag_b64(Bs, wn * (TN * 16) + j * 16 + row, kbyte, kStride);
+            }
+
+            #pragma unroll
+            for (int i = 0; i < TM; ++i)
+                #pragma unroll
+                for (int j = 0; j < TN; ++j)
+                    acc[i][j] = Mma::mma(af[cur][i], bf[cur][j], acc[i][j]);
+        }
+
+        if (has_next) {
+            __syncthreads();  // all warps have finished reading the current tile
+            sa.store(As);
+            sb.store(Bs);
+            __syncthreads();
+        }
+    }
+
+    epi.init();
+
+    // Row-major writeback: the TN column tiles of one accumulator row cover
+    // TN*16 consecutive columns, keeping the stores of an iteration contiguous.
+    const int col_lane = acc_col(lane);
+    #pragma unroll
+    for (int i = 0; i < TM; ++i) {
+        #pragma unroll
+        for (int e = 0; e < 8; ++e) {
+            const int r = m0 + wm * (TM * 16) + i * 16 + acc_row(lane, e);
+            if (r >= M) continue;
+            OutT* crow = C + static_cast<int64_t>(r) * N;
+            #pragma unroll
+            for (int j = 0; j < TN; ++j) {
+                const int col = n0 + wn * (TN * 16) + j * 16 + col_lane;
+                if (col >= N) continue;
+                crow[col] = static_cast<OutT>(epi(r, col, Mma::get(acc[i][j], e)));
+            }
+        }
+    }
+}
+
+}  // namespace comfy::hip_backend

--- a/comfy_kitchen/backends/hip/hadamard.h
+++ b/comfy_kitchen/backends/hip/hadamard.h
@@ -1,0 +1,163 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Fused ConvRot rotation + rowwise quantization.
+//
+// The regular Hadamard-G (G in {16, 64, 256}) is kron(H4, ...) / sqrt(G) and so
+// factors into log4(G) radix-4 butterfly stages over the base-4 digits of the
+// index, matching the eager _rotate_activation reference.
+//
+// One block per row: transform each G-group in LDS, track the row absmax, then
+// quantize. INT4 output packs two nibbles per byte (low nibble = even index),
+// which is the layout the iu4 A-fragment consumes directly.
+#pragma once
+
+#include <stdexcept>
+#include <string>
+
+#include <hip/hip_bf16.h>
+#include <hip/hip_fp16.h>
+#include <hip/hip_runtime.h>
+
+namespace comfy::hip_backend {
+
+// convrot_quant_kernel handles 256/G groups per pass and rotates in log4(G)
+// stages, so a G outside this set either divides to a zero-width pass or is not
+// a power of four. The dispatch wrappers fall back to eager before reaching here.
+inline void check_convrot_group_size(int group_size) {
+    if (group_size != 16 && group_size != 64 && group_size != 256) {
+        throw std::runtime_error("convrot: group_size must be 16, 64 or 256");
+    }
+}
+
+// The kernel's static LDS: the g[256] and red[256] reductions below.
+constexpr size_t kConvrotStaticLds = 2 * 256 * sizeof(float);
+
+// convrot_quant_kernel stages the whole rotated row in dynamic LDS, so K is
+// bounded by what is left of the workgroup budget. Past it the launch does not
+// fail cleanly, so the wrappers fall back to eager instead. 0 means unknown.
+inline int convrot_max_k() {
+    int device = 0;
+    if (hipGetDevice(&device) != hipSuccess) {
+        return 0;
+    }
+    int lds = 0;
+    if (hipDeviceGetAttribute(&lds, hipDeviceAttributeMaxSharedMemoryPerBlock, device) !=
+            hipSuccess ||
+        lds <= static_cast<int>(kConvrotStaticLds)) {
+        return 0;
+    }
+    return static_cast<int>((static_cast<size_t>(lds) - kConvrotStaticLds) /
+                            sizeof(__hip_bfloat16));
+}
+
+inline void check_convrot_k(int k, int group_size) {
+    // The kernel rotates K/G whole groups but reads back all K entries of the row
+    // buffer, so a partial trailing group would quantize uninitialized LDS.
+    if (group_size <= 0 || k % group_size != 0) {
+        throw std::runtime_error("convrot: K=" + std::to_string(k) +
+                                 " is not divisible by group_size=" + std::to_string(group_size));
+    }
+    const int max_k = convrot_max_k();
+    if (max_k <= 0 || k > max_k) {
+        throw std::runtime_error("convrot: K=" + std::to_string(k) +
+                                 " does not fit in LDS (max " + std::to_string(max_k) + ")");
+    }
+}
+
+// dtype codes match comfy_kitchen.backends.eager.quantization.DTYPE_TO_CODE
+__forceinline__ __device__ float load_in(const void* x, int64_t idx, int code) {
+    if (code == 0) return static_cast<const float*>(x)[idx];
+    if (code == 1) return __half2float(static_cast<const __half*>(x)[idx]);
+    return __bfloat162float(static_cast<const __hip_bfloat16*>(x)[idx]);
+}
+
+template <bool PACK_INT4>
+__global__ __launch_bounds__(256) void convrot_quant_kernel(
+    const void* __restrict__ x, int in_dtype,
+    int8_t* __restrict__ qout, float* __restrict__ scaleout,
+    int M, int K, int G) {
+
+    const float h4[4][4] = {{1, 1, 1, -1}, {1, 1, -1, 1}, {1, -1, 1, 1}, {-1, 1, 1, 1}};
+    __shared__ float g[256];
+    __shared__ float red[256];
+    extern __shared__ __hip_bfloat16 rowbuf[];  // K entries: the rotated row
+
+    const int row = blockIdx.x;
+    const int t = threadIdx.x;
+
+    int nstages = 0;
+    while ((1 << (2 * nstages)) < G) nstages++;  // log4(G)
+
+    const int gpw = 256 / G;      // groups handled per pass
+    const int glocal = t / G;     // this thread's group within the pass
+    const int e = t % G;          // element within the group
+    const int gbase_idx = glocal * G;
+    const float norm = rsqrtf(static_cast<float>(G));
+    const int ngrp = K / G;
+
+    float lmax = 0.0f;
+    for (int gbase = 0; gbase < ngrp; gbase += gpw) {
+        const int grp = gbase + glocal;
+        const bool active = grp < ngrp;
+        g[t] = active ? load_in(x, static_cast<int64_t>(row) * K + static_cast<int64_t>(grp) * G + e,
+                                in_dtype)
+                      : 0.0f;
+        __syncthreads();
+
+        for (int stage = 0; stage < nstages; ++stage) {
+            const int stride = 1 << (2 * stage);
+            const int ds = (e / stride) & 3;
+            const int b = gbase_idx + (e - ds * stride);
+            const float v0 = g[b], v1 = g[b + stride], v2 = g[b + 2 * stride], v3 = g[b + 3 * stride];
+            const float nv = h4[ds][0] * v0 + h4[ds][1] * v1 + h4[ds][2] * v2 + h4[ds][3] * v3;
+            __syncthreads();
+            g[t] = nv;
+            __syncthreads();
+        }
+
+        if (active) {
+            const float tv = g[t] * norm;
+            const __hip_bfloat16 bv = __float2bfloat16(tv);
+            rowbuf[static_cast<int64_t>(grp) * G + e] = bv;
+            lmax = fmaxf(lmax, fabsf(__bfloat162float(bv)));
+        }
+        __syncthreads();
+    }
+
+    red[t] = lmax;
+    __syncthreads();
+    for (int s = 128; s > 0; s >>= 1) {
+        if (t < s) red[t] = fmaxf(red[t], red[t + s]);
+        __syncthreads();
+    }
+
+    constexpr float kQMax = PACK_INT4 ? 7.0f : 127.0f;
+    const float rowmax = fmaxf(red[0], 1e-10f);
+    const float scale = rowmax / kQMax;
+    const float inv = kQMax / rowmax;
+    if (t == 0) scaleout[row] = scale;
+
+    if constexpr (PACK_INT4) {
+        const int Kp = K / 2;
+        for (int jb = t; jb < Kp; jb += 256) {
+            const float a = __bfloat162float(rowbuf[2 * jb]);
+            const float b = __bfloat162float(rowbuf[2 * jb + 1]);
+            int qa = static_cast<int>(rintf(a * inv));
+            int qb = static_cast<int>(rintf(b * inv));
+            qa = qa < -7 ? -7 : (qa > 7 ? 7 : qa);
+            qb = qb < -7 ? -7 : (qb > 7 ? 7 : qb);
+            qout[static_cast<int64_t>(row) * Kp + jb] =
+                static_cast<int8_t>(((qa & 0xF) | ((qb & 0xF) << 4)) & 0xFF);
+        }
+    } else {
+        for (int j = t; j < K; j += 256) {
+            const float v = __bfloat162float(rowbuf[j]);
+            int q = static_cast<int>(rintf(v * inv));
+            q = q < -127 ? -127 : (q > 127 ? 127 : q);
+            qout[static_cast<int64_t>(row) * K + j] = static_cast<int8_t>(q);
+        }
+    }
+}
+
+}  // namespace comfy::hip_backend

--- a/comfy_kitchen/backends/hip/ops/adaln.hip
+++ b/comfy_kitchen/backends/hip/ops/adaln.hip
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Fused AdaLN: layernorm(x, no affine) * (1 + scale) + shift.
+//
+// One block per row. The row is re-read for the normalization pass rather than
+// held in registers, which does not scale to large D.
+//
+// scale/shift broadcast over inner dims, expressed as a row group: output row r
+// reads modulation row r / group (see backends/_modulation.py).
+#include <stdexcept>
+
+#include "../hadamard.h"  // load_in / dtype codes
+
+namespace comfy::hip_backend {
+
+constexpr int kAdaLNThreads = 256;
+
+template <typename T>
+__forceinline__ __device__ void store_out(T* p, int64_t i, float v);
+
+template <>
+__forceinline__ __device__ void store_out<float>(float* p, int64_t i, float v) {
+    p[i] = v;
+}
+template <>
+__forceinline__ __device__ void store_out<__half>(__half* p, int64_t i, float v) {
+    p[i] = __float2half(v);
+}
+template <>
+__forceinline__ __device__ void store_out<__hip_bfloat16>(__hip_bfloat16* p, int64_t i, float v) {
+    p[i] = __float2bfloat16(v);
+}
+
+// scale/shift need not share x's dtype (e.g. fp32 modulation against a bf16
+// activation), so each buffer carries its own dtype code.
+template <typename T>
+__global__ __launch_bounds__(kAdaLNThreads) void adaln_kernel(
+    const void* __restrict__ x, const void* __restrict__ scale,
+    const void* __restrict__ shift, T* __restrict__ out,
+    int D, int scale_group, int shift_group, float eps,
+    int code, int scale_code, int shift_code) {
+
+    __shared__ float red_sum[kAdaLNThreads];
+    __shared__ float red_sq[kAdaLNThreads];
+
+    const int row = blockIdx.x;
+    const int t = threadIdx.x;
+
+    const int64_t xbase = static_cast<int64_t>(row) * D;
+    const int64_t sbase = static_cast<int64_t>(row / scale_group) * D;
+    const int64_t hbase = static_cast<int64_t>(row / shift_group) * D;
+
+    float sum = 0.0f;
+    for (int i = t; i < D; i += kAdaLNThreads) {
+        sum += load_in(x, xbase + i, code);
+    }
+
+    red_sum[t] = sum;
+    __syncthreads();
+    for (int s = kAdaLNThreads / 2; s > 0; s >>= 1) {
+        if (t < s) red_sum[t] += red_sum[t + s];
+        __syncthreads();
+    }
+
+    const float inv_d = 1.0f / static_cast<float>(D);
+    const float mean = red_sum[0] * inv_d;
+
+    // Sum the squared deviations rather than E[x^2] - mean^2: the latter cancels
+    // catastrophically once the row's offset dwarfs its spread.
+    float sq = 0.0f;
+    for (int i = t; i < D; i += kAdaLNThreads) {
+        const float d = load_in(x, xbase + i, code) - mean;
+        sq += d * d;
+    }
+
+    red_sq[t] = sq;
+    __syncthreads();
+    for (int s = kAdaLNThreads / 2; s > 0; s >>= 1) {
+        if (t < s) red_sq[t] += red_sq[t + s];
+        __syncthreads();
+    }
+
+    const float var = red_sq[0] * inv_d;
+    const float rstd = rsqrtf(var + eps);
+
+    for (int i = t; i < D; i += kAdaLNThreads) {
+        const float v = load_in(x, xbase + i, code);
+        const float norm = (v - mean) * rstd;
+        const float s = load_in(scale, sbase + i, scale_code);
+        const float h = load_in(shift, hbase + i, shift_code);
+        store_out<T>(out, xbase + i, norm * (1.0f + s) + h);
+    }
+}
+
+}  // namespace comfy::hip_backend
+
+extern "C" void launch_adaln_kernel(
+    const void* x, const void* scale, const void* shift, void* out,
+    int N, int D, int scale_group, int shift_group, float eps,
+    int code, int scale_code, int shift_code, hipStream_t stream) {
+
+    using namespace comfy::hip_backend;
+
+    if (N == 0) {
+        return;  // a zero-block launch is hipErrorInvalidConfiguration
+    }
+
+#define CK_ADALN_LAUNCH(T)                                                                    \
+    adaln_kernel<T><<<N, kAdaLNThreads, 0, stream>>>(x, scale, shift, static_cast<T*>(out), D, \
+                                                     scale_group, shift_group, eps, code,      \
+                                                     scale_code, shift_code)
+
+    if (code == 0) {
+        CK_ADALN_LAUNCH(float);
+    } else if (code == 1) {
+        CK_ADALN_LAUNCH(__half);
+    } else if (code == 2) {
+        CK_ADALN_LAUNCH(__hip_bfloat16);
+    } else {
+        throw std::runtime_error("adaln: unsupported dtype");
+    }
+#undef CK_ADALN_LAUNCH
+}

--- a/comfy_kitchen/backends/hip/ops/apply_rope.hip
+++ b/comfy_kitchen/backends/hip/ops/apply_rope.hip
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// RoPE. x is (batch, dim1, dim2, head_dim); freqs_cis is
+// (fb, fd1, fd2, head_dim/2, 2, 2), broadcasting over any of its leading dims.
+//
+// For pair k:
+//   out[a] = f[k][0][0] * x[a] + f[k][0][1] * x[b]
+//   out[b] = f[k][1][0] * x[a] + f[k][1][1] * x[b]
+// with (a, b) = (2k, 2k+1) for the interleaved layout and (k, k + head_dim/2)
+// for the split-half layout. The rotation is evaluated in fp32 regardless of the
+// storage dtype, matching the eager reference, which upcasts to the freqs dtype.
+#include <stdexcept>
+
+#include "../hadamard.h"  // load_in / dtype codes
+
+namespace comfy::hip_backend {
+
+constexpr int kRopeThreads = 256;
+
+template <typename T>
+__forceinline__ __device__ void rope_store(T* p, int64_t i, float v);
+
+template <>
+__forceinline__ __device__ void rope_store<float>(float* p, int64_t i, float v) {
+    p[i] = v;
+}
+template <>
+__forceinline__ __device__ void rope_store<__half>(__half* p, int64_t i, float v) {
+    p[i] = __float2half(v);
+}
+template <>
+__forceinline__ __device__ void rope_store<__hip_bfloat16>(__hip_bfloat16* p, int64_t i, float v) {
+    p[i] = __float2bfloat16(v);
+}
+
+template <typename T>
+__global__ void apply_rope_kernel(
+    const void* __restrict__ xq, const void* __restrict__ xk,
+    const void* __restrict__ freqs, T* __restrict__ xq_out, T* __restrict__ xk_out,
+    int64_t batch, int64_t dim1, int64_t dim2, int64_t head_dim,
+    int64_t fb, int64_t fd1, int64_t fd2,
+    int64_t sx_b, int64_t sx_d1, int64_t sx_d2, int64_t sx_d,
+    int64_t sf_b, int64_t sf_d1, int64_t sf_d2, int64_t sf_d, int64_t sf_rot,
+    int64_t sf_pair,
+    int x_code, int f_code, bool split_half) {
+
+    const int64_t n_pairs = head_dim / 2;
+    const int64_t total = batch * dim1 * dim2 * n_pairs;
+    const int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (idx >= total) return;
+
+    const int64_t k = idx % n_pairs;
+    int64_t tmp = idx / n_pairs;
+    const int64_t d2 = tmp % dim2;
+    tmp /= dim2;
+    const int64_t d1 = tmp % dim1;
+    const int64_t b = tmp / dim1;
+
+    const int64_t xoff = b * sx_b + d1 * sx_d1 + d2 * sx_d2;
+    const int64_t ia = split_half ? k : 2 * k;
+    const int64_t ib = split_half ? k + n_pairs : 2 * k + 1;
+    const int64_t oa = xoff + ia * sx_d;
+    const int64_t ob = xoff + ib * sx_d;
+
+    const int64_t foff = (fb == 1 ? 0 : b) * sf_b + (fd1 == 1 ? 0 : d1) * sf_d1 +
+                         (fd2 == 1 ? 0 : d2) * sf_d2 + k * sf_d;
+
+    const float f00 = load_in(freqs, foff, f_code);
+    const float f01 = load_in(freqs, foff + sf_pair, f_code);
+    const float f10 = load_in(freqs, foff + sf_rot, f_code);
+    const float f11 = load_in(freqs, foff + sf_rot + sf_pair, f_code);
+
+    const float qa = load_in(xq, oa, x_code);
+    const float qb = load_in(xq, ob, x_code);
+    rope_store<T>(xq_out, oa, f00 * qa + f01 * qb);
+    rope_store<T>(xq_out, ob, f10 * qa + f11 * qb);
+
+    if (xk != nullptr) {
+        const float ka = load_in(xk, oa, x_code);
+        const float kb = load_in(xk, ob, x_code);
+        rope_store<T>(xk_out, oa, f00 * ka + f01 * kb);
+        rope_store<T>(xk_out, ob, f10 * ka + f11 * kb);
+    }
+}
+
+}  // namespace comfy::hip_backend
+
+extern "C" void launch_apply_rope_kernel(
+    const void* xq, const void* xk, const void* freqs, void* xq_out, void* xk_out,
+    int64_t batch, int64_t dim1, int64_t dim2, int64_t head_dim,
+    int64_t fb, int64_t fd1, int64_t fd2,
+    int64_t sx_b, int64_t sx_d1, int64_t sx_d2, int64_t sx_d,
+    int64_t sf_b, int64_t sf_d1, int64_t sf_d2, int64_t sf_d, int64_t sf_rot, int64_t sf_pair,
+    int x_code, int f_code, bool split_half, hipStream_t stream) {
+
+    using namespace comfy::hip_backend;
+
+    const int64_t total = batch * dim1 * dim2 * (head_dim / 2);
+    const int blocks = static_cast<int>((total + kRopeThreads - 1) / kRopeThreads);
+    if (blocks == 0) return;
+
+#define CK_ROPE_LAUNCH(T)                                                                  \
+    apply_rope_kernel<T><<<blocks, kRopeThreads, 0, stream>>>(                             \
+        xq, xk, freqs, static_cast<T*>(xq_out), static_cast<T*>(xk_out), batch, dim1, dim2, \
+        head_dim, fb, fd1, fd2, sx_b, sx_d1, sx_d2, sx_d, sf_b, sf_d1, sf_d2, sf_d, sf_rot, \
+        sf_pair, x_code, f_code, split_half)
+
+    if (x_code == 0) {
+        CK_ROPE_LAUNCH(float);
+    } else if (x_code == 1) {
+        CK_ROPE_LAUNCH(__half);
+    } else if (x_code == 2) {
+        CK_ROPE_LAUNCH(__hip_bfloat16);
+    } else {
+        throw std::runtime_error("apply_rope: unsupported input dtype");
+    }
+#undef CK_ROPE_LAUNCH
+}

--- a/comfy_kitchen/backends/hip/ops/convrot_w4a4.hip
+++ b/comfy_kitchen/backends/hip/ops/convrot_w4a4.hip
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// ConvRot W4A4 on gfx12 WMMA (v_wmma_i32_16x16x32_iu4).
+//
+// out = (Aq[M, K/2] @ Wq[N, K/2]^T) * x_scale[row] * w_scale[col] + bias
+//
+// Both operands are signed int4 packed two per byte (low nibble = even index),
+// which is the byte layout the iu4 A-fragment consumes directly. The activation
+// rotation is fused into the quantizer.
+#include <stdexcept>
+#include <string>
+
+#include "../epilogue.h"
+#include "../gemm_wmma.h"
+#include "../hadamard.h"
+
+namespace comfy::hip_backend {
+
+__global__ void unpack_int4_kernel(const int8_t* __restrict__ q, int8_t* __restrict__ out,
+                                   int64_t nbytes) {
+    const int64_t i = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (i >= nbytes) return;
+    const int8_t b = q[i];
+    // sign-extend each nibble from 4 bits
+    const int lo = static_cast<int>(b & 0xF);
+    const int hi = static_cast<int>((b >> 4) & 0xF);
+    out[2 * i] = static_cast<int8_t>(lo > 7 ? lo - 16 : lo);
+    out[2 * i + 1] = static_cast<int8_t>(hi > 7 ? hi - 16 : hi);
+}
+
+template <typename OutT>
+static void launch_w4a4(const uint8_t* A, const uint8_t* B, OutT* C, int M, int N, int K,
+                        EpiRowwise epi, hipStream_t stream) {
+    const int kbytes = K / 2;
+    if (M >= 512 && N >= 128 && K > N) {
+        constexpr int BM = 256, BN = 128, BKB = 64;
+        dim3 grid((N + BN - 1) / BN, (M + BM - 1) / BM);
+        gemm_wmma_kernel<MmaInt4, EpiRowwise, OutT, BM, BN, BKB, 4, 2, 4, 4>
+            <<<grid, 256, 0, stream>>>(A, B, C, M, N, kbytes, epi);
+    } else if (M >= 96 && N >= 96) {
+        constexpr int BM = 128, BN = 128, BKB = 64;
+        dim3 grid((N + BN - 1) / BN, (M + BM - 1) / BM);
+        gemm_wmma_kernel<MmaInt4, EpiRowwise, OutT, BM, BN, BKB, 4, 2, 2, 4>
+            <<<grid, 256, 0, stream>>>(A, B, C, M, N, kbytes, epi);
+    } else {
+        constexpr int BM = 64, BN = 64, BKB = 64;
+        dim3 grid((N + BN - 1) / BN, (M + BM - 1) / BM);
+        gemm_wmma_kernel<MmaInt4, EpiRowwise, OutT, BM, BN, BKB, 2, 2, 2, 2>
+            <<<grid, 128, 0, stream>>>(A, B, C, M, N, kbytes, epi);
+    }
+}
+
+}  // namespace comfy::hip_backend
+
+extern "C" void launch_convrot_w4a4_gemm_kernel(
+    const void* a, const void* b, void* c,
+    const void* x_scale, const void* w_scale, const void* bias, int bias_code,
+    int M, int N, int K, int out_code, hipStream_t stream) {
+
+    using namespace comfy::hip_backend;
+
+    // The tile loader reads a row 16 bytes at a time and int4 packs two per byte,
+    // so the row length K/2 has to be a whole number of 16-byte chunks.
+    if (K % 32 != 0) {
+        throw std::runtime_error("convrot_w4a4_linear: K=" + std::to_string(K) +
+                                 " must be a multiple of 32");
+    }
+    if (M == 0 || N == 0) {
+        return;  // a zero-dimension grid is hipErrorInvalidConfiguration
+    }
+
+    EpiRowwise epi{static_cast<const float*>(x_scale), static_cast<const float*>(w_scale), 1,
+                   bias, bias_code};
+
+    const uint8_t* A = static_cast<const uint8_t*>(a);
+    const uint8_t* B = static_cast<const uint8_t*>(b);
+
+    if (out_code == kBF16) {
+        launch_w4a4<__bf16>(A, B, static_cast<__bf16*>(c), M, N, K, epi, stream);
+    } else if (out_code == kF16) {
+        launch_w4a4<__half>(A, B, static_cast<__half*>(c), M, N, K, epi, stream);
+    } else if (out_code == kF32) {
+        launch_w4a4<float>(A, B, static_cast<float*>(c), M, N, K, epi, stream);
+    } else {
+        throw std::runtime_error("convrot_w4a4_linear: unsupported output dtype");
+    }
+}
+
+// Fused Hadamard rotation + rowwise int4 quantize + nibble pack. Used for both
+// the activation and the weight: both rotate along K and quantize per row.
+extern "C" void launch_convrot_quant_int4_kernel(
+    const void* x, int in_code, void* qout, void* scales,
+    int M, int K, int group_size, hipStream_t stream) {
+
+    using namespace comfy::hip_backend;
+    check_convrot_group_size(group_size);
+    check_convrot_k(K, group_size);
+    if (M == 0) {
+        return;  // a zero-block launch is hipErrorInvalidConfiguration
+    }
+    const size_t shmem = static_cast<size_t>(K) * sizeof(__hip_bfloat16);
+    convrot_quant_kernel<true><<<M, 256, shmem, stream>>>(
+        x, in_code, static_cast<int8_t*>(qout), static_cast<float*>(scales), M, K, group_size);
+}
+
+// The largest K the fused rotation can stage in LDS, for the dispatch wrappers.
+extern "C" int convrot_max_k_host() { return comfy::hip_backend::convrot_max_k(); }
+
+extern "C" void launch_unpack_int4_kernel(
+    const void* q, void* out, int64_t nbytes, hipStream_t stream) {
+
+    using namespace comfy::hip_backend;
+    if (nbytes == 0) {
+        return;  // a zero-block launch is hipErrorInvalidConfiguration
+    }
+    const int threads = 256;
+    const int blocks = static_cast<int>((nbytes + threads - 1) / threads);
+    unpack_int4_kernel<<<blocks, threads, 0, stream>>>(
+        static_cast<const int8_t*>(q), static_cast<int8_t*>(out), nbytes);
+}

--- a/comfy_kitchen/backends/hip/ops/gemm_fp8.hip
+++ b/comfy_kitchen/backends/hip/ops/gemm_fp8.hip
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// FP8 scaled GEMM on gfx12 WMMA (v_wmma_f32_16x16x16_fp8_fp8).
+// C[M, N] = (A[M, K] @ B[N, K]^T) * scale_a * scale_b + bias
+#include <stdexcept>
+#include <string>
+
+#include "../epilogue.h"
+#include "../fp8_utils.h"
+#include "../gemm_wmma.h"
+
+namespace comfy::hip_backend {
+
+// Small-M path. A 16-row WMMA tile is mostly idle at small M, so reduce K
+// across the wave instead: one wave per output column.
+template <typename OutT>
+__global__ __launch_bounds__(256) void gemv_fp8_kernel(
+    const uint8_t* __restrict__ A, const uint8_t* __restrict__ B, OutT* __restrict__ C,
+    int M, int N, int K, EpiTensorwise epi) {
+
+    const int col = blockIdx.x * blockDim.y + threadIdx.y;
+    const int row = blockIdx.y;
+    if (col >= N || row >= M) return;
+
+    const uint8_t* a = A + static_cast<int64_t>(row) * K;
+    const uint8_t* b = B + static_cast<int64_t>(col) * K;
+
+    // Bandwidth-bound on streaming B: 16 bytes per lane is a 512-byte wave
+    // transaction.
+    float sum = 0.0f;
+    for (int k = threadIdx.x * 16; k < K; k += kWave * 16) {
+        // K is a multiple of 16, so a 16-byte chunk never straddles the end.
+        const uint4 av = *reinterpret_cast<const uint4*>(a + k);
+        const uint4 bv = *reinterpret_cast<const uint4*>(b + k);
+        const uint8_t* ab = reinterpret_cast<const uint8_t*>(&av);
+        const uint8_t* bb = reinterpret_cast<const uint8_t*>(&bv);
+        #pragma unroll
+        for (int i = 0; i < 16; ++i) sum += fp8_to_float(ab[i]) * fp8_to_float(bb[i]);
+    }
+    #pragma unroll
+    for (int off = 16; off > 0; off >>= 1) sum += __shfl_xor(sum, off, kWave);
+
+    if (threadIdx.x == 0) {
+        epi.init();
+        C[static_cast<int64_t>(row) * N + col] = static_cast<OutT>(epi(row, col, sum));
+    }
+}
+
+template <typename OutT>
+static void launch_fp8(const uint8_t* A, const uint8_t* B, OutT* C, int M, int N, int K,
+                       EpiTensorwise epi, hipStream_t stream) {
+    if (M <= 8) {
+        dim3 block(kWave, 8);
+        dim3 grid((N + 7) / 8, M);
+        gemv_fp8_kernel<OutT><<<grid, block, 0, stream>>>(A, B, C, M, N, K, epi);
+        return;
+    }
+    // A 256x128 block reads (256+128)*K bytes per output tile against
+    // (128+128)*K for 128x128, i.e. 25% less global traffic per output. Selected
+    // for deep-K shapes, which are bandwidth bound; wide-N shapes have enough
+    // reuse and prefer the larger grid of the squarer tile.
+    if (M >= 512 && N >= 128 && K > N) {
+        constexpr int BM = 256, BN = 128, BKB = 64;
+        dim3 grid((N + BN - 1) / BN, (M + BM - 1) / BM);
+        gemm_wmma_kernel<MmaFp8, EpiTensorwise, OutT, BM, BN, BKB, 4, 2, 4, 4>
+            <<<grid, 256, 0, stream>>>(A, B, C, M, N, K, epi);
+    } else if (M >= 96 && N >= 96) {
+        constexpr int BM = 128, BN = 128, BKB = 64;
+        dim3 grid((N + BN - 1) / BN, (M + BM - 1) / BM);
+        gemm_wmma_kernel<MmaFp8, EpiTensorwise, OutT, BM, BN, BKB, 4, 2, 2, 4>
+            <<<grid, 256, 0, stream>>>(A, B, C, M, N, K, epi);
+    } else {
+        constexpr int BM = 64, BN = 64, BKB = 64;
+        dim3 grid((N + BN - 1) / BN, (M + BM - 1) / BM);
+        gemm_wmma_kernel<MmaFp8, EpiTensorwise, OutT, BM, BN, BKB, 2, 2, 2, 2>
+            <<<grid, 128, 0, stream>>>(A, B, C, M, N, K, epi);
+    }
+}
+
+}  // namespace comfy::hip_backend
+
+extern "C" void launch_scaled_mm_fp8_kernel(
+    const void* a, const void* b, void* c,
+    const void* scale_a, const void* scale_b, const void* bias, int bias_code,
+    int M, int N, int K, int out_code, hipStream_t stream) {
+
+    using namespace comfy::hip_backend;
+
+    // Both the tile loader and the small-M GEMV read a row 16 bytes at a time; an
+    // unaligned K would take the last chunk past the end of the row.
+    if (K % 16 != 0) {
+        throw std::runtime_error("scaled_mm_fp8: K=" + std::to_string(K) +
+                                 " must be a multiple of 16");
+    }
+    if (M == 0 || N == 0) {
+        return;  // a zero-dimension grid is hipErrorInvalidConfiguration
+    }
+
+    EpiTensorwise epi{static_cast<const float*>(scale_a), static_cast<const float*>(scale_b),
+                      bias, bias_code, 0.0f};
+
+    const uint8_t* A = static_cast<const uint8_t*>(a);
+    const uint8_t* B = static_cast<const uint8_t*>(b);
+
+    if (out_code == kBF16) {
+        launch_fp8<__bf16>(A, B, static_cast<__bf16*>(c), M, N, K, epi, stream);
+    } else if (out_code == kF16) {
+        launch_fp8<__half>(A, B, static_cast<__half*>(c), M, N, K, epi, stream);
+    } else if (out_code == kF32) {
+        launch_fp8<float>(A, B, static_cast<float*>(c), M, N, K, epi, stream);
+    } else {
+        throw std::runtime_error("scaled_mm_fp8: unsupported output dtype");
+    }
+}

--- a/comfy_kitchen/backends/hip/ops/gemm_int8.hip
+++ b/comfy_kitchen/backends/hip/ops/gemm_int8.hip
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// INT8 GEMM on gfx12 WMMA (v_wmma_i32_16x16x16_iu8).
+// C[M, N] = (A[M, K] @ B[N, K]^T) * scale_a[row] * scale_b[col] + bias
+#include <stdexcept>
+#include <string>
+
+#include "../epilogue.h"
+#include "../gemm_wmma.h"
+
+namespace comfy::hip_backend {
+
+// Small-M path: reduce K across the wave, one wave per output column.
+template <typename OutT>
+__global__ __launch_bounds__(256) void gemv_int8_kernel(
+    const int8_t* __restrict__ A, const int8_t* __restrict__ B, OutT* __restrict__ C,
+    int M, int N, int K, EpiRowwise epi) {
+
+    const int col = blockIdx.x * blockDim.y + threadIdx.y;
+    const int row = blockIdx.y;
+    if (col >= N || row >= M) return;
+
+    const int8_t* a = A + static_cast<int64_t>(row) * K;
+    const int8_t* b = B + static_cast<int64_t>(col) * K;
+
+    int sum = 0;
+    for (int k = threadIdx.x * 16; k < K; k += kWave * 16) {
+        const uint4 av = *reinterpret_cast<const uint4*>(a + k);
+        const uint4 bv = *reinterpret_cast<const uint4*>(b + k);
+        const int8_t* ab = reinterpret_cast<const int8_t*>(&av);
+        const int8_t* bb = reinterpret_cast<const int8_t*>(&bv);
+        #pragma unroll
+        for (int i = 0; i < 16; ++i) sum += ab[i] * bb[i];
+    }
+    #pragma unroll
+    for (int off = 16; off > 0; off >>= 1) sum += __shfl_xor(sum, off, kWave);
+
+    if (threadIdx.x == 0) {
+        epi.init();
+        C[static_cast<int64_t>(row) * N + col] =
+            static_cast<OutT>(epi(row, col, static_cast<float>(sum)));
+    }
+}
+
+template <typename OutT>
+static void launch_int8(const int8_t* A, const int8_t* B, OutT* C, int M, int N, int K,
+                        EpiRowwise epi, hipStream_t stream) {
+    const uint8_t* Au = reinterpret_cast<const uint8_t*>(A);
+    const uint8_t* Bu = reinterpret_cast<const uint8_t*>(B);
+
+    if (M <= 8) {
+        dim3 block(kWave, 8);
+        dim3 grid((N + 7) / 8, M);
+        gemv_int8_kernel<OutT><<<grid, block, 0, stream>>>(A, B, C, M, N, K, epi);
+        return;
+    }
+    if (M >= 512 && N >= 128 && K > N) {
+        constexpr int BM = 256, BN = 128, BKB = 64;
+        dim3 grid((N + BN - 1) / BN, (M + BM - 1) / BM);
+        gemm_wmma_kernel<MmaInt8, EpiRowwise, OutT, BM, BN, BKB, 4, 2, 4, 4>
+            <<<grid, 256, 0, stream>>>(Au, Bu, C, M, N, K, epi);
+    } else if (M >= 96 && N >= 96) {
+        constexpr int BM = 128, BN = 128, BKB = 64;
+        dim3 grid((N + BN - 1) / BN, (M + BM - 1) / BM);
+        gemm_wmma_kernel<MmaInt8, EpiRowwise, OutT, BM, BN, BKB, 4, 2, 2, 4>
+            <<<grid, 256, 0, stream>>>(Au, Bu, C, M, N, K, epi);
+    } else {
+        constexpr int BM = 64, BN = 64, BKB = 64;
+        dim3 grid((N + BN - 1) / BN, (M + BM - 1) / BM);
+        gemm_wmma_kernel<MmaInt8, EpiRowwise, OutT, BM, BN, BKB, 2, 2, 2, 2>
+            <<<grid, 128, 0, stream>>>(Au, Bu, C, M, N, K, epi);
+    }
+}
+
+}  // namespace comfy::hip_backend
+
+// scale_b_stride is 1 for a per-output-channel weight scale, 0 for a scalar one.
+extern "C" void launch_int8_gemm_kernel(
+    const void* a, const void* b, void* c,
+    const void* scale_a, const void* scale_b, int scale_b_stride,
+    const void* bias, int bias_code,
+    int M, int N, int K, int out_code, hipStream_t stream) {
+
+    using namespace comfy::hip_backend;
+
+    // Both the tile loader and the small-M GEMV read a row 16 bytes at a time; an
+    // unaligned K would take the last chunk past the end of the row.
+    if (K % 16 != 0) {
+        throw std::runtime_error("int8_gemm: K=" + std::to_string(K) +
+                                 " must be a multiple of 16");
+    }
+    if (M == 0 || N == 0) {
+        return;  // a zero-dimension grid is hipErrorInvalidConfiguration
+    }
+
+    EpiRowwise epi{static_cast<const float*>(scale_a), static_cast<const float*>(scale_b),
+                   scale_b_stride, bias, bias_code};
+
+    const int8_t* A = static_cast<const int8_t*>(a);
+    const int8_t* B = static_cast<const int8_t*>(b);
+
+    if (out_code == kBF16) {
+        launch_int8<__bf16>(A, B, static_cast<__bf16*>(c), M, N, K, epi, stream);
+    } else if (out_code == kF16) {
+        launch_int8<__half>(A, B, static_cast<__half*>(c), M, N, K, epi, stream);
+    } else if (out_code == kF32) {
+        launch_int8<float>(A, B, static_cast<float*>(c), M, N, K, epi, stream);
+    } else {
+        throw std::runtime_error("int8_gemm: unsupported output dtype");
+    }
+}

--- a/comfy_kitchen/backends/hip/ops/gemv_awq.hip
+++ b/comfy_kitchen/backends/hip/ops/gemv_awq.hip
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// AWQ W4A16 GEMV: 4-bit weight, bf16/fp16 activation, per-group asymmetric.
+//
+//   W[n, k] = (q[n, k] - 8) * wscale[k / G, n] + wzero[k / G, n]
+//   y       = x @ W^T + bias
+//
+// Small-batch shapes are bandwidth bound on streaming the weight and offer no
+// operand reuse for a WMMA tile, so one wave reduces one output column.
+#include <stdexcept>
+
+#include "../epilogue.h"
+#include "../wmma_gfx12.h"
+
+namespace comfy::hip_backend {
+
+constexpr int kAwqWavesPerBlock = 8;
+
+template <typename OutT>
+__global__ __launch_bounds__(kWave* kAwqWavesPerBlock) void gemv_awq_kernel(
+    const void* __restrict__ x, const int8_t* __restrict__ qweight,
+    const void* __restrict__ wscales, const void* __restrict__ wzeros,
+    const void* __restrict__ bias, OutT* __restrict__ out,
+    int M, int N, int K, int group_size, int x_code, int s_code, int bias_code) {
+
+    const int lane = threadIdx.x;
+    const int n = blockIdx.x * kAwqWavesPerBlock + threadIdx.y;
+    const int m = blockIdx.y;
+    if (n >= N || m >= M) return;
+
+    const int8_t* wrow = qweight + static_cast<int64_t>(n) * (K / 2);
+
+    float sum = 0.0f;
+    // 4 packed bytes = 8 weights. group_size is a multiple of 8, so a chunk
+    // never straddles a group boundary and scale/zero are looked up per chunk.
+    for (int k = lane * 8; k < K; k += kWave * 8) {
+        const int g = k / group_size;
+        const float s = load_scalar(wscales, s_code, g * N + n);
+        const float z = load_scalar(wzeros, s_code, g * N + n);
+
+        const uchar4 packed = *reinterpret_cast<const uchar4*>(wrow + k / 2);
+        const uint8_t* pb = reinterpret_cast<const uint8_t*>(&packed);
+
+        #pragma unroll
+        for (int i = 0; i < 4; ++i) {
+            const int lo = pb[i] & 0x0F;
+            const int hi = (pb[i] >> 4) & 0x0F;
+            const float x0 = load_scalar(x, x_code, static_cast<int64_t>(m) * K + k + 2 * i);
+            const float x1 = load_scalar(x, x_code, static_cast<int64_t>(m) * K + k + 2 * i + 1);
+            sum += x0 * ((lo - 8.0f) * s + z);
+            sum += x1 * ((hi - 8.0f) * s + z);
+        }
+    }
+
+    #pragma unroll
+    for (int off = 16; off > 0; off >>= 1) sum += __shfl_xor(sum, off, kWave);
+
+    if (lane == 0) {
+        if (bias != nullptr) sum += load_scalar(bias, bias_code, n);
+        out[static_cast<int64_t>(m) * N + n] = static_cast<OutT>(sum);
+    }
+}
+
+}  // namespace comfy::hip_backend
+
+extern "C" void launch_gemv_awq_kernel(
+    const void* x, const void* qweight, const void* wscales, const void* wzeros,
+    const void* bias, void* out, int M, int N, int K, int group_size,
+    int x_code, int s_code, int bias_code, int out_code, hipStream_t stream) {
+
+    using namespace comfy::hip_backend;
+
+    if (M == 0 || N == 0) {
+        return;  // a zero-dimension grid is hipErrorInvalidConfiguration
+    }
+
+    dim3 block(kWave, kAwqWavesPerBlock);
+    dim3 grid((N + kAwqWavesPerBlock - 1) / kAwqWavesPerBlock, M);
+    const int8_t* q = static_cast<const int8_t*>(qweight);
+
+#define CK_AWQ_LAUNCH(T)                                                                     \
+    gemv_awq_kernel<T><<<grid, block, 0, stream>>>(x, q, wscales, wzeros, bias,               \
+                                                   static_cast<T*>(out), M, N, K, group_size, \
+                                                   x_code, s_code, bias_code)
+
+    if (out_code == kBF16) {
+        CK_AWQ_LAUNCH(__bf16);
+    } else if (out_code == kF16) {
+        CK_AWQ_LAUNCH(__half);
+    } else if (out_code == kF32) {
+        CK_AWQ_LAUNCH(float);
+    } else {
+        throw std::runtime_error("gemv_awq_w4a16: unsupported output dtype");
+    }
+#undef CK_AWQ_LAUNCH
+}

--- a/comfy_kitchen/backends/hip/ops/per_tensor_fp8.hip
+++ b/comfy_kitchen/backends/hip/ops/per_tensor_fp8.hip
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Per-tensor FP8 quantize/dequantize. The OCP encode/decode lives in fp8_utils.h
+// so this kernel and stochastic_round_fp8 cannot drift apart.
+#include <cmath>
+#include <cstdint>
+#include <stdexcept>
+
+#include <hip/hip_bfloat16.h>
+#include <hip/hip_fp16.h>
+#include <hip/hip_runtime.h>
+
+#include "../fp8_utils.h"
+
+namespace comfy::hip_backend {
+
+constexpr int kThreads = 256;
+
+template<typename T>
+__forceinline__ __device__ void store_value(void* dst, int64_t idx, float value) {
+    reinterpret_cast<T*>(dst)[idx] = static_cast<T>(value);
+}
+
+template<>
+__forceinline__ __device__ void store_value<__half>(void* dst, int64_t idx, float value) {
+    reinterpret_cast<__half*>(dst)[idx] = __float2half(value);
+}
+
+template<>
+__forceinline__ __device__ void store_value<hip_bfloat16>(void* dst, int64_t idx, float value) {
+    reinterpret_cast<hip_bfloat16*>(dst)[idx] = hip_bfloat16(value);
+}
+
+template<typename InputType>
+__global__ void quantize_per_tensor_fp8_kernel(
+    const InputType* input,
+    const float* scale,
+    uint8_t* output,
+    int64_t numel,
+    int output_dtype_code) {
+
+    const int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (idx >= numel) {
+        return;
+    }
+    const float scaled = to_float(input[idx]) / scale[0];
+    output[idx] = pack_fp8(scaled, output_dtype_code);
+}
+
+template<typename OutputType>
+__global__ void dequantize_per_tensor_fp8_kernel(
+    const uint8_t* input,
+    const float* scale,
+    void* output,
+    int64_t numel,
+    int input_dtype_code) {
+
+    const int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (idx >= numel) {
+        return;
+    }
+    store_value<OutputType>(output, idx, unpack_fp8(input[idx], input_dtype_code) * scale[0]);
+}
+
+} // namespace comfy::hip_backend
+
+extern "C" {
+
+void launch_quantize_per_tensor_fp8_kernel(
+    const void* input,
+    const void* scale,
+    void* output,
+    int64_t numel,
+    int input_dtype_code,
+    int output_dtype_code,
+    hipStream_t stream) {
+
+    if (numel == 0) {
+        return;  // a zero-block launch is hipErrorInvalidConfiguration
+    }
+
+    const int blocks = static_cast<int>((numel + comfy::hip_backend::kThreads - 1) / comfy::hip_backend::kThreads);
+    if (input_dtype_code == 0) {
+        comfy::hip_backend::quantize_per_tensor_fp8_kernel<float><<<blocks, comfy::hip_backend::kThreads, 0, stream>>>(static_cast<const float*>(input), static_cast<const float*>(scale), static_cast<uint8_t*>(output), numel, output_dtype_code);
+    } else if (input_dtype_code == 1) {
+        comfy::hip_backend::quantize_per_tensor_fp8_kernel<__half><<<blocks, comfy::hip_backend::kThreads, 0, stream>>>(static_cast<const __half*>(input), static_cast<const float*>(scale), static_cast<uint8_t*>(output), numel, output_dtype_code);
+    } else if (input_dtype_code == 2) {
+        comfy::hip_backend::quantize_per_tensor_fp8_kernel<hip_bfloat16><<<blocks, comfy::hip_backend::kThreads, 0, stream>>>(static_cast<const hip_bfloat16*>(input), static_cast<const float*>(scale), static_cast<uint8_t*>(output), numel, output_dtype_code);
+    } else {
+        throw std::runtime_error("Unsupported input dtype for quantize_per_tensor_fp8");
+    }
+}
+
+void launch_dequantize_per_tensor_fp8_kernel(
+    const void* input,
+    const void* scale,
+    void* output,
+    int64_t numel,
+    int input_dtype_code,
+    int output_dtype_code,
+    hipStream_t stream) {
+
+    if (numel == 0) {
+        return;  // a zero-block launch is hipErrorInvalidConfiguration
+    }
+
+    const int blocks = static_cast<int>((numel + comfy::hip_backend::kThreads - 1) / comfy::hip_backend::kThreads);
+    if (output_dtype_code == 0) {
+        comfy::hip_backend::dequantize_per_tensor_fp8_kernel<float><<<blocks, comfy::hip_backend::kThreads, 0, stream>>>(static_cast<const uint8_t*>(input), static_cast<const float*>(scale), output, numel, input_dtype_code);
+    } else if (output_dtype_code == 1) {
+        comfy::hip_backend::dequantize_per_tensor_fp8_kernel<__half><<<blocks, comfy::hip_backend::kThreads, 0, stream>>>(static_cast<const uint8_t*>(input), static_cast<const float*>(scale), output, numel, input_dtype_code);
+    } else if (output_dtype_code == 2) {
+        comfy::hip_backend::dequantize_per_tensor_fp8_kernel<hip_bfloat16><<<blocks, comfy::hip_backend::kThreads, 0, stream>>>(static_cast<const uint8_t*>(input), static_cast<const float*>(scale), output, numel, input_dtype_code);
+    } else {
+        throw std::runtime_error("Unsupported output dtype for dequantize_per_tensor_fp8");
+    }
+}
+
+} // extern "C"

--- a/comfy_kitchen/backends/hip/ops/quantize_int8.hip
+++ b/comfy_kitchen/backends/hip/ops/quantize_int8.hip
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// INT8 quantization kernels for the WMMA int8 GEMM.
+#include <stdexcept>
+
+#include "../hadamard.h"
+
+namespace comfy::hip_backend {
+
+constexpr float kInt8Max = 127.0f;
+
+__forceinline__ __device__ int8_t quant_round(float v, float inv) {
+    // rintf is round-half-to-even, matching torch.round.
+    int q = static_cast<int>(rintf(v * inv));
+    q = q < -128 ? -128 : (q > 127 ? 127 : q);
+    return static_cast<int8_t>(q);
+}
+
+// One block per row: block-reduce the row absmax, then quantize the row.
+__global__ __launch_bounds__(256) void quantize_int8_rowwise_kernel(
+    const void* __restrict__ x, int in_code, int8_t* __restrict__ q,
+    float* __restrict__ scales, int M, int K) {
+
+    __shared__ float red[256];
+    const int row = blockIdx.x;
+    const int t = threadIdx.x;
+
+    float lmax = 0.0f;
+    for (int j = t; j < K; j += 256)
+        lmax = fmaxf(lmax, fabsf(load_in(x, static_cast<int64_t>(row) * K + j, in_code)));
+
+    red[t] = lmax;
+    __syncthreads();
+    for (int s = 128; s > 0; s >>= 1) {
+        if (t < s) red[t] = fmaxf(red[t], red[t + s]);
+        __syncthreads();
+    }
+
+    const float scale = fmaxf(red[0] / kInt8Max, 1e-30f);
+    if (t == 0) scales[row] = scale;
+    const float inv = 1.0f / scale;
+
+    for (int j = t; j < K; j += 256) {
+        const float v = load_in(x, static_cast<int64_t>(row) * K + j, in_code);
+        q[static_cast<int64_t>(row) * K + j] = quant_round(v, inv);
+    }
+}
+
+__global__ void absmax_kernel(const void* __restrict__ x, int in_code,
+                              unsigned int* __restrict__ out, int64_t numel) {
+    __shared__ float red[256];
+    const int t = threadIdx.x;
+
+    float lmax = 0.0f;
+    for (int64_t i = static_cast<int64_t>(blockIdx.x) * blockDim.x + t; i < numel;
+         i += static_cast<int64_t>(gridDim.x) * blockDim.x)
+        lmax = fmaxf(lmax, fabsf(load_in(x, i, in_code)));
+
+    red[t] = lmax;
+    __syncthreads();
+    for (int s = 128; s > 0; s >>= 1) {
+        if (t < s) red[t] = fmaxf(red[t], red[t + s]);
+        __syncthreads();
+    }
+    // Non-negative floats compare identically to their bit patterns as unsigned.
+    if (t == 0) atomicMax(out, __float_as_uint(red[0]));
+}
+
+__global__ void scale_from_absmax_kernel(const unsigned int* __restrict__ absmax,
+                                         float* __restrict__ scale) {
+    if (threadIdx.x == 0) *scale = fmaxf(__uint_as_float(*absmax) / kInt8Max, 1e-30f);
+}
+
+__global__ void quantize_int8_tensorwise_kernel(
+    const void* __restrict__ x, int in_code, int8_t* __restrict__ q,
+    const float* __restrict__ scale, int64_t numel) {
+
+    const int64_t i = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (i >= numel) return;
+    q[i] = quant_round(load_in(x, i, in_code), 1.0f / scale[0]);
+}
+
+}  // namespace comfy::hip_backend
+
+extern "C" void launch_quantize_int8_rowwise_kernel(
+    const void* x, int in_code, void* q, void* scales, int M, int K, hipStream_t stream) {
+
+    using namespace comfy::hip_backend;
+    if (M == 0) {
+        return;  // a zero-block launch is hipErrorInvalidConfiguration
+    }
+    quantize_int8_rowwise_kernel<<<M, 256, 0, stream>>>(
+        x, in_code, static_cast<int8_t*>(q), static_cast<float*>(scales), M, K);
+}
+
+// Fused ConvRot rotation + rowwise int8 quantize.
+extern "C" void launch_quantize_int8_convrot_kernel(
+    const void* x, int in_code, void* q, void* scales,
+    int M, int K, int group_size, hipStream_t stream) {
+
+    using namespace comfy::hip_backend;
+    check_convrot_group_size(group_size);
+    check_convrot_k(K, group_size);
+    if (M == 0) {
+        return;  // a zero-block launch is hipErrorInvalidConfiguration
+    }
+    const size_t shmem = static_cast<size_t>(K) * sizeof(__hip_bfloat16);
+    convrot_quant_kernel<false><<<M, 256, shmem, stream>>>(
+        x, in_code, static_cast<int8_t*>(q), static_cast<float*>(scales), M, K, group_size);
+}
+
+// scratch is a 4-byte device buffer, pre-zeroed by the caller.
+extern "C" void launch_quantize_int8_tensorwise_kernel(
+    const void* x, int in_code, void* q, void* scale, void* scratch,
+    int64_t numel, hipStream_t stream) {
+
+    using namespace comfy::hip_backend;
+    const int threads = 256;
+    const int blocks = static_cast<int>((numel + threads - 1) / threads);
+    const int rblocks = blocks < 1024 ? blocks : 1024;
+
+    // An empty input has no absmax and nothing to quantize, but the scale is still
+    // an output, so only the zero-block launches are skipped. scratch is zeroed,
+    // which the scale kernel clamps.
+    if (numel > 0) {
+        absmax_kernel<<<rblocks, threads, 0, stream>>>(
+            x, in_code, static_cast<unsigned int*>(scratch), numel);
+    }
+    scale_from_absmax_kernel<<<1, 1, 0, stream>>>(
+        static_cast<const unsigned int*>(scratch), static_cast<float*>(scale));
+    if (numel > 0) {
+        quantize_int8_tensorwise_kernel<<<blocks, threads, 0, stream>>>(
+            x, in_code, static_cast<int8_t*>(q), static_cast<const float*>(scale), numel);
+    }
+}

--- a/comfy_kitchen/backends/hip/ops/stochastic_round_fp8.hip
+++ b/comfy_kitchen/backends/hip/ops/stochastic_round_fp8.hip
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Stochastic-rounding FP8 quantize. The OCP encode lives in fp8_utils.h so this
+// kernel and per_tensor_fp8 cannot drift apart.
+#include <cmath>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+
+#include <hip/hip_bfloat16.h>
+#include <hip/hip_fp16.h>
+#include <hip/hip_runtime.h>
+
+#include "../fp8_utils.h"
+
+namespace comfy::hip_backend {
+
+constexpr int kMaxKernelThreads = 128;
+
+template<typename InputType>
+__global__ void stochastic_round_fp8_kernel(
+    uint8_t* rng_and_dst,
+    const InputType* src,
+    int64_t size,
+    int output_dtype_code) {
+
+    const bool e4m3 = output_dtype_code == 5;
+    const float fp8_max = e4m3 ? 448.0f : 57344.0f;
+    const int exponent_bits = e4m3 ? 4 : 5;
+    const int mantissa_bits = e4m3 ? 3 : 2;
+    const int exponent_bias = e4m3 ? 7 : 15;
+    const float mantissa_levels = static_cast<float>(1 << mantissa_bits);
+    const float subnormal_mantissa_scale = exp2f(-exponent_bias + 1 - mantissa_bits);
+    const float subnormal_value_scale = exp2f(-exponent_bias + 1);
+
+    const int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (idx >= size) {
+        return;
+    }
+
+    // Match the CUDA implementation: reduce the source value through FP16 before
+    // applying stochastic mantissa rounding.
+    const float value = __half2float(__float2half(to_float(src[idx])));
+    const float abs_value = fabsf(value);
+    const float sign = value < 0.0f ? -1.0f : (value > 0.0f ? 1.0f : 0.0f);
+
+    // log2f(0) is -inf, which -ffast-math is free to assume never happens. A NaN
+    // has to leave here too: the fp8_clamp below would drop it for a finite bound
+    // before pack_fp8 could encode it.
+    if (fp8_is_nan(value)) {
+        rng_and_dst[idx] = pack_fp8(value, output_dtype_code);
+        return;
+    }
+    if (abs_value == 0.0f) {
+        rng_and_dst[idx] = pack_fp8(0.0f, output_dtype_code);
+        return;
+    }
+
+    float exponent = floorf(log2f(abs_value)) + exponent_bias;
+    exponent = fp8_clamp(exponent, 0.0f, static_cast<float>((1 << exponent_bits) - 1));
+    const bool normal = exponent != 0.0f;
+    const float exponent_scale = exp2f(exponent - exponent_bias);
+
+    const float normal_mantissa = (abs_value / exponent_scale - 1.0f) * mantissa_levels;
+    const float subnormal_mantissa = abs_value / subnormal_mantissa_scale;
+    const float random = static_cast<float>(rng_and_dst[idx]) * (1.0f / 256.0f);
+    const float mantissa = floorf((normal ? normal_mantissa : subnormal_mantissa) + random) / mantissa_levels;
+    const float rounded = sign * (normal ? exponent_scale * (1.0f + mantissa) : subnormal_value_scale * mantissa);
+
+    rng_and_dst[idx] = pack_fp8(fp8_clamp(rounded, -fp8_max, fp8_max), output_dtype_code);
+}
+
+} // namespace comfy::hip_backend
+
+extern "C" {
+
+void launch_stochastic_round_fp8_kernel(
+    void* rng_and_output,
+    const void* input,
+    int64_t numel,
+    int rng_dtype_code,
+    int input_dtype_code,
+    int output_dtype_code,
+    hipStream_t stream) {
+
+    if (numel == 0) {
+        return;
+    }
+
+    if (rng_dtype_code != 3) {
+        throw std::runtime_error("stochastic_round_fp8 requires uint8 RNG storage");
+    }
+
+    const int blocks = static_cast<int>((numel + comfy::hip_backend::kMaxKernelThreads - 1) /
+                                        comfy::hip_backend::kMaxKernelThreads);
+
+    if (input_dtype_code == 0) {
+        comfy::hip_backend::stochastic_round_fp8_kernel<float>
+            <<<blocks, comfy::hip_backend::kMaxKernelThreads, 0, stream>>>(
+                static_cast<uint8_t*>(rng_and_output),
+                static_cast<const float*>(input),
+                numel,
+                output_dtype_code);
+    } else if (input_dtype_code == 1) {
+        comfy::hip_backend::stochastic_round_fp8_kernel<__half>
+            <<<blocks, comfy::hip_backend::kMaxKernelThreads, 0, stream>>>(
+                static_cast<uint8_t*>(rng_and_output),
+                static_cast<const __half*>(input),
+                numel,
+                output_dtype_code);
+    } else if (input_dtype_code == 2) {
+        comfy::hip_backend::stochastic_round_fp8_kernel<hip_bfloat16>
+            <<<blocks, comfy::hip_backend::kMaxKernelThreads, 0, stream>>>(
+                static_cast<uint8_t*>(rng_and_output),
+                static_cast<const hip_bfloat16*>(input),
+                numel,
+                output_dtype_code);
+    } else {
+        throw std::runtime_error("Unsupported input dtype for stochastic_round_fp8");
+    }
+
+    hipError_t err = hipGetLastError();
+    if (err != hipSuccess) {
+        throw std::runtime_error(std::string("HIP kernel launch failed: ") + hipGetErrorString(err));
+    }
+}
+
+} // extern "C"

--- a/comfy_kitchen/backends/hip/ops/svdquant_w4a4.hip
+++ b/comfy_kitchen/backends/hip/ops/svdquant_w4a4.hip
@@ -1,0 +1,302 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// SVDQuant W4A4 on gfx12 WMMA (v_wmma_i32_16x16x32_iu4).
+//
+//   out = (x/smooth quantized to int4) @ (W_int4 * wscales_group)^T
+//       + (x @ proj_down) @ proj_up^T
+//       + bias
+//
+// Both operands carry one scale per group of 64 elements along K, so the int32
+// accumulator is flushed and rescaled once per group rather than once at the end
+// of the K loop.
+//
+// The LoRA-up correction is folded into the writeback: rank R is small, so an
+// R-length dot per output is cheap relative to the K loop and avoids a second
+// pass over the output.
+#include <stdexcept>
+#include <string>
+
+#include "../epilogue.h"
+#include "../gemm_wmma.h"
+#include "../hadamard.h"  // load_in
+
+namespace comfy::hip_backend {
+
+constexpr int kSvdGroup = 64;       // quantization group, in elements
+constexpr int kSvdGroupBytes = 32;  // ... and in packed int4 bytes
+
+// x @ proj_down -> (M, R), fp32. One thread per output column: proj_down is
+// (K, R), so consecutive threads read consecutive addresses.
+__global__ __launch_bounds__(256) void lora_down_kernel(
+    const void* __restrict__ x, const void* __restrict__ lora_down,
+    float* __restrict__ lora_act, int M, int K, int R, int x_code, int d_code) {
+
+    const int m = blockIdx.x;
+    const int r = threadIdx.x;
+    if (r >= R) return;
+
+    float sum = 0.0f;
+    for (int k = 0; k < K; ++k) {
+        sum += load_in(x, static_cast<int64_t>(m) * K + k, x_code) *
+               load_in(lora_down, static_cast<int64_t>(k) * R + r, d_code);
+    }
+    lora_act[static_cast<int64_t>(m) * R + r] = sum;
+}
+
+// Smooth, then per-row per-group int4 quantize + pack. ascales is stored
+// transposed as (K/64, M_pad).
+template <bool UNSIGNED>
+__global__ __launch_bounds__(256) void svdquant_quant_kernel(
+    const void* __restrict__ x, const void* __restrict__ smooth,
+    int8_t* __restrict__ q, void* __restrict__ ascales,
+    int M, int M_pad, int K, int x_code, int s_code) {
+
+    const int m = blockIdx.x;
+    const int ngroups = K / kSvdGroup;
+
+    constexpr float kQMax = UNSIGNED ? 15.0f : 7.0f;
+    constexpr float kQMin = UNSIGNED ? 0.0f : -7.0f;
+
+    for (int g = threadIdx.x; g < ngroups; g += 256) {
+        const int64_t base = static_cast<int64_t>(m) * K + static_cast<int64_t>(g) * kSvdGroup;
+
+        float absmax = 0.0f;
+        for (int i = 0; i < kSvdGroup; ++i) {
+            const int k = g * kSvdGroup + i;
+            const float v = load_in(x, base + i, x_code) / load_in(smooth, k, s_code);
+            absmax = fmaxf(absmax, fabsf(v));
+        }
+        absmax = fmaxf(absmax, 1e-10f);
+        const float scale = absmax / kQMax;
+        const float inv = kQMax / absmax;
+
+        // (K/64, M_pad), so the group stride is M_pad.
+        store_scalar(ascales, s_code, static_cast<int64_t>(g) * M_pad + m, scale);
+
+        int8_t* qrow = q + static_cast<int64_t>(m) * (K / 2) + g * kSvdGroupBytes;
+        for (int i = 0; i < kSvdGroup; i += 2) {
+            const int k = g * kSvdGroup + i;
+            const float v0 = load_in(x, base + i, x_code) / load_in(smooth, k, s_code);
+            const float v1 = load_in(x, base + i + 1, x_code) / load_in(smooth, k + 1, s_code);
+
+            int q0 = static_cast<int>(rintf(v0 * inv));
+            int q1 = static_cast<int>(rintf(v1 * inv));
+            q0 = q0 < static_cast<int>(kQMin) ? static_cast<int>(kQMin)
+                                              : (q0 > static_cast<int>(kQMax) ? static_cast<int>(kQMax) : q0);
+            q1 = q1 < static_cast<int>(kQMin) ? static_cast<int>(kQMin)
+                                              : (q1 > static_cast<int>(kQMax) ? static_cast<int>(kQMax) : q1);
+            qrow[i / 2] = static_cast<int8_t>(((q0 & 0xF) | ((q1 & 0xF) << 4)) & 0xFF);
+        }
+    }
+}
+
+// Group-scaled int4 GEMM with the LoRA-up correction folded into the writeback.
+template <typename OutT, bool UNSIGNED>
+__global__ __launch_bounds__(256) void svdquant_gemm_kernel(
+    const uint8_t* __restrict__ A, const uint8_t* __restrict__ B, OutT* __restrict__ C,
+    const void* __restrict__ ascales, const void* __restrict__ wscales,
+    const void* __restrict__ lora_act, const void* __restrict__ lora_up,
+    const void* __restrict__ bias,
+    int M, int N, int K, int R,
+    int as_code, int ws_code, int la_code, int lu_code, int bias_code) {
+
+    constexpr int BM = 128, BN = 128, BKB = 64, TM = 2, TN = 4;
+    constexpr int kStride = BKB + kLdsPad;
+
+    __shared__ uint8_t As[BM * kStride];
+    __shared__ uint8_t Bs[BN * kStride];
+
+    const int tid = threadIdx.x;
+    const int lane = tid % kWave;
+    const int warp = tid / kWave;
+    const int wm = warp / 2;
+    const int wn = warp % 2;
+
+    const int m0 = blockIdx.y * BM;
+    const int n0 = blockIdx.x * BN;
+    const int kbytes = K / 2;
+
+    float fout[TM][TN][8] = {};
+
+    const int row = frag_row(lane);
+    const int khalf = frag_khalf(lane);
+
+    TileStager<BM, BKB, 256> sa;
+    TileStager<BN, BKB, 256> sb;
+
+    sa.load(A, m0, M, 0, kbytes);
+    sb.load(B, n0, N, 0, kbytes);
+    sa.store(As);
+    sb.store(Bs);
+    __syncthreads();
+
+    for (int kb0 = 0; kb0 < kbytes; kb0 += BKB) {
+        const int knext = kb0 + BKB;
+        const bool has_next = knext < kbytes;
+        if (has_next) {
+            sa.load(A, m0, M, knext, kbytes);
+            sb.load(B, n0, N, knext, kbytes);
+        }
+
+        // BKB bytes = 128 elements = 2 groups of 64. Each group spans 2 WMMA
+        // k-steps (one k-step is 16 bytes = 32 int4 values).
+        #pragma unroll
+        for (int grp = 0; grp < BKB / kSvdGroupBytes; ++grp) {
+            // A K that is not a multiple of the tile leaves the trailing group
+            // entirely in the zero padding; its scales do not exist.
+            if (kb0 + grp * kSvdGroupBytes >= kbytes) continue;
+
+            v8i acc[TM][TN];
+            #pragma unroll
+            for (int i = 0; i < TM; ++i)
+                #pragma unroll
+                for (int j = 0; j < TN; ++j) acc[i][j] = v8i{0, 0, 0, 0, 0, 0, 0, 0};
+
+            #pragma unroll
+            for (int s = 0; s < 2; ++s) {
+                const int kbyte = grp * kSvdGroupBytes + s * 16 + 8 * khalf;
+
+                v2i af[TM];
+                #pragma unroll
+                for (int i = 0; i < TM; ++i)
+                    af[i] = load_frag_b64(As, wm * (TM * 16) + i * 16 + row, kbyte, kStride);
+
+                v2i bf[TN];
+                #pragma unroll
+                for (int j = 0; j < TN; ++j)
+                    bf[j] = load_frag_b64(Bs, wn * (TN * 16) + j * 16 + row, kbyte, kStride);
+
+                #pragma unroll
+                for (int i = 0; i < TM; ++i)
+                    #pragma unroll
+                    for (int j = 0; j < TN; ++j) {
+                        acc[i][j] = UNSIGNED ? wmma_iu4_ua(af[i], bf[j], acc[i][j])
+                                             : wmma_iu4(af[i], bf[j], acc[i][j]);
+                    }
+            }
+
+            // Flush the group: rescale the int32 accumulator into fp32.
+            const int g = kb0 / kSvdGroupBytes + grp;
+            #pragma unroll
+            for (int j = 0; j < TN; ++j) {
+                const int col = n0 + wn * (TN * 16) + j * 16 + acc_col(lane);
+                if (col >= N) continue;
+                const float ws = load_in(wscales, static_cast<int64_t>(g) * N + col, ws_code);
+                #pragma unroll
+                for (int i = 0; i < TM; ++i) {
+                    #pragma unroll
+                    for (int e = 0; e < 8; ++e) {
+                        const int r = m0 + wm * (TM * 16) + i * 16 + acc_row(lane, e);
+                        if (r >= M) continue;
+                        const float as =
+                            load_in(ascales, static_cast<int64_t>(g) * M + r, as_code);
+                        fout[i][j][e] += static_cast<float>(acc[i][j][e]) * as * ws;
+                    }
+                }
+            }
+        }
+
+        if (has_next) {
+            __syncthreads();
+            sa.store(As);
+            sb.store(Bs);
+            __syncthreads();
+        }
+    }
+
+    #pragma unroll
+    for (int j = 0; j < TN; ++j) {
+        const int col = n0 + wn * (TN * 16) + j * 16 + acc_col(lane);
+        if (col >= N) continue;
+        #pragma unroll
+        for (int i = 0; i < TM; ++i) {
+            #pragma unroll
+            for (int e = 0; e < 8; ++e) {
+                const int r = m0 + wm * (TM * 16) + i * 16 + acc_row(lane, e);
+                if (r >= M) continue;
+
+                float v = fout[i][j][e];
+                for (int t = 0; t < R; ++t) {
+                    v += load_in(lora_act, static_cast<int64_t>(r) * R + t, la_code) *
+                         load_in(lora_up, static_cast<int64_t>(col) * R + t, lu_code);
+                }
+                if (bias != nullptr) v += load_scalar(bias, bias_code, col);
+                C[static_cast<int64_t>(r) * N + col] = static_cast<OutT>(v);
+            }
+        }
+    }
+}
+
+}  // namespace comfy::hip_backend
+
+extern "C" void launch_svdquant_lora_down_kernel(
+    const void* x, const void* lora_down, void* lora_act, int M, int K, int R, int x_code,
+    int d_code, hipStream_t stream) {
+
+    using namespace comfy::hip_backend;
+    if (R > 256) throw std::runtime_error("svdquant: LoRA rank above 256 is not supported");
+    if (M == 0) {
+        return;  // a zero-block launch is hipErrorInvalidConfiguration
+    }
+    lora_down_kernel<<<M, 256, 0, stream>>>(x, lora_down, static_cast<float*>(lora_act), M, K, R,
+                                            x_code, d_code);
+}
+
+extern "C" void launch_svdquant_quant_kernel(
+    const void* x, const void* smooth, void* q, void* ascales, int M, int M_pad, int K,
+    int x_code, int s_code, bool act_unsigned, hipStream_t stream) {
+
+    using namespace comfy::hip_backend;
+    if (M == 0) {
+        return;  // a zero-block launch is hipErrorInvalidConfiguration
+    }
+    if (act_unsigned) {
+        svdquant_quant_kernel<true><<<M, 256, 0, stream>>>(
+            x, smooth, static_cast<int8_t*>(q), ascales, M, M_pad, K, x_code, s_code);
+    } else {
+        svdquant_quant_kernel<false><<<M, 256, 0, stream>>>(
+            x, smooth, static_cast<int8_t*>(q), ascales, M, M_pad, K, x_code, s_code);
+    }
+}
+
+extern "C" void launch_svdquant_gemm_kernel(
+    const void* a, const void* b, void* c, const void* ascales, const void* wscales,
+    const void* lora_act, const void* lora_up, const void* bias,
+    int M, int N, int K, int R,
+    int as_code, int ws_code, int la_code, int lu_code, int bias_code, int out_code,
+    bool act_unsigned, hipStream_t stream) {
+
+    using namespace comfy::hip_backend;
+
+    // One scale per 64-element group, and the tile loader reads the packed row
+    // (K/2 bytes) in 16-byte chunks: K must be a whole number of groups.
+    if (K % kSvdGroup != 0) {
+        throw std::runtime_error("scaled_mm_svdquant_w4a4: K=" + std::to_string(K) +
+                                 " must be a multiple of 64");
+    }
+    if (M == 0 || N == 0) {
+        return;  // a zero-dimension grid is hipErrorInvalidConfiguration
+    }
+
+    dim3 grid((N + 127) / 128, (M + 127) / 128);
+    const uint8_t* A = static_cast<const uint8_t*>(a);
+    const uint8_t* B = static_cast<const uint8_t*>(b);
+
+#define CK_SVD_LAUNCH(T, U)                                                                    \
+    svdquant_gemm_kernel<T, U><<<grid, 256, 0, stream>>>(A, B, static_cast<T*>(c), ascales,     \
+                                                         wscales, lora_act, lora_up, bias, M, N, \
+                                                         K, R, as_code, ws_code, la_code,        \
+                                                         lu_code, bias_code)
+
+    if (out_code == kBF16) {
+        if (act_unsigned) { CK_SVD_LAUNCH(__bf16, true); } else { CK_SVD_LAUNCH(__bf16, false); }
+    } else if (out_code == kF16) {
+        if (act_unsigned) { CK_SVD_LAUNCH(__half, true); } else { CK_SVD_LAUNCH(__half, false); }
+    } else if (out_code == kF32) {
+        if (act_unsigned) { CK_SVD_LAUNCH(float, true); } else { CK_SVD_LAUNCH(float, false); }
+    } else {
+        throw std::runtime_error("scaled_mm_svdquant_w4a4: unsupported output dtype");
+    }
+#undef CK_SVD_LAUNCH
+}

--- a/comfy_kitchen/backends/hip/wmma_gfx12.h
+++ b/comfy_kitchen/backends/hip/wmma_gfx12.h
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// WMMA intrinsics and fragment addressing for RDNA4 (gfx12), wave32.
+//
+// Fragment layout for the w32 gfx12 WMMA instructions:
+//   A (M x K, row-major): lane l, element e -> A[l % 16][kbase + e]
+//   B (N x K, row-major): lane l, element e -> B[l % 16][kbase + e]
+//   D (M x N):            lane l, element e -> D[e + 8 * (l / 16)][l % 16]
+// with kbase = (K_STEP / 2) * (l / 16).
+//
+// K_STEP is 16 for fp8/iu8/bf16 (8 elements per lane) and 32 for iu4 (16
+// nibbles per lane). fp8, iu8 and iu4 all hold 8 bytes per lane, so their
+// operand fragments are a v2i regardless of element type, which is what lets one
+// byte-addressed tile kernel serve all three. bf16 is the exception: 8 elements
+// of 2 bytes is a 16-byte v8bf fragment, and only wmma_bf16 below consumes it.
+#pragma once
+
+#include <hip/hip_runtime.h>
+
+namespace comfy::hip_backend {
+
+typedef int v2i __attribute__((ext_vector_type(2)));
+typedef int v8i __attribute__((ext_vector_type(8)));
+typedef float v8f __attribute__((ext_vector_type(8)));
+typedef __bf16 v8bf __attribute__((ext_vector_type(8)));
+
+constexpr int kWave = 32;
+
+// Operand bytes for one lane of a 16x16xK tile whose rows are `stride` bytes
+// apart in LDS. `row` is the lane's row (A) or column (B); `kbyte` is the byte
+// offset of the K-step within the row.
+__forceinline__ __device__ v2i load_frag_b64(const void* lds, int row, int kbyte, int stride) {
+    const char* p = static_cast<const char*>(lds) + row * stride + kbyte;
+    return *reinterpret_cast<const v2i*>(p);
+}
+
+__forceinline__ __device__ int frag_row(int lane) { return lane % 16; }
+__forceinline__ __device__ int frag_khalf(int lane) { return lane / 16; }
+
+// Row of accumulator element `e` for this lane; the column is lane % 16.
+__forceinline__ __device__ int acc_row(int lane, int e) { return e + 8 * (lane / 16); }
+__forceinline__ __device__ int acc_col(int lane) { return lane % 16; }
+
+__forceinline__ __device__ v8f wmma_fp8(v2i a, v2i b, v8f acc) {
+    return __builtin_amdgcn_wmma_f32_16x16x16_fp8_fp8_w32_gfx12(a, b, acc);
+}
+
+__forceinline__ __device__ v8f wmma_bf8(v2i a, v2i b, v8f acc) {
+    return __builtin_amdgcn_wmma_f32_16x16x16_bf8_bf8_w32_gfx12(a, b, acc);
+}
+
+__forceinline__ __device__ v8i wmma_iu8(v2i a, v2i b, v8i acc) {
+    return __builtin_amdgcn_wmma_i32_16x16x16_iu8_w32_gfx12(true, a, true, b, acc, false);
+}
+
+// Operand signedness is an immediate operand of the instruction, so an unsigned
+// A operand requires a separate entry point rather than a runtime flag.
+__forceinline__ __device__ v8i wmma_iu8_ua(v2i a, v2i b, v8i acc) {
+    return __builtin_amdgcn_wmma_i32_16x16x16_iu8_w32_gfx12(false, a, true, b, acc, false);
+}
+
+__forceinline__ __device__ v8i wmma_iu4(v2i a, v2i b, v8i acc) {
+    return __builtin_amdgcn_wmma_i32_16x16x32_iu4_w32_gfx12(true, a, true, b, acc, false);
+}
+
+__forceinline__ __device__ v8i wmma_iu4_ua(v2i a, v2i b, v8i acc) {
+    return __builtin_amdgcn_wmma_i32_16x16x32_iu4_w32_gfx12(false, a, true, b, acc, false);
+}
+
+__forceinline__ __device__ v8f wmma_bf16(v8bf a, v8bf b, v8f acc) {
+    return __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(a, b, acc);
+}
+
+}  // namespace comfy::hip_backend

--- a/comfy_kitchen/scaled_mm_v2.py
+++ b/comfy_kitchen/scaled_mm_v2.py
@@ -24,6 +24,76 @@ else:
 def has_scaled_mm_v2() -> bool:
     return _HAS_SCALED_MM_V2
 
+
+_FP8_E4M3 = torch.float8_e4m3fn
+
+
+def _hip_fp8_gemm(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    scale_a: torch.Tensor,
+    scale_b: torch.Tensor,
+    bias: torch.Tensor | None,
+    out_dtype: torch.dtype | None,
+    scale_recipe_a,
+    scale_recipe_b,
+    swizzle_a,
+    swizzle_b,
+):
+    """Route an fp8 matmul to the gfx12 WMMA kernel.
+
+    Returns None when the HIP backend is unavailable or the call is outside the
+    kernel's domain (non-e4m3 operands, non-tensor-wise scaling, swizzled
+    operands, K not a multiple of 16, unsupported output dtype), in which case
+    the caller falls back to torch.
+    """
+    from .registry import registry
+
+    if not registry.is_available("hip"):
+        return None
+    # Availability is process-wide, but the kernel launches on one device and takes
+    # raw pointers: every operand has to live on the input's own GPU.
+    if input.device.type != "cuda":
+        return None
+    others = [weight, scale_a, scale_b] + ([] if bias is None else [bias])
+    if any(not torch.is_tensor(t) or t.device != input.device for t in others):
+        return None
+    # The kernel reads both operands row-major.
+    if any(s not in (None, SwizzleType.NO_SWIZZLE) for s in (swizzle_a, swizzle_b)):
+        return None
+    if input.dtype is not _FP8_E4M3 or weight.dtype is not _FP8_E4M3:
+        return None
+    if input.dim() != 2 or weight.dim() != 2:
+        return None
+    if scale_recipe_a != ScalingType.TensorWise or scale_recipe_b != ScalingType.TensorWise:
+        return None
+    if isinstance(scale_a, list) or isinstance(scale_b, list):
+        return None
+    if scale_a.numel() != 1 or scale_b.numel() != 1:
+        return None
+    # The WMMA K-step reads 16 bytes of a row at a time.
+    if input.shape[1] % 16 != 0:
+        return None
+    if out_dtype is not None and out_dtype not in (
+        torch.bfloat16, torch.float16, torch.float32
+    ):
+        return None
+    # The epilogue indexes bias[col] with a single dtype code.
+    if bias is not None and (
+        bias.dim() != 1
+        or bias.numel() != weight.shape[1]
+        or bias.dtype not in (torch.bfloat16, torch.float16, torch.float32)
+    ):
+        return None
+
+    from .backends import hip
+
+    return hip.scaled_mm_fp8(
+        input, weight, scale_a, scale_b, bias,
+        out_dtype if out_dtype is not None else torch.bfloat16,
+    )
+
+
 def scaled_mm_v2(
     input: torch.Tensor,
     weight: torch.Tensor,
@@ -36,6 +106,13 @@ def scaled_mm_v2(
     swizzle_a: Optional['SwizzleType'] = SwizzleType.NO_SWIZZLE,
     swizzle_b: Optional['SwizzleType'] = SwizzleType.NO_SWIZZLE,
 ) -> torch.Tensor:
+
+    out = _hip_fp8_gemm(
+        input, weight, scale_a, scale_b, bias, out_dtype, scale_recipe_a, scale_recipe_b,
+        swizzle_a, swizzle_b,
+    )
+    if out is not None:
+        return out
 
     if has_scaled_mm_v2():
         return torch.nn.functional.scaled_mm(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,12 @@ requires = [
     "setuptools>=61.0",
     "wheel",
     "nanobind>=2.0.0",
+    # setup.py drives both extensions through CMake. 3.21 is the HIP language's
+    # floor: CMAKE_HIP_ARCHITECTURES does not exist before it.
+    "cmake>=3.21",
+    # The HIP extension pins the Ninja generator on every platform: CMake's default
+    # generator on Windows is Visual Studio, which cannot build the HIP language.
+    "ninja",
     "tomli; python_version < '3.11'",
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -28,11 +28,33 @@ if "--no-cuda" in sys.argv:
     print("CUDA backend excluded - only eager, triton backends")
     print("=" * 80 + "\n")
 
+# The HIP backend is built whenever a ROCm compiler is present. --hip turns a
+# missing compiler into an error rather than a skip; --no-hip suppresses it.
+BUILD_HIP = os.getenv("COMFY_KITCHEN_BUILD_HIP") == "1"
+if "--hip" in sys.argv:
+    BUILD_HIP = True
+    sys.argv.remove("--hip")
+
+BUILD_NO_HIP = os.getenv("COMFY_KITCHEN_BUILD_NO_HIP") == "1"
+if "--no-hip" in sys.argv:
+    BUILD_NO_HIP = True
+    sys.argv.remove("--no-hip")
+
+# build_ext parses --hip-archs itself, but the extension list is built before its
+# options are finalized, so the value has to be read here too. Left in argv for it.
+HIP_ARCHS_CLI = ""
+for _arg in sys.argv:
+    if _arg.startswith("--hip-archs="):
+        HIP_ARCHS_CLI = _arg.split("=", 1)[1]
+
 
 class CMakeExtension(Extension):
-    def __init__(self, name: str, source_dir: str = ""):
+    def __init__(self, name: str, source_dir: str = "", backend: str = "cuda",
+                 hip_archs: str = ""):
         super().__init__(name, sources=[])
         self.source_dir = os.path.abspath(source_dir) if source_dir else ""
+        self.backend = backend
+        self.hip_archs = hip_archs
 
 
 class CMakeBuildExt(build_ext):
@@ -40,6 +62,7 @@ class CMakeBuildExt(build_ext):
     user_options: ClassVar = [
         *build_ext.user_options,
         ('cuda-archs=', None, 'CUDA architectures to build for (semicolon-separated, e.g., "80;89;90a")'),
+        ('hip-archs=', None, 'HIP architectures to build for (semicolon-separated, e.g., "gfx1200;gfx1201")'),
         ('debug-build', None, 'Build in debug mode with debug symbols'),
         ('lineinfo', None, 'Enable NVCC line information for profiling (adds -lineinfo flag)'),
     ]
@@ -52,6 +75,7 @@ class CMakeBuildExt(build_ext):
         super().initialize_options()
         # Set defaults - can be overridden by command-line arguments
         self.cuda_archs = None  # Will use platform-specific default in finalize_options
+        self.hip_archs = None  # None lets the HIP CMakeLists pick its gfx12 default
         self.debug_build = False  # Default: Release build
         self.lineinfo = False  # Default: disabled
 
@@ -107,23 +131,53 @@ class CMakeBuildExt(build_ext):
             f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={ext_dir}",
             f"-DCMAKE_BUILD_TYPE={config}",
             f"-DPython_EXECUTABLE={sys.executable}",
-            f"-DCOMFY_CUDA_ARCHS={cuda_archs}",
             f"-DCOMFY_ENABLE_LINEINFO={'ON' if enable_lineinfo else 'OFF'}",
         ]
 
-        cuda_home, nvcc_bin = get_cuda_path()
-        cmake_args.append(f"-DCUDAToolkit_ROOT={cuda_home}")
-        cmake_args.append(f"-DCMAKE_CUDA_COMPILER={nvcc_bin}")
+        if ext.backend == "hip":
+            # CMake's default generator on Windows is Visual Studio, which does
+            # not support the HIP language.
+            cmake_args.extend(["-G", "Ninja"])
+
+            rocm_home, hip_compiler = get_rocm_path()
+            cmake_args.append(f"-DCMAKE_HIP_COMPILER={hip_compiler.as_posix()}")
+
+            # CMake refuses to mix a GNU-like clang with a CL-compatible C/C++
+            # compiler, and would otherwise pick MSVC for C/C++ while using clang
+            # for HIP. Pin all three languages to the ROCm driver. The C driver
+            # drops the ++ (clang++ -> clang, amdclang++ -> amdclang); hipcc
+            # compiles both.
+            c_name = hip_compiler.stem.removesuffix("++")
+            c_compiler = hip_compiler.with_name(c_name + hip_compiler.suffix)
+            if c_compiler.is_file():
+                cmake_args.append(f"-DCMAKE_C_COMPILER={c_compiler.as_posix()}")
+            cmake_args.append(f"-DCMAKE_CXX_COMPILER={hip_compiler.as_posix()}")
+
+            if rocm_home:
+                rocm_posix = pathlib.Path(rocm_home).as_posix()
+                cmake_args.append(f"-DCMAKE_PREFIX_PATH={rocm_posix}")
+                cmake_args.append(f"-DCMAKE_HIP_COMPILER_ROCM_ROOT={rocm_posix}")
+
+            # --hip-archs beats the environment, which beats what setup_hip_extension
+            # resolved from the visible devices.
+            hip_archs = self.hip_archs or ext.hip_archs
+            if hip_archs:
+                cmake_args.append(f"-DCOMFY_HIP_ARCHS={hip_archs}")
+        else:
+            cmake_args.append(f"-DCOMFY_CUDA_ARCHS={cuda_archs}")
+            cuda_home, nvcc_bin = get_cuda_path()
+            cmake_args.append(f"-DCUDAToolkit_ROOT={cuda_home}")
+            cmake_args.append(f"-DCMAKE_CUDA_COMPILER={nvcc_bin}")
 
         build_args = ["--config", config]
 
         max_jobs = os.cpu_count() or 1
-        # Use appropriate parallel build syntax for the platform
-        if os.name == "nt":
+        # Use appropriate parallel build syntax for the generator
+        if os.name == "nt" and ext.backend != "hip":
             # Windows MSBuild uses /m:N for parallel builds
             build_args.extend(["--", f"/m:{max_jobs}"])
         else:
-            # Unix make uses -jN for parallel builds
+            # Ninja and Unix make both take -jN
             build_args.extend(["--", f"-j{max_jobs}"])
 
         # Run CMake configure
@@ -184,8 +238,188 @@ def get_cuda_path():
 
     return cuda_home, nvcc_bin
 
+DEFAULT_HIP_ARCHS = "gfx1200;gfx1201"
+
+
+def normalize_archs(value: str) -> list[str]:
+    """Split an arch list on , or ; and drop the :xnack+/-like feature suffixes."""
+    archs = []
+    for part in value.replace(";", ",").split(","):
+        arch = part.strip().split(":", 1)[0]
+        if arch and arch not in archs:
+            archs.append(arch)
+    return archs
+
+
+def get_hip_archs_override() -> list[str]:
+    if HIP_ARCHS_CLI:
+        return normalize_archs(HIP_ARCHS_CLI)
+    # PYTORCH_ROCM_ARCH and GPU_ARCHS are the conventional ROCm spellings.
+    for var in ("COMFY_HIP_ARCHS", "PYTORCH_ROCM_ARCH", "GPU_ARCHS"):
+        value = os.getenv(var)
+        if value:
+            return normalize_archs(value)
+    return []
+
+
+def detect_hip_archs() -> list[str]:
+    """gfx names of the visible AMD devices, empty when none can be enumerated."""
+    try:
+        import torch
+
+        if torch.version.hip is None or not torch.cuda.is_available():
+            return []
+        names = [
+            torch.cuda.get_device_properties(i).gcnArchName
+            for i in range(torch.cuda.device_count())
+        ]
+    except Exception:
+        return []
+    return normalize_archs(";".join(n for n in names if n))
+
+
+def rocm_sdk_root() -> str | None:
+    """Ask the pip rocm-sdk wheel for its root, if it is installed."""
+    try:
+        root = subprocess.run(
+            [sys.executable, "-m", "rocm_sdk", "path", "--root"],
+            capture_output=True,
+            check=True,
+            text=True,
+        ).stdout.strip()
+    except (subprocess.CalledProcessError, OSError):
+        return None
+    return root if root and pathlib.Path(root).exists() else None
+
+
+def get_rocm_path() -> tuple[str | None, pathlib.Path | None]:
+    """Locate a ROCm root and its clang driver.
+
+    Handles the pip ``rocm-sdk`` layout (site-packages/_rocm_sdk_devel) as well
+    as a system ROCm install.
+    """
+    rocm_home = os.getenv("ROCM_HOME") or os.getenv("ROCM_PATH") or os.getenv("HIP_PATH")
+
+    if rocm_home is None:
+        rocm_home = rocm_sdk_root()
+
+    if rocm_home is None:
+        sdk = pathlib.Path(sys.prefix) / "Lib" / "site-packages" / "_rocm_sdk_devel"
+        if not sdk.exists():
+            sdk = (
+                pathlib.Path(sys.prefix)
+                / "lib"
+                / f"python{sys.version_info.major}.{sys.version_info.minor}"
+                / "site-packages"
+                / "_rocm_sdk_devel"
+            )
+        if sdk.exists():
+            rocm_home = str(sdk)
+
+    if rocm_home is None and pathlib.Path("/opt/rocm").exists():
+        rocm_home = "/opt/rocm"
+
+    compiler = None
+    if rocm_home:
+        root = pathlib.Path(rocm_home)
+        for candidate in (
+            root / "lib" / "llvm" / "bin" / "clang++",
+            root / "lib" / "llvm" / "bin" / "clang++.exe",
+            root / "bin" / "amdclang++",
+            root / "bin" / "hipcc",
+        ):
+            if candidate.is_file():
+                compiler = candidate
+                break
+
+    if compiler is None:
+        for name in ("amdclang++", "hipcc"):
+            found = shutil.which(name)
+            if found:
+                compiler = pathlib.Path(found)
+                if rocm_home is None:
+                    rocm_home = str(compiler.parent.parent)
+                break
+
+    return rocm_home, compiler
+
+
+def setup_hip_extension() -> CMakeExtension | None:
+    print("=" * 80)
+    print("Checking for HIP/ROCm availability...")
+    print("=" * 80)
+
+    if BUILD_NO_HIP:
+        print("HIP extension disabled by --no-hip flag")
+        return None
+
+    rocm_home, hip_compiler = get_rocm_path()
+    if hip_compiler is None:
+        if BUILD_HIP:
+            raise RuntimeError(
+                "ERROR: --hip requested but no ROCm compiler was found "
+                "(looked for clang++/amdclang++/hipcc). Install ROCm or the rocm-sdk wheel."
+            )
+        print("No ROCm compiler detected; skipping HIP backend")
+        return None
+
+    print(f"Found ROCm root: {rocm_home or 'auto'}")
+    print(f"Found HIP compiler: {hip_compiler}")
+
+    # The kernels use gfx12-only WMMA intrinsics, so an arch list that names any
+    # other target does not compile. An explicit override is taken as given; a
+    # detected non-gfx12 GPU means there is nothing worth building here.
+    archs = get_hip_archs_override()
+    if archs:
+        # An override skips the device gate below, so it is the only other place a
+        # non-gfx12 target can get through to the gfx12-only sources.
+        unsupported = [arch for arch in archs if not arch.startswith("gfx12")]
+        if unsupported:
+            raise RuntimeError(
+                f"ERROR: the HIP backend's WMMA kernels are gfx12-only (RDNA4); "
+                f"cannot build for {';'.join(unsupported)}"
+            )
+        print(f"HIP architectures from the override: {';'.join(archs)}")
+    else:
+        detected = detect_hip_archs()
+        if detected:
+            archs = [arch for arch in detected if arch.startswith("gfx12")]
+            if not archs:
+                message = (
+                    f"Visible AMD GPUs ({';'.join(detected)}) are not gfx12/RDNA4; "
+                    "the WMMA kernels would not run on them."
+                )
+                if BUILD_HIP:
+                    raise RuntimeError(f"ERROR: --hip requested but {message}")
+                print(f"{message} Skipping the HIP backend.")
+                print("Set COMFY_HIP_ARCHS to build for a target anyway.")
+                return None
+            print(f"Detected gfx12 devices: {';'.join(archs)}")
+        else:
+            archs = normalize_archs(DEFAULT_HIP_ARCHS)
+            print(f"No AMD GPU visible; building for the default {';'.join(archs)}")
+
+    root_dir = pathlib.Path(__file__).resolve().parent
+    hip_backend_dir = root_dir / "comfy_kitchen" / "backends" / "hip"
+    if not hip_backend_dir.exists():
+        raise RuntimeError(f"HIP backend directory not found: {hip_backend_dir}")
+
+    print("Building HIP extension with CMake + nanobind: comfy_kitchen.backends.hip._C")
+    return CMakeExtension(
+        name="comfy_kitchen.backends.hip._C",
+        source_dir=str(hip_backend_dir),
+        backend="hip",
+        hip_archs=";".join(archs),
+    )
+
+
 def get_cuda_version() -> tuple[int, ...] | None:
-    _cuda_home, nvcc_bin = get_cuda_path()
+    # get_cuda_path() returns None rather than a pair when nvcc is absent.
+    cuda_path = get_cuda_path()
+    if cuda_path is None:
+        return None
+
+    _cuda_home, nvcc_bin = cuda_path
     try:
         output = subprocess.run(
             [nvcc_bin, "-V"],
@@ -193,7 +427,7 @@ def get_cuda_version() -> tuple[int, ...] | None:
             check=True,
             text=True,
         )
-    except subprocess.CalledProcessError:
+    except (subprocess.CalledProcessError, OSError):
         return None
 
     match = re.search(r"release\s*([\d.]+)", output.stdout)
@@ -259,26 +493,34 @@ def setup_cuda_extension() -> CMakeExtension | None:
 def get_extensions() -> list[setuptools.Extension]:
     extensions = []
 
-    if BUILD_NO_CUDA:
-        print("\n" + "=" * 80)
-        print("Building CPU-only variant (COMFY_KITCHEN_BUILD_NO_CUDA=1)")
-        print("CUDA backend excluded - only eager, triton backends")
-        print("=" * 80 + "\n")
-        return extensions
+    if not BUILD_NO_CUDA:
+        try:
+            cuda_ext = setup_cuda_extension()
+            if cuda_ext is not None:
+                extensions.append(cuda_ext)
+        except RuntimeError as e:
+            # A machine without nvcc is only fatal when there is no ROCm
+            # toolchain to fall back on.
+            _rocm_home, hip_compiler = get_rocm_path()
+            if hip_compiler is None or BUILD_NO_HIP:
+                raise
+            print(f"\nCUDA toolkit not usable ({e})")
+            print("A ROCm toolchain was found, so building the HIP backend instead.\n")
 
-    cuda_ext = setup_cuda_extension()
-    if cuda_ext is not None:
-        extensions.append(cuda_ext)
-    else:
+    hip_ext = setup_hip_extension()
+    if hip_ext is not None:
+        extensions.append(hip_ext)
+
+    if not extensions:
         print("\n" + "=" * 80)
-        print("Installing comfy_kitchen without CUDA backend")
+        print("Installing comfy_kitchen without a native backend")
         print("Available backends: eager, triton (if installed)")
         print("=" * 80 + "\n")
 
     return extensions
 
 
-def get_cmdclass(has_extensions):
+def get_cmdclass(has_extensions, has_hip_extension=False):
     cmdclass = {}
 
     if has_extensions:
@@ -292,7 +534,9 @@ def get_cmdclass(has_extensions):
                 super().finalize_options()
                 # Set stable ABI tag only for Python 3.12+ (nanobind requirement)
                 # For 3.10/3.11, leave as version-specific (cpXXX-cpXXX)
-                if not BUILD_NO_CUDA and sys.version_info >= (3, 12):
+                # The HIP extension is not built against the stable ABI, so a
+                # wheel containing it must stay version-specific.
+                if not BUILD_NO_CUDA and not has_hip_extension and sys.version_info >= (3, 12):
                     self.py_limited_api = "cp312"
 
         cmdclass["bdist_wheel"] = CUDABdistWheel
@@ -323,9 +567,16 @@ def get_packages():
 
 extensions = get_extensions()
 
+has_hip_extension = any(
+    isinstance(ext, CMakeExtension) and ext.backend == "hip" for ext in extensions
+)
+
 setup_kwargs = {
     "ext_modules": extensions,
-    "cmdclass": get_cmdclass(has_extensions=bool(extensions)),
+    "cmdclass": get_cmdclass(
+        has_extensions=bool(extensions),
+        has_hip_extension=has_hip_extension,
+    ),
 }
 
 if BUILD_NO_CUDA:

--- a/tests/test_hip_wmma.py
+++ b/tests/test_hip_wmma.py
@@ -1,0 +1,827 @@
+"""Correctness tests for the HIP (gfx12 WMMA) backend.
+
+Skipped unless the backend registered, which requires an RDNA4 device and the
+compiled extension.
+"""
+import pytest
+import torch
+
+import comfy_kitchen as ck
+from comfy_kitchen.registry import registry
+
+pytestmark = pytest.mark.skipif(
+    not registry.is_available("hip"), reason="HIP backend (gfx12) not available"
+)
+
+DEV = "cuda"
+
+
+@pytest.fixture
+def hip():
+    from comfy_kitchen.backends import hip as hip_backend
+
+    return hip_backend
+
+
+# Covers each tile path: GEMV (M <= 8), 64x64, 128x128 and 256x128 (K > N), plus
+# sizes that are not multiples of the macro tile.
+GEMM_SHAPES = [
+    (1, 256, 256),
+    (8, 512, 256),
+    (17, 256, 512),
+    (128, 512, 256),
+    (333, 1152, 1152),
+    (512, 256, 1024),
+    (1024, 2048, 512),
+]
+
+
+@pytest.mark.parametrize(("m", "n", "k"), GEMM_SHAPES)
+@pytest.mark.parametrize("bias", [False, True])
+def test_scaled_mm_fp8_matches_reference(hip, m, n, k, bias):
+    torch.manual_seed(0)
+    a = torch.randn(m, k, device=DEV, dtype=torch.bfloat16)
+    b = torch.randn(n, k, device=DEV, dtype=torch.bfloat16)
+    sa = (a.abs().max() / 448).float()
+    sb = (b.abs().max() / 448).float()
+    aq = (a / sa).to(torch.float8_e4m3fn)
+    bq = (b / sb).to(torch.float8_e4m3fn)
+    bias_t = torch.randn(n, device=DEV, dtype=torch.bfloat16) if bias else None
+
+    out = hip.scaled_mm_fp8(aq, bq.t(), sa, sb, bias_t, torch.bfloat16)
+
+    ref = (aq.float() * sa) @ (bq.float() * sb).t()
+    if bias:
+        ref += bias_t.float()
+
+    assert out.shape == (m, n)
+    torch.testing.assert_close(out.float(), ref, rtol=2e-2, atol=2e-2)
+
+
+@pytest.mark.parametrize(("m", "n", "k"), GEMM_SHAPES)
+@pytest.mark.parametrize("per_channel", [False, True])
+def test_int8_linear_matches_eager(m, n, k, per_channel):
+    torch.manual_seed(0)
+    x = torch.randn(m, k, device=DEV, dtype=torch.bfloat16)
+    w = torch.randn(n, k, device=DEV, dtype=torch.bfloat16)
+
+    wq, ws = ck.quantize_int8_rowwise(w)
+    ws = ws.reshape(-1) if per_channel else ws.reshape(-1)[:1]
+    bias = torch.randn(n, device=DEV, dtype=torch.bfloat16)
+
+    with ck.use_backend("hip"):
+        out = ck.int8_linear(x, wq, ws, bias, torch.bfloat16)
+    with ck.use_backend("eager"):
+        ref = ck.int8_linear(x, wq, ws, bias, torch.bfloat16)
+
+    assert out.shape == (m, n)
+    # Both paths quantize x per row and differ only in the rounding of the
+    # activation quantizer, so compare with an int8-sized tolerance.
+    scale = ref.float().abs().max().item()
+    assert (out.float() - ref.float()).abs().max().item() < 0.05 * scale
+
+
+def test_int8_linear_convrot_matches_eager():
+    torch.manual_seed(0)
+    m, n, k = 256, 512, 512
+    x = torch.randn(m, k, device=DEV, dtype=torch.bfloat16)
+    w = torch.randn(n, k, device=DEV, dtype=torch.bfloat16)
+    wq, ws = ck.quantize_int8_rowwise(w)
+
+    with ck.use_backend("hip"):
+        out = ck.int8_linear(x, wq, ws.reshape(-1), None, torch.bfloat16, convrot=True,
+                             convrot_groupsize=256)
+    with ck.use_backend("eager"):
+        ref = ck.int8_linear(x, wq, ws.reshape(-1), None, torch.bfloat16, convrot=True,
+                             convrot_groupsize=256)
+
+    scale = ref.float().abs().max().item()
+    assert (out.float() - ref.float()).abs().max().item() < 0.05 * scale
+
+
+@pytest.mark.parametrize("group_size", [16, 64, 256])
+def test_convrot_w4a4_weight_quant_close_to_eager(hip, group_size):
+    """The fused rotation runs in fp32; eager rotates in the weight dtype.
+
+    Codes may therefore differ by one level, but no more.
+    """
+    torch.manual_seed(0)
+    from comfy_kitchen.backends.eager.convrot_w4a4 import _unpack_int4_row_major
+
+    w = torch.randn(256, 1024, device=DEV, dtype=torch.bfloat16)
+
+    qw_h, ws_h = hip.quantize_convrot_w4a4_weight(w, group_size)
+    with ck.use_backend("eager"):
+        qw_e, ws_e = ck.quantize_convrot_w4a4_weight(w, group_size)
+
+    assert qw_h.shape == qw_e.shape
+    codes_h = _unpack_int4_row_major(qw_h).int()
+    codes_e = _unpack_int4_row_major(qw_e).int()
+
+    delta = (codes_h - codes_e).abs()
+    assert delta.max().item() <= 1
+    assert (delta > 0).float().mean().item() < 0.02
+
+    torch.testing.assert_close(ws_h, ws_e, rtol=1e-2, atol=0)
+
+
+@pytest.mark.parametrize(("m", "n", "k"), [(128, 512, 512), (512, 256, 1024), (333, 512, 512)])
+def test_convrot_w4a4_linear_matches_eager(hip, m, n, k):
+    torch.manual_seed(0)
+    x = torch.randn(m, k, device=DEV, dtype=torch.bfloat16)
+    w = torch.randn(n, k, device=DEV, dtype=torch.bfloat16)
+
+    qw, ws = hip.quantize_convrot_w4a4_weight(w, 256)
+    out = hip.convrot_w4a4_linear(x, qw, ws, None, 256)
+
+    with ck.use_backend("eager"):
+        qw_e, ws_e = ck.quantize_convrot_w4a4_weight(w, 256)
+        ref = ck.convrot_w4a4_linear(x, qw_e, ws_e, None, 256)
+
+    assert out.shape == (m, n)
+    # W4A4 has 15 levels per operand, so agreement is coarse: this asserts the
+    # kernel computes the same function, not that it rounds identically.
+    scale = ref.float().abs().max().item()
+    assert (out.float() - ref.float()).abs().max().item() < 0.25 * scale
+
+
+def test_convrot_w4a4_roundtrip(hip):
+    torch.manual_seed(0)
+    w = torch.randn(128, 512, device=DEV, dtype=torch.bfloat16)
+
+    qw, ws = hip.quantize_convrot_w4a4_weight(w, 256)
+    deq = hip.dequantize_convrot_w4a4_weight(qw, ws, 256, output_dtype=torch.float32)
+
+    assert deq.shape == w.shape
+    rel = (deq - w.float()).norm() / w.float().norm()
+    assert rel < 0.2  # int4 weight fidelity
+
+
+def test_quantize_int8_rowwise_matches_eager():
+    torch.manual_seed(0)
+    x = torch.randn(64, 512, device=DEV, dtype=torch.bfloat16)
+
+    with ck.use_backend("hip"):
+        q, s = ck.quantize_int8_rowwise(x)
+    with ck.use_backend("eager"):
+        qe, se = ck.quantize_int8_rowwise(x)
+
+    torch.testing.assert_close(s.float(), se.float(), rtol=1e-2, atol=0)
+    assert (q.int() - qe.int()).abs().max().item() <= 1
+
+
+def test_quantize_int8_tensorwise_matches_eager():
+    torch.manual_seed(0)
+    x = torch.randn(64, 512, device=DEV, dtype=torch.bfloat16)
+
+    with ck.use_backend("hip"):
+        q, s = ck.quantize_int8_tensorwise(x)
+    with ck.use_backend("eager"):
+        qe, se = ck.quantize_int8_tensorwise(x)
+
+    torch.testing.assert_close(s.float().reshape(()), se.float().reshape(()), rtol=1e-2, atol=0)
+    assert (q.int() - qe.int()).abs().max().item() <= 1
+
+
+def test_fp8_quantize_dequantize_roundtrip():
+    torch.manual_seed(0)
+    x = torch.randn(128, 256, device=DEV, dtype=torch.bfloat16)
+    scale = (x.abs().max() / 448).float()
+
+    with ck.use_backend("hip"):
+        q = ck.quantize_per_tensor_fp8(x, scale)
+        deq = ck.dequantize_per_tensor_fp8(q, scale, torch.bfloat16)
+
+    assert q.dtype == torch.float8_e4m3fn
+    rel = (deq.float() - x.float()).norm() / x.float().norm()
+    assert rel < 0.1
+
+
+@pytest.mark.parametrize(
+    ("shape", "mshape"),
+    [((2, 4096, 3072), (2, 1, 3072)), ((4, 256, 1152), (4, 1, 1152)), ((8, 128), (8, 128))],
+)
+def test_adaln_matches_eager(shape, mshape):
+    torch.manual_seed(0)
+    x = torch.randn(*shape, device=DEV, dtype=torch.bfloat16)
+    scale = torch.randn(*mshape, device=DEV, dtype=torch.bfloat16)
+    shift = torch.randn(*mshape, device=DEV, dtype=torch.bfloat16)
+
+    with ck.use_backend("hip"):
+        out = ck.adaln(x, scale, shift)
+    with ck.use_backend("eager"):
+        ref = ck.adaln(x, scale, shift)
+
+    # Both results are bf16 and round apart by roughly a ULP regardless of
+    # correctness, so comparing them to each other measures only that rounding.
+    # Score both against an fp32 reference and require the kernel to be no worse
+    # than eager; it reduces in fp32 throughout.
+    xf = x.float()
+    truth = torch.nn.functional.layer_norm(xf, xf.shape[-1:], eps=1e-6)
+    truth = truth * (1 + scale.float()) + shift.float()
+
+    err_hip = (out.float() - truth).norm() / truth.norm()
+    err_eager = (ref.float() - truth).norm() / truth.norm()
+
+    assert err_hip < 1e-2
+    assert err_hip <= err_eager * 1.1
+
+
+@pytest.mark.parametrize("split_half", [False, True])
+@pytest.mark.parametrize("freqs_dtype", [torch.float32, torch.bfloat16])
+def test_rope_matches_eager(split_half, freqs_dtype):
+    torch.manual_seed(0)
+    B, H, L, D = 2, 8, 128, 64
+    xq = torch.randn(B, H, L, D, device=DEV, dtype=torch.bfloat16)
+    xk = torch.randn(B, H, L, D, device=DEV, dtype=torch.bfloat16)
+    freqs = torch.randn(1, 1, L, D // 2, 2, 2, device=DEV, dtype=freqs_dtype)
+
+    pair = ck.apply_rope_split_half if split_half else ck.apply_rope
+    with ck.use_backend("hip"):
+        q, k = pair(xq, xk, freqs)
+    with ck.use_backend("eager"):
+        qr, kr = pair(xq, xk, freqs)
+
+    torch.testing.assert_close(q.float(), qr.float(), rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(k.float(), kr.float(), rtol=2e-2, atol=2e-2)
+
+
+@pytest.mark.parametrize(("m", "n", "k"), [(1, 512, 512), (8, 1024, 1024), (64, 1152, 1152)])
+def test_gemv_awq_w4a16_matches_eager(m, n, k):
+    torch.manual_seed(0)
+    g = 64
+    x = torch.randn(m, k, device=DEV, dtype=torch.bfloat16)
+    qw = torch.randint(0, 256, (n, k // 2), dtype=torch.uint8, device=DEV).view(torch.int8)
+    ws = torch.randn(k // g, n, device=DEV, dtype=torch.bfloat16).abs() * 0.01
+    wz = torch.randn(k // g, n, device=DEV, dtype=torch.bfloat16) * 0.01
+    bias = torch.randn(n, device=DEV, dtype=torch.bfloat16)
+
+    with ck.use_backend("hip"):
+        out = ck.gemv_awq_w4a16(x, qw, ws, wz, bias, g)
+    with ck.use_backend("eager"):
+        ref = ck.gemv_awq_w4a16(x, qw, ws, wz, bias, g)
+
+    assert out.shape == (m, n)
+    # Identical dequant math on both sides; only the accumulation order differs.
+    rel = (out.float() - ref.float()).norm() / ref.float().norm()
+    assert rel < 1e-2
+
+
+@pytest.mark.parametrize("act_unsigned", [False, True])
+@pytest.mark.parametrize(("m", "n", "k", "r"), [(256, 1024, 1024, 32), (333, 512, 512, 16)])
+def test_svdquant_w4a4_beats_eager_against_fp32_truth(m, n, k, r, act_unsigned):
+    """HIP quantizes in fp32 where eager quantizes in bf16, so the two do not
+    match bitwise. Score both against an fp32 simulation of the same W4A4 math
+    and require HIP to be no worse.
+    """
+    torch.manual_seed(0)
+    from comfy_kitchen.backends.eager.svdquant import (
+        _unpack_int4_row_major,
+        _unpack_uint4_row_major,
+    )
+
+    x = torch.randn(m, k, device=DEV, dtype=torch.bfloat16)
+    if act_unsigned:
+        x = x.abs()  # the caller pre-shifts for the unsigned path
+    smooth = torch.rand(k, device=DEV, dtype=torch.bfloat16) + 0.5
+    lora_down = torch.randn(k, r, device=DEV, dtype=torch.bfloat16) * 0.05
+    lora_up = torch.randn(n, r, device=DEV, dtype=torch.bfloat16) * 0.05
+    wgt = torch.randint(0, 256, (n, k // 2), dtype=torch.uint8, device=DEV).view(torch.int8)
+    wscales = torch.randn(k // 64, n, device=DEV, dtype=torch.bfloat16).abs() * 0.02
+    bias = torch.randn(n, device=DEV, dtype=torch.bfloat16)
+
+    qmax = 15.0 if act_unsigned else 7.0
+    qmin = 0.0 if act_unsigned else -7.0
+
+    xs = x.float() / smooth.float()
+    groups = xs.view(m, k // 64, 64)
+    scales = groups.abs().amax(-1).clamp(min=1e-10) / qmax
+    q_true = (groups / scales.unsqueeze(-1)).round().clamp(qmin, qmax)
+    act_fp = (q_true * scales.unsqueeze(-1)).view(m, k)
+
+    w_int = _unpack_int4_row_major(wgt).float().view(n, k // 64, 64)
+    w_fp = (w_int * wscales.t().float().unsqueeze(-1)).view(n, k)
+
+    truth = act_fp @ w_fp.t()
+    truth += (x.float() @ lora_down.float()) @ lora_up.float().t()
+    truth += bias.float()
+
+    with ck.use_backend("hip"):
+        q, asc, la = ck.quantize_svdquant_w4a4(x, smooth, lora_down, 256, act_unsigned)
+        out = ck.scaled_mm_svdquant_w4a4(q, wgt, asc, wscales, la, lora_up, bias, act_unsigned)
+    with ck.use_backend("eager"):
+        qe, asce, lae = ck.quantize_svdquant_w4a4(x, smooth, lora_down, 256, act_unsigned)
+        ref = ck.scaled_mm_svdquant_w4a4(qe, wgt, asce, wscales, lae, lora_up, bias, act_unsigned)
+
+    assert q.shape == qe.shape
+    assert asc.shape == asce.shape
+
+    err_hip = (out[:m].float() - truth).norm() / truth.norm()
+    err_eager = (ref[:m].float() - truth).norm() / truth.norm()
+
+    assert err_hip < 2e-2
+    assert err_hip <= err_eager * 1.1
+
+    # Activation codes must land on the fp32 grid to within one level; a larger
+    # deviation indicates the group scaling or the packing is wrong.
+    unpack = _unpack_uint4_row_major if act_unsigned else _unpack_int4_row_major
+    codes = unpack(q[:m]).int()
+    assert (codes - q_true.view(m, k).int()).abs().max() <= 1
+
+
+def test_no_hipblaslt_on_the_quantized_paths(monkeypatch):
+    """The quantized paths must not reach hipBLASLt.
+
+    torch._scaled_mm and torch._int_mm are the entry points that route there, so
+    trap both and exercise every quantized path.
+    """
+    from comfy_kitchen.tensor import QuantizedTensor
+
+    called = []
+    monkeypatch.setattr(torch, "_scaled_mm", lambda *a, **k: called.append("_scaled_mm"))
+    monkeypatch.setattr(torch, "_int_mm", lambda *a, **k: called.append("_int_mm"))
+    if hasattr(torch.nn.functional, "scaled_mm"):
+        monkeypatch.setattr(
+            torch.nn.functional, "scaled_mm", lambda *a, **k: called.append("F.scaled_mm")
+        )
+
+    torch.manual_seed(0)
+    x = torch.randn(512, 1024, device=DEV, dtype=torch.bfloat16)
+    w = torch.randn(2048, 1024, device=DEV, dtype=torch.bfloat16)
+
+    # fp8 linear via QuantizedTensor
+    xq = QuantizedTensor.from_float(x, "TensorCoreFP8Layout")
+    wq = QuantizedTensor.from_float(w, "TensorCoreFP8Layout")
+    out = torch.nn.functional.linear(xq, wq)
+    assert out.shape == (512, 2048)
+
+    # int8 linear
+    w8, ws = ck.quantize_int8_rowwise(w)
+    ck.int8_linear(x, w8, ws.reshape(-1), None, torch.bfloat16)
+
+    # int4 ConvRot
+    from comfy_kitchen.backends import hip as hip_backend
+
+    qw, wsc = hip_backend.quantize_convrot_w4a4_weight(w, 256)
+    hip_backend.convrot_w4a4_linear(x, qw, wsc, None, 256)
+
+    # AWQ W4A16 and SVDQuant W4A4 reach BLAS through eager's torch.matmul
+    qawq = torch.randint(0, 256, (2048, 512), dtype=torch.uint8, device=DEV).view(torch.int8)
+    sc = torch.ones(1024 // 64, 2048, device=DEV, dtype=torch.bfloat16)
+    ck.gemv_awq_w4a16(x, qawq, sc, sc, None, 64)
+
+    smooth = torch.ones(1024, device=DEV, dtype=torch.bfloat16)
+    ld = torch.randn(1024, 32, device=DEV, dtype=torch.bfloat16) * 0.05
+    lu = torch.randn(2048, 32, device=DEV, dtype=torch.bfloat16) * 0.05
+    q, asc, la = ck.quantize_svdquant_w4a4(x, smooth, ld)
+    ck.scaled_mm_svdquant_w4a4(q, qawq, asc, sc, la, lu, None)
+
+    assert called == [], f"quantized path fell through to hipBLASLt: {called}"
+
+
+def test_hip_registers_on_gfx12():
+    """The backend registered, and it did so for a gfx12 device."""
+    from comfy_kitchen.backends import hip as hip_backend
+
+    arch = hip_backend._gfx_arch()
+    assert arch is not None and arch.startswith("gfx12")
+    assert hip_backend.is_available()
+
+
+@pytest.mark.parametrize(
+    "arches",
+    [
+        [],
+        ["gfx1100"],
+        ["gfx90a"],
+        ["gfx1201", "gfx1100"],  # kernels launch on the tensor's device, so one is enough
+    ],
+)
+def test_hip_declines_on_non_gfx12(arches):
+    """The registration guard keeps these kernels off anything but an all-gfx12 process."""
+    from comfy_kitchen.backends import hip as hip_backend
+
+    assert hip_backend._unsupported_arch_reason(arches) is not None
+
+
+def test_hip_accepts_all_gfx12():
+    from comfy_kitchen.backends import hip as hip_backend
+
+    assert hip_backend._unsupported_arch_reason(["gfx1201", "gfx1200"]) is None
+
+
+# The kernels are compiled with -ffast-math, under which isnan() folds to false
+# and the finite clamps drop a NaN operand. These pin the encoding of the values
+# that exercise those paths.
+FP8_EDGE_VALUES = [
+    float("nan"), -float("nan"), float("inf"), -float("inf"),
+    1e30, -1e30, 448.0, -448.0, 0.0, -0.0, 1.0, 1e-9,
+]
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("out_dtype", [torch.float8_e4m3fn, torch.float8_e5m2])
+def test_fp8_quantize_edge_values_match_eager(dtype, out_dtype):
+    x = torch.tensor(FP8_EDGE_VALUES, device=DEV, dtype=dtype)
+    scale = torch.tensor(1.0, device=DEV)
+
+    with ck.use_backend("hip"):
+        q = ck.quantize_per_tensor_fp8(x, scale, out_dtype)
+    with ck.use_backend("eager"):
+        ref = ck.quantize_per_tensor_fp8(x, scale, out_dtype)
+
+    assert torch.equal(q.view(torch.uint8), ref.view(torch.uint8))
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16, torch.float16])
+def test_stochastic_rounding_fp8_edge_values_match_eager(dtype):
+    x = torch.tensor(FP8_EDGE_VALUES, device=DEV, dtype=dtype)
+    rng = torch.randint(0, 256, (x.numel(),), dtype=torch.uint8, device=DEV)
+
+    with ck.use_backend("hip"):
+        q = ck.stochastic_rounding_fp8(x.clone(), rng.clone(), torch.float8_e4m3fn)
+    with ck.use_backend("eager"):
+        ref = ck.stochastic_rounding_fp8(x.clone(), rng.clone(), torch.float8_e4m3fn)
+
+    finite = ~torch.isnan(x.float())
+    assert torch.equal(q.view(torch.uint8)[finite], ref.view(torch.uint8)[finite])
+    # eager drops the sign of a NaN here while the kernel keeps it; both are NaN.
+    assert torch.isnan(q.float()[~finite]).all()
+
+
+# A zero-length dimension makes the grid zero-dimensional, which HIP rejects with
+# hipErrorInvalidConfiguration rather than treating as a no-op.
+def test_empty_inputs_do_not_launch_zero_grids(hip):
+    k, n = 128, 64
+    empty = torch.empty(0, k, device=DEV, dtype=torch.bfloat16)
+    w = torch.randn(n, k, device=DEV, dtype=torch.bfloat16) / 8
+    scale = torch.tensor(1.0, device=DEV)
+
+    assert hip.quantize_per_tensor_fp8(empty, scale).shape == (0, k)
+    assert hip.quantize_int8_rowwise(empty)[0].shape == (0, k)
+    assert hip.quantize_int8_tensorwise(empty)[0].shape == (0, k)
+    assert hip.scaled_mm_fp8(
+        empty.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn).t(),
+        scale, scale, None, torch.bfloat16,
+    ).shape == (0, n)
+    assert hip.int8_linear(empty, *hip.quantize_int8_rowwise(w)).shape == (0, n)
+
+    cw, cs = hip.quantize_convrot_w4a4_weight(w, 64)
+    assert hip.convrot_w4a4_linear(empty, cw, cs, None, 64).shape == (0, n)
+
+    adaln_mod = torch.randn(1, k, device=DEV, dtype=torch.bfloat16)
+    assert hip.adaln(empty, adaln_mod, adaln_mod).shape == (0, k)
+    torch.cuda.synchronize()
+
+
+def test_scaled_mm_v2_declines_a_bias_it_cannot_index():
+    """The epilogue indexes bias[col] with one dtype code; anything else falls back."""
+    from comfy_kitchen.scaled_mm_v2 import ScalingType, SwizzleType, _hip_fp8_gemm
+
+    a = (torch.randn(64, 128, device=DEV) / 8).to(torch.float8_e4m3fn)
+    b = (torch.randn(128, 128, device=DEV) / 8).to(torch.float8_e4m3fn)
+    scale = torch.tensor(1.0, device=DEV)
+    tw, no = ScalingType.TensorWise, SwizzleType.NO_SWIZZLE
+
+    def routes_to_hip(bias):
+        out = _hip_fp8_gemm(a, b, scale, scale, bias, torch.bfloat16, tw, tw, no, no)
+        return out is not None
+
+    assert routes_to_hip(None)
+    assert routes_to_hip(torch.randn(128, device=DEV, dtype=torch.bfloat16))
+    assert not routes_to_hip(torch.randn(8, device=DEV, dtype=torch.bfloat16))
+    assert not routes_to_hip(torch.randn(1, 128, device=DEV, dtype=torch.bfloat16))
+    assert not routes_to_hip(torch.randn(128, device=DEV, dtype=torch.float64))
+
+
+def test_rope_binding_rejects_mismatched_operands(hip):
+    """The kernel addresses xk and both outputs with xq's strides and dtype code, and
+    writes xk_out whenever xk is present."""
+    xq = torch.randn(2, 4, 64, 64, device=DEV, dtype=torch.bfloat16)
+    freqs = torch.randn(1, 1, 64, 32, 2, 2, device=DEV, dtype=torch.float32)
+    xq_out = torch.empty_like(xq)
+    xk = torch.empty_like(xq)
+    xk_out = torch.empty_like(xq)
+    dl, stream = hip._dl, hip._stream(xq)
+
+    def call(xk_a, xq_out_a, xk_out_a):
+        hip._C.apply_rope(
+            dl(xq), None if xk_a is None else dl(xk_a), dl(freqs),
+            dl(xq_out_a), None if xk_out_a is None else dl(xk_out_a), False, stream,
+        )
+
+    with pytest.raises(RuntimeError, match="together or not at all"):
+        call(xk, xq_out, None)
+    with pytest.raises(RuntimeError, match="together or not at all"):
+        call(None, xq_out, xk_out)
+    with pytest.raises(RuntimeError, match="xq's dtype"):
+        call(xk.to(torch.float16), xq_out, xk_out)
+    with pytest.raises(RuntimeError, match="shape and strides"):
+        call(None, torch.empty(2, 4, 64, 32, device=DEV, dtype=torch.bfloat16), None)
+
+    call(xk, xq_out, xk_out)
+    torch.cuda.synchronize()
+
+
+def test_convrot_rejects_k_not_divisible_by_the_group(hip):
+    """The kernel rotates K/G groups but reads back all K, so a partial group
+    would quantize uninitialized LDS."""
+    x = torch.randn(4, 192, device=DEV, dtype=torch.bfloat16)
+    q = torch.zeros(4, 96, dtype=torch.int8, device=DEV)
+    scales = torch.zeros(4, dtype=torch.float32, device=DEV)
+
+    with pytest.raises(RuntimeError, match="divisible"):
+        hip._C.convrot_quant_int4(
+            hip._dl(x), hip._dl(q), hip._dl(scales), 4, 192, 256, hip._stream(x)
+        )
+
+    # The wrapper declines rather than reaching the kernel; a divisible K still runs.
+    with pytest.raises(ValueError, match="divisible"):
+        hip.quantize_and_rotate_rowwise(x, torch.eye(256, device=DEV, dtype=torch.bfloat16), 256)
+    qw, ws = hip.quantize_convrot_w4a4_weight(
+        torch.randn(64, 192, device=DEV, dtype=torch.bfloat16), 64
+    )
+    assert torch.isfinite(hip.convrot_w4a4_linear(x, qw, ws, None, 64)).all()
+
+
+def test_bias_shape_is_validated(hip):
+    """The epilogue indexes bias[col], so a mis-shaped bias reads out of bounds."""
+    x = torch.randn(8, 128, device=DEV, dtype=torch.bfloat16)
+    wq, ws = hip.quantize_int8_rowwise(torch.randn(64, 128, device=DEV, dtype=torch.bfloat16))
+
+    for bad in (torch.randn(32, device=DEV), torch.randn(1, 64, device=DEV)):
+        with pytest.raises(ValueError, match="bias must be 1D"):
+            hip.int8_linear(x, wq, ws.reshape(-1), bad.bfloat16(), torch.bfloat16)
+
+    # A bias on another device is moved to the launch device, not passed as-is.
+    out = hip.int8_linear(x, wq, ws.reshape(-1), torch.randn(64).bfloat16(), torch.bfloat16)
+    assert out.shape == (8, 64)
+
+
+def test_exported_gemms_reject_unaligned_k(hip):
+    """The tile loader and the small-M GEMV read a row 16 bytes at a time, so an
+    unaligned K reads past the end of it. The registry constraints enforce this for
+    dispatched calls; the exported helpers are reachable directly."""
+    scale = torch.tensor(1.0, device=DEV)
+
+    a = (torch.randn(4, 24, device=DEV) / 8).to(torch.float8_e4m3fn)
+    b = (torch.randn(32, 24, device=DEV) / 8).to(torch.float8_e4m3fn)
+    with pytest.raises(ValueError, match="divisible by 16"):
+        hip.scaled_mm_fp8(a, b.t(), scale, scale, None, torch.bfloat16)
+
+    x = torch.randn(4, 24, device=DEV, dtype=torch.bfloat16)
+    wq, ws = hip.quantize_int8_rowwise(torch.randn(32, 24, device=DEV, dtype=torch.bfloat16))
+    with pytest.raises(ValueError, match="divisible by 16"):
+        hip.int8_linear(x, wq, ws.reshape(-1), None, torch.bfloat16)
+
+    # int4 packs two per byte, so the packed row needs K/2 to be a whole 16-byte chunk.
+    xc = torch.randn(4, 48, device=DEV, dtype=torch.bfloat16)
+    qw = torch.zeros(32, 24, dtype=torch.int8, device=DEV)
+    with pytest.raises(ValueError, match="divisible by 32"):
+        hip.convrot_w4a4_linear(xc, qw, torch.ones(32, device=DEV), None, 16)
+
+    # The native launcher refuses too, so a C++ caller cannot slip past.
+    out = torch.empty(4, 32, dtype=torch.bfloat16, device=DEV)
+    with pytest.raises(RuntimeError, match="multiple of 16"):
+        hip._C.scaled_mm_fp8(
+            hip._dl(a.view(torch.uint8)), hip._dl(b.contiguous().view(torch.uint8)),
+            hip._dl(out), hip._dl(torch.ones(1, device=DEV)), hip._dl(torch.ones(1, device=DEV)),
+            None, 4, 32, 24, 2, hip._stream(a),
+        )
+
+
+def test_fp8_scale_must_be_a_single_element(hip):
+    """The kernels read one float off a raw pointer on the launch stream."""
+    x = torch.randn(64, device=DEV, dtype=torch.bfloat16)
+
+    with pytest.raises(ValueError, match="single per-tensor scale"):
+        hip.quantize_per_tensor_fp8(x, torch.ones(2, device=DEV))
+
+    # A scale on another device is moved to the launch device, not passed as-is.
+    assert hip.quantize_per_tensor_fp8(x, torch.tensor(1.0)).shape == (64,)
+
+
+def test_svdquant_rejects_partial_scale_group(hip):
+    """One scale per 64-element group: a partial trailing group has no scale."""
+    act = torch.zeros(64, 48, dtype=torch.int8, device=DEV)  # K = 96, not a multiple of 64
+    wgt = torch.zeros(32, 48, dtype=torch.int8, device=DEV)
+    ascales = torch.ones(1, 64, device=DEV, dtype=torch.bfloat16)
+    wscales = torch.ones(1, 32, device=DEV, dtype=torch.bfloat16)
+    lora_act = torch.zeros(64, 8, device=DEV, dtype=torch.float32)
+    lora_up = torch.zeros(32, 8, device=DEV, dtype=torch.bfloat16)
+
+    with pytest.raises(ValueError, match="not divisible by group_size"):
+        hip.scaled_mm_svdquant_w4a4(act, wgt, ascales, wscales, lora_act, lora_up)
+
+
+def test_scaled_mm_fp8_validates_bias(hip):
+    """scaled_mm_fp8 is public, so it enforces the same bias contract as the rest."""
+    a = (torch.randn(64, 128, device=DEV) / 8).to(torch.float8_e4m3fn)
+    b = (torch.randn(128, 128, device=DEV) / 8).to(torch.float8_e4m3fn)
+    scale = torch.tensor(1.0, device=DEV)
+
+    for bad in (
+        torch.randn(8, device=DEV, dtype=torch.bfloat16),
+        torch.randn(1, 128, device=DEV, dtype=torch.bfloat16),
+    ):
+        with pytest.raises(ValueError, match="bias must be 1D"):
+            hip.scaled_mm_fp8(a, b.t(), scale, scale, bad, torch.bfloat16)
+
+    with pytest.raises(ValueError, match="bias dtype"):
+        hip.scaled_mm_fp8(
+            a, b.t(), scale, scale, torch.randn(128, device=DEV, dtype=torch.float64),
+            torch.bfloat16,
+        )
+
+    # A bias on another device is moved to the launch device, not passed as-is.
+    out = hip.scaled_mm_fp8(
+        a, b.t(), scale, scale, torch.randn(128, dtype=torch.bfloat16), torch.bfloat16
+    )
+    assert out.shape == (64, 128)
+
+
+def test_gemv_awq_validates_its_memory_contract(hip):
+    """The inner loop decodes eight weights at a time and rescales the chunk once."""
+    k, n, g = 128, 64, 64
+    x = torch.randn(1, k, device=DEV, dtype=torch.bfloat16)
+    qw = torch.randint(-8, 8, (n, k // 2), device=DEV, dtype=torch.int8)
+    ws = torch.randn(k // g, n, device=DEV, dtype=torch.bfloat16).abs() + 0.1
+    wz = torch.zeros(k // g, n, device=DEV, dtype=torch.bfloat16)
+
+    with pytest.raises(ValueError, match="multiple of 8"):
+        hip.gemv_awq_w4a16(x, qw, ws, wz, None, 12)
+    with pytest.raises(ValueError, match="wscales must have shape"):
+        hip.gemv_awq_w4a16(x, qw, ws.reshape(-1), wz, None, g)
+    with pytest.raises(ValueError, match="bias must be 1D"):
+        hip.gemv_awq_w4a16(x, qw, ws, wz, torch.randn(8, device=DEV, dtype=torch.bfloat16), g)
+
+    assert hip.gemv_awq_w4a16(x, qw, ws, wz, None, g).shape == (1, n)
+
+
+def test_svdquant_validates_its_operands(hip):
+    """The kernels get M, N, K and R but no tensor bounds of their own."""
+    m, k, n, r = 64, 256, 128, 16
+    x = torch.randn(m, k, device=DEV, dtype=torch.bfloat16)
+    smooth = torch.randn(k, device=DEV, dtype=torch.bfloat16).abs() + 0.1
+    lora_down = torch.randn(k, r, device=DEV, dtype=torch.bfloat16) / 8
+    lora_up = torch.randn(n, r, device=DEV, dtype=torch.bfloat16) / 8
+    wgt = torch.randint(-8, 8, (n, k // 2), device=DEV, dtype=torch.int8)
+    wscales = torch.randn(k // 64, n, device=DEV, dtype=torch.bfloat16).abs() + 0.1
+
+    with pytest.raises(ValueError, match="smooth must have shape"):
+        hip.quantize_svdquant_w4a4(x, smooth[:32], lora_down)
+    with pytest.raises(ValueError, match="lora_down must have shape"):
+        hip.quantize_svdquant_w4a4(x, smooth, lora_down[:64])
+    with pytest.raises(ValueError, match="lora_x must have shape"):
+        hip.quantize_svdquant_w4a4(x, smooth, lora_down, lora_x=x[:8])
+
+    q, ascales, lora_act = hip.quantize_svdquant_w4a4(x, smooth, lora_down)
+    with pytest.raises(ValueError, match="wscales must have shape"):
+        hip.scaled_mm_svdquant_w4a4(q, wgt, ascales, wscales.reshape(-1), lora_act, lora_up)
+    with pytest.raises(ValueError, match="lora_up must have shape"):
+        hip.scaled_mm_svdquant_w4a4(q, wgt, ascales, wscales, lora_act, lora_up[:8])
+
+    out = hip.scaled_mm_svdquant_w4a4(q, wgt, ascales, wscales, lora_act, lora_up)
+    assert torch.isfinite(out).all()
+
+
+def test_hip_declines_when_an_arch_cannot_be_read():
+    """A device whose architecture is unknown cannot be shown to be gfx12."""
+    from comfy_kitchen.backends import hip as hip_backend
+
+    assert hip_backend._unsupported_arch_reason([None]) is not None
+    assert hip_backend._unsupported_arch_reason(["gfx1200", None]) is not None
+
+
+def test_stochastic_rounding_rejects_non_contiguous_rng(hip):
+    """The kernel writes the result into rng, which a copy would silently discard."""
+    x = torch.randn(8, 16, device=DEV, dtype=torch.bfloat16)
+    rng = torch.randint(0, 256, (8, 32), dtype=torch.uint8, device=DEV)[:, ::2]
+
+    with pytest.raises(ValueError, match="contiguous"):
+        hip.stochastic_rounding_fp8(x, rng, torch.float8_e4m3fn)
+
+    rng = torch.randint(0, 256, (8, 16), dtype=torch.uint8, device=DEV)
+    out = hip.stochastic_rounding_fp8(x, rng, torch.float8_e4m3fn)
+    assert out.data_ptr() == rng.data_ptr()
+
+
+def test_fp8_nan_survives_dequantize(hip):
+    """pack_fp8 emits the NaN encoding, so unpack_fp8 has to decode it back."""
+    x = torch.tensor([float("nan"), 1.0, -448.0, 0.0], device=DEV, dtype=torch.float32)
+    scale = torch.tensor(1.0, device=DEV)
+
+    q = hip.quantize_per_tensor_fp8(x, scale)
+    deq = hip.dequantize_per_tensor_fp8(q, scale, torch.float32)
+
+    assert deq[0].isnan()
+    torch.testing.assert_close(deq[1:], x[1:])
+
+
+@pytest.mark.parametrize("offset", [0.0, 1e3, 1e4])
+def test_adaln_variance_survives_a_large_row_offset(hip, offset):
+    """E[x^2] - mean^2 cancels catastrophically once the offset dwarfs the spread."""
+    torch.manual_seed(0)
+    x = torch.randn(4, 2048, device=DEV, dtype=torch.float32) + offset
+    zeros = torch.zeros(4, 2048, device=DEV, dtype=torch.float32)
+
+    out = hip.adaln(x, zeros, zeros)
+
+    xf = x.double()
+    ref = (xf - xf.mean(-1, keepdim=True)) * (
+        xf.var(-1, unbiased=False, keepdim=True) + 1e-6
+    ).rsqrt()
+    assert (out.double() - ref).abs().max().item() < 1e-2
+
+
+# K % 128 == 64 leaves the last tile's second group entirely in the padding, and
+# its scales do not exist.
+@pytest.mark.parametrize("k", [192, 320, 576, 1088])
+def test_svdquant_tail_group_stays_in_bounds(hip, k):
+    torch.manual_seed(0)
+    m, n, r = 64, 128, 16
+    x = torch.randn(m, k, device=DEV, dtype=torch.bfloat16)
+    smooth = torch.randn(k, device=DEV, dtype=torch.bfloat16).abs() + 0.1
+    lora_down = torch.randn(k, r, device=DEV, dtype=torch.bfloat16) / 8
+    lora_up = torch.randn(n, r, device=DEV, dtype=torch.bfloat16) / 8
+    wq = torch.randint(-8, 8, (n, k // 2), device=DEV, dtype=torch.int8)
+    wscales = torch.randn(k // 64, n, device=DEV, dtype=torch.bfloat16).abs() + 0.1
+
+    q, ascales, lora_act = hip.quantize_svdquant_w4a4(x, smooth, lora_down, pad_size=256)
+    out = hip.scaled_mm_svdquant_w4a4(q, wq, ascales, wscales, lora_act, lora_up)
+    torch.cuda.synchronize()
+
+    assert out.shape[1] == n
+    assert torch.isfinite(out).all()
+
+
+def test_rope_splits_mismatched_xk_dtype(hip):
+    """One dtype code is passed for both tensors, so a differing xk must not share it."""
+    xq = torch.randn(2, 4, 64, 64, device=DEV, dtype=torch.bfloat16)
+    xk = xq.to(torch.float16)
+    freqs = torch.randn(1, 1, 64, 32, 2, 2, device=DEV, dtype=torch.float32)
+
+    q, k = hip.apply_rope(xq, xk, freqs)
+
+    assert q.dtype == torch.bfloat16
+    assert k.dtype == torch.float16
+    torch.testing.assert_close(q.float(), hip.apply_rope1(xq, freqs).float())
+    torch.testing.assert_close(k.float(), hip.apply_rope1(xk, freqs).float())
+
+
+@pytest.mark.parametrize(
+    ("shape", "why"),
+    [
+        ((1, 1, 64, 16, 2, 2), "head_dim/2 too small"),
+        ((1, 1, 64, 32, 3, 2), "rotation dim is not 2"),
+        ((3, 1, 64, 32, 2, 2), "leading dim neither 1 nor the batch"),
+    ],
+)
+def test_rope_rejects_malformed_freqs(hip, shape, why):
+    """The kernel indexes the trailing dims blind, so the binding has to check them."""
+    xq = torch.randn(2, 4, 64, 64, device=DEV, dtype=torch.bfloat16)
+    freqs = torch.randn(*shape, device=DEV, dtype=torch.float32)
+
+    with pytest.raises(RuntimeError, match="freqs_cis"):
+        hip.apply_rope1(xq, freqs)
+
+
+def test_convrot_falls_back_to_eager_past_the_lds_bound(hip):
+    """The fused rotation stages a whole row in LDS, so a large K does not fit.
+
+    The launch does not fail cleanly past the budget, so the wrapper has to route
+    those shapes to eager rather than reach the kernel.
+    """
+    max_k = hip._C.convrot_max_k()
+    assert max_k > 0
+
+    k = (max_k + 1024) & ~63  # past the bound, still a multiple of the group size
+    x = torch.randn(2, k, device=DEV, dtype=torch.bfloat16)
+    h = torch.eye(64, device=DEV, dtype=torch.bfloat16)
+
+    q, scales = hip.quantize_and_rotate_rowwise(x, h, 64)
+    torch.cuda.synchronize()
+    assert q.shape == (2, k)
+    assert torch.isfinite(scales).all()
+
+    # The launcher itself still refuses, so a C++ caller cannot slip past.
+    qb = torch.zeros(2, k, dtype=torch.int8, device=DEV)
+    sb = torch.zeros(2, dtype=torch.float32, device=DEV)
+    with pytest.raises(RuntimeError, match="LDS"):
+        hip._C.quantize_int8_convrot(
+            hip._dl(x), hip._dl(qb), hip._dl(sb), 2, k, 64, hip._stream(x)
+        )
+
+
+@pytest.mark.parametrize("group_size", [0, 32, 512])
+def test_convrot_launcher_rejects_unsupported_group_size(hip, group_size):
+    """The fused rotation only handles G in {16, 64, 256}; the dispatch wrappers
+    fall back to eager, so guard the launcher the C++ callers see."""
+    x = torch.randn(8, 128, device=DEV, dtype=torch.bfloat16)
+    q = torch.zeros(8, 64, dtype=torch.int8, device=DEV)
+    scales = torch.zeros(8, dtype=torch.float32, device=DEV)
+
+    with pytest.raises(RuntimeError, match="group_size"):
+        hip._C.convrot_quant_int4(
+            hip._dl(x), hip._dl(q), hip._dl(scales), 8, 128, group_size, hip._stream(x)
+        )


### PR DESCRIPTION
Adds `comfy_kitchen/backends/hip`, a native backend for AMD RDNA4 (gfx12) built on the `v_wmma_*_w32_gfx12` intrinsics. It does not link hipBLAS/hipBLASLt, and no linear op calls into them; every GEMM is compiled from source in the backend directory. Weight preparation and unsupported configurations fall back to eager.

### Design

fp8, int8 and int4 all hold 8 bytes per lane per WMMA, so one K-step is 16 bytes of a row whether those bytes hold 16 fp8/int8 values or 32 int4 nibbles. The tile kernel (`gemm_wmma.h`) is byte-addressed and shared by the fp8, int8 and int4 GEMMs; the element type appears only in the `Mma` policy. It is software-pipelined at both the global (tile prefetch) and LDS (fragment) level, and uses grouped block ordering for L2 locality.

The lane/fragment layout for the gfx12 w32 WMMA instructions is documented in `wmma_gfx12.h`.

### Ops

| Op | Instruction |
|----|-------------|
| fp8 `scaled_mm` | `f32_16x16x16_fp8_fp8` |
| `int8_linear` | `i32_16x16x16_iu8` |
| `convrot_w4a4_linear` | `i32_16x16x32_iu4`, rotation fused into the quantizer; `linear_dtype="int8"` unpacks the weight onto the iu8 kernel |
| `scaled_mm_svdquant_w4a4` | `i32_16x16x32_iu4`, per-64 group scales, fused LoRA-up |
| `gemv_awq_w4a16` | scalar; bandwidth bound, no operand reuse for a tile |

Plus fp8/int8 quantization, `adaln`, and the four `apply_rope` variants.

On ROCm, `int8_linear` fell through to eager, which routes torch._int_mm to hipBLASLt; it is now a WMMA kernel. NVFP4 and MXFP8 remain on eager: RDNA4 has neither fp4 WMMA nor microscaling hardware.

### Dispatch

The backend registers only when every visible device is known to be gfx12 (the intrinsics have no gfx11 encoding); a device whose architecture cannot be read counts against it, since it cannot be shown to be gfx12. Registration is per-process while kernels launch on the tensor's own device, so one non-gfx12 GPU makes it decline and dispatch falls through to triton/eager. `COMFY_KITCHEN_DISABLE_HIP=1` removes it from dispatch.

ROCm's fp8 `scaled_mm` is competitive on RDNA4 and is faster than the WMMA kernel on square, deep-K and small-M shapes, while the WMMA kernel is faster at large N. fp8 is routed to WMMA on every call the kernel supports, with no shape gate, to keep the backend free of BLAS calls. Calls outside its domain (swizzled operands, scaling other than tensor-wise, a K that is not a multiple of 16, a bias that is not 1-D of length N, operands not on the input's device) fall back to torch.

### Build

`setup.py` builds the extension whenever a ROCm toolchain is present, on Linux and Windows alike:

```bash
pip install .
```

ROCm is discovered from `ROCM_HOME`/`ROCM_PATH`/`HIP_PATH`, then from the pip `rocm-sdk` wheel (via `rocm-sdk path --root`, which a ROCm PyTorch build already pulls in), then from `/opt/rocm`. No environment variables, no `CC`/`CXX` override and no Visual Studio developer shell are needed: the ROCm clang drives C, C++ and HIP alike, and locates the MSVC toolchain itself. The HIP extension pins the Ninja generator on every platform; CMake's default generator on Windows is Visual Studio, which cannot build the HIP language at all.

Target architectures default to the gfx12 GPUs the build machine can see, and to `gfx1200`;`gfx1201` when it can see none (CI, cross-builds). To pick them explicitly:

```bash
COMFY_HIP_ARCHS=gfx1201 pip install .     # PYTORCH_ROCM_ARCH and GPU_ARCHS also honoured
```

Because the kernels are gfx12-only, the extension is skipped rather than built when the visible AMD GPUs are all of another architecture. `COMFY_KITCHEN_BUILD_HIP=1` turns that skip (and a missing toolchain) into an error; `COMFY_KITCHEN_BUILD_NO_HIP=1` suppresses the backend entirely.

### Tests

`tests/test_hip_wmma.py` (95 tests) skips unless the backend registered, so it is inert on CI without an RDNA4 device. Kernels are validated against eager, and against an fp32 reference where the two legitimately differ (the HIP kernels quantize and reduce in fp32 where eager works in bf16, so they are not bitwise equal to eager, and are closer to the fp32 result). One test traps `torch._scaled_mm` and `torch._int_mm` and exercises every quantized path to assert neither is reached.

Tested on gfx1200 (RDNA4), ROCm 7.15 / PyTorch 2.12, Windows.