### PR TITLE
Add HIP backend for AMD RDNA2-RDNA4 to the existing wheels

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -37,12 +37,12 @@ jobs:
         with:
           python-version: "3.12"
 
-      # Build CUDA wheel using cibuildwheel with manylinux container
-      - name: Build CUDA wheel (manylinux)
+      # Build one wheel containing both CUDA and HIP native extensions.
+      # cibuildwheel invokes setup.py once inside a manylinux container; setup.py
+      # auto-detects both toolchains and emits cuda/_C*.so plus hip/_C*.so.
+      - name: Build CUDA+HIP wheel (manylinux)
         uses: pypa/cibuildwheel@v2.22.0
         env:
-          # Use NVIDIA's CUDA devel image based on UBI8 (manylinux_2_28 compatible)
-          # CUDA 13.0 will be installed inside the container
           CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux_2_28_x86_64
 
           # Build for Python 3.10, 3.11, and 3.12
@@ -50,15 +50,37 @@ jobs:
           CIBW_BUILD: "cp310-manylinux_x86_64 cp311-manylinux_x86_64 cp312-manylinux_x86_64"
           CIBW_SKIP: "*-musllinux_*"
 
-          # Install CUDA 13.0 toolkit inside the container
+          # Install CUDA 13.0 and ROCm HIP SDK inside the same container so the
+          # wheel contains both native backends.
           CIBW_BEFORE_ALL_LINUX: |
             # Install dnf plugins for config-manager command
             dnf install -y dnf-plugins-core
             # Add NVIDIA CUDA repository for RHEL 8
             dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo
+            # Add AMD ROCm repository for RHEL 8 / manylinux_2_28. Signature checks
+            # stay on: these RPMs carry the compiler that builds the shipped wheel.
+            printf '%s\n' \
+              '[rocm]' \
+              'name=ROCm 7.2 repository' \
+              'baseurl=https://repo.radeon.com/rocm/el8/7.2.4/main' \
+              'enabled=1' \
+              'priority=50' \
+              'gpgcheck=1' \
+              'gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key' \
+              '' \
+              '[amdgraphics]' \
+              'name=AMD Graphics 7.2 repository' \
+              'baseurl=https://repo.radeon.com/graphics/7.2.4/el/8/main/x86_64/' \
+              'enabled=1' \
+              'priority=50' \
+              'gpgcheck=1' \
+              'gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key' \
+              >/etc/yum.repos.d/rocm.repo
+            rpm --import https://repo.radeon.com/rocm/rocm.gpg.key
             dnf clean all
-            # Install ONLY the minimal CUDA packages needed for compilation (not the full toolkit)
+            # Install only the CUDA packages needed for compilation, plus HIP SDK.
             dnf install -y cuda-nvcc-13-0 cuda-cudart-devel-13-0 libcublas-devel-13-0 libnvjitlink-devel-13-0
+            dnf install -y rocm-hip-sdk rocm-device-libs
             # Install Python development headers (fallback for CMake FindPython)
             dnf install -y python3-devel curl ninja-build tar xz
             # EL8 ships ccache 3.7.7, which predates NVCC -x cu handling.
@@ -78,14 +100,18 @@ jobs:
             ccache --version
             # Reset counters, but retain restored compiler objects.
             CCACHE_DIR=/host${{ github.workspace }}/.ccache ccache --zero-stats
-            # Verify CUDA installation
+            # Verify compiler installations
             /usr/local/cuda-13.0/bin/nvcc --version
+            /opt/rocm/bin/amdclang++ --version
+            /opt/rocm/bin/hipcc --version
 
-          # Set CUDA environment and install build dependencies
+          # Set CUDA and ROCm environments.
           CIBW_ENVIRONMENT_LINUX: >
             CUDA_HOME=/usr/local/cuda-13.0
-            PATH=/usr/local/cuda-13.0/bin:$PATH
-            LD_LIBRARY_PATH=/usr/local/cuda-13.0/lib64:$LD_LIBRARY_PATH
+            ROCM_HOME=/opt/rocm
+            ROCM_PATH=/opt/rocm
+            PATH=/usr/local/cuda-13.0/bin:/opt/rocm/bin:$PATH
+            LD_LIBRARY_PATH=/usr/local/cuda-13.0/lib64:/opt/rocm/lib:/opt/rocm/lib64:$LD_LIBRARY_PATH
             LIBRARY_PATH=/usr/local/cuda-13.0/lib64/stubs:$LIBRARY_PATH
             CMAKE_GENERATOR=Ninja
             COMFY_CUDA_COMPILER_LAUNCHER=ccache
@@ -93,6 +119,8 @@ jobs:
             CCACHE_DIR=/host${{ github.workspace }}/.ccache
             CCACHE_BASEDIR=/project
             CCACHE_COMPILERCHECK=content
+          # COMFY_HIP_ARCHS is unset on purpose: with no AMD GPU visible,
+          # setup_hip_extension() already builds DEFAULT_HIP_ARCHS.
 
           # Report the previous interpreter build's cache result, then install build dependencies.
           CIBW_BEFORE_BUILD: |
@@ -100,8 +128,8 @@ jobs:
             ccache --show-stats
             pip install nanobind cmake setuptools wheel
 
-          # Repair wheel for manylinux compliance, excluding CUDA runtime libs
-          # Users must have CUDA installed on their system
+          # Repair wheel for manylinux compliance, excluding GPU runtime libs.
+          # Users must have the matching CUDA or ROCm runtime installed locally.
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: >
             auditwheel repair -w {dest_dir} {wheel}
             --exclude libcuda.so.1
@@ -110,6 +138,15 @@ jobs:
             --exclude libcublas.so.13
             --exclude libcublasLt.so.13
             --exclude libnvJitLink.so.13
+            --exclude libamdhip64.so.7
+            --exclude libamdhip64.so
+            --exclude libhsa-runtime64.so.1
+            --exclude libhsa-runtime64.so
+            --exclude libamd_comgr.so.3
+            --exclude libamd_comgr.so
+            --exclude libdrm.so.2
+            --exclude libdrm_amdgpu.so.1
+            --exclude librocm-core.so.1
 
         with:
           output-dir: wheelhouse
@@ -124,13 +161,45 @@ jobs:
           tar -xJf "$archive" -C "$RUNNER_TEMP"
           CCACHE_DIR="$GITHUB_WORKSPACE/.ccache" "$RUNNER_TEMP/ccache-$ccache_version-linux-x86_64-musl-static/ccache" --show-stats
 
+      - name: Verify Linux wheels contain CUDA and HIP extensions
+        shell: bash
+        run: |
+          python - <<'PY'
+          import zipfile
+          from pathlib import Path
+
+          wheels = sorted(Path("wheelhouse").glob("*manylinux*.whl"))
+          if not wheels:
+              raise SystemExit("No manylinux wheels found")
+
+          for wheel in wheels:
+              # 3.10/3.11 are version-specific; 3.12 must stay abi3 or it silently
+              # stops covering 3.13+. Assert the tag before the member checks below.
+              pytag, abitag = wheel.name.split("-")[-3:-1]
+              if pytag == "cp312" and abitag != "abi3":
+                  raise SystemExit(f"{wheel.name}: cp312 wheel lost its abi3 tag (got {abitag})")
+              with zipfile.ZipFile(wheel) as zf:
+                  names = zf.namelist()
+              has_cuda = any(
+                  name.startswith("comfy_kitchen/backends/cuda/_C") and name.endswith(".so")
+                  for name in names
+              )
+              has_hip = any(
+                  name.startswith("comfy_kitchen/backends/hip/_C") and name.endswith(".so")
+                  for name in names
+              )
+              print(f"{wheel.name}: cuda={has_cuda} hip={has_hip}")
+              if not has_cuda or not has_hip:
+                  raise SystemExit(f"{wheel.name} does not contain both CUDA and HIP extensions")
+          PY
+
       - name: Build CPU-only wheel (py3-none-any)
         shell: bash
         run: |
           python -m pip install --upgrade pip
           pip install build setuptools wheel
-          # Build CPU-only variant (pure Python, no CUDA)
-          python setup.py bdist_wheel --no-cuda
+          # Build pure Python variant (no native CUDA/HIP extensions)
+          python setup.py bdist_wheel --no-cuda --no-hip
           # Move to wheelhouse directory
           mv dist/*py3-none-any.whl wheelhouse/
 
@@ -141,10 +210,10 @@ jobs:
           echo "Built wheels:"
           ls -1 wheelhouse/*.whl
 
-      - name: Upload Linux CUDA wheel
+      - name: Upload Linux CUDA+HIP wheel
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-linux-cuda
+          name: wheels-linux-cuda-hip
           path: wheelhouse/*manylinux*.whl
           if-no-files-found: error
 
@@ -367,14 +436,105 @@ jobs:
         shell: bash
         run: |
           python -m pip install --upgrade pip
-          pip install build setuptools wheel nanobind
+          # ninja: CMake's default Windows generator is Visual Studio, which has no
+          # HIP language support, so setup.py drives the HIP build with Ninja.
+          pip install build setuptools wheel nanobind ninja
 
-      - name: Build CUDA wheel
+      - name: Install ROCm HIP SDK (Windows)
+        shell: bash
+        env:
+          ROCM_SDK_VERSION: "7.2.1"
+        run: |
+          # ROCm on Windows is not on PyPI (pypi.org/project/rocm-sdk-devel is a 0.1.0
+          # placeholder), so the toolchain comes from AMD's own release directory, the
+          # same host the Linux job takes its RPMs from. Pinned to a versioned release,
+          # so the toolchain cannot drift under a given commit.
+          #
+          # setup.py finds the toolchain via `python -m rocm_sdk path --root`; no
+          # ROCM_PATH and no Visual Studio developer shell are needed.
+          #
+          # [libraries] is not optional here even though these kernels never call
+          # hipBLAS: expanding the devel tree hardlinks against it, and the install
+          # fails without it. The compiler it ships is not tied to a GPU family and
+          # builds every gfx in COMFY_HIP_ARCHS, RDNA2 through RDNA4.
+          #
+          # --no-index keeps the whole resolve inside AMD's directory rather than
+          # leaving PyPI open for it, and PyPI does hold placeholder projects under
+          # these names. The meta-package is an sdist, so --no-build-isolation is
+          # what lets its build requirements come from the step above instead of an
+          # index that is no longer reachable.
+          pip install --no-index --no-build-isolation \
+            --find-links "https://repo.radeon.com/rocm/windows/rocm-rel-${ROCM_SDK_VERSION}/" \
+            "rocm[libraries,devel]==${ROCM_SDK_VERSION}"
+          python -m rocm_sdk path --root
+
+      - name: Build CUDA+HIP wheel
         shell: bash
         run: |
-          # Build with default platform-specific CUDA architectures from setup.py
-          # Python 3.12 will produce abi3 wheel, 3.10/3.11 will be version-specific
+          # setup.py detects both toolchains and emits cuda/_C* plus hip/_C* into one
+          # wheel. Python 3.12 produces an abi3 wheel (both extensions are built
+          # against the limited API); 3.10/3.11 stay version-specific.
+          #
+          # COMFY_HIP_ARCHS is unset on purpose: with no AMD GPU visible,
+          # setup_hip_extension() already builds DEFAULT_HIP_ARCHS.
           python setup.py bdist_wheel
+
+      - name: Verify the Windows wheel contains CUDA and HIP extensions
+        shell: bash
+        run: |
+          pip install pefile
+          python - <<'PY'
+          import re
+          import zipfile
+          from pathlib import Path
+
+          import pefile
+
+          wheels = sorted(Path("dist").glob("*.whl"))
+          if not wheels:
+              raise SystemExit("No wheels found")
+
+          for wheel in wheels:
+              # 3.10/3.11 are version-specific; 3.12 must stay abi3 or it silently
+              # stops covering 3.13+. Assert the tag before the member/linkage checks.
+              pytag, abitag = wheel.name.split("-")[-3:-1]
+              if pytag == "cp312" and abitag != "abi3":
+                  raise SystemExit(f"{wheel.name}: cp312 wheel lost its abi3 tag (got {abitag})")
+              with zipfile.ZipFile(wheel) as zf:
+                  names = zf.namelist()
+                  pyds = [n for n in names
+                          if n.startswith("comfy_kitchen/backends/") and n.endswith(".pyd")]
+
+                  def has(backend):
+                      return any(
+                          n.startswith(f"comfy_kitchen/backends/{backend}/_C")
+                          and n.endswith(".pyd")
+                          for n in names
+                      )
+                  print(f"{wheel.name}: cuda={has('cuda')} hip={has('hip')}")
+                  if not has("cuda") or not has("hip"):
+                      raise SystemExit(f"{wheel.name} does not contain both extensions")
+
+                  # An abi3-tagged wheel must link the stable python3.dll, not a
+                  # versioned interpreter DLL, or it is version-locked despite the tag.
+                  if "abi3" in wheel.name:
+                      for n in pyds:
+                          # No import directory means no python3.dll either, which
+                          # the check below reports; the attribute is absent rather
+                          # than empty in that case.
+                          pe = pefile.PE(data=zf.read(n))
+                          imports = {
+                              entry.dll.decode("ascii", "replace").lower()
+                              for entry in getattr(pe, "DIRECTORY_ENTRY_IMPORT", [])
+                          }
+                          versioned = sorted(d for d in imports if re.fullmatch(r"python3\d+\.dll", d))
+                          if "python3.dll" not in imports or versioned:
+                              raise SystemExit(
+                                  f"{wheel.name}:{n} is not stable-ABI linked "
+                                  f"(python3.dll missing or versioned {versioned})"
+                              )
+                          print(f"  {n}: abi3 OK (links python3.dll)")
+          PY
 
       - name: Report compiler-cache statistics
         shell: pwsh
@@ -390,7 +550,7 @@ jobs:
       - name: Upload Windows wheel
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-windows-cuda-${{ matrix.python-version }}
+          name: wheels-windows-cuda-hip-${{ matrix.python-version }}
           path: dist/*.whl
           if-no-files-found: error
 
@@ -463,7 +623,7 @@ jobs:
       - name: Download Windows wheel
         uses: actions/download-artifact@v4
         with:
-          name: wheels-windows-cuda-${{ matrix.python-version }}
+          name: wheels-windows-cuda-hip-${{ matrix.python-version }}
           path: dist/
 
       - name: Install wheel and test dependencies
@@ -822,10 +982,10 @@ jobs:
     environment: pypi
 
     steps:
-      - name: Download Linux CUDA wheel
+      - name: Download Linux CUDA+HIP wheel
         uses: actions/download-artifact@v4
         with:
-          name: wheels-linux-cuda
+          name: wheels-linux-cuda-hip
           path: dist/
 
       - name: Download Linux ARM64 CUDA wheel
@@ -834,22 +994,22 @@ jobs:
           name: wheels-linux-arm64-cuda
           path: dist/
 
-      - name: Download Windows CUDA wheel (3.10)
+      - name: Download Windows CUDA+HIP wheel (3.10)
         uses: actions/download-artifact@v4
         with:
-          name: wheels-windows-cuda-3.10
+          name: wheels-windows-cuda-hip-3.10
           path: dist/
 
-      - name: Download Windows CUDA wheel (3.11)
+      - name: Download Windows CUDA+HIP wheel (3.11)
         uses: actions/download-artifact@v4
         with:
-          name: wheels-windows-cuda-3.11
+          name: wheels-windows-cuda-hip-3.11
           path: dist/
 
-      - name: Download Windows CUDA wheel (3.12)
+      - name: Download Windows CUDA+HIP wheel (3.12)
         uses: actions/download-artifact@v4
         with:
-          name: wheels-windows-cuda-3.12
+          name: wheels-windows-cuda-hip-3.12
           path: dist/
 
       - name: Download Windows ARM CUDA abi3 wheel

--- a/README.md
+++ b/README.md
@@ -4,18 +4,132 @@ Fast kernel library for Diffusion inference with multiple compute backends.
 
 ## Backend Capabilities Matrix
 
-| Function                    | eager | cuda | triton |
-|-----------------------------|-------|------|--------|
-| `quantize_per_tensor_fp8`   | ✓     | ✓    | ✓      |
-| `dequantize_per_tensor_fp8` | ✓     | ✓    | ✓      |
-| `quantize_nvfp4`            | ✓     | ✓    | ✓      |
-| `dequantize_nvfp4`          | ✓     | ✓    |        |
-| `scaled_mm_nvfp4`           | ✓     | ✓    |        |
-| `quantize_mxfp8`            | ✓     | ✓    | ✓      |
-| `dequantize_mxfp8`          | ✓     |      |        |
-| `scaled_mm_mxfp8`           | ✓     |      |        |
-| `apply_rope`                | ✓     | ✓    | ✓      |
-| `apply_rope1`               | ✓     | ✓    | ✓      |
+| Function                    | eager | cuda | triton | hip |
+|-----------------------------|-------|------|--------|-----|
+| `quantize_per_tensor_fp8`   | ✓     | ✓    | ✓      | ✓   |
+| `dequantize_per_tensor_fp8` | ✓     | ✓    | ✓      | ✓   |
+| `stochastic_rounding_fp8`   | ✓     | ✓    |        | ✓   |
+| `quantize_nvfp4`            | ✓     | ✓    | ✓      |     |
+| `dequantize_nvfp4`          | ✓     | ✓    | ✓      |     |
+| `scaled_mm_nvfp4`           | ✓     | ✓    |        |     |
+| `quantize_mxfp8`            | ✓     | ✓    | ✓      |     |
+| `dequantize_mxfp8`          | ✓     |      |        |     |
+| `scaled_mm_mxfp8`           | ✓     |      |        |     |
+| `adaln`                     | ✓     | ✓    | ✓      | ✓   |
+| `rms_adaln`                 | ✓     | ✓    | ✓      | ✓   |
+| `apply_rope`                | ✓     | ✓    | ✓      | ✓   |
+| `apply_rope1`               | ✓     | ✓    | ✓      | ✓   |
+| `apply_rope_split_half`     | ✓     | ✓    | ✓      | ✓   |
+| `apply_rope_split_half1`    | ✓     | ✓    | ✓      | ✓   |
+| `rms_rope`                  | ✓     | ✓    | ✓      | ✓   |
+| `rms_rope1`                 | ✓     | ✓    | ✓      | ✓   |
+| `rms_rope_split_half`       | ✓     | ✓    | ✓      | ✓   |
+| `rms_rope_split_half1`      | ✓     | ✓    | ✓      | ✓   |
+| `quantize_int8_rowwise`     | ✓     | ✓    | ✓      | ✓   |
+| `quantize_int8_tensorwise`  | ✓     | ✓    |        | ✓   |
+| `quantize_and_rotate_rowwise` | ✓   | ✓    | ✓      | ✓   |
+| `quantize_int8_convrot_weight` | ✓  | ✓    |        | ✓   |
+| `int8_linear`               | ✓     | ✓    | ✓      | ✓   |
+| `gemv_awq_w4a16`            | ✓     | ✓    |        | ✓   |
+| `quantize_svdquant_w4a4`    | ✓     | ✓    |        | ✓   |
+| `scaled_mm_svdquant_w4a4`   | ✓     | ✓    |        | ✓   |
+| `convrot_w4a4_linear`       | ✓     | ✓    |        | ✓   |
+| `quantize_convrot_w4a4_weight` | ✓  | ✓    |        | ✓   |
+| `dequantize_convrot_w4a4_weight` | ✓ | ✓   |        | ✓   |
+
+Each of the eight rope entries also has an in-place form (`apply_rope_`,
+`rms_rope_split_half1_`, ...) with the same backend coverage as the row above.
+
+## HIP backend (AMD RDNA2 / RDNA3 / RDNA3.5 / RDNA4)
+
+The `hip` backend implements the quantized paths with its own kernels: WMMA
+matrix-core GEMMs on RDNA3/RDNA3.5/RDNA4, and non-WMMA kernels (quantizers, RoPE
+and the fused RMSNorm+RoPE, AdaLN and RMS-AdaLN, the AWQ GEMV) that also run on
+RDNA2. It does not link or call hipBLAS/hipBLASLt; every matmul is compiled from
+the sources in `comfy_kitchen/backends/hip/`.
+
+Both rope kernels address their inputs through the tensor's own strides, so a q/k
+pair permuted or sliced out of a packed qkv is read where it lies rather than
+copied contiguous first. The in-place entries (`apply_rope_`, `rms_rope_` and
+their split-half and single-tensor siblings) rotate a strided view in place for
+the same reason: each thread owns one element pair and loads both before storing
+either.
+
+`int8_linear(input_act=...)` folds the activation into the fused ConvRot
+quantizer's load, so an MLP's `linear(act(proj(x)))` never writes act's output to
+HBM just to read it straight back.
+
+What a GPU gets depends on whether it has matrix cores:
+
+| Generation | gfx targets                 | Matrix cores | What runs                               |
+|------------|-----------------------------|--------------|-----------------------------------------|
+| RDNA4      | `gfx1200`, `gfx1201`        | WMMA + fp8   | All HIP-supported kernels, fp8 native   |
+| RDNA3.5    | `gfx1150`-`gfx1153`         | WMMA, no fp8 | All HIP-supported kernels; fp8 widened  |
+| RDNA3      | `gfx1100`-`gfx1103`         | WMMA, no fp8 | All HIP-supported kernels; fp8 widened  |
+| RDNA2      | `gfx1030`-`gfx1036`         | none         | Non-WMMA kernels incl. AWQ GEMV; WMMA GEMMs decline |
+
+fp8, int8 and int4 share one byte-addressed tile kernel (`gemm_wmma.h`). RDNA3
+and RDNA4 spread a WMMA operand across the wave differently and RDNA3 has no fp8
+WMMA (it widens to bf16, which is exact), so each has its own set of `Mma`
+policies in `mma.h`; the tile kernel itself is shared.
+
+RDNA2 has no matrix cores. It runs the kernels that do not need them (RoPE,
+AdaLN and RMS-AdaLN, the quantizers, stochastic rounding, the AWQ GEMV) and does
+not advertise the GEMMs, which fall through to triton/eager. In a process with a
+mix of GPUs the capability set is the intersection, since kernels launch on the
+tensor's own device.
+
+A request outside a kernel's domain (swizzled operands, scaling other than
+tensor-wise, a K that is not a multiple of 16) falls back to torch or eager.
+NVFP4 and MXFP8 stay on eager everywhere: RDNA has neither fp4 WMMA nor
+microscaling hardware. Set `COMFY_KITCHEN_DISABLE_HIP=1` to remove the backend
+from dispatch.
+
+### Building
+
+The backend is built whenever a ROCm toolchain is found. Both a system ROCm
+install and the pip `rocm-sdk` layout (which a ROCm PyTorch build already pulls
+in) are detected automatically, so on Linux and Windows alike the build is:
+
+```bash
+pip install .
+```
+
+No environment variables, `CC`/`CXX` override or Visual Studio developer shell
+are needed: the ROCm clang builds C, C++ and HIP alike and locates the MSVC
+toolchain itself. CMake >= 3.26 and Ninja are required (Windows only ships a
+Visual Studio generator, which has no HIP language support). On Windows the
+Microsoft C++ build tools and Windows SDK must be installed, since clang links
+against them and CMake compiles a resource file with the SDK's `rc.exe`, which
+the build locates itself rather than expecting on `PATH`. Use the Visual Studio
+2022 v143 toolset; newer MSVC toolsets are not yet reliable with ROCm.
+
+Architectures default to the supported GPUs the build machine can see, or to
+every RDNA2/3/3.5/4 target ROCm supports when it can see none (a CI box), which
+is what the wheels carry. Detection reads the visible devices through PyTorch, so
+under PEP 517 build isolation (a plain `pip install .`) it sees nothing and falls
+back to the full target list; set `COMFY_HIP_ARCHS`, or pass
+`--no-build-isolation`, to build for the local GPU instead. Building for one
+target is much faster:
+
+```bash
+COMFY_HIP_ARCHS=gfx1201 pip install .
+```
+
+```powershell
+$env:COMFY_HIP_ARCHS = "gfx1201"; pip install .
+```
+
+`PYTORCH_ROCM_ARCH` and `GPU_ARCHS` are honoured too. When the build machine sees
+AMD GPUs but none is RDNA2/3/3.5/4 (CDNA has MFMA, not WMMA), the extension is
+skipped rather than built (seeing no GPU at all falls back to the full target list
+above instead);
+`COMFY_KITCHEN_BUILD_HIP=1` makes that a hard error instead, and
+`COMFY_KITCHEN_BUILD_NO_HIP=1` suppresses the backend entirely.
+
+Both extensions are built against the Python limited API on 3.12+, so a wheel
+carrying CUDA and HIP side by side keeps its `abi3` tag. Each backend withdraws
+itself at import when its runtime is absent.
 
 
 ## Quantized Tensors
@@ -107,7 +221,7 @@ python setup.py build_ext --debug-build --lineinfo bdist_wheel
   - Pre-built wheels require NVIDIA Driver r580+
   - Building from source requires CUDA Toolkit ≥12.8 and `CUDA_HOME` environment variable
 - **nanobind**: ≥2.0.0 (for building from source)
-- **CMake**: ≥3.18 (for building from source)
+- **CMake**: ≥3.26 (for building from source; the abi3 modules need FindPython's `Development.SABIModule`)
 
 ## Quick Start
 
@@ -115,7 +229,7 @@ python setup.py build_ext --debug-build --lineinfo bdist_wheel
 import comfy_kitchen as ck
 import torch
 
-# Automatic backend selection (triton -> cuda -> eager)
+# Automatic backend selection (hip -> cuda -> triton -> eager)
 x = torch.randn(100, 100, device="cuda")
 scale = torch.tensor([1.0], device="cuda")
 result = ck.quantize_per_tensor_fp8(x, scale)
@@ -136,11 +250,12 @@ with ck.use_backend("triton"):
 The library supports multiple backends:
 - **eager**: Pure PyTorch implementation
 - **cuda**: Custom CUDA C kernels (CUDA only)
+- **hip**: Custom HIP kernels (WMMA GEMMs on RDNA3/3.5/4; non-WMMA kernels also on RDNA2)
 - **triton**: Triton JIT-compiled kernels
 
 ### Automatic Backend Selection
 
-When you call a function, the registry selects the best backend by checking **constraints** in priority order (`cuda` → `triton` → `eager`):
+When you call a function, the registry selects the best backend by checking **constraints** in priority order (`hip` → `cuda` → `triton` → `eager`):
 
 ```python
 # Backend is selected automatically based on input constraints

--- a/comfy_kitchen/__init__.py
+++ b/comfy_kitchen/__init__.py
@@ -4,6 +4,7 @@ from .backends import cuda as _cuda_backend  # noqa: F401
 
 # Import backends to trigger auto-registration
 from .backends import eager as _eager_backend  # noqa: F401
+from .backends import hip as _hip_backend  # noqa: F401
 from .backends import triton as _triton_backend  # noqa: F401
 from .backends.eager.quantization import DTYPE_TO_CODE
 from .backends.eager.quantization import mm_int8 as _mm_int8
@@ -22,6 +23,11 @@ from .tensor.convrot_w4a4 import (
     dequantize_convrot_w4a4_weight,
     quantize_convrot_w4a4_weight,
 )
+
+# The HIP backend registers only on a supported AMD device (RDNA2/3/3.5/4), and
+# advertises only the ops that device can run; prefer it where it registers.
+if registry.is_available("hip"):
+    registry.set_priority(["hip", "cuda", "triton", "eager"])
 
 __all__ = [
     # Normalization

--- a/comfy_kitchen/backends/hip/CMakeLists.txt
+++ b/comfy_kitchen/backends/hip/CMakeLists.txt
@@ -1,0 +1,168 @@
+# 3.21 for the HIP language (CMAKE_HIP_ARCHITECTURES), 3.26 for the
+# Development.SABIModule component the abi3 module below needs.
+cmake_minimum_required(VERSION 3.26)
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_HIP_STANDARD 20)
+set(CMAKE_HIP_STANDARD_REQUIRED ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+# RDNA2/3/4. The GEMMs select a WMMA path per target in mma.h (gfx11 and gfx12
+# have different fragment layouts); RDNA2 has no matrix cores and builds only the
+# elementwise kernels. Override with --hip-archs / COMFY_HIP_ARCHS. Must precede
+# project(), which fails HIP compiler detection when CMAKE_HIP_ARCHITECTURES is unset.
+#
+# setup.py always passes -DCOMFY_HIP_ARCHS, so this is the default for a direct
+# cmake run only. test_hip_default_archs_match_the_cmake_default keeps it equal
+# to DEFAULT_HIP_ARCHS in setup.py.
+if(NOT DEFINED COMFY_HIP_ARCHS OR COMFY_HIP_ARCHS STREQUAL "")
+    # set() already joins its arguments with ";", so these must not carry their own.
+    set(COMFY_HIP_ARCHS
+        "gfx1030" "gfx1031" "gfx1032" "gfx1033" "gfx1034" "gfx1035" "gfx1036"  # RDNA2
+        "gfx1100" "gfx1101" "gfx1102" "gfx1103"                                # RDNA3
+        "gfx1150" "gfx1151" "gfx1152" "gfx1153"                                # RDNA3.5
+        "gfx1200" "gfx1201")                                                   # RDNA4
+endif()
+set(CMAKE_HIP_ARCHITECTURES "${COMFY_HIP_ARCHS}")
+
+# A pip-installed rocm-sdk places the device bitcode under
+# lib/llvm/amdgcn/bitcode rather than the <root>/amdgcn/bitcode clang probes for.
+# Must precede project(), which compiles a test program with these flags.
+if(DEFINED CMAKE_HIP_COMPILER_ROCM_ROOT)
+    set(_ck_devlib "${CMAKE_HIP_COMPILER_ROCM_ROOT}/lib/llvm/amdgcn/bitcode")
+    if(EXISTS "${_ck_devlib}" AND NOT EXISTS "${CMAKE_HIP_COMPILER_ROCM_ROOT}/amdgcn/bitcode")
+        # Quote the path: a ROCm root with spaces would otherwise split into extra
+        # compiler arguments and fail the project() HIP probe.
+        set(CMAKE_HIP_FLAGS "${CMAKE_HIP_FLAGS} --rocm-device-lib-path=\"${_ck_devlib}\"")
+    endif()
+
+    # A stale HIP_PATH from an older SDK install outranks both the compiler's own
+    # search and --rocm-path, so pin the runtime to the root that was resolved.
+    if(EXISTS "${CMAKE_HIP_COMPILER_ROCM_ROOT}/include/hip/hip_version.h")
+        set(CMAKE_HIP_FLAGS "${CMAKE_HIP_FLAGS} --hip-path=\"${CMAKE_HIP_COMPILER_ROCM_ROOT}\"")
+    endif()
+endif()
+
+project(comfy_kitchen_hip LANGUAGES CXX HIP)
+
+message(STATUS "HIP architectures: ${CMAKE_HIP_ARCHITECTURES}")
+
+# After project(), so ccache never wraps the compiler detection probes. HIP is
+# the same clang++ driver as CXX here, so it defaults to the C++ launcher.
+if(DEFINED COMFY_CXX_COMPILER_LAUNCHER)
+    set(CMAKE_CXX_COMPILER_LAUNCHER "${COMFY_CXX_COMPILER_LAUNCHER}")
+    message(STATUS "C++ compiler launcher: ${CMAKE_CXX_COMPILER_LAUNCHER}")
+endif()
+if(NOT DEFINED COMFY_HIP_COMPILER_LAUNCHER)
+    set(COMFY_HIP_COMPILER_LAUNCHER "${COMFY_CXX_COMPILER_LAUNCHER}")
+endif()
+if(COMFY_HIP_COMPILER_LAUNCHER)
+    set(CMAKE_HIP_COMPILER_LAUNCHER "${COMFY_HIP_COMPILER_LAUNCHER}")
+    message(STATUS "HIP compiler launcher: ${CMAKE_HIP_COMPILER_LAUNCHER}")
+endif()
+
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release)
+endif()
+
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -O0")
+else()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3")
+endif()
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden -fdiagnostics-color=always")
+
+# Same components as the CUDA backend. A wheel only keeps the abi3 tag if every
+# extension in it is abi3, so this has to match.
+find_package(Python REQUIRED COMPONENTS Interpreter Development.Module Development.SABIModule)
+
+execute_process(
+    COMMAND "${Python_EXECUTABLE}" -c "import nanobind; print(nanobind.cmake_dir())"
+    OUTPUT_VARIABLE NB_DIR
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    RESULT_VARIABLE NB_RESULT
+)
+
+if(NOT NB_RESULT EQUAL 0)
+    message(FATAL_ERROR "nanobind not found. Install with: pip install nanobind")
+endif()
+
+list(APPEND CMAKE_PREFIX_PATH "${NB_DIR}")
+find_package(nanobind CONFIG REQUIRED)
+
+# hip-config.cmake hard-errors ("Unexpected HIP_PLATFORM") when this is unset;
+# only some ROCm layouts default it. amd is the only platform these kernels target.
+if(NOT DEFINED HIP_PLATFORM)
+    set(HIP_PLATFORM "amd")
+endif()
+
+find_package(hip REQUIRED CONFIG)
+
+set(HIP_SOURCES
+    ops/per_tensor_fp8.hip
+    ops/stochastic_round_fp8.hip
+    ops/quantize_int8.hip
+    ops/gemm_fp8.hip
+    ops/gemm_int8.hip
+    ops/convrot_w4a4.hip
+    ops/adaln.hip
+    ops/apply_rope.hip
+    ops/rms_rope.hip
+    ops/gemv_awq.hip
+    ops/svdquant_w4a4.hip
+)
+
+set(CPP_SOURCES
+    dlpack_bindings.cpp
+)
+
+# NOMINSIZE: nanobind_add_module() otherwise puts -Os on the whole target, which the
+# -O3 below would have to override by flag order alone. The kernels are the point of
+# this module, so opt out rather than rely on which -O wins.
+if(Python_VERSION VERSION_GREATER_EQUAL "3.12")
+    message(STATUS "Python ${Python_VERSION} detected - enabling stable ABI (abi3)")
+    nanobind_add_module(_C NB_STATIC STABLE_ABI LTO NOMINSIZE ${CPP_SOURCES} ${HIP_SOURCES})
+    if(WIN32)
+        set_target_properties(_C PROPERTIES SUFFIX ".abi3.pyd")
+    else()
+        set_target_properties(_C PROPERTIES SUFFIX ".abi3.so")
+    endif()
+    target_compile_definitions(_C PRIVATE Py_LIMITED_API=0x030C0000)
+else()
+    message(STATUS "Python ${Python_VERSION} detected - building version-specific module")
+    nanobind_add_module(_C NB_STATIC LTO NOMINSIZE ${CPP_SOURCES} ${HIP_SOURCES})
+endif()
+
+target_compile_definitions(_C PRIVATE NB_STATIC)
+
+target_compile_options(_C PRIVATE
+    $<$<COMPILE_LANGUAGE:HIP>:-O3>
+    $<$<COMPILE_LANGUAGE:HIP>:-ffast-math>
+)
+
+if(COMFY_ENABLE_LINEINFO OR CMAKE_BUILD_TYPE STREQUAL "Debug")
+    target_compile_options(_C PRIVATE $<$<COMPILE_LANGUAGE:HIP>:-gline-tables-only>)
+endif()
+
+target_include_directories(_C PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+target_link_libraries(_C PRIVATE hip::host)
+
+if(CMAKE_CONFIGURATION_TYPES)
+    set_target_properties(_C PROPERTIES
+        LIBRARY_OUTPUT_DIRECTORY_DEBUG "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}"
+        LIBRARY_OUTPUT_DIRECTORY_RELEASE "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}"
+        LIBRARY_OUTPUT_DIRECTORY_RELWITHDEBINFO "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}"
+        LIBRARY_OUTPUT_DIRECTORY_MINSIZEREL "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}"
+        RUNTIME_OUTPUT_DIRECTORY_DEBUG "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}"
+        RUNTIME_OUTPUT_DIRECTORY_RELEASE "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}"
+        RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}"
+        RUNTIME_OUTPUT_DIRECTORY_MINSIZEREL "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}"
+    )
+endif()
+
+install(TARGETS _C
+    LIBRARY DESTINATION .
+    RUNTIME DESTINATION .
+)

--- a/comfy_kitchen/backends/hip/__init__.py
+++ b/comfy_kitchen/backends/hip/__init__.py
@@ -1,0 +1,1414 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""HIP backend for AMD RDNA2, RDNA3/3.5 and RDNA4.
+
+Every matmul is a WMMA kernel compiled from the sources in this directory; the
+backend does not link or call hipBLAS/hipBLASLt.
+
+RDNA3 (gfx11xx) and RDNA4 (gfx12xx) have matrix cores and get everything. Their
+fragment layouts differ, and RDNA3 has no fp8 WMMA, so it widens fp8 to bf16;
+see mma.h.
+
+RDNA2 (gfx103x) has no matrix cores. It runs the elementwise kernels (RoPE,
+AdaLN and RMS-AdaLN, the quantizers, stochastic rounding, the AWQ GEMV) and
+declines the GEMMs, which fall through to triton/eager.
+"""
+import functools
+import importlib.util
+import logging
+import os
+import sys
+from collections.abc import Sequence
+
+import torch
+
+from comfy_kitchen._rope_utils import check_rope_inplace
+from comfy_kitchen.backends import eager as _eager
+from comfy_kitchen.backends._activations import apply_input_act as _apply_input_act
+from comfy_kitchen.backends._activations import input_act_code as _input_act_code
+from comfy_kitchen.backends.eager.quantization import DTYPE_TO_CODE
+
+logger = logging.getLogger("comfy_kitchen.hip")
+
+__all__ = [
+    "adaln",
+    "rms_adaln",
+    "gemv_awq_w4a16",
+    "quantize_svdquant_w4a4",
+    "scaled_mm_svdquant_w4a4",
+    "apply_rope",
+    "apply_rope_",
+    "apply_rope1",
+    "apply_rope1_",
+    "apply_rope_split_half",
+    "apply_rope_split_half_",
+    "apply_rope_split_half1",
+    "apply_rope_split_half1_",
+    "convrot_w4a4_linear",
+    "dequantize_convrot_w4a4_weight",
+    "dequantize_per_tensor_fp8",
+    "has_wmma",
+    "int8_linear",
+    "is_available",
+    "quantize_and_rotate_rowwise",
+    "quantize_convrot_w4a4_weight",
+    "quantize_int8_convrot_weight",
+    "quantize_int8_rowwise",
+    "quantize_int8_tensorwise",
+    "quantize_per_tensor_fp8",
+    "rms_rope",
+    "rms_rope_",
+    "rms_rope1",
+    "rms_rope1_",
+    "rms_rope_split_half",
+    "rms_rope_split_half_",
+    "rms_rope_split_half1",
+    "rms_rope_split_half1_",
+    "scaled_mm_fp8",
+    "stochastic_rounding_fp8",
+]
+
+_C = None
+_EXT_AVAILABLE = False
+_EXT_ERROR = None
+
+try:
+    _dir = os.path.dirname(__file__)
+    _module_path = None
+    for _fn in os.listdir(_dir):
+        if _fn.startswith("_C.") and _fn.endswith((".so", ".pyd")):
+            _module_path = os.path.join(_dir, _fn)
+            break
+
+    if _module_path is None:
+        _EXT_ERROR = "HIP extension not built (no _C module in backends/hip)"
+    else:
+        _spec = importlib.util.spec_from_file_location("comfy_kitchen.backends.hip._C", _module_path)
+        _C = importlib.util.module_from_spec(_spec)
+        sys.modules["comfy_kitchen.backends.hip._C"] = _C
+        _spec.loader.exec_module(_C)
+        _EXT_AVAILABLE = True
+except Exception as e:  # a broken extension must not break import
+    # exec_module can fail after the module was cached above, leaving a
+    # half-initialized _C importable from sys.modules. Drop it so a later import
+    # does not pick up the broken object.
+    if _C is not None and sys.modules.get("comfy_kitchen.backends.hip._C") is _C:
+        del sys.modules["comfy_kitchen.backends.hip._C"]
+    _EXT_ERROR = f"Failed to load HIP extension: {e}"
+    _C = None
+
+
+def _gfx_arch(device: torch.device | int | None = None) -> str | None:
+    """gfx architecture of ``device``, e.g. "gfx1201". Defaults to the current device."""
+    if not torch.cuda.is_available() or not getattr(torch.version, "hip", None):
+        return None
+    try:
+        return torch.cuda.get_device_properties(device).gcnArchName.split(":")[0]
+    except Exception:
+        return None
+
+
+@functools.lru_cache(maxsize=1)
+def _visible_gfx_arches() -> tuple[str | None, ...]:
+    """One entry per visible device; None where the architecture could not be read.
+
+    Cached: the visible device set is fixed for the life of the process, and
+    scaled_mm_v2 consults has_wmma() on every candidate GEMM.
+    """
+    if not torch.cuda.is_available() or not getattr(torch.version, "hip", None):
+        return ()
+    return tuple(_gfx_arch(i) for i in range(torch.cuda.device_count()))
+
+
+# RDNA2 has no matrix cores; RDNA3/3.5 and RDNA4 do. RDNA1 and older have neither
+# these nor the dot-product paths, and CDNA uses MFMA rather than WMMA.
+_ARCH_SUPPORTED = ("gfx103", "gfx11", "gfx12")
+_ARCH_WMMA = ("gfx11", "gfx12")
+
+# The GEMMs, and only the GEMMs, need matrix cores. Everything else is elementwise
+# or a scalar reduction and runs on any supported architecture. This set names the
+# registry-dispatched GEMMs so _build_constraints can drop them on RDNA2; the fp8
+# GEMM is not among them because it is reached through scaled_mm_v2's _hip_fp8_gemm,
+# which gates on has_wmma() itself rather than through the registry.
+_WMMA_ONLY_OPS = frozenset({
+    "int8_linear",
+    "convrot_w4a4_linear",
+    "scaled_mm_svdquant_w4a4",
+})
+
+
+def _unsupported_arch_reason(arches: Sequence[str | None]) -> str | None:
+    """Why the backend must not register for this set of devices, or None if it may.
+
+    A device whose architecture cannot be read counts against it: it cannot be
+    shown to be supported.
+    """
+    if not arches:
+        return "no HIP device available"
+    if any(a is None for a in arches):
+        return "could not read the architecture of every visible device"
+    unsupported = sorted({a for a in arches if not a.startswith(_ARCH_SUPPORTED)})
+    if unsupported:
+        return f"kernels require RDNA2/3/4, found {', '.join(unsupported)}"
+    return None
+
+
+def _has_wmma(arches: Sequence[str | None]) -> bool:
+    """Whether every visible device has matrix cores.
+
+    Registration is per-process while kernels launch on the tensor's own device, so
+    the capability set has to be the intersection over the visible devices: one
+    RDNA2 card in an otherwise RDNA4 box means no GEMM is safe to advertise.
+    """
+    return bool(arches) and all(a is not None and a.startswith(_ARCH_WMMA) for a in arches)
+
+
+def is_available() -> bool:
+    return _EXT_AVAILABLE and _unsupported_arch_reason(_visible_gfx_arches()) is None
+
+
+def has_wmma() -> bool:
+    """Whether the GEMM kernels can run: every visible device has matrix cores.
+
+    is_available() is true on RDNA2 as well, where only the elementwise kernels
+    exist, so callers that reach a GEMM without going through the registry (see
+    scaled_mm_v2) have to test this instead. One arch snapshot per call: this sits
+    on the per-GEMM dispatch path.
+    """
+    arches = _visible_gfx_arches()
+    return (
+        _EXT_AVAILABLE
+        and _unsupported_arch_reason(arches) is None
+        and _has_wmma(arches)
+    )
+
+
+def _stream(t: torch.Tensor) -> int:
+    return torch.cuda.current_stream(t.device).cuda_stream
+
+
+# The epilogues read a scalar per element with one dtype code.
+_EPILOGUE_DTYPES = (torch.float32, torch.float16, torch.bfloat16)
+
+
+def _aligned(t: torch.Tensor) -> torch.Tensor:
+    """``t`` on a 16-byte boundary, which the GEMMs' uint4 row loads require.
+
+    contiguous() keeps a slice whose storage offset is not aligned, so a fresh
+    allocation is the only way to move the base.
+    """
+    return t.clone() if t.data_ptr() % 16 else t
+
+
+def _operand(t: torch.Tensor, device: torch.device, name: str, shape=None) -> torch.Tensor:
+    """A contiguous view of ``t`` on ``device``, since the kernels take raw pointers.
+
+    Every launch uses one stream and one set of extents, so an operand left on
+    another device would be dereferenced there, and a mis-shaped one read past its
+    end.
+    """
+    if shape is not None and tuple(t.shape) != tuple(shape):
+        raise ValueError(f"{name} must have shape {tuple(shape)}, got {tuple(t.shape)}")
+    return _aligned(t.to(device=device).contiguous())
+
+
+def _scale_operand(scale: torch.Tensor, device: torch.device) -> torch.Tensor:
+    """The fp8 kernels read one float scale off a raw pointer on the launch stream."""
+    scale = scale.reshape(-1)
+    if scale.numel() != 1:
+        raise ValueError(f"expected a single per-tensor scale, got {scale.numel()} elements")
+    return scale.to(device=device, dtype=torch.float32).contiguous()
+
+
+def _bias_operand(bias: torch.Tensor, n: int, device: torch.device) -> torch.Tensor:
+    """The epilogue indexes bias[col], so it must be 1D of length N and decodable."""
+    if bias.dim() != 1 or bias.numel() != n:
+        raise ValueError(f"bias must be 1D of length {n}, got {tuple(bias.shape)}")
+    if bias.dtype not in _EPILOGUE_DTYPES:
+        raise ValueError(f"bias dtype {bias.dtype} is not supported, expected one of "
+                         f"{[str(d) for d in _EPILOGUE_DTYPES]}")
+    return bias.to(device=device).contiguous()
+
+
+def _dl(t: torch.Tensor):
+    # __dlpack__ refuses a tensor that requires grad, and weights arrive as
+    # nn.Parameters. Neither no_grad nor inference_mode clears the flag. Detaching
+    # shares storage, so it costs nothing.
+    if t.requires_grad:
+        t = t.detach()
+    # stream=-1 tells PyTorch to skip synchronization (DLPack spec)
+    return t.__dlpack__(stream=-1)
+
+
+# ---------------------------------------------------------------------------
+# FP8 elementwise
+# ---------------------------------------------------------------------------
+
+def quantize_per_tensor_fp8(
+    x: torch.Tensor,
+    scale: torch.Tensor,
+    output_type: torch.dtype = torch.float8_e4m3fn,
+) -> torch.Tensor:
+    x = x.contiguous()
+    scale = _scale_operand(scale, x.device)
+
+    out = torch.empty(x.shape, dtype=torch.uint8, device=x.device)
+    _C.quantize_per_tensor_fp8(
+        _dl(x), _dl(scale), _dl(out),
+        DTYPE_TO_CODE[x.dtype], DTYPE_TO_CODE[output_type], x.numel(), _stream(x),
+    )
+    return out.view(output_type)
+
+
+def dequantize_per_tensor_fp8(
+    x: torch.Tensor,
+    scale: torch.Tensor,
+    output_type: torch.dtype = torch.bfloat16,
+) -> torch.Tensor:
+    x = x.contiguous()
+    scale = _scale_operand(scale, x.device)
+
+    out = torch.empty(x.shape, dtype=output_type, device=x.device)
+    _C.dequantize_per_tensor_fp8(
+        _dl(x.view(torch.uint8)), _dl(scale), _dl(out),
+        DTYPE_TO_CODE[x.dtype], DTYPE_TO_CODE[output_type], x.numel(), _stream(x),
+    )
+    return out
+
+
+def stochastic_rounding_fp8(
+    x: torch.Tensor,
+    rng: torch.Tensor,
+    output_type: torch.dtype = torch.float8_e4m3fn,
+) -> torch.Tensor:
+    """Quantize x to fp8 with stochastic rounding, consuming rng as the random source.
+
+    The kernel writes the fp8 result into rng's storage, so the caller's rng
+    tensor is overwritten and the returned tensor is a view of it.
+    """
+    if rng.device != x.device:
+        raise ValueError("rng must be on the same device as x")
+    if rng.shape != x.shape:
+        raise ValueError("rng must have the same shape as x")
+    # .contiguous() would hand the kernel a copy, leaving the caller's rng
+    # untouched and the returned view backed by the wrong storage.
+    if not rng.is_contiguous():
+        raise ValueError("rng must be contiguous: the kernel writes the result into it")
+
+    x = x.contiguous()
+    _C.stochastic_round_fp8(
+        _dl(rng), _dl(x), DTYPE_TO_CODE[output_type], x.numel(), _stream(x),
+    )
+    return rng.view(output_type)
+
+
+# ---------------------------------------------------------------------------
+# FP8 GEMM (v_wmma_f32_16x16x16_fp8_fp8)
+# ---------------------------------------------------------------------------
+
+def _weight_as_nk(b: torch.Tensor) -> torch.Tensor:
+    """Return the weight as a contiguous (N, K) tensor.
+
+    The B operand of ``a @ b`` arrives with shape (K, N). When it is a transposed
+    view of a contiguous (N, K) weight, as it is for linear, the transpose is
+    free; otherwise it costs a copy.
+    """
+    if b.dim() != 2:
+        raise ValueError(f"expected a 2D weight, got {tuple(b.shape)}")
+    bt = b.t()
+    return bt if bt.is_contiguous() else bt.contiguous()
+
+
+def scaled_mm_fp8(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    scale_a: torch.Tensor,
+    scale_b: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    out_dtype: torch.dtype = torch.bfloat16,
+) -> torch.Tensor:
+    """out = (a @ b) * scale_a * scale_b + bias, with a (M, K) and b (K, N) fp8."""
+    # The kernel reads both operands as raw e4m3 bytes; anything else viewed as
+    # uint8 would compute nonsense. _C is reachable directly, and this wrapper is a
+    # public entry too, so gate here rather than trust the caller.
+    if a.dtype is not torch.float8_e4m3fn or b.dtype is not torch.float8_e4m3fn:
+        raise ValueError(
+            f"scaled_mm_fp8 requires float8_e4m3fn operands, got a={a.dtype}, b={b.dtype}"
+        )
+    a = _aligned(a.contiguous())
+    b_nk = _aligned(_weight_as_nk(b).to(device=a.device))
+
+    m, k = a.shape
+    n = b_nk.shape[0]
+    if b_nk.shape[1] != k:
+        raise ValueError(f"inner dimension mismatch: a K={k}, b K={b_nk.shape[1]}")
+
+    # The WMMA K-step and the small-M GEMV both read a row 16 bytes at a time.
+    if k % 16 != 0:
+        raise ValueError(f"scaled_mm_fp8 requires K divisible by 16, got {k}")
+    # The kernel takes raw pointers on a's stream, so the scales and bias have to
+    # live on a's device, and the epilogue indexes bias[col].
+    scale_a = _scale_operand(scale_a, a.device)
+    scale_b = _scale_operand(scale_b, a.device)
+    if bias is not None:
+        bias = _bias_operand(bias, n, a.device)
+
+    out = torch.empty((m, n), dtype=out_dtype, device=a.device)
+    _C.scaled_mm_fp8(
+        _dl(a.view(torch.uint8)), _dl(b_nk.view(torch.uint8)), _dl(out),
+        _dl(scale_a), _dl(scale_b), None if bias is None else _dl(bias),
+        m, n, k, DTYPE_TO_CODE[out_dtype], _stream(a),
+    )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# INT8 quantization + GEMM (v_wmma_i32_16x16x16_iu8)
+# ---------------------------------------------------------------------------
+
+def quantize_int8_rowwise(
+    x: torch.Tensor,
+    stochastic_rounding: int | None = 0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if stochastic_rounding:
+        return _eager.quantize_int8_rowwise(x, stochastic_rounding=stochastic_rounding)
+
+    x2d = x.reshape(-1, x.shape[-1]).contiguous()
+    m, k = x2d.shape
+    q = torch.empty((m, k), dtype=torch.int8, device=x.device)
+    scales = torch.empty((m,), dtype=torch.float32, device=x.device)
+    _C.quantize_int8_rowwise(_dl(x2d), _dl(q), _dl(scales), m, k, _stream(x))
+    return q.reshape(x.shape), scales.reshape(*x.shape[:-1], 1)
+
+
+def quantize_int8_tensorwise(
+    x: torch.Tensor,
+    scale: torch.Tensor | float | str | None = None,
+    stochastic_rounding: int | None = 0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    # A caller-supplied scale reduces to an elementwise quantize; only the
+    # absmax-derived scale needs the fused reduction kernel.
+    if stochastic_rounding or (scale is not None and not isinstance(scale, str)):
+        return _eager.quantize_int8_tensorwise(x, scale=scale, stochastic_rounding=stochastic_rounding)
+
+    xc = x.contiguous()
+    q = torch.empty(xc.shape, dtype=torch.int8, device=x.device)
+    out_scale = torch.empty((), dtype=torch.float32, device=x.device)
+    scratch = torch.zeros((), dtype=torch.int32, device=x.device)
+    _C.quantize_int8_tensorwise(
+        _dl(xc), _dl(q), _dl(out_scale.reshape(1)), _dl(scratch.reshape(1)), xc.numel(), _stream(x)
+    )
+    return q, out_scale
+
+
+# Keyed by device: convrot_max_k() reports the LDS budget of whichever device is
+# current, which a process with more than one GPU can switch under a shared cache.
+_convrot_max_k: dict[int, int] = {}
+
+
+def _convrot_supported(k: int, group_size: int, device: torch.device) -> bool:
+    """Whether the fused rotation can take a row of this width on ``device``.
+
+    It stages the whole row in LDS, which bounds K per device, and it rotates K/G
+    whole groups while reading back all K entries, so a partial trailing group
+    would quantize uninitialized LDS.
+
+    The budget is read for the operand's own device, not the process-current one:
+    the kernels launch on the operand's stream, so in a multi-GPU process the two
+    can be different cards with different budgets.
+    """
+    if group_size not in (16, 64, 256) or k % group_size != 0:
+        return False
+
+    index = device.index if device.index is not None else torch.cuda.current_device()
+    max_k = _convrot_max_k.get(index)
+    if max_k is None:
+        with torch.cuda.device(index):
+            max_k = _C.convrot_max_k()
+        _convrot_max_k[index] = max_k
+    return max_k > 0 and k <= max_k
+
+
+def _rotate_quant_int8(
+    x2d: torch.Tensor, group_size: int, input_act: str | None = None
+) -> tuple[torch.Tensor, torch.Tensor]:
+    m, k = x2d.shape
+    q = torch.empty((m, k), dtype=torch.int8, device=x2d.device)
+    scales = torch.empty((m,), dtype=torch.float32, device=x2d.device)
+    # check_convrot_k queries the current device's LDS budget, so pin it to the
+    # operand's device rather than trusting the caller thread's current device.
+    with torch.cuda.device(x2d.device):
+        _C.quantize_int8_convrot(
+            _dl(x2d), _dl(q), _dl(scales), m, k, group_size,
+            _input_act_code(input_act), _stream(x2d),
+        )
+    return q, scales
+
+
+def quantize_and_rotate_rowwise(
+    x: torch.Tensor,
+    h: torch.Tensor,
+    group_size: int,
+    stochastic_rounding: int | None = 0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Fused ConvRot rotation + rowwise int8 quantize.
+
+    ``h`` is the pre-built Hadamard matrix the eager path multiplies by. The
+    fused kernel synthesizes the same transform from radix-4 butterflies, so the
+    argument is accepted and unused.
+    """
+    if stochastic_rounding or not _convrot_supported(x.shape[-1], group_size, x.device):
+        return _eager.quantize_and_rotate_rowwise(
+            x, h, group_size, stochastic_rounding=stochastic_rounding
+        )
+
+    x2d = x.reshape(-1, x.shape[-1]).contiguous()
+    q, scales = _rotate_quant_int8(x2d, group_size)
+    return q.reshape(x.shape), scales.reshape(*x.shape[:-1], 1)
+
+
+def quantize_int8_convrot_weight(
+    weight: torch.Tensor,
+    group_size: int,
+    stochastic_rounding: int | None = 0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Offline ConvRot weight rotation + rowwise int8 quantize.
+
+    Uses the same fused kernel as the activation path.
+    """
+    if stochastic_rounding or not _convrot_supported(weight.shape[-1], group_size, weight.device):
+        return _eager.quantize_int8_convrot_weight(
+            weight, group_size, stochastic_rounding=stochastic_rounding
+        )
+
+    w2d = weight.reshape(-1, weight.shape[-1]).contiguous()
+    q, scales = _rotate_quant_int8(w2d, group_size)
+    return q.reshape(weight.shape), scales.reshape(*weight.shape[:-1], 1)
+
+
+def int8_linear(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    out_dtype: torch.dtype = torch.bfloat16,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+    input_act: str | None = None,
+) -> torch.Tensor:
+    """INT8 linear with dynamic row-wise activation quantization, on WMMA."""
+    # Rejected here so every route fails the same way, not just the fused one.
+    _input_act_code(input_act)
+    if x.shape[-1] != weight.shape[-1]:
+        raise ValueError(
+            f"Input and weight inner dimensions must match, got {x.shape[-1]} and {weight.shape[-1]}"
+        )
+
+    weight = _aligned(weight.to(device=x.device).contiguous())
+    weight_scale = weight_scale.to(device=x.device, dtype=torch.float32).reshape(-1)
+    if weight_scale.numel() not in (1, weight.shape[0]):
+        raise ValueError(
+            f"INT8 weight scale must be scalar or per-output-channel, got {tuple(weight_scale.shape)}"
+        )
+
+    orig_shape = x.shape
+    x2d = x.reshape(-1, orig_shape[-1]).contiguous()
+    m, k = x2d.shape
+    n = weight.shape[0]
+
+    # The WMMA K-step and the small-M GEMV both read a row 16 bytes at a time.
+    if k % 16 != 0:
+        raise ValueError(f"int8_linear requires K divisible by 16, got {k}")
+
+    if convrot:
+        if convrot_groupsize not in (16, 64, 256):
+            raise ValueError(f"ConvRot group size must be 16, 64 or 256, got {convrot_groupsize}")
+        if k % convrot_groupsize != 0:
+            raise ValueError(
+                f"ConvRot group size {convrot_groupsize} does not divide input features {k}"
+            )
+        if not _convrot_supported(k, convrot_groupsize, x.device):
+            return _eager.int8_linear(
+                x, weight, weight_scale, bias, out_dtype, convrot, convrot_groupsize,
+                input_act=input_act,
+            )
+        # The only route that absorbs the activation; the rest apply it eagerly.
+        q, x_scale = _rotate_quant_int8(x2d, convrot_groupsize, input_act)
+    else:
+        x2d = _apply_input_act(x2d, input_act)
+        q = torch.empty((m, k), dtype=torch.int8, device=x.device)
+        x_scale = torch.empty((m,), dtype=torch.float32, device=x.device)
+        _C.quantize_int8_rowwise(_dl(x2d), _dl(q), _dl(x_scale), m, k, _stream(x))
+
+    x_scale = x_scale.reshape(-1).contiguous()
+    if bias is not None:
+        bias = _bias_operand(bias, n, x.device)
+
+    out = torch.empty((m, n), dtype=out_dtype, device=x.device)
+    _C.int8_gemm(
+        _dl(q), _dl(weight), _dl(out),
+        _dl(x_scale), _dl(weight_scale), 0 if weight_scale.numel() == 1 else 1,
+        None if bias is None else _dl(bias),
+        m, n, k, DTYPE_TO_CODE[out_dtype], _stream(x),
+    )
+    return out.reshape(*orig_shape[:-1], n)
+
+
+# ---------------------------------------------------------------------------
+# ConvRot W4A4 (v_wmma_i32_16x16x32_iu4)
+# ---------------------------------------------------------------------------
+
+_INT4_GROUP_SIZE = 64
+
+
+def quantize_convrot_w4a4_weight(
+    weight: torch.Tensor,
+    convrot_groupsize: int = 256,
+    quant_group_size: int = _INT4_GROUP_SIZE,
+    stochastic_rounding: int | None = 0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if quant_group_size != _INT4_GROUP_SIZE:
+        raise ValueError(f"int4 MMA kernel requires quant_group_size {_INT4_GROUP_SIZE}")
+    if stochastic_rounding or not _convrot_supported(weight.shape[-1], convrot_groupsize, weight.device):
+        return _eager.quantize_convrot_w4a4_weight(
+            weight, convrot_groupsize, quant_group_size, stochastic_rounding
+        )
+
+    w = weight.reshape(-1, weight.shape[-1]).contiguous()
+    n, k = w.shape
+    q = torch.empty((n, k // 2), dtype=torch.int8, device=w.device)
+    scales = torch.empty((n,), dtype=torch.float32, device=w.device)
+    # Pin the current device so check_convrot_k reads this operand's LDS budget.
+    with torch.cuda.device(w.device):
+        _C.convrot_quant_int4(_dl(w), _dl(q), _dl(scales), n, k, convrot_groupsize, _stream(w))
+    return q, scales
+
+
+def dequantize_convrot_w4a4_weight(
+    qdata: torch.Tensor,
+    scales: torch.Tensor,
+    convrot_groupsize: int = 256,
+    quant_group_size: int = _INT4_GROUP_SIZE,
+    output_dtype: torch.dtype = torch.float32,
+) -> torch.Tensor:
+    # Only the nibble unpack runs on device; the inverse rotation reuses the
+    # eager Hadamard.
+    from comfy_kitchen.backends.eager.convrot_w4a4 import _build_hadamard, _rotate_weight
+
+    if quant_group_size != _INT4_GROUP_SIZE:
+        raise ValueError(f"int4 MMA kernel requires quant_group_size {_INT4_GROUP_SIZE}")
+
+    n, kp = qdata.shape
+    unpacked = torch.empty((n, kp * 2), dtype=torch.int8, device=qdata.device)
+    _C.unpack_int4(_dl(qdata.contiguous()), _dl(unpacked), n * kp, _stream(qdata))
+
+    w_rot = unpacked.float() * scales.to(device=qdata.device, dtype=torch.float32).reshape(-1, 1)
+    h = _build_hadamard(convrot_groupsize, device=qdata.device, dtype=torch.float32)
+    return _rotate_weight(w_rot, h, convrot_groupsize).to(output_dtype)
+
+
+def convrot_w4a4_linear(
+    x: torch.Tensor,
+    qweight: torch.Tensor,
+    wscales: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    convrot_groupsize: int = 256,
+    quant_group_size: int = _INT4_GROUP_SIZE,
+    linear_dtype: str = "int4",
+) -> torch.Tensor:
+    if linear_dtype not in {"int4", "int8"}:
+        raise ValueError(f"ConvRot W4A4 linear_dtype must be 'int4' or 'int8', got {linear_dtype!r}")
+    if quant_group_size != _INT4_GROUP_SIZE:
+        raise ValueError(f"int4 MMA kernel requires quant_group_size {_INT4_GROUP_SIZE}")
+    if x.shape[-1] != qweight.shape[-1] * 2:
+        raise ValueError(f"Input K={x.shape[-1]} does not match qweight K={qweight.shape[-1] * 2}")
+    # An empty output (zero rows, or zero output features) does no packed reads; the
+    # launcher accepts it, so return before the alignment checks below rather than
+    # tripping over them. A zero-K input is not empty: its output is a pure bias
+    # broadcast (an empty contraction sums to zero), so build it here rather than
+    # launch, and never leak uninitialized values through torch.empty.
+    if 0 in x.shape[:-1] or qweight.shape[0] == 0:
+        return torch.empty((*x.shape[:-1], qweight.shape[0]), dtype=x.dtype, device=x.device)
+    if x.shape[-1] == 0:
+        out = torch.zeros((*x.shape[:-1], qweight.shape[0]), dtype=x.dtype, device=x.device)
+        if bias is not None:
+            out = out + _bias_operand(bias, qweight.shape[0], x.device)
+        return out
+    # The tile loader reads the packed row (K/2 bytes) in 16-byte chunks. A group
+    # size of 16 alone would allow a K that packs to a partial chunk.
+    if x.shape[-1] % 32 != 0:
+        raise ValueError(f"convrot_w4a4_linear requires K divisible by 32, got {x.shape[-1]}")
+    # A group size the kernel does not implement falls back to eager below rather
+    # than raising here, so only the accepted sizes get the divisibility check.
+    # Testing membership first also keeps a zero group size off the modulo.
+    if convrot_groupsize in (16, 64, 256) and x.shape[-1] % convrot_groupsize != 0:
+        raise ValueError(
+            f"Input K={x.shape[-1]} not divisible by convrot_groupsize {convrot_groupsize}"
+        )
+    if not _convrot_supported(x.shape[-1], convrot_groupsize, x.device):
+        return _eager.convrot_w4a4_linear(
+            x, qweight, wscales, bias, convrot_groupsize, quant_group_size, linear_dtype
+        )
+
+    if linear_dtype == "int8":
+        # As on CUDA: the int4 weight is unpacked to int8 values and the whole
+        # linear runs on the int8 WMMA kernel with int8 activations.
+        qw = _operand(qweight, x.device, "qweight")
+        w_int8 = torch.empty((qw.shape[0], qw.shape[1] * 2), dtype=torch.int8, device=x.device)
+        _C.unpack_int4(_dl(qw), _dl(w_int8), qw.numel(), _stream(x))
+        return int8_linear(
+            x, w_int8, wscales, bias, x.dtype,
+            convrot=True, convrot_groupsize=convrot_groupsize,
+        )
+
+    orig_shape = x.shape
+    x2d = x.reshape(-1, orig_shape[-1]).contiguous()
+    m, k = x2d.shape
+    n = qweight.shape[0]
+
+    qact = torch.empty((m, k // 2), dtype=torch.int8, device=x.device)
+    x_scale = torch.empty((m,), dtype=torch.float32, device=x.device)
+    # Pin the current device so check_convrot_k reads this operand's LDS budget.
+    with torch.cuda.device(x.device):
+        _C.convrot_quant_int4(_dl(x2d), _dl(qact), _dl(x_scale), m, k, convrot_groupsize, _stream(x))
+
+    wscales = wscales.to(device=x.device, dtype=torch.float32).reshape(-1)
+    if wscales.numel() != n:
+        raise ValueError(f"wscales must have {n} entries, got {wscales.numel()}")
+    if bias is not None:
+        bias = _bias_operand(bias, n, x.device)
+    qw = _operand(qweight, x.device, "qweight", shape=(n, k // 2))
+
+    out = torch.empty((m, n), dtype=x.dtype, device=x.device)
+    _C.convrot_w4a4_gemm(
+        _dl(qact), _dl(qw), _dl(out),
+        _dl(x_scale), _dl(wscales), None if bias is None else _dl(bias),
+        m, n, k, DTYPE_TO_CODE[x.dtype], _stream(x),
+    )
+    return out.reshape(*orig_shape[:-1], n)
+
+
+# ---------------------------------------------------------------------------
+# AWQ W4A16 and SVDQuant W4A4
+# ---------------------------------------------------------------------------
+
+def gemv_awq_w4a16(
+    x: torch.Tensor,
+    qweight: torch.Tensor,
+    wscales: torch.Tensor,
+    wzeros: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    group_size: int = 64,
+) -> torch.Tensor:
+    orig_shape = x.shape
+    x2d = x.reshape(-1, orig_shape[-1]).contiguous()
+    m, k = x2d.shape
+    n = qweight.shape[0]
+
+    # The inner loop decodes eight weights at a time and rescales the chunk once,
+    # so a chunk must not straddle a group boundary.
+    if group_size <= 0 or group_size % 8 != 0:
+        raise ValueError(f"group_size must be a positive multiple of 8, got {group_size}")
+    if k % group_size != 0:
+        raise ValueError(f"K={k} not divisible by group_size={group_size}")
+    if qweight.shape[1] * 2 != k:
+        raise ValueError(f"qweight K//2={qweight.shape[1]} inconsistent with x K={k}")
+
+    # The kernel decodes scales and zeros with a single dtype code, taken from
+    # wscales; a wzeros of another dtype would be read as that one.
+    wscales = _operand(wscales, x.device, "wscales", shape=(k // group_size, n))
+    if wscales.dtype not in _EPILOGUE_DTYPES:
+        raise ValueError(f"wscales dtype {wscales.dtype} is not supported")
+    wzeros = _operand(wzeros, x.device, "wzeros", shape=(k // group_size, n)).to(wscales.dtype)
+    qw = _operand(qweight, x.device, "qweight", shape=(n, k // 2))
+    if bias is not None:
+        bias = _bias_operand(bias, n, x.device)
+
+    out_dtype = wscales.dtype
+    out = torch.empty((m, n), dtype=out_dtype, device=x.device)
+    _C.gemv_awq_w4a16(
+        _dl(x2d), _dl(qw), _dl(wscales), _dl(wzeros),
+        None if bias is None else _dl(bias), _dl(out),
+        m, n, k, group_size, _stream(x),
+    )
+    return out.reshape(*orig_shape[:-1], n)
+
+
+_SVD_GROUP = 64
+
+
+def quantize_svdquant_w4a4(
+    x: torch.Tensor,
+    smooth: torch.Tensor,
+    lora_down: torch.Tensor,
+    pad_size: int = 256,
+    act_unsigned: bool = False,
+    lora_x: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    if x.dim() != 2:
+        raise ValueError(f"expected 2D input, got shape {tuple(x.shape)}")
+    m, k = x.shape
+    if k % _SVD_GROUP != 0:
+        raise ValueError(f"K={k} not divisible by group_size={_SVD_GROUP}")
+
+    if pad_size <= 0:
+        raise ValueError(f"pad_size must be positive, got {pad_size}")
+    if lora_down.dim() != 2:
+        raise ValueError(f"lora_down must be 2D, got {tuple(lora_down.shape)}")
+
+    r = lora_down.shape[1]
+    m_pad = -(-m // pad_size) * pad_size
+
+    # The kernels take M, K and R with no bounds of their own, so every operand
+    # has to match those extents and sit on x's device.
+    xc = x.contiguous()
+    # The kernel decodes smooth with the same dtype code it uses for ascales, which
+    # is allocated from x.dtype, so a smooth of any other dtype would be read as
+    # x.dtype and misdecoded.
+    smooth = _operand(smooth.reshape(-1).to(x.dtype), x.device, "smooth", shape=(k,))
+    lora_down = _operand(lora_down, x.device, "lora_down", shape=(k, r))
+    # The LoRA branch is defined on the un-shifted, un-smoothed activation.
+    lora_src = _operand(lora_x if lora_x is not None else x, x.device, "lora_x", shape=(m, k))
+
+    # Padded rows stay zero: q = 0 and scale = 0 contribute nothing downstream.
+    q = torch.zeros((m_pad, k // 2), dtype=torch.int8, device=x.device)
+    ascales = torch.zeros((k // _SVD_GROUP, m_pad), dtype=x.dtype, device=x.device)
+    lora_act = torch.zeros((m_pad, r), dtype=torch.float32, device=x.device)
+
+    _C.svdquant_quantize(
+        _dl(xc), _dl(smooth), _dl(q), _dl(ascales),
+        m, m_pad, k, act_unsigned, _stream(x),
+    )
+    _C.svdquant_lora_down(
+        _dl(lora_src), _dl(lora_down), _dl(lora_act[:m]), m, k, r, _stream(x)
+    )
+    return q, ascales, lora_act
+
+
+def scaled_mm_svdquant_w4a4(
+    act: torch.Tensor,
+    wgt: torch.Tensor,
+    ascales: torch.Tensor,
+    wscales: torch.Tensor,
+    lora_act_in: torch.Tensor,
+    lora_up: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    act_unsigned: bool = False,
+) -> torch.Tensor:
+    # act is the padded output of quantize_svdquant_w4a4, so M here is m_pad, which
+    # is also the row stride of ascales. The kernel indexes ascales as g * M + row.
+    if act.dim() != 2 or wgt.dim() != 2 or lora_up.dim() != 2:
+        raise ValueError("act, wgt and lora_up must be 2D")
+
+    m, k_half = act.shape
+    n = wgt.shape[0]
+    k = k_half * 2
+    r = lora_up.shape[1]
+
+    # One scale per 64-element group: a partial trailing group has no scale, and the
+    # (K // 64, ...) scale shapes below would silently truncate it away.
+    if k % _SVD_GROUP != 0:
+        raise ValueError(f"K={k} not divisible by group_size={_SVD_GROUP}")
+
+    # The kernel gets M, N, K and R but no tensor bounds, so each operand has to
+    # match those extents and share act's device.
+    dev = act.device
+    act = _operand(act, dev, "act")
+    wgt = _operand(wgt, dev, "wgt", shape=(n, k_half))
+    ascales = _operand(ascales, dev, "ascales", shape=(k // _SVD_GROUP, m))
+    wscales = _operand(wscales, dev, "wscales", shape=(k // _SVD_GROUP, n))
+    if wscales.dtype not in _EPILOGUE_DTYPES:
+        raise ValueError(f"wscales dtype {wscales.dtype} is not supported")
+    lora_act_in = _operand(lora_act_in, dev, "lora_act_in", shape=(m, r))
+    lora_up = _operand(lora_up, dev, "lora_up", shape=(n, r))
+    if bias is not None:
+        bias = _bias_operand(bias, n, dev)
+
+    out = torch.empty((m, n), dtype=wscales.dtype, device=dev)
+    _C.svdquant_gemm(
+        _dl(act), _dl(wgt), _dl(out),
+        _dl(ascales), _dl(wscales),
+        _dl(lora_act_in), _dl(lora_up),
+        None if bias is None else _dl(bias),
+        m, n, k, r, act_unsigned, _stream(act),
+    )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Normalization and positional encoding
+# ---------------------------------------------------------------------------
+
+def _adaln_impl(kernel, x, scale, shift, eps) -> torch.Tensor:
+    """``kernel`` is _C.adaln (LayerNorm) or _C.rms_adaln (RMSNorm)."""
+    from comfy_kitchen.backends._modulation import adaln_prep_modulation
+
+    orig_shape = x.shape
+    d = x.shape[-1]
+    n = x.numel() // d
+
+    x_flat = x.reshape(n, d).contiguous()
+    scale_flat, scale_group = adaln_prep_modulation(scale, x, n, d)
+    shift_flat, shift_group = adaln_prep_modulation(shift, x, n, d)
+
+    out = torch.empty_like(x_flat)
+    kernel(
+        _dl(x_flat), _dl(scale_flat), _dl(shift_flat), _dl(out),
+        n, d, scale_group, shift_group, eps, _stream(x),
+    )
+    return out.reshape(orig_shape)
+
+
+def adaln(
+    x: torch.Tensor,
+    scale: torch.Tensor,
+    shift: torch.Tensor,
+    eps: float = 1e-6,
+) -> torch.Tensor:
+    return _adaln_impl(_C.adaln, x, scale, shift, eps)
+
+
+def rms_adaln(
+    x: torch.Tensor,
+    scale: torch.Tensor,
+    shift: torch.Tensor,
+    eps: float = 1e-6,
+) -> torch.Tensor:
+    return _adaln_impl(_C.rms_adaln, x, scale, shift, eps)
+
+
+def _effective_strides(t: torch.Tensor) -> tuple[int, ...]:
+    """Strides of the axes the kernels walk: a length-1 axis is only indexed at 0."""
+    return tuple(s for s, n in zip(t.stride(), t.shape, strict=True) if n != 1)
+
+
+def _rope_rows(q: torch.Tensor, k: torch.Tensor | None):
+    """``q`` and ``k`` in a layout the rope kernels can address with one stride set.
+
+    Both walk the inputs through their strides, so a q/k pair permuted or sliced out
+    of a packed qkv is read where it lies. head_dim is read one element at a time,
+    so a row that is not dense would scatter every load and is copied instead.
+    """
+    dense = q.stride(-1) == 1 and (k is None or k.stride(-1) == 1)
+    matched = k is None or _effective_strides(q) == _effective_strides(k)
+    if dense and matched:
+        return q, k
+    return q.contiguous(), None if k is None else k.contiguous()
+
+
+def _rope(xq, xk, freqs_cis, split_half, inplace=False):
+    # One dtype code and one stream are passed for the whole launch, so every
+    # buffer has to agree on device, and xq/xk on dtype.
+    if freqs_cis.device != xq.device:
+        raise ValueError("freqs_cis must be on the same device as the input")
+    if xk is not None:
+        if xk.device != xq.device:
+            raise ValueError("xq and xk must be on the same device")
+        if xk.dtype != xq.dtype:
+            raise ValueError("xq and xk must have the same dtype")
+
+    if inplace:
+        # Each thread owns one (a, b) pair and loads both before storing either,
+        # so rotating a view where it lies is well defined. _rope_rows must not
+        # run: its copy would move the result off the caller's storage.
+        xq_out, xk_out = xq, xk
+    else:
+        # freqs_cis is indexed through its own strides, so a strided view is free.
+        xq, xk = _rope_rows(xq, xk)
+        xq_out = torch.empty(xq.shape, dtype=xq.dtype, device=xq.device)
+        xk_out = None if xk is None else torch.empty(xk.shape, dtype=xk.dtype, device=xk.device)
+
+    _C.apply_rope(
+        _dl(xq), None if xk is None else _dl(xk), _dl(freqs_cis),
+        _dl(xq_out), None if xk_out is None else _dl(xk_out),
+        split_half, _stream(xq),
+    )
+    return xq_out, xk_out
+
+
+def _rope_pair(xq, xk, freqs_cis, split_half, inplace=False):
+    # The kernel indexes one set of strides and reads both tensors with one dtype
+    # code, so a difference in either is done one at a time. Out of place a stride
+    # mismatch is resolved by densifying both instead.
+    if (
+        xq.shape != xk.shape
+        or xq.dtype != xk.dtype
+        or (inplace and _effective_strides(xq) != _effective_strides(xk))
+    ):
+        return (
+            _rope(xq, None, freqs_cis, split_half, inplace)[0],
+            _rope(xk, None, freqs_cis, split_half, inplace)[0],
+        )
+    return _rope(xq, xk, freqs_cis, split_half, inplace)
+
+
+def apply_rope1(x: torch.Tensor, freqs_cis: torch.Tensor) -> torch.Tensor:
+    return _rope(x, None, freqs_cis, False)[0]
+
+
+def apply_rope1_(x: torch.Tensor, freqs_cis: torch.Tensor) -> torch.Tensor:
+    check_rope_inplace(x, readonly=(freqs_cis,))
+    return _rope(x, None, freqs_cis, False, inplace=True)[0]
+
+
+def apply_rope(
+    xq: torch.Tensor, xk: torch.Tensor, freqs_cis: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    return _rope_pair(xq, xk, freqs_cis, False)
+
+
+def apply_rope_(
+    xq: torch.Tensor, xk: torch.Tensor, freqs_cis: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    check_rope_inplace(xq, xk, readonly=(freqs_cis,))
+    return _rope_pair(xq, xk, freqs_cis, False, inplace=True)
+
+
+def apply_rope_split_half1(x: torch.Tensor, freqs_cis: torch.Tensor) -> torch.Tensor:
+    return _rope(x, None, freqs_cis, True)[0]
+
+
+def apply_rope_split_half1_(x: torch.Tensor, freqs_cis: torch.Tensor) -> torch.Tensor:
+    check_rope_inplace(x, readonly=(freqs_cis,))
+    return _rope(x, None, freqs_cis, True, inplace=True)[0]
+
+
+def apply_rope_split_half(
+    xq: torch.Tensor, xk: torch.Tensor, freqs_cis: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    return _rope_pair(xq, xk, freqs_cis, True)
+
+
+def apply_rope_split_half_(
+    xq: torch.Tensor, xk: torch.Tensor, freqs_cis: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    check_rope_inplace(xq, xk, readonly=(freqs_cis,))
+    return _rope_pair(xq, xk, freqs_cis, True, inplace=True)
+
+
+def _rms_rope_weight(scale: torch.Tensor, head_dim: int) -> torch.Tensor | None:
+    """The weight as a contiguous 1D tensor of length ``head_dim``, else None.
+
+    Anything eager's rms_norm would broadcast instead has no kernel.
+    """
+    if scale.dim() != 1 or scale.numel() != head_dim:
+        return None
+    return scale.contiguous()
+
+
+def _rms_rope(q, k, freqs_cis, q_scale, k_scale, epsilon, split_half, inplace=False):
+    if k is not None and k_scale is None:
+        k_scale = q_scale
+    # One dtype code and one stream are passed for the whole launch, so every
+    # buffer has to agree on device, and q/k on dtype.
+    if freqs_cis.device != q.device or q_scale.device != q.device:
+        raise ValueError("freqs_cis and the scales must be on the same device as the input")
+    if k is not None:
+        if k.device != q.device or k_scale.device != q.device:
+            raise ValueError("q and k must be on the same device")
+        if k.dtype != q.dtype:
+            raise ValueError("q and k must have the same dtype")
+
+    q_weight = _rms_rope_weight(q_scale, q.shape[-1])
+    k_weight = None if k is None else _rms_rope_weight(k_scale, q.shape[-1])
+    if q_weight is None or (k is not None and k_weight is None):
+        # No fused path; eager returns fresh tensors, so in place they are
+        # written back through the views.
+        if k is None:
+            impl = _eager.rms_rope_split_half1 if split_half else _eager.rms_rope1
+            out = impl(q, freqs_cis, q_scale, epsilon)
+            return (q.copy_(out) if inplace else out), None
+        impl = _eager.rms_rope_split_half if split_half else _eager.rms_rope
+        q_out, k_out = impl(q, k, freqs_cis, q_scale, k_scale, epsilon)
+        if inplace:
+            return q.copy_(q_out), k.copy_(k_out)
+        return q_out, k_out
+
+    if inplace:
+        # See _rope: the row is re-read only after the norm's __syncthreads, so
+        # rotating it in place is well defined.
+        q_out, k_out = q, k
+    else:
+        # freqs_cis is indexed through its own strides, so a strided view is free.
+        q, k = _rope_rows(q, k)
+        q_out = torch.empty(q.shape, dtype=q.dtype, device=q.device)
+        k_out = None if k is None else torch.empty(k.shape, dtype=k.dtype, device=k.device)
+
+    _C.rms_rope(
+        _dl(q), None if k is None else _dl(k), _dl(freqs_cis),
+        _dl(q_weight), None if k_weight is None else _dl(k_weight),
+        _dl(q_out), None if k_out is None else _dl(k_out),
+        epsilon, split_half, _stream(q),
+    )
+    return q_out, k_out
+
+
+def _rms_rope_pair(q, k, freqs_cis, q_scale, k_scale, epsilon, split_half, inplace=False):
+    if k_scale is None:
+        k_scale = q_scale
+    # One dtype code covers both inputs and one more both weights, so a difference
+    # in either is done one at a time.
+    if (
+        q.shape != k.shape
+        or q.dtype != k.dtype
+        or q_scale.dtype != k_scale.dtype
+        or (inplace and _effective_strides(q) != _effective_strides(k))
+    ):
+        return (
+            _rms_rope(q, None, freqs_cis, q_scale, None, epsilon, split_half, inplace)[0],
+            _rms_rope(k, None, freqs_cis, k_scale, None, epsilon, split_half, inplace)[0],
+        )
+    return _rms_rope(q, k, freqs_cis, q_scale, k_scale, epsilon, split_half, inplace)
+
+
+def rms_rope1(
+    x: torch.Tensor,
+    freqs_cis: torch.Tensor,
+    scale: torch.Tensor,
+    epsilon: float = 1e-6,
+) -> torch.Tensor:
+    return _rms_rope(x, None, freqs_cis, scale, None, epsilon, False)[0]
+
+
+def rms_rope1_(
+    x: torch.Tensor,
+    freqs_cis: torch.Tensor,
+    scale: torch.Tensor,
+    epsilon: float = 1e-6,
+) -> torch.Tensor:
+    check_rope_inplace(x, readonly=(freqs_cis, scale))
+    return _rms_rope(x, None, freqs_cis, scale, None, epsilon, False, inplace=True)[0]
+
+
+def rms_rope(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    freqs_cis: torch.Tensor,
+    q_scale: torch.Tensor,
+    k_scale: torch.Tensor | None = None,
+    epsilon: float = 1e-6,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    return _rms_rope_pair(q, k, freqs_cis, q_scale, k_scale, epsilon, False)
+
+
+def rms_rope_(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    freqs_cis: torch.Tensor,
+    q_scale: torch.Tensor,
+    k_scale: torch.Tensor | None = None,
+    epsilon: float = 1e-6,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if k_scale is None:
+        k_scale = q_scale
+    check_rope_inplace(q, k, readonly=(freqs_cis, q_scale, k_scale))
+    return _rms_rope_pair(q, k, freqs_cis, q_scale, k_scale, epsilon, False, inplace=True)
+
+
+def rms_rope_split_half1(
+    x: torch.Tensor,
+    freqs_cis: torch.Tensor,
+    scale: torch.Tensor,
+    epsilon: float = 1e-6,
+) -> torch.Tensor:
+    return _rms_rope(x, None, freqs_cis, scale, None, epsilon, True)[0]
+
+
+def rms_rope_split_half1_(
+    x: torch.Tensor,
+    freqs_cis: torch.Tensor,
+    scale: torch.Tensor,
+    epsilon: float = 1e-6,
+) -> torch.Tensor:
+    check_rope_inplace(x, readonly=(freqs_cis, scale))
+    return _rms_rope(x, None, freqs_cis, scale, None, epsilon, True, inplace=True)[0]
+
+
+def rms_rope_split_half(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    freqs_cis: torch.Tensor,
+    q_scale: torch.Tensor,
+    k_scale: torch.Tensor | None = None,
+    epsilon: float = 1e-6,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    return _rms_rope_pair(q, k, freqs_cis, q_scale, k_scale, epsilon, True)
+
+
+def rms_rope_split_half_(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    freqs_cis: torch.Tensor,
+    q_scale: torch.Tensor,
+    k_scale: torch.Tensor | None = None,
+    epsilon: float = 1e-6,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if k_scale is None:
+        k_scale = q_scale
+    check_rope_inplace(q, k, readonly=(freqs_cis, q_scale, k_scale))
+    return _rms_rope_pair(q, k, freqs_cis, q_scale, k_scale, epsilon, True, inplace=True)
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+def _build_constraints(has_wmma: bool = True) -> dict:
+    from comfy_kitchen.constraints import (
+        DivisibleBy,
+        ExactDims,
+        FunctionConstraints,
+        ParamConstraint,
+    )
+
+    # PyTorch exposes ROCm tensors with device type "cuda".
+    dev = frozenset({"cuda", "hip"})
+    floats = frozenset({torch.float32, torch.float16, torch.bfloat16})
+    fp8s = frozenset({torch.float8_e4m3fn, torch.float8_e5m2})
+    out_floats = frozenset({torch.float32, torch.float16, torch.bfloat16})
+
+    constraints = {
+        "quantize_per_tensor_fp8": FunctionConstraints(
+            params={
+                "x": ParamConstraint(dtypes=floats),
+                "scale": ParamConstraint(dtypes=frozenset({torch.float32})),
+                "output_type": ParamConstraint(dtypes=fp8s),
+            },
+            default_devices=dev,
+        ),
+        "dequantize_per_tensor_fp8": FunctionConstraints(
+            params={
+                "x": ParamConstraint(dtypes=fp8s),
+                "scale": ParamConstraint(dtypes=frozenset({torch.float32})),
+                "output_type": ParamConstraint(dtypes=out_floats),
+            },
+            default_devices=dev,
+        ),
+        "stochastic_rounding_fp8": FunctionConstraints(
+            params={
+                "x": ParamConstraint(dtypes=floats),
+                "rng": ParamConstraint(dtypes=frozenset({torch.uint8})),
+                "output_type": ParamConstraint(dtypes=fp8s),
+            },
+            default_devices=dev,
+        ),
+        "quantize_int8_rowwise": FunctionConstraints(
+            params={"x": ParamConstraint(dtypes=floats)},
+            default_devices=dev,
+        ),
+        "quantize_int8_tensorwise": FunctionConstraints(
+            params={"x": ParamConstraint(dtypes=floats)},
+            default_devices=dev,
+        ),
+        "quantize_and_rotate_rowwise": FunctionConstraints(
+            params={"x": ParamConstraint(dtypes=floats)},
+            default_devices=dev,
+        ),
+        "quantize_int8_convrot_weight": FunctionConstraints(
+            params={"weight": ParamConstraint(dtypes=floats)},
+            default_devices=dev,
+        ),
+        # K must be a multiple of 16 so a WMMA K-step never straddles a row end.
+        "int8_linear": FunctionConstraints(
+            params={
+                "x": ParamConstraint(dtypes=floats, shape_rules=(DivisibleBy(-1, 16),)),
+                "weight": ParamConstraint(dtypes=frozenset({torch.int8})),
+                "out_dtype": ParamConstraint(dtypes=out_floats),
+            },
+            default_devices=dev,
+        ),
+        "quantize_convrot_w4a4_weight": FunctionConstraints(
+            params={"weight": ParamConstraint(dtypes=floats, shape_rules=(DivisibleBy(-1, 32),))},
+            default_devices=dev,
+        ),
+        "dequantize_convrot_w4a4_weight": FunctionConstraints(
+            params={"qdata": ParamConstraint(dtypes=frozenset({torch.int8}))},
+            default_devices=dev,
+        ),
+        "convrot_w4a4_linear": FunctionConstraints(
+            params={
+                "x": ParamConstraint(dtypes=floats, shape_rules=(DivisibleBy(-1, 32),)),
+                "qweight": ParamConstraint(dtypes=frozenset({torch.int8})),
+            },
+            default_devices=dev,
+        ),
+        # 2D only: the tile-packed weight/scale variants have no HIP kernel and
+        # fall through to eager.
+        "gemv_awq_w4a16": FunctionConstraints(
+            params={
+                "x": ParamConstraint(dtypes=floats),
+                "qweight": ParamConstraint(
+                    dtypes=frozenset({torch.int8}), shape_rules=(ExactDims(2),)
+                ),
+            },
+            default_devices=dev,
+        ),
+        "quantize_svdquant_w4a4": FunctionConstraints(
+            params={
+                "x": ParamConstraint(
+                    dtypes=floats, shape_rules=(ExactDims(2), DivisibleBy(-1, 64))
+                ),
+                "smooth": ParamConstraint(dtypes=floats),
+                "lora_down": ParamConstraint(dtypes=floats, shape_rules=(ExactDims(2),)),
+            },
+            default_devices=dev,
+        ),
+        "scaled_mm_svdquant_w4a4": FunctionConstraints(
+            params={
+                "act": ParamConstraint(
+                    dtypes=frozenset({torch.int8}), shape_rules=(ExactDims(2),)
+                ),
+                "wgt": ParamConstraint(
+                    dtypes=frozenset({torch.int8}), shape_rules=(ExactDims(2),)
+                ),
+                "wscales": ParamConstraint(dtypes=floats, shape_rules=(ExactDims(2),)),
+                "lora_up": ParamConstraint(dtypes=floats, shape_rules=(ExactDims(2),)),
+            },
+            default_devices=dev,
+        ),
+        "adaln": FunctionConstraints(
+            params={
+                "x": ParamConstraint(dtypes=floats),
+                "scale": ParamConstraint(dtypes=floats),
+                "shift": ParamConstraint(dtypes=floats),
+            },
+            default_devices=dev,
+        ),
+        "rms_adaln": FunctionConstraints(
+            params={
+                "x": ParamConstraint(dtypes=floats),
+                "scale": ParamConstraint(dtypes=floats),
+                "shift": ParamConstraint(dtypes=floats),
+            },
+            default_devices=dev,
+        ),
+        # The rope kernel indexes x as 4D and freqs_cis as 6D.
+        "apply_rope": FunctionConstraints(
+            params={
+                "xq": ParamConstraint(dtypes=floats, shape_rules=(ExactDims(4),)),
+                "xk": ParamConstraint(dtypes=floats, shape_rules=(ExactDims(4),)),
+                "freqs_cis": ParamConstraint(dtypes=floats, shape_rules=(ExactDims(6),)),
+            },
+            default_devices=dev,
+        ),
+        "apply_rope1": FunctionConstraints(
+            params={
+                "x": ParamConstraint(dtypes=floats, shape_rules=(ExactDims(4),)),
+                "freqs_cis": ParamConstraint(dtypes=floats, shape_rules=(ExactDims(6),)),
+            },
+            default_devices=dev,
+        ),
+        "apply_rope_split_half": FunctionConstraints(
+            params={
+                "xq": ParamConstraint(dtypes=floats, shape_rules=(ExactDims(4),)),
+                "xk": ParamConstraint(dtypes=floats, shape_rules=(ExactDims(4),)),
+                "freqs_cis": ParamConstraint(dtypes=floats, shape_rules=(ExactDims(6),)),
+            },
+            default_devices=dev,
+        ),
+        "apply_rope_split_half1": FunctionConstraints(
+            params={
+                "x": ParamConstraint(dtypes=floats, shape_rules=(ExactDims(4),)),
+                "freqs_cis": ParamConstraint(dtypes=floats, shape_rules=(ExactDims(6),)),
+            },
+            default_devices=dev,
+        ),
+        # Normalized over the last axis, so BHND and BNHD both work. A weight that
+        # is not one entry per head_dim falls through to eager.
+        "rms_rope": FunctionConstraints(
+            params={
+                "q": ParamConstraint(dtypes=floats, shape_rules=(ExactDims(4),)),
+                "k": ParamConstraint(dtypes=floats, shape_rules=(ExactDims(4),)),
+                "freqs_cis": ParamConstraint(dtypes=floats, shape_rules=(ExactDims(6),)),
+                "q_scale": ParamConstraint(dtypes=floats, shape_rules=(ExactDims(1),)),
+                "k_scale": ParamConstraint(dtypes=floats, shape_rules=(ExactDims(1),)),
+            },
+            default_devices=dev,
+        ),
+        "rms_rope1": FunctionConstraints(
+            params={
+                "x": ParamConstraint(dtypes=floats, shape_rules=(ExactDims(4),)),
+                "freqs_cis": ParamConstraint(dtypes=floats, shape_rules=(ExactDims(6),)),
+                "scale": ParamConstraint(dtypes=floats, shape_rules=(ExactDims(1),)),
+            },
+            default_devices=dev,
+        ),
+        "rms_rope_split_half": FunctionConstraints(
+            params={
+                "q": ParamConstraint(dtypes=floats, shape_rules=(ExactDims(4),)),
+                "k": ParamConstraint(dtypes=floats, shape_rules=(ExactDims(4),)),
+                "freqs_cis": ParamConstraint(dtypes=floats, shape_rules=(ExactDims(6),)),
+                "q_scale": ParamConstraint(dtypes=floats, shape_rules=(ExactDims(1),)),
+                "k_scale": ParamConstraint(dtypes=floats, shape_rules=(ExactDims(1),)),
+            },
+            default_devices=dev,
+        ),
+        "rms_rope_split_half1": FunctionConstraints(
+            params={
+                "x": ParamConstraint(dtypes=floats, shape_rules=(ExactDims(4),)),
+                "freqs_cis": ParamConstraint(dtypes=floats, shape_rules=(ExactDims(6),)),
+                "scale": ParamConstraint(dtypes=floats, shape_rules=(ExactDims(1),)),
+            },
+            default_devices=dev,
+        ),
+    }
+
+    # Same operands and the same kernel as the functional siblings.
+    for inplace_name, functional_name in {
+        "apply_rope_": "apply_rope",
+        "apply_rope1_": "apply_rope1",
+        "apply_rope_split_half_": "apply_rope_split_half",
+        "apply_rope_split_half1_": "apply_rope_split_half1",
+        "rms_rope_": "rms_rope",
+        "rms_rope1_": "rms_rope1",
+        "rms_rope_split_half_": "rms_rope_split_half",
+        "rms_rope_split_half1_": "rms_rope_split_half1",
+    }.items():
+        constraints[inplace_name] = constraints[functional_name]
+
+    if not has_wmma:
+        # RDNA2: the GEMM kernels are compiled but trap, so they must not be
+        # advertised. Dropping them here routes those ops to triton/eager while the
+        # elementwise kernels below still dispatch to HIP.
+        constraints = {k: v for k, v in constraints.items() if k not in _WMMA_ONLY_OPS}
+
+    return constraints
+
+
+def _register():
+    from comfy_kitchen.registry import registry
+
+    # COMFY_KITCHEN_DISABLE_HIP=1 removes the backend from dispatch, leaving
+    # triton/eager to handle every op.
+    if os.getenv("COMFY_KITCHEN_DISABLE_HIP") == "1":
+        registry.mark_unavailable("hip", "disabled by COMFY_KITCHEN_DISABLE_HIP=1")
+        return
+
+    if not _EXT_AVAILABLE:
+        registry.mark_unavailable("hip", _EXT_ERROR or "HIP extension not built")
+        return
+
+    if not getattr(torch.version, "hip", None):
+        registry.mark_unavailable("hip", "PyTorch ROCm/HIP runtime not available")
+        return
+
+    arches = _visible_gfx_arches()
+    reason = _unsupported_arch_reason(arches)
+    if reason is not None:
+        registry.mark_unavailable("hip", reason)
+        return
+
+    has_wmma = _has_wmma(arches)
+    registry.register(
+        name="hip",
+        module=sys.modules[__name__],
+        capabilities=_build_constraints(has_wmma),
+    )
+    logger.debug(
+        "registered HIP backend for %s (%s)",
+        ", ".join(sorted({a for a in arches if a})),
+        "with WMMA" if has_wmma else "elementwise only, no matrix cores",
+    )
+
+
+_register()

--- a/comfy_kitchen/backends/hip/dlpack_bindings.cpp
+++ b/comfy_kitchen/backends/hip/dlpack_bindings.cpp
@@ -1,0 +1,805 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+#include <cstring>
+#include <optional>
+#include <stdexcept>
+#include <string>
+
+#include <hip/hip_runtime.h>
+#include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
+#include <nanobind/stl/optional.h>
+
+namespace nb = nanobind;
+
+// Maps a DLPack dtype onto comfy_kitchen.backends.eager.quantization.DTYPE_TO_CODE:
+// 0=float32, 1=float16, 2=bfloat16, 3=uint8, 4=int8.
+//
+// The fp8 codes (5=e4m3, 6=e5m2) are never produced here. DLPack gives e4m3 and
+// e5m2 their own dtype codes (10 and 12), which nanobind's dtype_code does not
+// name, so an fp8 tensor would land in the -1 branch. The Python layer therefore
+// hands fp8 across as uint8 and passes the fp8 code alongside it as an int.
+int map_dtype_to_code(const nb::dlpack::dtype& dtype) {
+    if (dtype.code == static_cast<uint8_t>(nb::dlpack::dtype_code::Float)) {
+        if (dtype.bits == 32) return 0;
+        if (dtype.bits == 16) return 1;
+    } else if (dtype.code == static_cast<uint8_t>(nb::dlpack::dtype_code::Bfloat) && dtype.bits == 16) {
+        return 2;
+    } else if (dtype.code == static_cast<uint8_t>(nb::dlpack::dtype_code::UInt) && dtype.bits == 8) {
+        return 3;
+    } else if (dtype.code == static_cast<uint8_t>(nb::dlpack::dtype_code::Int) && dtype.bits == 8) {
+        return 4;
+    }
+    return -1;
+}
+
+extern "C" {
+void launch_quantize_per_tensor_fp8_kernel(const void*, const void*, void*, int64_t, int, int,
+                                           hipStream_t);
+void launch_dequantize_per_tensor_fp8_kernel(const void*, const void*, void*, int64_t, int, int,
+                                             hipStream_t);
+void launch_stochastic_round_fp8_kernel(void*, const void*, int64_t, int, int, int, hipStream_t);
+
+void launch_scaled_mm_fp8_kernel(const void*, const void*, void*, const void*, const void*,
+                                 const void*, int, int, int, int, int, hipStream_t);
+void launch_int8_gemm_kernel(const void*, const void*, void*, const void*, const void*, int,
+                             const void*, int, int, int, int, int, hipStream_t);
+void launch_convrot_w4a4_gemm_kernel(const void*, const void*, void*, const void*, const void*,
+                                     const void*, int, int, int, int, int, hipStream_t);
+
+void launch_quantize_int8_rowwise_kernel(const void*, int, void*, void*, int, int, hipStream_t);
+void launch_quantize_int8_convrot_kernel(const void*, int, void*, void*, int, int, int, int,
+                                         hipStream_t);
+void launch_quantize_int8_tensorwise_kernel(const void*, int, void*, void*, void*, int64_t,
+                                            hipStream_t);
+void launch_convrot_quant_int4_kernel(const void*, int, void*, void*, int, int, int, hipStream_t);
+void launch_unpack_int4_kernel(const void*, void*, int64_t, hipStream_t);
+int convrot_max_k_host();
+
+void launch_adaln_kernel(const void*, const void*, const void*, void*, int, int, int, int, float,
+                         int, int, int, bool, hipStream_t);
+void launch_gemv_awq_kernel(const void*, const void*, const void*, const void*, const void*, void*,
+                            int, int, int, int, int, int, int, int, hipStream_t);
+void launch_svdquant_lora_down_kernel(const void*, const void*, void*, int, int, int, int, int,
+                                      hipStream_t);
+void launch_svdquant_quant_kernel(const void*, const void*, void*, void*, int, int, int, int, int,
+                                  bool, hipStream_t);
+void launch_svdquant_gemm_kernel(const void*, const void*, void*, const void*, const void*,
+                                 const void*, const void*, const void*, int, int, int, int, int,
+                                 int, int, int, int, int, bool, hipStream_t);
+void launch_apply_rope_kernel(const void*, const void*, const void*, void*, void*, int64_t, int64_t,
+                              int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t,
+                              int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t,
+                              int64_t, int64_t, int64_t, int, int, bool, hipStream_t);
+void launch_rms_rope_kernel(const void*, const void*, const void*, const void*, const void*, void*,
+                            void*, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t,
+                            int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t,
+                            int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, int, int, int,
+                            float, bool, hipStream_t);
+}
+
+static void check_hip_launch() {
+    hipError_t err = hipGetLastError();
+    if (err != hipSuccess) {
+        throw std::runtime_error(std::string("HIP kernel launch failed: ") + hipGetErrorString(err));
+    }
+}
+
+using OptArray = std::optional<nb::ndarray<>>;
+
+static const void* opt_data(const OptArray& t) {
+    return t.has_value() ? t->data() : nullptr;
+}
+
+static int opt_code(const OptArray& t) {
+    return t.has_value() ? map_dtype_to_code(t->dtype()) : 0;
+}
+
+// _C is importable, so these entry points cannot assume the Python layer put them
+// together. The kernels dereference scale[0] and index up to numel off raw
+// pointers, so a caller-supplied count larger than the tensor, or a scale of the
+// wrong dtype, is an out-of-bounds device access rather than an exception.
+// The epilogues cast the scales to raw float32 and index scale_a[row] up to M and
+// scale_b[col * stride] up to N, so a short or wrongly-typed scale is an
+// out-of-bounds device read rather than an exception.
+static void require_scale_len(const nb::ndarray<>& s, size_t need, const char* fn,
+                              const char* name) {
+    if (map_dtype_to_code(s.dtype()) != 0) {
+        throw std::runtime_error(std::string(fn) + ": " + name + " must be float32");
+    }
+    if (s.size() < need) {
+        throw std::runtime_error(std::string(fn) + ": " + name + " has " +
+                                 std::to_string(s.size()) + " elements, needs at least " +
+                                 std::to_string(need));
+    }
+}
+
+static void require_scale(const nb::ndarray<>& scale, const char* fn) {
+    require_scale_len(scale, 1, fn, "scale");
+}
+
+// Every kernel takes raw pointers plus caller-supplied extents and indexes up to
+// those extents with no bounds of its own, so a tensor smaller than the extents it
+// is launched with is an out-of-bounds device access. _C is importable, so these
+// are checked here rather than trusted from the Python layer.
+static void require_len(const nb::ndarray<>& t, int64_t need, const char* fn, const char* name) {
+    if (need < 0 || t.size() < static_cast<size_t>(need)) {
+        throw std::runtime_error(std::string(fn) + ": " + name + " has " +
+                                 std::to_string(t.size()) + " elements, needs at least " +
+                                 std::to_string(need));
+    }
+}
+
+// lo..hi are DTYPE_TO_CODE values: 0..2 float32/16/bfloat16, 3 uint8, 4 int8.
+static void require_dtype(const nb::ndarray<>& t, int lo, int hi, const char* fn,
+                          const char* name) {
+    const int code = map_dtype_to_code(t.dtype());
+    if (code < lo || code > hi) {
+        throw std::runtime_error(std::string(fn) + ": " + name + " has an unsupported dtype");
+    }
+}
+
+// Mirrors kSvdGroup in ops/svdquant_w4a4.hip: one scale per 64-element group.
+constexpr int kSvdGroup = 64;
+
+static void require_positive(int v, const char* fn, const char* name) {
+    if (v <= 0) {
+        throw std::runtime_error(std::string(fn) + ": " + name + " must be positive, got " +
+                                 std::to_string(v));
+    }
+}
+
+// A negative extent survives require_len whenever it is multiplied by another
+// negative one (M*K stays positive), then reaches a launcher where it becomes an
+// enormous unsigned grid. Reject each extent on its own before any product.
+static void require_nonneg(int v, const char* fn, const char* name) {
+    if (v < 0) {
+        throw std::runtime_error(std::string(fn) + ": " + name + " must be non-negative, got " +
+                                 std::to_string(v));
+    }
+}
+
+// The GEMM launchers pick the output element width from out_code, independently
+// of c's own dtype, and write c at that width. A wider out_code than c's dtype
+// overruns the allocation, so the two have to name the same type.
+static void require_out_matches(const nb::ndarray<>& c, int out_code, const char* fn) {
+    if (out_code != map_dtype_to_code(c.dtype())) {
+        throw std::runtime_error(std::string(fn) + ": out_code does not match the output dtype");
+    }
+}
+
+// The epilogues also index bias[col] up to N, decoded with bias_code.
+static void require_bias(const OptArray& bias, int n, const char* fn) {
+    if (!bias.has_value()) return;
+    const int code = map_dtype_to_code(bias->dtype());
+    if (code < 0 || code > 2) {
+        throw std::runtime_error(std::string(fn) + ": bias must be float32/float16/bfloat16");
+    }
+    if (bias->size() < static_cast<size_t>(n)) {
+        throw std::runtime_error(std::string(fn) + ": bias has " + std::to_string(bias->size()) +
+                                 " elements, needs at least " + std::to_string(n));
+    }
+}
+
+static void require_numel(int64_t numel, const nb::ndarray<>& t, const char* fn, const char* name) {
+    if (numel < 0 || static_cast<size_t>(numel) > t.size()) {
+        throw std::runtime_error(std::string(fn) + ": numel=" + std::to_string(numel) +
+                                 " exceeds " + name + " (" + std::to_string(t.size()) +
+                                 " elements)");
+    }
+}
+
+// fp8 crosses as uint8 (see map_dtype_to_code), so the fp8 side is checked as a
+// code and the float side against the tensor's own dtype.
+static void require_code(int code, int lo, int hi, const char* fn, const char* name) {
+    if (code < lo || code > hi) {
+        throw std::runtime_error(std::string(fn) + ": unsupported " + name + " code " +
+                                 std::to_string(code));
+    }
+}
+
+void quantize_per_tensor_fp8(nb::ndarray<> input, nb::ndarray<> scale, nb::ndarray<> output,
+                             int input_dtype_code, int output_dtype_code, int64_t numel,
+                             uintptr_t stream_ptr) {
+    constexpr const char* kFn = "quantize_per_tensor_fp8";
+    require_code(input_dtype_code, 0, 2, kFn, "input dtype");
+    require_code(output_dtype_code, 5, 6, kFn, "output dtype");
+    if (map_dtype_to_code(input.dtype()) != input_dtype_code) {
+        throw std::runtime_error(std::string(kFn) + ": input dtype does not match its code");
+    }
+    // fp8 crosses as uint8; the output buffer must be that storage (as in scaled_mm_fp8).
+    require_dtype(output, 3, 3, kFn, "output");
+    require_scale(scale, kFn);
+    require_numel(numel, input, kFn, "input");
+    require_numel(numel, output, kFn, "output");
+
+    launch_quantize_per_tensor_fp8_kernel(input.data(), scale.data(), output.data(), numel,
+                                          input_dtype_code, output_dtype_code,
+                                          reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+void dequantize_per_tensor_fp8(nb::ndarray<> input, nb::ndarray<> scale, nb::ndarray<> output,
+                               int input_dtype_code, int output_dtype_code, int64_t numel,
+                               uintptr_t stream_ptr) {
+    constexpr const char* kFn = "dequantize_per_tensor_fp8";
+    require_code(input_dtype_code, 5, 6, kFn, "input dtype");
+    require_code(output_dtype_code, 0, 2, kFn, "output dtype");
+    if (map_dtype_to_code(output.dtype()) != output_dtype_code) {
+        throw std::runtime_error(std::string(kFn) + ": output dtype does not match its code");
+    }
+    // fp8 crosses as uint8; the input buffer must be that storage (as in scaled_mm_fp8).
+    require_dtype(input, 3, 3, kFn, "input");
+    require_scale(scale, kFn);
+    require_numel(numel, input, kFn, "input");
+    require_numel(numel, output, kFn, "output");
+
+    launch_dequantize_per_tensor_fp8_kernel(input.data(), scale.data(), output.data(), numel,
+                                            input_dtype_code, output_dtype_code,
+                                            reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+void stochastic_round_fp8(nb::ndarray<> rng_and_output, nb::ndarray<> input, int output_dtype_code,
+                          int64_t numel, uintptr_t stream_ptr) {
+    constexpr const char* kFn = "stochastic_round_fp8";
+    int rng_dtype_code = map_dtype_to_code(rng_and_output.dtype());
+    if (rng_dtype_code != 3) {
+        throw std::runtime_error("stochastic_round_fp8 requires uint8 RNG storage");
+    }
+    int input_dtype_code = map_dtype_to_code(input.dtype());
+    require_code(input_dtype_code, 0, 2, kFn, "input dtype");
+    require_code(output_dtype_code, 5, 6, kFn, "output dtype");
+    require_numel(numel, input, kFn, "input");
+    require_numel(numel, rng_and_output, kFn, "rng");
+
+    launch_stochastic_round_fp8_kernel(rng_and_output.data(), input.data(), numel, rng_dtype_code,
+                                       input_dtype_code, output_dtype_code,
+                                       reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+void scaled_mm_fp8(nb::ndarray<> a, nb::ndarray<> b, nb::ndarray<> c, nb::ndarray<> scale_a,
+                   nb::ndarray<> scale_b, OptArray bias, int M, int N, int K, int out_code,
+                   uintptr_t stream_ptr) {
+    constexpr const char* kFn = "scaled_mm_fp8";
+    require_nonneg(M, kFn, "M");
+    require_nonneg(N, kFn, "N");
+    require_nonneg(K, kFn, "K");
+    // fp8 crosses the boundary as uint8: a is (M, K), b is (N, K), c is (M, N).
+    require_dtype(a, 3, 3, kFn, "a");
+    require_dtype(b, 3, 3, kFn, "b");
+    require_dtype(c, 0, 2, kFn, "c");
+    require_out_matches(c, out_code, kFn);
+    require_len(a, static_cast<int64_t>(M) * K, kFn, "a");
+    require_len(b, static_cast<int64_t>(N) * K, kFn, "b");
+    require_len(c, static_cast<int64_t>(M) * N, kFn, "c");
+    // EpiTensorwise reads scale_a[0] * scale_b[0].
+    require_scale_len(scale_a, 1, kFn, "scale_a");
+    require_scale_len(scale_b, 1, kFn, "scale_b");
+    require_bias(bias, N, kFn);
+
+    launch_scaled_mm_fp8_kernel(a.data(), b.data(), c.data(), scale_a.data(), scale_b.data(),
+                                opt_data(bias), opt_code(bias), M, N, K, out_code,
+                                reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+void int8_gemm(nb::ndarray<> a, nb::ndarray<> b, nb::ndarray<> c, nb::ndarray<> scale_a,
+               nb::ndarray<> scale_b, int scale_b_stride, OptArray bias, int M, int N, int K,
+               int out_code, uintptr_t stream_ptr) {
+    constexpr const char* kFn = "int8_gemm";
+    // EpiRowwise reads scale_a[row] over M rows and scale_b[col * stride] over N
+    // columns; a stride of 0 collapses the weight scale to a single scalar.
+    if (scale_b_stride != 0 && scale_b_stride != 1) {
+        throw std::runtime_error(std::string(kFn) + ": scale_b_stride must be 0 or 1, got " +
+                                 std::to_string(scale_b_stride));
+    }
+    require_nonneg(M, kFn, "M");
+    require_nonneg(N, kFn, "N");
+    require_nonneg(K, kFn, "K");
+    // a is (M, K) int8, b is (N, K) int8, c is (M, N).
+    require_dtype(a, 4, 4, kFn, "a");
+    require_dtype(b, 4, 4, kFn, "b");
+    require_dtype(c, 0, 2, kFn, "c");
+    require_out_matches(c, out_code, kFn);
+    require_len(a, static_cast<int64_t>(M) * K, kFn, "a");
+    require_len(b, static_cast<int64_t>(N) * K, kFn, "b");
+    require_len(c, static_cast<int64_t>(M) * N, kFn, "c");
+    require_scale_len(scale_a, static_cast<size_t>(M), kFn, "scale_a");
+    require_scale_len(scale_b, scale_b_stride == 1 ? static_cast<size_t>(N) : 1, kFn, "scale_b");
+    require_bias(bias, N, kFn);
+
+    launch_int8_gemm_kernel(a.data(), b.data(), c.data(), scale_a.data(), scale_b.data(),
+                            scale_b_stride, opt_data(bias), opt_code(bias), M, N, K, out_code,
+                            reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+void convrot_w4a4_gemm(nb::ndarray<> a, nb::ndarray<> b, nb::ndarray<> c, nb::ndarray<> x_scale,
+                       nb::ndarray<> w_scale, OptArray bias, int M, int N, int K, int out_code,
+                       uintptr_t stream_ptr) {
+    constexpr const char* kFn = "convrot_w4a4_gemm";
+    require_nonneg(M, kFn, "M");
+    require_nonneg(N, kFn, "N");
+    require_nonneg(K, kFn, "K");
+    // int4 packs two nibbles per byte, so the operand rows are K / 2 bytes wide.
+    if (K % 2 != 0) {
+        throw std::runtime_error(std::string(kFn) + ": K must be even, got " + std::to_string(K));
+    }
+    require_dtype(a, 4, 4, kFn, "a");
+    require_dtype(b, 4, 4, kFn, "b");
+    require_dtype(c, 0, 2, kFn, "c");
+    require_out_matches(c, out_code, kFn);
+    require_len(a, static_cast<int64_t>(M) * (K / 2), kFn, "a");
+    require_len(b, static_cast<int64_t>(N) * (K / 2), kFn, "b");
+    require_len(c, static_cast<int64_t>(M) * N, kFn, "c");
+    // EpiRowwise with a stride of 1: per-row activation scale, per-column weight scale.
+    require_scale_len(x_scale, static_cast<size_t>(M), kFn, "x_scale");
+    require_scale_len(w_scale, static_cast<size_t>(N), kFn, "w_scale");
+    require_bias(bias, N, kFn);
+
+    launch_convrot_w4a4_gemm_kernel(a.data(), b.data(), c.data(), x_scale.data(), w_scale.data(),
+                                    opt_data(bias), opt_code(bias), M, N, K, out_code,
+                                    reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+// The int4 quantizers pack two nibbles per byte, so the packed row is K / 2 bytes
+// and an odd K would round it down and drop the tail.
+static void require_convrot_group(int k, int group_size, const char* fn) {
+    // A negative K divisible by group_size would clear the divisibility check below,
+    // and with M=0 the length products collapse to zero, so it would otherwise reach
+    // the launcher as a negative extent.
+    require_nonneg(k, fn, "K");
+    if (group_size != 16 && group_size != 64 && group_size != 256) {
+        throw std::runtime_error(std::string(fn) + ": group_size must be 16, 64 or 256, got " +
+                                 std::to_string(group_size));
+    }
+    if (k % group_size != 0) {
+        throw std::runtime_error(std::string(fn) + ": K=" + std::to_string(k) +
+                                 " is not divisible by group_size=" + std::to_string(group_size));
+    }
+}
+
+void quantize_int8_rowwise(nb::ndarray<> x, nb::ndarray<> q, nb::ndarray<> scales, int M, int K,
+                           uintptr_t stream_ptr) {
+    constexpr const char* kFn = "quantize_int8_rowwise";
+    require_nonneg(M, kFn, "M");
+    require_nonneg(K, kFn, "K");
+    require_dtype(x, 0, 2, kFn, "x");
+    require_dtype(q, 4, 4, kFn, "q");
+    require_len(x, static_cast<int64_t>(M) * K, kFn, "x");
+    require_len(q, static_cast<int64_t>(M) * K, kFn, "q");
+    require_scale_len(scales, static_cast<size_t>(M), kFn, "scales");
+
+    launch_quantize_int8_rowwise_kernel(x.data(), map_dtype_to_code(x.dtype()), q.data(),
+                                        scales.data(), M, K,
+                                        reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+// act_code folds an elementwise activation into the rotation's load.
+void quantize_int8_convrot(nb::ndarray<> x, nb::ndarray<> q, nb::ndarray<> scales, int M, int K,
+                           int group_size, int act_code, uintptr_t stream_ptr) {
+    constexpr const char* kFn = "quantize_int8_convrot";
+    require_nonneg(M, kFn, "M");
+    require_convrot_group(K, group_size, kFn);
+    require_dtype(x, 0, 2, kFn, "x");
+    require_dtype(q, 4, 4, kFn, "q");
+    require_len(x, static_cast<int64_t>(M) * K, kFn, "x");
+    require_len(q, static_cast<int64_t>(M) * K, kFn, "q");
+    require_scale_len(scales, static_cast<size_t>(M), kFn, "scales");
+
+    launch_quantize_int8_convrot_kernel(x.data(), map_dtype_to_code(x.dtype()), q.data(),
+                                        scales.data(), M, K, group_size, act_code,
+                                        reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+void quantize_int8_tensorwise(nb::ndarray<> x, nb::ndarray<> q, nb::ndarray<> scale,
+                              nb::ndarray<> scratch, int64_t numel, uintptr_t stream_ptr) {
+    constexpr const char* kFn = "quantize_int8_tensorwise";
+    require_dtype(x, 0, 2, kFn, "x");
+    require_dtype(q, 4, 4, kFn, "q");
+    require_len(x, numel, kFn, "x");
+    require_len(q, numel, kFn, "q");
+    require_scale_len(scale, 1, kFn, "scale");
+    // scratch is the kernel's int32 atomic accumulator, not a float scale: it has
+    // to be a single 4-byte element, and the kernel atomicMaxes into it, so it must
+    // start at zero rather than carry a stale absmax from the caller's buffer.
+    require_len(scratch, 1, kFn, "scratch");
+    if (scratch.dtype().bits != 32) {
+        throw std::runtime_error(std::string(kFn) + ": scratch must be a 32-bit element");
+    }
+    auto stream = reinterpret_cast<hipStream_t>(stream_ptr);
+    if (hipMemsetAsync(scratch.data(), 0, sizeof(unsigned int), stream) != hipSuccess) {
+        throw std::runtime_error(std::string(kFn) + ": failed to clear scratch");
+    }
+
+    launch_quantize_int8_tensorwise_kernel(x.data(), map_dtype_to_code(x.dtype()), q.data(),
+                                           scale.data(), scratch.data(), numel, stream);
+    check_hip_launch();
+}
+
+void convrot_quant_int4(nb::ndarray<> x, nb::ndarray<> q, nb::ndarray<> scales, int M, int K,
+                        int group_size, uintptr_t stream_ptr) {
+    constexpr const char* kFn = "convrot_quant_int4";
+    require_nonneg(M, kFn, "M");
+    require_convrot_group(K, group_size, kFn);
+    if (K % 2 != 0) {
+        throw std::runtime_error(std::string(kFn) + ": K must be even, got " + std::to_string(K));
+    }
+    require_dtype(x, 0, 2, kFn, "x");
+    require_dtype(q, 4, 4, kFn, "q");
+    require_len(x, static_cast<int64_t>(M) * K, kFn, "x");
+    require_len(q, static_cast<int64_t>(M) * (K / 2), kFn, "q");
+    require_scale_len(scales, static_cast<size_t>(M), kFn, "scales");
+
+    launch_convrot_quant_int4_kernel(x.data(), map_dtype_to_code(x.dtype()), q.data(),
+                                     scales.data(), M, K, group_size,
+                                     reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+void unpack_int4(nb::ndarray<> q, nb::ndarray<> out, int64_t nbytes, uintptr_t stream_ptr) {
+    constexpr const char* kFn = "unpack_int4";
+    require_dtype(q, 4, 4, kFn, "q");
+    require_dtype(out, 4, 4, kFn, "out");
+    require_len(q, nbytes, kFn, "q");
+    require_len(out, nbytes * 2, kFn, "out");  // one byte unpacks to two nibbles
+
+    launch_unpack_int4_kernel(q.data(), out.data(), nbytes,
+                              reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+// subtract_mean selects LayerNorm (adaln) or RMSNorm (rms_adaln) statistics.
+static void adaln_impl(const char* kFn, nb::ndarray<>& x, nb::ndarray<>& scale,
+                       nb::ndarray<>& shift, nb::ndarray<>& out, int N, int D, int scale_group,
+                       int shift_group, float eps, bool subtract_mean, uintptr_t stream_ptr) {
+    require_nonneg(N, kFn, "N");
+    require_nonneg(D, kFn, "D");
+    require_dtype(x, 0, 2, kFn, "x");
+    require_dtype(out, 0, 2, kFn, "out");
+    require_dtype(scale, 0, 2, kFn, "scale");
+    require_dtype(shift, 0, 2, kFn, "shift");
+    // The launcher gets one dtype code (x's) and writes out at that width, so a
+    // wider x than out would overrun the output buffer.
+    if (map_dtype_to_code(out.dtype()) != map_dtype_to_code(x.dtype())) {
+        throw std::runtime_error(std::string(kFn) + ": out must have the same dtype as x");
+    }
+    require_len(x, static_cast<int64_t>(N) * D, kFn, "x");
+    require_len(out, static_cast<int64_t>(N) * D, kFn, "out");
+    // The kernel reads scale[(row / scale_group) * D + i] for row < N, i < D. An
+    // empty input divides by nothing and launches no blocks, and the group sizes
+    // the caller derives from it are 0, so only constrain them when there are rows.
+    if (N > 0 && D > 0) {
+        require_positive(scale_group, kFn, "scale_group");
+        require_positive(shift_group, kFn, "shift_group");
+        require_len(scale, (static_cast<int64_t>(N - 1) / scale_group + 1) * D, kFn, "scale");
+        require_len(shift, (static_cast<int64_t>(N - 1) / shift_group + 1) * D, kFn, "shift");
+    }
+
+    launch_adaln_kernel(x.data(), scale.data(), shift.data(), out.data(), N, D, scale_group,
+                        shift_group, eps, map_dtype_to_code(x.dtype()),
+                        map_dtype_to_code(scale.dtype()), map_dtype_to_code(shift.dtype()),
+                        subtract_mean, reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+void adaln(nb::ndarray<> x, nb::ndarray<> scale, nb::ndarray<> shift, nb::ndarray<> out, int N,
+           int D, int scale_group, int shift_group, float eps, uintptr_t stream_ptr) {
+    adaln_impl("adaln", x, scale, shift, out, N, D, scale_group, shift_group, eps,
+               /*subtract_mean=*/true, stream_ptr);
+}
+
+void rms_adaln(nb::ndarray<> x, nb::ndarray<> scale, nb::ndarray<> shift, nb::ndarray<> out, int N,
+               int D, int scale_group, int shift_group, float eps, uintptr_t stream_ptr) {
+    adaln_impl("rms_adaln", x, scale, shift, out, N, D, scale_group, shift_group, eps,
+               /*subtract_mean=*/false, stream_ptr);
+}
+
+// x is (batch, dim1, dim2, head_dim); freqs is (fb, fd1, fd2, head_dim/2, 2, 2).
+// Shapes and strides are read off the arrays so the broadcast rules stay in one
+// place rather than being recomputed on the Python side. Shared by apply_rope and
+// rms_rope, which index both tensors the same way.
+static void require_rope_shapes(const nb::ndarray<>& x, const nb::ndarray<>& freqs,
+                                const char* fn) {
+    // map_dtype_to_code returns -1 for anything else, which the device decoder
+    // would misread; the other operands are checked against x's dtype separately.
+    require_dtype(x, 0, 2, fn, "x");
+    require_dtype(freqs, 0, 2, fn, "freqs_cis");
+    if (x.ndim() != 4) throw std::runtime_error(std::string(fn) + " expects a 4D input");
+    if (freqs.ndim() != 6) throw std::runtime_error(std::string(fn) + " expects a 6D freqs_cis");
+    if (x.shape(3) % 2 != 0) {
+        throw std::runtime_error(std::string(fn) + " expects an even head_dim");
+    }
+
+    // The kernel indexes freqs as (fb, fd1, fd2, head_dim/2, 2, 2), broadcasting a
+    // leading dim only when it is 1. Anything else walks off the end of the array.
+    if (freqs.shape(3) != x.shape(3) / 2 || freqs.shape(4) != 2 || freqs.shape(5) != 2) {
+        throw std::runtime_error(std::string(fn) +
+                                 " expects freqs_cis trailing dims (head_dim/2, 2, 2)");
+    }
+    for (size_t i = 0; i < 3; ++i) {
+        if (freqs.shape(i) != 1 && freqs.shape(i) != x.shape(i)) {
+            throw std::runtime_error(
+                std::string(fn) +
+                " expects each leading freqs_cis dim to be 1 or match the input");
+        }
+    }
+}
+
+// An output is walked with its own strides, so it only has to match the extents.
+static void require_rope_extents(const nb::ndarray<>& x, const nb::ndarray<>& t, const char* name,
+                                 const char* fn) {
+    if (t.ndim() != 4 || t.dtype() != x.dtype()) {
+        throw std::runtime_error(std::string(fn) + " expects " + name +
+                                 " to be 4D with the input's dtype");
+    }
+    for (size_t i = 0; i < 4; ++i) {
+        if (t.shape(i) != x.shape(i)) {
+            throw std::runtime_error(std::string(fn) + " expects " + name +
+                                     " to have the input's shape");
+        }
+    }
+}
+
+// A q/k pair is read off one set of strides and one dtype code, so the two have
+// to agree on both. The stride of a length-1 axis is skipped: it is only ever
+// multiplied by index zero.
+static void require_rope_layout(const nb::ndarray<>& x, const nb::ndarray<>& t, const char* name,
+                                const char* fn) {
+    require_rope_extents(x, t, name, fn);
+    for (size_t i = 0; i < 4; ++i) {
+        if (x.shape(i) > 1 && t.stride(i) != x.stride(i)) {
+            throw std::runtime_error(std::string(fn) + " expects " + name +
+                                     " to have the input's strides");
+        }
+    }
+}
+
+void apply_rope(nb::ndarray<> xq, OptArray xk, nb::ndarray<> freqs, nb::ndarray<> xq_out,
+                OptArray xk_out, bool split_half, uintptr_t stream_ptr) {
+    constexpr const char* kFn = "apply_rope";
+    require_rope_shapes(xq, freqs, kFn);
+
+    if (xk.has_value() != xk_out.has_value()) {
+        throw std::runtime_error("apply_rope expects xk and xk_out together or not at all");
+    }
+    // Inputs share one stride set and outputs another, so the two sets are
+    // independent: xq may be a strided view while xq_out is dense.
+    require_rope_extents(xq, xq_out, "xq_out", kFn);
+    if (xk.has_value()) {
+        require_rope_layout(xq, *xk, "xk", kFn);
+        require_rope_layout(xq_out, *xk_out, "xk_out", kFn);
+    }
+
+    launch_apply_rope_kernel(
+        xq.data(), xk.has_value() ? xk->data() : nullptr, freqs.data(), xq_out.data(),
+        xk_out.has_value() ? xk_out->data() : nullptr,
+        static_cast<int64_t>(xq.shape(0)), static_cast<int64_t>(xq.shape(1)),
+        static_cast<int64_t>(xq.shape(2)), static_cast<int64_t>(xq.shape(3)),
+        static_cast<int64_t>(freqs.shape(0)), static_cast<int64_t>(freqs.shape(1)),
+        static_cast<int64_t>(freqs.shape(2)),
+        static_cast<int64_t>(xq.stride(0)), static_cast<int64_t>(xq.stride(1)),
+        static_cast<int64_t>(xq.stride(2)), static_cast<int64_t>(xq.stride(3)),
+        static_cast<int64_t>(xq_out.stride(0)), static_cast<int64_t>(xq_out.stride(1)),
+        static_cast<int64_t>(xq_out.stride(2)), static_cast<int64_t>(xq_out.stride(3)),
+        static_cast<int64_t>(freqs.stride(0)), static_cast<int64_t>(freqs.stride(1)),
+        static_cast<int64_t>(freqs.stride(2)), static_cast<int64_t>(freqs.stride(3)),
+        static_cast<int64_t>(freqs.stride(4)), static_cast<int64_t>(freqs.stride(5)),
+        map_dtype_to_code(xq.dtype()), map_dtype_to_code(freqs.dtype()), split_half,
+        reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+// Fused RMSNorm + RoPE. Same operand layout as apply_rope, plus a per-head_dim
+// weight for each input.
+void rms_rope(nb::ndarray<> q, OptArray k, nb::ndarray<> freqs, nb::ndarray<> q_scale,
+              OptArray k_scale, nb::ndarray<> q_out, OptArray k_out, float epsilon,
+              bool split_half, uintptr_t stream_ptr) {
+    constexpr const char* kFn = "rms_rope";
+    require_rope_shapes(q, freqs, kFn);
+
+    // k, its scale and its output are one operand set.
+    if (k.has_value() != k_out.has_value() || k.has_value() != k_scale.has_value()) {
+        throw std::runtime_error("rms_rope expects k, k_scale and k_out together or not at all");
+    }
+    require_rope_extents(q, q_out, "q_out", kFn);
+    if (k.has_value()) {
+        require_rope_layout(q, *k, "k", kFn);
+        require_rope_layout(q_out, *k_out, "k_out", kFn);
+    }
+
+    // The weight is indexed by element within the row, so it needs one entry per
+    // head_dim, decoded with a single code shared by both weights.
+    const int64_t head_dim = static_cast<int64_t>(q.shape(3));
+    require_dtype(q_scale, 0, 2, kFn, "q_scale");
+    require_len(q_scale, head_dim, kFn, "q_scale");
+    if (k_scale.has_value()) {
+        if (k_scale->dtype() != q_scale.dtype()) {
+            throw std::runtime_error("rms_rope expects k_scale to have q_scale's dtype");
+        }
+        require_len(*k_scale, head_dim, kFn, "k_scale");
+    }
+
+    launch_rms_rope_kernel(
+        q.data(), k.has_value() ? k->data() : nullptr, freqs.data(), q_scale.data(),
+        k_scale.has_value() ? k_scale->data() : nullptr, q_out.data(),
+        k_out.has_value() ? k_out->data() : nullptr,
+        static_cast<int64_t>(q.shape(0)), static_cast<int64_t>(q.shape(1)),
+        static_cast<int64_t>(q.shape(2)), head_dim,
+        static_cast<int64_t>(freqs.shape(0)), static_cast<int64_t>(freqs.shape(1)),
+        static_cast<int64_t>(freqs.shape(2)),
+        static_cast<int64_t>(q.stride(0)), static_cast<int64_t>(q.stride(1)),
+        static_cast<int64_t>(q.stride(2)), static_cast<int64_t>(q.stride(3)),
+        static_cast<int64_t>(q_out.stride(0)), static_cast<int64_t>(q_out.stride(1)),
+        static_cast<int64_t>(q_out.stride(2)), static_cast<int64_t>(q_out.stride(3)),
+        static_cast<int64_t>(freqs.stride(0)), static_cast<int64_t>(freqs.stride(1)),
+        static_cast<int64_t>(freqs.stride(2)), static_cast<int64_t>(freqs.stride(3)),
+        static_cast<int64_t>(freqs.stride(4)), static_cast<int64_t>(freqs.stride(5)),
+        map_dtype_to_code(q.dtype()), map_dtype_to_code(freqs.dtype()),
+        map_dtype_to_code(q_scale.dtype()), epsilon, split_half,
+        reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+void gemv_awq_w4a16(nb::ndarray<> x, nb::ndarray<> qweight, nb::ndarray<> wscales,
+                    nb::ndarray<> wzeros, OptArray bias, nb::ndarray<> out, int M, int N, int K,
+                    int group_size, uintptr_t stream_ptr) {
+    constexpr const char* kFn = "gemv_awq_w4a16";
+    require_nonneg(M, kFn, "M");
+    require_nonneg(N, kFn, "N");
+    require_nonneg(K, kFn, "K");
+    // The launcher enforces the packing invariants (group_size a positive multiple
+    // of 8, K a multiple of both 8 and group_size); these are the operand extents.
+    require_dtype(x, 0, 2, kFn, "x");
+    require_dtype(qweight, 4, 4, kFn, "qweight");
+    require_dtype(out, 0, 2, kFn, "out");
+    require_dtype(wscales, 0, 2, kFn, "wscales");
+    require_dtype(wzeros, 0, 2, kFn, "wzeros");
+    // Only wscales' dtype code reaches the kernel; it decodes wzeros with the same
+    // code, so a differing wzeros dtype would be misread.
+    if (map_dtype_to_code(wzeros.dtype()) != map_dtype_to_code(wscales.dtype())) {
+        throw std::runtime_error(std::string(kFn) + ": wzeros must have the same dtype as wscales");
+    }
+    require_len(x, static_cast<int64_t>(M) * K, kFn, "x");
+    require_len(out, static_cast<int64_t>(M) * N, kFn, "out");
+    if (group_size > 0 && K % 2 == 0) {
+        require_len(qweight, static_cast<int64_t>(N) * (K / 2), kFn, "qweight");
+        // scale and zero are read at (k / group_size) * N + n.
+        const int64_t groups = static_cast<int64_t>(K) / group_size;
+        require_len(wscales, groups * N, kFn, "wscales");
+        require_len(wzeros, groups * N, kFn, "wzeros");
+    }
+    require_bias(bias, N, kFn);
+
+    launch_gemv_awq_kernel(x.data(), qweight.data(), wscales.data(), wzeros.data(), opt_data(bias),
+                           out.data(), M, N, K, group_size, map_dtype_to_code(x.dtype()),
+                           map_dtype_to_code(wscales.dtype()), opt_code(bias),
+                           map_dtype_to_code(out.dtype()),
+                           reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+void svdquant_lora_down(nb::ndarray<> x, nb::ndarray<> lora_down, nb::ndarray<> lora_act, int M,
+                        int K, int R, uintptr_t stream_ptr) {
+    constexpr const char* kFn = "svdquant_lora_down";
+    require_nonneg(M, kFn, "M");
+    require_nonneg(K, kFn, "K");
+    require_nonneg(R, kFn, "R");
+    require_dtype(x, 0, 2, kFn, "x");
+    require_dtype(lora_down, 0, 2, kFn, "lora_down");
+    // The launcher writes lora_act through a float*, so it must be float32 storage.
+    require_dtype(lora_act, 0, 0, kFn, "lora_act");
+    require_len(x, static_cast<int64_t>(M) * K, kFn, "x");
+    require_len(lora_down, static_cast<int64_t>(K) * R, kFn, "lora_down");
+    require_len(lora_act, static_cast<int64_t>(M) * R, kFn, "lora_act");
+
+    launch_svdquant_lora_down_kernel(x.data(), lora_down.data(), lora_act.data(), M, K, R,
+                                     map_dtype_to_code(x.dtype()),
+                                     map_dtype_to_code(lora_down.dtype()),
+                                     reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+void svdquant_quantize(nb::ndarray<> x, nb::ndarray<> smooth, nb::ndarray<> q,
+                       nb::ndarray<> ascales, int M, int M_pad, int K, bool act_unsigned,
+                       uintptr_t stream_ptr) {
+    constexpr const char* kFn = "svdquant_quantize";
+    if (K % kSvdGroup != 0) {
+        throw std::runtime_error(std::string(kFn) + ": K=" + std::to_string(K) +
+                                 " must be a multiple of " + std::to_string(kSvdGroup));
+    }
+    if (M_pad < M) {
+        throw std::runtime_error(std::string(kFn) + ": M_pad must be at least M");
+    }
+    require_nonneg(M, kFn, "M");
+    require_nonneg(K, kFn, "K");
+    require_dtype(x, 0, 2, kFn, "x");
+    require_dtype(smooth, 0, 2, kFn, "smooth");
+    require_dtype(q, 4, 4, kFn, "q");
+    require_dtype(ascales, 0, 2, kFn, "ascales");
+    // The launcher passes only ascales' dtype code; the kernel decodes smooth with
+    // it too, so a differing smooth dtype would be misread.
+    if (map_dtype_to_code(smooth.dtype()) != map_dtype_to_code(ascales.dtype())) {
+        throw std::runtime_error(std::string(kFn) + ": smooth must have the same dtype as ascales");
+    }
+    require_len(x, static_cast<int64_t>(M) * K, kFn, "x");
+    require_len(smooth, K, kFn, "smooth");
+    require_len(q, static_cast<int64_t>(M_pad) * (K / 2), kFn, "q");
+    // ascales is (K / 64, M_pad): the group stride is M_pad.
+    require_len(ascales, (static_cast<int64_t>(K) / kSvdGroup) * M_pad, kFn, "ascales");
+
+    launch_svdquant_quant_kernel(x.data(), smooth.data(), q.data(), ascales.data(), M, M_pad, K,
+                                 map_dtype_to_code(x.dtype()), map_dtype_to_code(ascales.dtype()),
+                                 act_unsigned, reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+void svdquant_gemm(nb::ndarray<> a, nb::ndarray<> b, nb::ndarray<> c, nb::ndarray<> ascales,
+                   nb::ndarray<> wscales, nb::ndarray<> lora_act, nb::ndarray<> lora_up,
+                   OptArray bias, int M, int N, int K, int R, bool act_unsigned,
+                   uintptr_t stream_ptr) {
+    constexpr const char* kFn = "svdquant_gemm";
+    require_nonneg(M, kFn, "M");
+    require_nonneg(N, kFn, "N");
+    require_nonneg(K, kFn, "K");
+    require_nonneg(R, kFn, "R");
+    if (K % kSvdGroup != 0) {
+        throw std::runtime_error(std::string(kFn) + ": K=" + std::to_string(K) +
+                                 " must be a multiple of " + std::to_string(kSvdGroup));
+    }
+    require_dtype(a, 4, 4, kFn, "act");
+    require_dtype(b, 4, 4, kFn, "wgt");
+    require_dtype(c, 0, 2, kFn, "out");
+    require_dtype(ascales, 0, 2, kFn, "ascales");
+    require_dtype(wscales, 0, 2, kFn, "wscales");
+    require_dtype(lora_act, 0, 2, kFn, "lora_act");
+    require_dtype(lora_up, 0, 2, kFn, "lora_up");
+
+    const int64_t groups = static_cast<int64_t>(K) / kSvdGroup;
+    require_len(a, static_cast<int64_t>(M) * (K / 2), kFn, "act");
+    require_len(b, static_cast<int64_t>(N) * (K / 2), kFn, "wgt");
+    require_len(c, static_cast<int64_t>(M) * N, kFn, "out");
+    // The kernel reads ascales at g * M + row, so M is also its row stride.
+    require_len(ascales, groups * M, kFn, "ascales");
+    require_len(wscales, groups * N, kFn, "wscales");
+    require_len(lora_act, static_cast<int64_t>(M) * R, kFn, "lora_act");
+    require_len(lora_up, static_cast<int64_t>(N) * R, kFn, "lora_up");
+    require_bias(bias, N, kFn);
+
+    launch_svdquant_gemm_kernel(
+        a.data(), b.data(), c.data(), ascales.data(), wscales.data(), lora_act.data(),
+        lora_up.data(), opt_data(bias), M, N, K, R, map_dtype_to_code(ascales.dtype()),
+        map_dtype_to_code(wscales.dtype()), map_dtype_to_code(lora_act.dtype()),
+        map_dtype_to_code(lora_up.dtype()), opt_code(bias), map_dtype_to_code(c.dtype()),
+        act_unsigned, reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+NB_MODULE(_C, m) {
+    m.doc() = "ComfyKitchen HIP backend native operations (RDNA2-RDNA4, WMMA on gfx11/gfx12)";
+    m.def("quantize_per_tensor_fp8", &quantize_per_tensor_fp8);
+    m.def("dequantize_per_tensor_fp8", &dequantize_per_tensor_fp8);
+    m.def("stochastic_round_fp8", &stochastic_round_fp8);
+    m.def("scaled_mm_fp8", &scaled_mm_fp8);
+    m.def("int8_gemm", &int8_gemm);
+    m.def("convrot_w4a4_gemm", &convrot_w4a4_gemm);
+    m.def("quantize_int8_rowwise", &quantize_int8_rowwise);
+    m.def("quantize_int8_convrot", &quantize_int8_convrot);
+    m.def("quantize_int8_tensorwise", &quantize_int8_tensorwise);
+    m.def("convrot_quant_int4", &convrot_quant_int4);
+    m.def("convrot_max_k", &convrot_max_k_host);
+    m.def("unpack_int4", &unpack_int4);
+    m.def("adaln", &adaln);
+    m.def("rms_adaln", &rms_adaln);
+    m.def("apply_rope", &apply_rope);
+    m.def("rms_rope", &rms_rope);
+    m.def("gemv_awq_w4a16", &gemv_awq_w4a16);
+    m.def("svdquant_lora_down", &svdquant_lora_down);
+    m.def("svdquant_quantize", &svdquant_quantize);
+    m.def("svdquant_gemm", &svdquant_gemm);
+}

--- a/comfy_kitchen/backends/hip/epilogue.h
+++ b/comfy_kitchen/backends/hip/epilogue.h
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// GEMM epilogues. Each holds device pointers only and is passed to the tile
+// kernel by value. init() runs once per thread before the writeback loop, so
+// scalar scales are loaded once rather than per output element.
+#pragma once
+
+#include <hip/hip_fp16.h>
+#include <hip/hip_runtime.h>
+
+namespace comfy::hip_backend {
+
+// dtype codes match comfy_kitchen.backends.eager.quantization.DTYPE_TO_CODE
+constexpr int kF32 = 0;
+constexpr int kF16 = 1;
+constexpr int kBF16 = 2;
+
+__forceinline__ __device__ float load_scalar(const void* p, int code, int64_t i) {
+    if (code == kF32) return static_cast<const float*>(p)[i];
+    if (code == kF16) return __half2float(static_cast<const __half*>(p)[i]);
+    return static_cast<float>(static_cast<const __bf16*>(p)[i]);
+}
+
+__forceinline__ __device__ void store_scalar(void* p, int code, int64_t i, float v) {
+    if (code == kF32) {
+        static_cast<float*>(p)[i] = v;
+    } else if (code == kF16) {
+        static_cast<__half*>(p)[i] = __float2half(v);
+    } else {
+        static_cast<__bf16*>(p)[i] = static_cast<__bf16>(v);
+    }
+}
+
+// out = acc * (scale_a * scale_b) + bias[col]
+struct EpiTensorwise {
+    const float* scale_a;
+    const float* scale_b;
+    const void* bias;
+    int bias_code;
+    float alpha;
+
+    __forceinline__ __device__ void init() { alpha = scale_a[0] * scale_b[0]; }
+
+    __forceinline__ __device__ float operator()(int, int col, float acc) const {
+        float v = acc * alpha;
+        if (bias) v += load_scalar(bias, bias_code, col);
+        return v;
+    }
+};
+
+// out = acc * scale_a[row] * scale_b[col * scale_b_stride] + bias[col]
+// scale_b_stride is 1 for a per-output-channel weight scale, 0 for a scalar.
+struct EpiRowwise {
+    const float* scale_a;
+    const float* scale_b;
+    int scale_b_stride;
+    const void* bias;
+    int bias_code;
+
+    __forceinline__ __device__ void init() {}
+
+    __forceinline__ __device__ float operator()(int row, int col, float acc) const {
+        float v = acc * scale_a[row] * scale_b[col * scale_b_stride];
+        if (bias) v += load_scalar(bias, bias_code, col);
+        return v;
+    }
+};
+
+}  // namespace comfy::hip_backend

--- a/comfy_kitchen/backends/hip/fp8_utils.h
+++ b/comfy_kitchen/backends/hip/fp8_utils.h
@@ -1,0 +1,189 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// OCP FP8 encode/decode shared by the elementwise quantization kernels and the
+// scalar small-M GEMV path. The WMMA path consumes fp8 as raw bytes and needs
+// none of this.
+#pragma once
+
+#include <hip/hip_fp16.h>
+#include <hip/hip_runtime.h>
+
+#include <cmath>
+#include <cstdint>
+
+namespace comfy::hip_backend {
+
+// dtype codes match comfy_kitchen.backends.eager.quantization.DTYPE_TO_CODE
+constexpr int kFp8E4M3Code = 5;
+
+__forceinline__ __device__ float fp8_clamp(float v, float lo, float hi) {
+    return fminf(hi, fmaxf(lo, v));
+}
+
+// The kernels are compiled with -ffast-math, which implies -ffinite-math-only:
+// isnan() folds to false there, and fp8_clamp() drops a NaN operand outright.
+// Test the bits instead, so a NaN input still encodes as a NaN.
+__forceinline__ __device__ bool fp8_is_nan(float v) {
+    return (__float_as_uint(v) & 0x7fffffffu) > 0x7f800000u;
+}
+
+// Round to nearest, ties to even. OCP FP8 and torch's cast both round this way, so
+// the packed code has to agree at the exact midpoints that floorf(x + 0.5f) would
+// otherwise push up (e.g. e4m3 1.0625 must land on 1.0, not 1.125). x is finite and
+// non-negative here, so the -ffast-math finiteness assumption is not in play.
+__forceinline__ __device__ int round_to_even(float x) {
+    const float floor_x = floorf(x);
+    const float frac = x - floor_x;
+    int n = static_cast<int>(floor_x);
+    if (frac > 0.5f) {
+        n += 1;
+    } else if (frac == 0.5f) {
+        n += (n & 1);  // tie to the even neighbour
+    }
+    return n;
+}
+
+template <typename T>
+__forceinline__ __device__ float to_float(T value) {
+    return static_cast<float>(value);
+}
+
+template <>
+__forceinline__ __device__ float to_float<__half>(__half value) {
+    return __half2float(value);
+}
+
+// e4m3fn: 1-4-3, bias 7, no infinities. e5m2: 1-5-2, bias 15.
+__forceinline__ __device__ uint8_t pack_fp8(float value, int dtype_code) {
+    const bool e4m3 = dtype_code == kFp8E4M3Code;
+    const int mantissa_bits = e4m3 ? 3 : 2;
+    const int exponent_bias = e4m3 ? 7 : 15;
+    const int mantissa_levels = 1 << mantissa_bits;
+    const int max_exponent_field = e4m3 ? 15 : 30;
+    const int max_mantissa_field = e4m3 ? 6 : (mantissa_levels - 1);
+    const float fp8_max = e4m3 ? 448.0f : 57344.0f;
+
+    const uint8_t sign_bit = (__float_as_uint(value) >> 31) ? 0x80 : 0x00;
+    float abs_value = fabsf(value);
+    // Exponent all ones, mantissa all ones: the NaN torch encodes for both formats.
+    if (fp8_is_nan(value)) {
+        return static_cast<uint8_t>(sign_bit | 0x7f);
+    }
+
+    // Non-finite magnitudes saturate here, matching eager's clamp-then-cast: a
+    // raw torch cast would keep e5m2's 0x7c, the op does not.
+    abs_value = fp8_clamp(abs_value, 0.0f, fp8_max);
+    if (abs_value == 0.0f) {
+        return sign_bit;
+    }
+
+    const float min_normal = exp2f(1 - exponent_bias);
+    int exponent_field = 0;
+    int mantissa_field = 0;
+    if (abs_value < min_normal) {
+        const float subnormal_scale = exp2f(1 - exponent_bias - mantissa_bits);
+        mantissa_field = round_to_even(abs_value / subnormal_scale);
+        if (mantissa_field >= mantissa_levels) {
+            exponent_field = 1;
+            mantissa_field = 0;
+        }
+    } else {
+        exponent_field = static_cast<int>(floorf(log2f(abs_value))) + exponent_bias;
+        const float exponent_scale = exp2f(exponent_field - exponent_bias);
+        mantissa_field = round_to_even((abs_value / exponent_scale - 1.0f) * mantissa_levels);
+        if (mantissa_field >= mantissa_levels) {
+            mantissa_field = 0;
+            exponent_field += 1;
+        }
+    }
+
+    if (exponent_field > max_exponent_field ||
+        (exponent_field == max_exponent_field && mantissa_field > max_mantissa_field)) {
+        exponent_field = max_exponent_field;
+        mantissa_field = max_mantissa_field;
+    }
+
+    return static_cast<uint8_t>(sign_bit | (exponent_field << mantissa_bits) | mantissa_field);
+}
+
+__forceinline__ __device__ float unpack_fp8(uint8_t value, int dtype_code = kFp8E4M3Code) {
+    const bool e4m3 = dtype_code == kFp8E4M3Code;
+    const int mantissa_bits = e4m3 ? 3 : 2;
+    const int exponent_bits = e4m3 ? 4 : 5;
+    const int exponent_bias = e4m3 ? 7 : 15;
+    const int mantissa_mask = (1 << mantissa_bits) - 1;
+    const int exponent_mask = (1 << exponent_bits) - 1;
+
+    const float sign = (value & 0x80) ? -1.0f : 1.0f;
+    const int exponent = (value >> mantissa_bits) & exponent_mask;
+    const int mantissa = value & mantissa_mask;
+
+    // e4m3fn has no infinities: an all-ones exponent with an all-ones mantissa is
+    // its only NaN. e5m2 follows IEEE: all-ones exponent is inf, or NaN when the
+    // mantissa is non-zero. pack_fp8 emits only the NaN code, since it saturates
+    // infinities, but a tensor from any other producer can carry either. The
+    // result is assembled from bits, not float literals: -ffast-math assumes no
+    // NaN and would fold a branch that only ever returns one.
+    if (exponent == exponent_mask && (!e4m3 || mantissa == mantissa_mask)) {
+        const uint32_t sign_bits = (value & 0x80) ? 0x80000000u : 0u;
+        const uint32_t payload = (!e4m3 && mantissa == 0) ? 0x7f800000u   // e5m2 inf
+                                                          : 0x7fc00000u;  // quiet NaN
+        return __uint_as_float(sign_bits | payload);
+    }
+
+    if (exponent == 0) {
+        if (mantissa == 0) {
+            return sign * 0.0f;
+        }
+        return sign * exp2f(1 - exponent_bias) *
+               (static_cast<float>(mantissa) / (1 << mantissa_bits));
+    }
+    return sign * exp2f(exponent - exponent_bias) *
+           (1.0f + static_cast<float>(mantissa) / (1 << mantissa_bits));
+}
+
+// Fast e4m3fn decode for the small-M GEMV and, on gfx11, for widening the WMMA
+// operands to bf16. Both feed arbitrary user tensors, so the specials have to
+// survive: gfx12 hardware propagates a NaN operand through the fp8 WMMA, and the
+// widened gfx11 path has to agree with it. Results are assembled from bits, not
+// float literals, because -ffast-math would fold a branch that only ever returns
+// a NaN.
+__forceinline__ __device__ float fp8_to_float(uint8_t b) {
+    const uint32_t sign_bits = (b & 0x80) ? 0x80000000u : 0u;
+    const int exp = (b >> 3) & 0xF;
+    const int man = b & 0x7;
+
+    // e4m3fn has no infinities: 0x7f/0xff is its only NaN.
+    if (exp == 0xF && man == 0x7) {
+        return __uint_as_float(sign_bits | 0x7fc00000u);
+    }
+
+    const float sign = (b & 0x80) ? -1.0f : 1.0f;
+    if (exp == 0) return sign * man * 0.001953125f;  // subnormal step: 2^-9
+
+    const uint32_t bits = (static_cast<uint32_t>(exp - 7 + 127) << 23) |
+                          (static_cast<uint32_t>(man) << 20);
+    return sign * __uint_as_float(bits);
+}
+
+// e5m2 counterpart. Unlike e4m3fn it follows IEEE: an all-ones exponent is an
+// infinity when the mantissa is zero and a NaN otherwise.
+__forceinline__ __device__ float bf8_to_float(uint8_t b) {
+    const uint32_t sign_bits = (b & 0x80) ? 0x80000000u : 0u;
+    const int exp = (b >> 2) & 0x1F;
+    const int man = b & 0x3;
+
+    if (exp == 0x1F) {
+        return __uint_as_float(sign_bits | (man == 0 ? 0x7f800000u : 0x7fc00000u));
+    }
+
+    const float sign = (b & 0x80) ? -1.0f : 1.0f;
+    if (exp == 0) return sign * man * 0.0000152587890625f;  // subnormal step: 2^-16
+
+    const uint32_t bits = (static_cast<uint32_t>(exp - 15 + 127) << 23) |
+                          (static_cast<uint32_t>(man) << 21);
+    return sign * __uint_as_float(bits);
+}
+
+}  // namespace comfy::hip_backend

--- a/comfy_kitchen/backends/hip/gemm_wmma.h
+++ b/comfy_kitchen/backends/hip/gemm_wmma.h
@@ -1,0 +1,219 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Tiled WMMA GEMM core, shared by the fp8, int8 and int4 paths on both gfx11 and
+// gfx12.
+//
+// Computes C[M, N] = epilogue(A[M, K] @ B[N, K]^T). The B operand is the weight
+// in its natural (N, K) row-major form, matching torch linear.
+//
+// The tile loop is byte-addressed: LDS holds raw rows, and how many bytes of a
+// row one MMA consumes (Mma::kStepBytes) and how a lane reads its fragment out of
+// them (Mma::load) belong to the policy, which is where the two architectures
+// differ. See mma.h.
+//
+// The K loop is software-pipelined: the next tile's global loads are issued into
+// registers before the current tile's math.
+#pragma once
+
+#include "mma.h"
+
+namespace comfy::hip_backend {
+
+// LDS row padding, in bytes. 8 spreads the 16 lanes of a fragment read across
+// distinct banks. 16 would preserve 128-bit LDS access but aliases rows
+// 0/4/8/... onto the same bank.
+constexpr int kLdsPad = 8;
+
+// Staging for one ROWS x BKB byte tile. load() issues only the global reads, so
+// the caller can place the tile's math between load() and store().
+//
+// kbytes is the source row length in bytes (K for 8-bit types, K/2 for int4) and
+// is a multiple of 16, so a 16-byte chunk starting inside a row also ends inside
+// it. Out-of-range rows and the K tail are zero-filled.
+template <int ROWS, int BKB, int THREADS>
+struct TileStager {
+    static constexpr int kChunksPerRow = BKB / 16;
+    static constexpr int kChunks = ROWS * kChunksPerRow;
+    static constexpr int kPerThread = kChunks / THREADS;
+    static constexpr int kStride = BKB + kLdsPad;
+    // Both divisions truncate, and either remainder would leave part of the tile
+    // unwritten in LDS for the math to then read as stale.
+    static_assert(BKB % 16 == 0, "BKB must be a whole number of 16-byte chunks");
+    static_assert(kChunks % THREADS == 0, "THREADS must divide the tile's 16-byte chunks");
+
+    uint4 regs[kPerThread];
+
+    __forceinline__ __device__ void load(const uint8_t* __restrict__ src, int row0, int rows_total,
+                                         int kbyte0, int kbytes) {
+        const int tid = threadIdx.x;
+        #pragma unroll
+        for (int i = 0; i < kPerThread; ++i) {
+            const int c = tid * kPerThread + i;
+            const int grow = row0 + c / kChunksPerRow;
+            const int gk = kbyte0 + (c % kChunksPerRow) * 16;
+
+            regs[i] = (grow < rows_total && gk < kbytes)
+                          ? *reinterpret_cast<const uint4*>(
+                                src + static_cast<int64_t>(grow) * kbytes + gk)
+                          : make_uint4(0, 0, 0, 0);
+        }
+    }
+
+    __forceinline__ __device__ void store(uint8_t* __restrict__ lds) const {
+        const int tid = threadIdx.x;
+        #pragma unroll
+        for (int i = 0; i < kPerThread; ++i) {
+            const int c = tid * kPerThread + i;
+            uint8_t* dst = lds + (c / kChunksPerRow) * kStride + (c % kChunksPerRow) * 16;
+            // 8-byte stores: kLdsPad breaks 16-byte LDS alignment.
+            *reinterpret_cast<uint2*>(dst) = make_uint2(regs[i].x, regs[i].y);
+            *reinterpret_cast<uint2*>(dst + 8) = make_uint2(regs[i].z, regs[i].w);
+        }
+    }
+};
+
+// Epi is a functor: float operator()(int row, int col, float acc) const.
+template <typename Mma, typename Epi, typename OutT,
+          int BM, int BN, int BKB, int WARPS_M, int WARPS_N, int TM, int TN>
+__global__ __launch_bounds__(WARPS_M* WARPS_N* kWave) void gemm_wmma_kernel(
+    const uint8_t* __restrict__ A, const uint8_t* __restrict__ B, OutT* __restrict__ C,
+    int M, int N, int kbytes, Epi epi) {
+
+    constexpr int kThreads = WARPS_M * WARPS_N * kWave;
+    constexpr int kStride = BKB + kLdsPad;
+    constexpr int kStepBytes = Mma::kStepBytes;
+    constexpr int kSteps = BKB / kStepBytes;
+
+    // The fragment reads below index As by wm * (TM * 16) + i * 16 + row, which
+    // reaches WARPS_M * TM * 16 - 1, and Bs likewise. The warp grid has to tile the
+    // block exactly: a smaller product leaves part of the tile unread, a larger one
+    // walks off the end of the LDS array.
+    static_assert(BM == WARPS_M * TM * 16, "the M warp grid must tile BM exactly");
+    static_assert(BN == WARPS_N * TN * 16, "the N warp grid must tile BN exactly");
+    // A partial K-step would read past the tile's bytes in LDS.
+    static_assert(BKB % kStepBytes == 0, "BKB must be a whole number of MMA K-steps");
+
+    // Byte arrays, but every access is a uint2/v2i/v4i reinterpret at a multiple
+    // of 8 from the base, so the base itself has to be at least 8-byte aligned.
+    // uint8_t alone only promises 1.
+    __shared__ __align__(16) uint8_t As[BM * kStride];
+    __shared__ __align__(16) uint8_t Bs[BN * kStride];
+
+    const int tid = threadIdx.x;
+    const int lane = tid % kWave;
+    const int warp = tid / kWave;
+    const int wm = warp / WARPS_N;
+    const int wn = warp % WARPS_N;
+
+    // Grouped block ordering for L2 locality: consecutive blocks advance along M
+    // within a group of kGroupM block-rows, so concurrently resident blocks share
+    // the same B columns.
+    constexpr int kGroupM = 4;
+    const int blocks_n = gridDim.x;
+    const int blocks_m = gridDim.y;
+    const int bid = blockIdx.y * blocks_n + blockIdx.x;
+    const int per_group = kGroupM * blocks_n;
+    const int group = bid / per_group;
+    const int idx_in_group = bid - group * per_group;
+    const int group_rows = min(kGroupM, blocks_m - group * kGroupM);
+    const int bm = group * kGroupM + idx_in_group % group_rows;
+    const int bn = idx_in_group / group_rows;
+
+    const int m0 = bm * BM;
+    const int n0 = bn * BN;
+
+    typename Mma::Acc acc[TM][TN];
+    #pragma unroll
+    for (int i = 0; i < TM; ++i)
+        #pragma unroll
+        for (int j = 0; j < TN; ++j) acc[i][j] = Mma::zero();
+
+    const int row = frag_row(lane);
+
+    TileStager<BM, BKB, kThreads> sa;
+    TileStager<BN, BKB, kThreads> sb;
+
+    sa.load(A, m0, M, 0, kbytes);
+    sb.load(B, n0, N, 0, kbytes);
+    sa.store(As);
+    sb.store(Bs);
+    __syncthreads();
+
+    for (int kb0 = 0; kb0 < kbytes; kb0 += BKB) {
+        const int knext = kb0 + BKB;
+        const bool has_next = knext < kbytes;
+
+        // Prefetch the next tile's global reads ahead of the current tile's math.
+        if (has_next) {
+            sa.load(A, m0, M, knext, kbytes);
+            sb.load(B, n0, N, knext, kbytes);
+        }
+
+        // Register-level pipeline over K-steps: the LDS reads for step kk+1 are
+        // issued before the MMAs of step kk.
+        typename Mma::Frag af[2][TM];
+        typename Mma::Frag bf[2][TN];
+
+        #pragma unroll
+        for (int i = 0; i < TM; ++i)
+            af[0][i] = Mma::load(As, wm * (TM * 16) + i * 16 + row, 0, kStride, lane);
+        #pragma unroll
+        for (int j = 0; j < TN; ++j)
+            bf[0][j] = Mma::load(Bs, wn * (TN * 16) + j * 16 + row, 0, kStride, lane);
+
+        #pragma unroll
+        for (int kk = 0; kk < kSteps; ++kk) {
+            const int cur = kk & 1;
+            const int nxt = cur ^ 1;
+
+            if (kk + 1 < kSteps) {
+                const int kbyte = (kk + 1) * kStepBytes;
+                #pragma unroll
+                for (int i = 0; i < TM; ++i)
+                    af[nxt][i] =
+                        Mma::load(As, wm * (TM * 16) + i * 16 + row, kbyte, kStride, lane);
+                #pragma unroll
+                for (int j = 0; j < TN; ++j)
+                    bf[nxt][j] =
+                        Mma::load(Bs, wn * (TN * 16) + j * 16 + row, kbyte, kStride, lane);
+            }
+
+            #pragma unroll
+            for (int i = 0; i < TM; ++i)
+                #pragma unroll
+                for (int j = 0; j < TN; ++j)
+                    acc[i][j] = Mma::mma(af[cur][i], bf[cur][j], acc[i][j]);
+        }
+
+        if (has_next) {
+            __syncthreads();  // all warps have finished reading the current tile
+            sa.store(As);
+            sb.store(Bs);
+            __syncthreads();
+        }
+    }
+
+    epi.init();
+
+    // Row-major writeback: the TN column tiles of one accumulator row cover
+    // TN*16 consecutive columns, keeping the stores of an iteration contiguous.
+    const int col_lane = acc_col(lane);
+    #pragma unroll
+    for (int i = 0; i < TM; ++i) {
+        #pragma unroll
+        for (int e = 0; e < 8; ++e) {
+            const int r = m0 + wm * (TM * 16) + i * 16 + acc_row(lane, e);
+            if (r >= M) continue;
+            OutT* crow = C + static_cast<int64_t>(r) * N;
+            #pragma unroll
+            for (int j = 0; j < TN; ++j) {
+                const int col = n0 + wn * (TN * 16) + j * 16 + col_lane;
+                if (col >= N) continue;
+                crow[col] = static_cast<OutT>(epi(r, col, Mma::get(acc[i][j], e)));
+            }
+        }
+    }
+}
+
+}  // namespace comfy::hip_backend

--- a/comfy_kitchen/backends/hip/hadamard.h
+++ b/comfy_kitchen/backends/hip/hadamard.h
@@ -1,0 +1,183 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Fused ConvRot rotation + rowwise quantization.
+//
+// The regular Hadamard-G (G in {16, 64, 256}) is kron(H4, ...) / sqrt(G) and so
+// factors into log4(G) radix-4 butterfly stages over the base-4 digits of the
+// index, matching the eager _rotate_activation reference.
+//
+// One block per row: transform each G-group in LDS, track the row absmax, then
+// quantize. INT4 output packs two nibbles per byte (low nibble = even index),
+// which is the layout the iu4 A-fragment consumes directly.
+#pragma once
+
+#include <stdexcept>
+#include <string>
+
+#include <hip/hip_fp16.h>
+#include <hip/hip_runtime.h>
+
+namespace comfy::hip_backend {
+
+// convrot_quant_kernel handles 256/G groups per pass and rotates in log4(G)
+// stages, so a G outside this set either divides to a zero-width pass or is not
+// a power of four. The dispatch wrappers fall back to eager before reaching here.
+inline void check_convrot_group_size(int group_size) {
+    if (group_size != 16 && group_size != 64 && group_size != 256) {
+        throw std::runtime_error("convrot: group_size must be 16, 64 or 256");
+    }
+}
+
+// The kernel's static LDS: the g[256] and red[256] reductions below.
+constexpr size_t kConvrotStaticLds = 2 * 256 * sizeof(float);
+
+// convrot_quant_kernel stages the whole rotated row in dynamic LDS, so K is
+// bounded by what is left of the workgroup budget. Past it the launch does not
+// fail cleanly, so the wrappers fall back to eager instead. 0 means unknown.
+inline int convrot_max_k() {
+    int device = 0;
+    if (hipGetDevice(&device) != hipSuccess) {
+        return 0;
+    }
+    int lds = 0;
+    if (hipDeviceGetAttribute(&lds, hipDeviceAttributeMaxSharedMemoryPerBlock, device) !=
+            hipSuccess ||
+        lds <= static_cast<int>(kConvrotStaticLds)) {
+        return 0;
+    }
+    return static_cast<int>((static_cast<size_t>(lds) - kConvrotStaticLds) /
+                            sizeof(__bf16));
+}
+
+inline void check_convrot_k(int k, int group_size) {
+    // The kernel rotates K/G whole groups but reads back all K entries of the row
+    // buffer, so a partial trailing group would quantize uninitialized LDS.
+    if (group_size <= 0 || k % group_size != 0) {
+        throw std::runtime_error("convrot: K=" + std::to_string(k) +
+                                 " is not divisible by group_size=" + std::to_string(group_size));
+    }
+    const int max_k = convrot_max_k();
+    if (max_k <= 0 || k > max_k) {
+        throw std::runtime_error("convrot: K=" + std::to_string(k) +
+                                 " does not fit in LDS (max " + std::to_string(max_k) + ")");
+    }
+}
+
+// dtype codes match comfy_kitchen.backends.eager.quantization.DTYPE_TO_CODE
+__forceinline__ __device__ float load_in(const void* x, int64_t idx, int code) {
+    if (code == 0) return static_cast<const float*>(x)[idx];
+    if (code == 1) return __half2float(static_cast<const __half*>(x)[idx]);
+    return static_cast<float>(static_cast<const __bf16*>(x)[idx]);
+}
+
+// Codes match comfy_kitchen.backends._activations.INPUT_ACT_TO_CODE.
+enum : int { kActNone = 0, kActGeluTanh = 1 };
+
+inline void check_convrot_act(int act) {
+    if (act != kActNone && act != kActGeluTanh) {
+        throw std::runtime_error("convrot: unsupported input activation code");
+    }
+}
+
+template <int ACT>
+__forceinline__ __device__ float apply_input_act(float v) {
+    if constexpr (ACT == kActGeluTanh) {
+        // Matches torch.nn.functional.gelu(x, approximate="tanh").
+        constexpr float kBeta = 0.7978845608028654f;  // sqrt(2/pi)
+        constexpr float kKappa = 0.044715f;
+        return 0.5f * v * (1.0f + tanhf(kBeta * (v + kKappa * v * v * v)));
+    }
+    return v;
+}
+
+template <bool PACK_INT4, int ACT = kActNone>
+__global__ __launch_bounds__(256) void convrot_quant_kernel(
+    const void* __restrict__ x, int in_dtype,
+    int8_t* __restrict__ qout, float* __restrict__ scaleout,
+    int M, int K, int G) {
+
+    const float h4[4][4] = {{1, 1, 1, -1}, {1, 1, -1, 1}, {1, -1, 1, 1}, {-1, 1, 1, 1}};
+    __shared__ float g[256];
+    __shared__ float red[256];
+    extern __shared__ __bf16 rowbuf[];  // K entries: the rotated row
+
+    const int row = blockIdx.x;
+    const int t = threadIdx.x;
+
+    int nstages = 0;
+    while ((1 << (2 * nstages)) < G) nstages++;  // log4(G)
+
+    const int gpw = 256 / G;      // groups handled per pass
+    const int glocal = t / G;     // this thread's group within the pass
+    const int e = t % G;          // element within the group
+    const int gbase_idx = glocal * G;
+    const float norm = rsqrtf(static_cast<float>(G));
+    const int ngrp = K / G;
+
+    float lmax = 0.0f;
+    for (int gbase = 0; gbase < ngrp; gbase += gpw) {
+        const int grp = gbase + glocal;
+        const bool active = grp < ngrp;
+        g[t] = active ? apply_input_act<ACT>(load_in(
+                            x, static_cast<int64_t>(row) * K + static_cast<int64_t>(grp) * G + e,
+                            in_dtype))
+                      : 0.0f;
+        __syncthreads();
+
+        for (int stage = 0; stage < nstages; ++stage) {
+            const int stride = 1 << (2 * stage);
+            const int ds = (e / stride) & 3;
+            const int b = gbase_idx + (e - ds * stride);
+            const float v0 = g[b], v1 = g[b + stride], v2 = g[b + 2 * stride], v3 = g[b + 3 * stride];
+            const float nv = h4[ds][0] * v0 + h4[ds][1] * v1 + h4[ds][2] * v2 + h4[ds][3] * v3;
+            __syncthreads();
+            g[t] = nv;
+            __syncthreads();
+        }
+
+        if (active) {
+            const float tv = g[t] * norm;
+            const __bf16 bv = static_cast<__bf16>(tv);
+            rowbuf[static_cast<int64_t>(grp) * G + e] = bv;
+            lmax = fmaxf(lmax, fabsf(static_cast<float>(bv)));
+        }
+        __syncthreads();
+    }
+
+    red[t] = lmax;
+    __syncthreads();
+    for (int s = 128; s > 0; s >>= 1) {
+        if (t < s) red[t] = fmaxf(red[t], red[t + s]);
+        __syncthreads();
+    }
+
+    constexpr float kQMax = PACK_INT4 ? 7.0f : 127.0f;
+    const float rowmax = fmaxf(red[0], 1e-10f);
+    const float scale = rowmax / kQMax;
+    const float inv = kQMax / rowmax;
+    if (t == 0) scaleout[row] = scale;
+
+    if constexpr (PACK_INT4) {
+        const int Kp = K / 2;
+        for (int jb = t; jb < Kp; jb += 256) {
+            const float a = static_cast<float>(rowbuf[2 * jb]);
+            const float b = static_cast<float>(rowbuf[2 * jb + 1]);
+            int qa = static_cast<int>(rintf(a * inv));
+            int qb = static_cast<int>(rintf(b * inv));
+            qa = qa < -7 ? -7 : (qa > 7 ? 7 : qa);
+            qb = qb < -7 ? -7 : (qb > 7 ? 7 : qb);
+            qout[static_cast<int64_t>(row) * Kp + jb] =
+                static_cast<int8_t>(((qa & 0xF) | ((qb & 0xF) << 4)) & 0xFF);
+        }
+    } else {
+        for (int j = t; j < K; j += 256) {
+            const float v = static_cast<float>(rowbuf[j]);
+            int q = static_cast<int>(rintf(v * inv));
+            q = q < -127 ? -127 : (q > 127 ? 127 : q);
+            qout[static_cast<int64_t>(row) * K + j] = static_cast<int8_t>(q);
+        }
+    }
+}
+
+}  // namespace comfy::hip_backend

--- a/comfy_kitchen/backends/hip/mma.h
+++ b/comfy_kitchen/backends/hip/mma.h
@@ -1,0 +1,310 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// WMMA policies for RDNA3 (gfx11) and RDNA4 (gfx12), wave32.
+//
+// A policy holds the operand fragment type, the bytes of a K-row one MMA consumes
+// (kStepBytes), the LDS read, and the MMA. The tile kernels stay byte-addressed;
+// only the policy changes per architecture.
+//
+// Operand layout differs:
+//   gfx12: K is split across the half-waves. A lane holds 8 bytes at byte offset
+//          8 * (lane / 16) of its row. Every type is a v2i, which is what lets one
+//          kernel serve fp8, iu8 and iu4.
+//   gfx11: no K split. A lane holds the whole K-step of its row and both
+//          half-waves hold the same data (rocWMMA calls it input duplication),
+//          which reading at row = lane % 16 with no half-wave offset gives for
+//          free. Fragment width is the K-step: 16B iu8, 8B iu4, 32B bf16 for fp8.
+//
+// Accumulators are v8f/v8i on both, column lane % 16, but the row differs:
+// gfx12 gives each half-wave a contiguous block, D[e + 8 * (lane / 16)]; gfx11
+// interleaves the halves, D[2 * e + (lane / 16)]. See acc_row. rocWMMA's "padded
+// acc" gfx11 quirk applies to the 16-bit accumulators, not these.
+//
+// gfx11 has no fp8 WMMA, so MmaFp8/MmaBf8 widen to bf16 there. The widening is
+// exact (e4m3 and e5m2 mantissas fit bf16's 7) and both paths accumulate in f32,
+// so gfx11 fp8 matches gfx12 numerically, just slower.
+#pragma once
+
+#include <hip/hip_runtime.h>
+
+#include <cstdint>
+
+#include "fp8_utils.h"
+
+namespace comfy::hip_backend {
+
+typedef int int32_t_v2 __attribute__((ext_vector_type(2)));
+typedef int int32_t_v4 __attribute__((ext_vector_type(4)));
+
+typedef int32_t_v2 v2i;
+typedef int32_t_v4 v4i;
+typedef int v8i __attribute__((ext_vector_type(8)));
+typedef float v8f __attribute__((ext_vector_type(8)));
+typedef __bf16 v8bf __attribute__((ext_vector_type(8)));
+typedef __bf16 v16bf __attribute__((ext_vector_type(16)));
+
+constexpr int kWave = 32;
+
+// __gfx*__ is defined only in device passes; the host pass falls through to the
+// stubs at the bottom. It never generates code for a kernel body but does
+// typecheck one, so every policy must still name valid types.
+//
+// gfx110x (RDNA3) and gfx115x (RDNA3.5) share one WMMA encoding. The list is
+// exhaustive over the targets ROCm supports: a missing one does not fail the
+// build, it silently drops that GPU into the no-WMMA stub.
+#if defined(__gfx1200__) || defined(__gfx1201__)
+#define COMFY_MMA_GFX12 1
+#elif defined(__gfx1100__) || defined(__gfx1101__) || defined(__gfx1102__) || \
+    defined(__gfx1103__) || defined(__gfx1150__) || defined(__gfx1151__) ||   \
+    defined(__gfx1152__) || defined(__gfx1153__)
+#define COMFY_MMA_GFX11 1
+#endif
+
+#if defined(COMFY_MMA_GFX12) || defined(COMFY_MMA_GFX11)
+#define COMFY_HAS_WMMA 1
+#endif
+
+// ---------------------------------------------------------------------------
+// Fragment addressing, shared by both architectures.
+// ---------------------------------------------------------------------------
+
+// Sum a value across the wave. The first offset comes from kWave rather than a
+// literal 16: at wave64 a hardcoded 16 would fold only half the lanes and say
+// nothing about it.
+template <typename T>
+__forceinline__ __device__ T wave_reduce_sum(T v) {
+    #pragma unroll
+    for (int off = kWave / 2; off > 0; off >>= 1) v += __shfl_xor(v, off, kWave);
+    return v;
+}
+
+__forceinline__ __device__ int frag_row(int lane) { return lane % 16; }
+
+// Row of accumulator element `e` for this lane; the column is lane % 16. The two
+// architectures lay the 16 result rows across the wave differently. gfx12 gives
+// each half-wave a contiguous block of 8 rows. gfx11 interleaves them: element e
+// is row 2e for the low half-wave and 2e + 1 for the high one, so consecutive
+// elements are two rows apart. Both are 32-bit accumulators (v8f/v8i), so neither
+// has the padded-acc read the 16-bit gfx11 accumulators need.
+#if defined(COMFY_MMA_GFX11)
+__forceinline__ __device__ int acc_row(int lane, int e) { return 2 * e + (lane / 16); }
+#else
+__forceinline__ __device__ int acc_row(int lane, int e) { return e + 8 * (lane / 16); }
+#endif
+__forceinline__ __device__ int acc_col(int lane) { return lane % 16; }
+
+// Bytes of a row that live `stride` apart in LDS. `row` is the lane's row (A) or
+// column (B); `kbyte` is the byte offset within that row.
+__forceinline__ __device__ v2i load_frag_b64(const void* lds, int row, int kbyte, int stride) {
+    const char* p = static_cast<const char*>(lds) + row * stride + kbyte;
+    return *reinterpret_cast<const v2i*>(p);
+}
+
+__forceinline__ __device__ v4i load_frag_b128(const void* lds, int row, int kbyte, int stride) {
+    const char* p = static_cast<const char*>(lds) + row * stride + kbyte;
+    // kLdsPad breaks 16-byte alignment, so this must not become a single b128 load.
+    v4i r;
+    const int* q = reinterpret_cast<const int*>(p);
+    r[0] = q[0];
+    r[1] = q[1];
+    r[2] = q[2];
+    r[3] = q[3];
+    return r;
+}
+
+// 16 fp8 bytes of a row -> the 16 bf16 lanes of one gfx11 K-step.
+template <bool E5M2>
+__forceinline__ __device__ v16bf load_frag_fp8_as_bf16(const void* lds, int row, int kbyte,
+                                                       int stride) {
+    const uint8_t* p = static_cast<const uint8_t*>(lds) + row * stride + kbyte;
+    v16bf r;
+#pragma unroll
+    for (int i = 0; i < 16; ++i) {
+        r[i] = static_cast<__bf16>(E5M2 ? bf8_to_float(p[i]) : fp8_to_float(p[i]));
+    }
+    return r;
+}
+
+// ---------------------------------------------------------------------------
+// Policies
+// ---------------------------------------------------------------------------
+
+#if defined(COMFY_MMA_GFX12)
+
+struct MmaFp8 {
+    using Acc = v8f;
+    using Frag = v2i;
+    static constexpr int kStepBytes = 16;
+    static __forceinline__ __device__ Frag load(const void* lds, int row, int kbyte, int stride,
+                                                int lane) {
+        return load_frag_b64(lds, row, kbyte + 8 * (lane / 16), stride);
+    }
+    static __forceinline__ __device__ Acc zero() { return Acc{0, 0, 0, 0, 0, 0, 0, 0}; }
+    static __forceinline__ __device__ Acc mma(Frag a, Frag b, Acc c) {
+        return __builtin_amdgcn_wmma_f32_16x16x16_fp8_fp8_w32_gfx12(a, b, c);
+    }
+    static __forceinline__ __device__ float get(Acc c, int e) { return c[e]; }
+};
+
+struct MmaBf8 {
+    using Acc = v8f;
+    using Frag = v2i;
+    static constexpr int kStepBytes = 16;
+    static __forceinline__ __device__ Frag load(const void* lds, int row, int kbyte, int stride,
+                                                int lane) {
+        return load_frag_b64(lds, row, kbyte + 8 * (lane / 16), stride);
+    }
+    static __forceinline__ __device__ Acc zero() { return Acc{0, 0, 0, 0, 0, 0, 0, 0}; }
+    static __forceinline__ __device__ Acc mma(Frag a, Frag b, Acc c) {
+        return __builtin_amdgcn_wmma_f32_16x16x16_bf8_bf8_w32_gfx12(a, b, c);
+    }
+    static __forceinline__ __device__ float get(Acc c, int e) { return c[e]; }
+};
+
+struct MmaInt8 {
+    using Acc = v8i;
+    using Frag = v2i;
+    static constexpr int kStepBytes = 16;
+    static __forceinline__ __device__ Frag load(const void* lds, int row, int kbyte, int stride,
+                                                int lane) {
+        return load_frag_b64(lds, row, kbyte + 8 * (lane / 16), stride);
+    }
+    static __forceinline__ __device__ Acc zero() { return Acc{0, 0, 0, 0, 0, 0, 0, 0}; }
+    static __forceinline__ __device__ Acc mma(Frag a, Frag b, Acc c) {
+        return __builtin_amdgcn_wmma_i32_16x16x16_iu8_w32_gfx12(true, a, true, b, c, false);
+    }
+    // Signedness is an instruction immediate, so an unsigned A needs its own entry.
+    static __forceinline__ __device__ Acc mma_ua(Frag a, Frag b, Acc c) {
+        return __builtin_amdgcn_wmma_i32_16x16x16_iu8_w32_gfx12(false, a, true, b, c, false);
+    }
+    static __forceinline__ __device__ float get(Acc c, int e) { return static_cast<float>(c[e]); }
+};
+
+// The one type whose K-step differs: gfx12 does K=32 per MMA, gfx11 does K=16.
+struct MmaInt4 {
+    using Acc = v8i;
+    using Frag = v2i;
+    static constexpr int kStepBytes = 16;
+    static __forceinline__ __device__ Frag load(const void* lds, int row, int kbyte, int stride,
+                                                int lane) {
+        return load_frag_b64(lds, row, kbyte + 8 * (lane / 16), stride);
+    }
+    static __forceinline__ __device__ Acc zero() { return Acc{0, 0, 0, 0, 0, 0, 0, 0}; }
+    static __forceinline__ __device__ Acc mma(Frag a, Frag b, Acc c) {
+        return __builtin_amdgcn_wmma_i32_16x16x32_iu4_w32_gfx12(true, a, true, b, c, false);
+    }
+    static __forceinline__ __device__ Acc mma_ua(Frag a, Frag b, Acc c) {
+        return __builtin_amdgcn_wmma_i32_16x16x32_iu4_w32_gfx12(false, a, true, b, c, false);
+    }
+    static __forceinline__ __device__ float get(Acc c, int e) { return static_cast<float>(c[e]); }
+};
+
+#elif defined(COMFY_MMA_GFX11)
+
+struct MmaFp8 {
+    using Acc = v8f;
+    using Frag = v16bf;
+    static constexpr int kStepBytes = 16;  // 16 fp8 bytes == K-step of 16
+    static __forceinline__ __device__ Frag load(const void* lds, int row, int kbyte, int stride,
+                                                int lane) {
+        return load_frag_fp8_as_bf16<false>(lds, row, kbyte, stride);
+    }
+    static __forceinline__ __device__ Acc zero() { return Acc{0, 0, 0, 0, 0, 0, 0, 0}; }
+    static __forceinline__ __device__ Acc mma(Frag a, Frag b, Acc c) {
+        return __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a, b, c);
+    }
+    static __forceinline__ __device__ float get(Acc c, int e) { return c[e]; }
+};
+
+struct MmaBf8 {
+    using Acc = v8f;
+    using Frag = v16bf;
+    static constexpr int kStepBytes = 16;
+    static __forceinline__ __device__ Frag load(const void* lds, int row, int kbyte, int stride,
+                                                int lane) {
+        return load_frag_fp8_as_bf16<true>(lds, row, kbyte, stride);
+    }
+    static __forceinline__ __device__ Acc zero() { return Acc{0, 0, 0, 0, 0, 0, 0, 0}; }
+    static __forceinline__ __device__ Acc mma(Frag a, Frag b, Acc c) {
+        return __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a, b, c);
+    }
+    static __forceinline__ __device__ float get(Acc c, int e) { return c[e]; }
+};
+
+struct MmaInt8 {
+    using Acc = v8i;
+    using Frag = v4i;  // whole K-step of 16 int8, duplicated across half-waves
+    static constexpr int kStepBytes = 16;
+    static __forceinline__ __device__ Frag load(const void* lds, int row, int kbyte, int stride,
+                                                int lane) {
+        return load_frag_b128(lds, row, kbyte, stride);
+    }
+    static __forceinline__ __device__ Acc zero() { return Acc{0, 0, 0, 0, 0, 0, 0, 0}; }
+    static __forceinline__ __device__ Acc mma(Frag a, Frag b, Acc c) {
+        return __builtin_amdgcn_wmma_i32_16x16x16_iu8_w32(true, a, true, b, c, false);
+    }
+    static __forceinline__ __device__ Acc mma_ua(Frag a, Frag b, Acc c) {
+        return __builtin_amdgcn_wmma_i32_16x16x16_iu8_w32(false, a, true, b, c, false);
+    }
+    static __forceinline__ __device__ float get(Acc c, int e) { return static_cast<float>(c[e]); }
+};
+
+struct MmaInt4 {
+    using Acc = v8i;
+    using Frag = v2i;  // K=16 nibbles == 8 bytes, whole step, duplicated
+    static constexpr int kStepBytes = 8;
+    static __forceinline__ __device__ Frag load(const void* lds, int row, int kbyte, int stride,
+                                                int lane) {
+        return load_frag_b64(lds, row, kbyte, stride);
+    }
+    static __forceinline__ __device__ Acc zero() { return Acc{0, 0, 0, 0, 0, 0, 0, 0}; }
+    static __forceinline__ __device__ Acc mma(Frag a, Frag b, Acc c) {
+        return __builtin_amdgcn_wmma_i32_16x16x16_iu4_w32(true, a, true, b, c, false);
+    }
+    static __forceinline__ __device__ Acc mma_ua(Frag a, Frag b, Acc c) {
+        return __builtin_amdgcn_wmma_i32_16x16x16_iu4_w32(false, a, true, b, c, false);
+    }
+    static __forceinline__ __device__ float get(Acc c, int e) { return static_cast<float>(c[e]); }
+};
+
+#else
+
+// No matrix cores (RDNA2 and older) and the host pass. The GEMM kernels are
+// instantiated in every device pass so they must still compile, but the backend
+// reports no WMMA capability there and never launches them. Trap rather than
+// return a plausible wrong answer.
+#define COMFY_MMA_STUB_BODY \
+    __builtin_trap();       \
+    return c;
+
+struct MmaFp8 {
+    using Acc = v8f;
+    using Frag = v2i;
+    static constexpr int kStepBytes = 16;
+    static __forceinline__ __device__ Frag load(const void*, int, int, int, int) { return Frag{}; }
+    static __forceinline__ __device__ Acc zero() { return Acc{0, 0, 0, 0, 0, 0, 0, 0}; }
+    static __forceinline__ __device__ Acc mma(Frag, Frag, Acc c) { COMFY_MMA_STUB_BODY }
+    static __forceinline__ __device__ float get(Acc c, int e) { return c[e]; }
+};
+
+struct MmaBf8 : MmaFp8 {};
+
+struct MmaInt8 {
+    using Acc = v8i;
+    using Frag = v2i;
+    static constexpr int kStepBytes = 16;
+    static __forceinline__ __device__ Frag load(const void*, int, int, int, int) { return Frag{}; }
+    static __forceinline__ __device__ Acc zero() { return Acc{0, 0, 0, 0, 0, 0, 0, 0}; }
+    static __forceinline__ __device__ Acc mma(Frag, Frag, Acc c) { COMFY_MMA_STUB_BODY }
+    static __forceinline__ __device__ Acc mma_ua(Frag, Frag, Acc c) { COMFY_MMA_STUB_BODY }
+    static __forceinline__ __device__ float get(Acc c, int e) { return static_cast<float>(c[e]); }
+};
+
+struct MmaInt4 : MmaInt8 {};
+
+#undef COMFY_MMA_STUB_BODY
+
+#endif
+
+}  // namespace comfy::hip_backend

--- a/comfy_kitchen/backends/hip/ops/adaln.hip
+++ b/comfy_kitchen/backends/hip/ops/adaln.hip
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Fused AdaLN:
+//   adaln     - layernorm(x, no affine) * (1 + scale) + shift
+//   rms_adaln - rmsnorm(x, no affine)   * (1 + scale) + shift
+// RMSNorm is LayerNorm with the mean pinned to zero, so one kernel templated on
+// SubtractMean covers both.
+//
+// One block per row. The row is re-read for the normalization pass rather than
+// held in registers, which does not scale to large D.
+//
+// scale/shift broadcast over inner dims, expressed as a row group: output row r
+// reads modulation row r / group (see backends/_modulation.py).
+#include <stdexcept>
+
+#include "../hadamard.h"  // load_in / dtype codes
+
+namespace comfy::hip_backend {
+
+constexpr int kAdaLNThreads = 256;
+
+template <typename T>
+__forceinline__ __device__ void store_out(T* p, int64_t i, float v);
+
+template <>
+__forceinline__ __device__ void store_out<float>(float* p, int64_t i, float v) {
+    p[i] = v;
+}
+template <>
+__forceinline__ __device__ void store_out<__half>(__half* p, int64_t i, float v) {
+    p[i] = __float2half(v);
+}
+template <>
+__forceinline__ __device__ void store_out<__bf16>(__bf16* p, int64_t i, float v) {
+    p[i] = static_cast<__bf16>(v);
+}
+
+// scale/shift need not share x's dtype (e.g. fp32 modulation against a bf16
+// activation), so each buffer carries its own dtype code.
+template <typename T, bool SubtractMean>
+__global__ __launch_bounds__(kAdaLNThreads) void adaln_kernel(
+    const void* __restrict__ x, const void* __restrict__ scale,
+    const void* __restrict__ shift, T* __restrict__ out,
+    int D, int scale_group, int shift_group, float eps,
+    int code, int scale_code, int shift_code) {
+
+    __shared__ float red_sq[kAdaLNThreads];
+
+    const int row = blockIdx.x;
+    const int t = threadIdx.x;
+
+    const int64_t xbase = static_cast<int64_t>(row) * D;
+    const int64_t sbase = static_cast<int64_t>(row / scale_group) * D;
+    const int64_t hbase = static_cast<int64_t>(row / shift_group) * D;
+
+    const float inv_d = 1.0f / static_cast<float>(D);
+
+    float mean = 0.0f;
+    if constexpr (SubtractMean) {
+        __shared__ float red_sum[kAdaLNThreads];
+
+        float sum = 0.0f;
+        for (int i = t; i < D; i += kAdaLNThreads) {
+            sum += load_in(x, xbase + i, code);
+        }
+
+        red_sum[t] = sum;
+        __syncthreads();
+        for (int s = kAdaLNThreads / 2; s > 0; s >>= 1) {
+            if (t < s) red_sum[t] += red_sum[t + s];
+            __syncthreads();
+        }
+        mean = red_sum[0] * inv_d;
+    }
+
+    // Sum the squared deviations rather than E[x^2] - mean^2: the latter cancels
+    // catastrophically once the row's offset dwarfs its spread. mean == 0 makes
+    // this E[x^2], which is what RMSNorm wants.
+    float sq = 0.0f;
+    for (int i = t; i < D; i += kAdaLNThreads) {
+        const float d = load_in(x, xbase + i, code) - mean;
+        sq += d * d;
+    }
+
+    red_sq[t] = sq;
+    __syncthreads();
+    for (int s = kAdaLNThreads / 2; s > 0; s >>= 1) {
+        if (t < s) red_sq[t] += red_sq[t + s];
+        __syncthreads();
+    }
+
+    const float rstd = rsqrtf(red_sq[0] * inv_d + eps);
+
+    for (int i = t; i < D; i += kAdaLNThreads) {
+        const float v = load_in(x, xbase + i, code);
+        const float norm = (v - mean) * rstd;
+        const float s = load_in(scale, sbase + i, scale_code);
+        const float h = load_in(shift, hbase + i, shift_code);
+        store_out<T>(out, xbase + i, norm * (1.0f + s) + h);
+    }
+}
+
+}  // namespace comfy::hip_backend
+
+// subtract_mean selects LayerNorm (true) or RMSNorm (false) statistics.
+extern "C" void launch_adaln_kernel(
+    const void* x, const void* scale, const void* shift, void* out,
+    int N, int D, int scale_group, int shift_group, float eps,
+    int code, int scale_code, int shift_code, bool subtract_mean, hipStream_t stream) {
+
+    using namespace comfy::hip_backend;
+
+    if (N == 0 || D == 0) {
+        // No rows, or zero-width rows: nothing to normalize, and D == 0 would make
+        // the kernel's group divisions divide by zero.
+        return;  // a zero-block launch is hipErrorInvalidConfiguration
+    }
+
+#define CK_ADALN_LAUNCH(T, MEAN)                                                             \
+    adaln_kernel<T, MEAN><<<N, kAdaLNThreads, 0, stream>>>(                                  \
+        x, scale, shift, static_cast<T*>(out), D, scale_group, shift_group, eps, code,       \
+        scale_code, shift_code)
+#define CK_ADALN_DISPATCH(T)               \
+    if (subtract_mean) {                   \
+        CK_ADALN_LAUNCH(T, true);          \
+    } else {                               \
+        CK_ADALN_LAUNCH(T, false);         \
+    }
+
+    if (code == 0) {
+        CK_ADALN_DISPATCH(float);
+    } else if (code == 1) {
+        CK_ADALN_DISPATCH(__half);
+    } else if (code == 2) {
+        CK_ADALN_DISPATCH(__bf16);
+    } else {
+        throw std::runtime_error("adaln: unsupported dtype");
+    }
+#undef CK_ADALN_DISPATCH
+#undef CK_ADALN_LAUNCH
+}

--- a/comfy_kitchen/backends/hip/ops/apply_rope.hip
+++ b/comfy_kitchen/backends/hip/ops/apply_rope.hip
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// RoPE. x is (batch, dim1, dim2, head_dim); freqs_cis is
+// (fb, fd1, fd2, head_dim/2, 2, 2), broadcasting over any of its leading dims.
+//
+// For pair k:
+//   out[a] = f[k][0][0] * x[a] + f[k][0][1] * x[b]
+//   out[b] = f[k][1][0] * x[a] + f[k][1][1] * x[b]
+// with (a, b) = (2k, 2k+1) for the interleaved layout and (k, k + head_dim/2)
+// for the split-half layout. See rope_math.h for the rounding contract.
+#include <stdexcept>
+
+#include "../hadamard.h"    // load_in / dtype codes
+#include "../rope_math.h"   // rope_combine / rope_store
+
+namespace comfy::hip_backend {
+
+constexpr int kRopeThreads = 256;
+
+template <typename T>
+__global__ void apply_rope_kernel(
+    const void* __restrict__ xq, const void* __restrict__ xk,
+    const void* __restrict__ freqs, T* __restrict__ xq_out, T* __restrict__ xk_out,
+    int64_t batch, int64_t dim1, int64_t dim2, int64_t head_dim,
+    int64_t fb, int64_t fd1, int64_t fd2,
+    int64_t sx_b, int64_t sx_d1, int64_t sx_d2, int64_t sx_d,
+    int64_t so_b, int64_t so_d1, int64_t so_d2, int64_t so_d,
+    int64_t sf_b, int64_t sf_d1, int64_t sf_d2, int64_t sf_d, int64_t sf_rot,
+    int64_t sf_pair,
+    int x_code, int f_code, bool split_half) {
+
+    const int64_t n_pairs = head_dim / 2;
+    const int64_t total = batch * dim1 * dim2 * n_pairs;
+    const int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (idx >= total) return;
+
+    const int64_t k = idx % n_pairs;
+    int64_t tmp = idx / n_pairs;
+    const int64_t d2 = tmp % dim2;
+    tmp /= dim2;
+    const int64_t d1 = tmp % dim1;
+    const int64_t b = tmp / dim1;
+
+    // Inputs keep their own strides so a qkv slice is read in place; the outputs
+    // are freshly allocated, so they carry their own set.
+    const int64_t xoff = b * sx_b + d1 * sx_d1 + d2 * sx_d2;
+    const int64_t ooff = b * so_b + d1 * so_d1 + d2 * so_d2;
+    const int64_t ia = split_half ? k : 2 * k;
+    const int64_t ib = split_half ? k + n_pairs : 2 * k + 1;
+    const int64_t ia_in = xoff + ia * sx_d;
+    const int64_t ib_in = xoff + ib * sx_d;
+    const int64_t ia_out = ooff + ia * so_d;
+    const int64_t ib_out = ooff + ib * so_d;
+
+    const int64_t foff = (fb == 1 ? 0 : b) * sf_b + (fd1 == 1 ? 0 : d1) * sf_d1 +
+                         (fd2 == 1 ? 0 : d2) * sf_d2 + k * sf_d;
+
+    const float f00 = load_in(freqs, foff, f_code);
+    const float f01 = load_in(freqs, foff + sf_pair, f_code);
+    const float f10 = load_in(freqs, foff + sf_rot, f_code);
+    const float f11 = load_in(freqs, foff + sf_rot + sf_pair, f_code);
+
+    const float qa = load_in(xq, ia_in, x_code);
+    const float qb = load_in(xq, ib_in, x_code);
+    rope_store<T>(xq_out, ia_out, rope_combine(f00, qa, f01, qb, f_code, split_half));
+    rope_store<T>(xq_out, ib_out, rope_combine(f10, qa, f11, qb, f_code, split_half));
+
+    if (xk != nullptr) {
+        const float ka = load_in(xk, ia_in, x_code);
+        const float kb = load_in(xk, ib_in, x_code);
+        rope_store<T>(xk_out, ia_out, rope_combine(f00, ka, f01, kb, f_code, split_half));
+        rope_store<T>(xk_out, ib_out, rope_combine(f10, ka, f11, kb, f_code, split_half));
+    }
+}
+
+}  // namespace comfy::hip_backend
+
+extern "C" void launch_apply_rope_kernel(
+    const void* xq, const void* xk, const void* freqs, void* xq_out, void* xk_out,
+    int64_t batch, int64_t dim1, int64_t dim2, int64_t head_dim,
+    int64_t fb, int64_t fd1, int64_t fd2,
+    int64_t sx_b, int64_t sx_d1, int64_t sx_d2, int64_t sx_d,
+    int64_t so_b, int64_t so_d1, int64_t so_d2, int64_t so_d,
+    int64_t sf_b, int64_t sf_d1, int64_t sf_d2, int64_t sf_d, int64_t sf_rot, int64_t sf_pair,
+    int x_code, int f_code, bool split_half, hipStream_t stream) {
+
+    using namespace comfy::hip_backend;
+
+    const int64_t total = batch * dim1 * dim2 * (head_dim / 2);
+    const int blocks = static_cast<int>((total + kRopeThreads - 1) / kRopeThreads);
+    if (blocks == 0) return;
+
+#define CK_ROPE_LAUNCH(T)                                                                  \
+    apply_rope_kernel<T><<<blocks, kRopeThreads, 0, stream>>>(                             \
+        xq, xk, freqs, static_cast<T*>(xq_out), static_cast<T*>(xk_out), batch, dim1, dim2, \
+        head_dim, fb, fd1, fd2, sx_b, sx_d1, sx_d2, sx_d, so_b, so_d1, so_d2, so_d, sf_b,   \
+        sf_d1, sf_d2, sf_d, sf_rot, sf_pair, x_code, f_code, split_half)
+
+    if (x_code == 0) {
+        CK_ROPE_LAUNCH(float);
+    } else if (x_code == 1) {
+        CK_ROPE_LAUNCH(__half);
+    } else if (x_code == 2) {
+        CK_ROPE_LAUNCH(__bf16);
+    } else {
+        throw std::runtime_error("apply_rope: unsupported input dtype");
+    }
+#undef CK_ROPE_LAUNCH
+}

--- a/comfy_kitchen/backends/hip/ops/convrot_w4a4.hip
+++ b/comfy_kitchen/backends/hip/ops/convrot_w4a4.hip
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// ConvRot W4A4 on WMMA (iu4: 16x16x32 on gfx12, 16x16x16 on gfx11). See mma.h.
+//
+// out = (Aq[M, K/2] @ Wq[N, K/2]^T) * x_scale[row] * w_scale[col] + bias
+//
+// Both operands are signed int4 packed two per byte (low nibble = even index),
+// which is the byte layout the iu4 A-fragment consumes directly. The activation
+// rotation is fused into the quantizer.
+#include <stdexcept>
+#include <string>
+
+#include "../epilogue.h"
+#include "../gemm_wmma.h"
+#include "../hadamard.h"
+
+namespace comfy::hip_backend {
+
+__global__ void unpack_int4_kernel(const int8_t* __restrict__ q, int8_t* __restrict__ out,
+                                   int64_t nbytes) {
+    const int64_t i = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (i >= nbytes) return;
+    const int8_t b = q[i];
+    // sign-extend each nibble from 4 bits
+    const int lo = static_cast<int>(b & 0xF);
+    const int hi = static_cast<int>((b >> 4) & 0xF);
+    out[2 * i] = static_cast<int8_t>(lo > 7 ? lo - 16 : lo);
+    out[2 * i + 1] = static_cast<int8_t>(hi > 7 ? hi - 16 : hi);
+}
+
+template <typename OutT>
+static void launch_w4a4(const uint8_t* A, const uint8_t* B, OutT* C, int M, int N, int K,
+                        EpiRowwise epi, hipStream_t stream) {
+    const int kbytes = K / 2;
+    if (M >= 512 && N >= 128 && K > N) {
+        constexpr int BM = 256, BN = 128, BKB = 64;
+        dim3 grid((N + BN - 1) / BN, (M + BM - 1) / BM);
+        gemm_wmma_kernel<MmaInt4, EpiRowwise, OutT, BM, BN, BKB, 4, 2, 4, 4>
+            <<<grid, 256, 0, stream>>>(A, B, C, M, N, kbytes, epi);
+    } else if (M >= 96 && N >= 96) {
+        constexpr int BM = 128, BN = 128, BKB = 64;
+        dim3 grid((N + BN - 1) / BN, (M + BM - 1) / BM);
+        gemm_wmma_kernel<MmaInt4, EpiRowwise, OutT, BM, BN, BKB, 4, 2, 2, 4>
+            <<<grid, 256, 0, stream>>>(A, B, C, M, N, kbytes, epi);
+    } else {
+        constexpr int BM = 64, BN = 64, BKB = 64;
+        dim3 grid((N + BN - 1) / BN, (M + BM - 1) / BM);
+        gemm_wmma_kernel<MmaInt4, EpiRowwise, OutT, BM, BN, BKB, 2, 2, 2, 2>
+            <<<grid, 128, 0, stream>>>(A, B, C, M, N, kbytes, epi);
+    }
+}
+
+}  // namespace comfy::hip_backend
+
+extern "C" void launch_convrot_w4a4_gemm_kernel(
+    const void* a, const void* b, void* c,
+    const void* x_scale, const void* w_scale, const void* bias, int bias_code,
+    int M, int N, int K, int out_code, hipStream_t stream) {
+
+    using namespace comfy::hip_backend;
+
+    if (M == 0 || N == 0) {
+        return;  // a zero-dimension grid is hipErrorInvalidConfiguration
+    }
+    // The tile loader reads a row 16 bytes at a time and int4 packs two per byte,
+    // so the row length K/2 has to be a whole number of 16-byte chunks. An empty
+    // GEMM does no reads, so this only applies once there is real work above.
+    if (K % 32 != 0) {
+        throw std::runtime_error("convrot_w4a4_linear: K=" + std::to_string(K) +
+                                 " must be a multiple of 32");
+    }
+
+    EpiRowwise epi{static_cast<const float*>(x_scale), static_cast<const float*>(w_scale), 1,
+                   bias, bias_code};
+
+    const uint8_t* A = static_cast<const uint8_t*>(a);
+    const uint8_t* B = static_cast<const uint8_t*>(b);
+
+    if (out_code == kBF16) {
+        launch_w4a4<__bf16>(A, B, static_cast<__bf16*>(c), M, N, K, epi, stream);
+    } else if (out_code == kF16) {
+        launch_w4a4<__half>(A, B, static_cast<__half*>(c), M, N, K, epi, stream);
+    } else if (out_code == kF32) {
+        launch_w4a4<float>(A, B, static_cast<float*>(c), M, N, K, epi, stream);
+    } else {
+        throw std::runtime_error("convrot_w4a4_linear: unsupported output dtype");
+    }
+}
+
+// Fused Hadamard rotation + rowwise int4 quantize + nibble pack. Used for both
+// the activation and the weight: both rotate along K and quantize per row.
+extern "C" void launch_convrot_quant_int4_kernel(
+    const void* x, int in_code, void* qout, void* scales,
+    int M, int K, int group_size, hipStream_t stream) {
+
+    using namespace comfy::hip_backend;
+    check_convrot_group_size(group_size);
+    check_convrot_k(K, group_size);
+    if (M == 0) {
+        return;  // a zero-block launch is hipErrorInvalidConfiguration
+    }
+    const size_t shmem = static_cast<size_t>(K) * sizeof(__bf16);
+    convrot_quant_kernel<true><<<M, 256, shmem, stream>>>(
+        x, in_code, static_cast<int8_t*>(qout), static_cast<float*>(scales), M, K, group_size);
+}
+
+// The largest K the fused rotation can stage in LDS, for the dispatch wrappers.
+extern "C" int convrot_max_k_host() { return comfy::hip_backend::convrot_max_k(); }
+
+extern "C" void launch_unpack_int4_kernel(
+    const void* q, void* out, int64_t nbytes, hipStream_t stream) {
+
+    using namespace comfy::hip_backend;
+    if (nbytes == 0) {
+        return;  // a zero-block launch is hipErrorInvalidConfiguration
+    }
+    const int threads = 256;
+    const int blocks = static_cast<int>((nbytes + threads - 1) / threads);
+    unpack_int4_kernel<<<blocks, threads, 0, stream>>>(
+        static_cast<const int8_t*>(q), static_cast<int8_t*>(out), nbytes);
+}

--- a/comfy_kitchen/backends/hip/ops/gemm_fp8.hip
+++ b/comfy_kitchen/backends/hip/ops/gemm_fp8.hip
@@ -1,0 +1,116 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// FP8 scaled GEMM on WMMA (v_wmma_f32_16x16x16_fp8_fp8 on gfx12; gfx11 has no
+// fp8 WMMA and widens the operands to bf16). See mma.h.
+// C[M, N] = (A[M, K] @ B[N, K]^T) * scale_a * scale_b + bias
+#include <stdexcept>
+#include <string>
+
+#include "../epilogue.h"
+#include "../fp8_utils.h"
+#include "../gemm_wmma.h"
+
+namespace comfy::hip_backend {
+
+// Small-M path. A 16-row WMMA tile is mostly idle at small M, so reduce K
+// across the wave instead: one wave per output column.
+template <typename OutT>
+__global__ __launch_bounds__(256) void gemv_fp8_kernel(
+    const uint8_t* __restrict__ A, const uint8_t* __restrict__ B, OutT* __restrict__ C,
+    int M, int N, int K, EpiTensorwise epi) {
+
+    const int col = blockIdx.x * blockDim.y + threadIdx.y;
+    const int row = blockIdx.y;
+    if (col >= N || row >= M) return;
+
+    const uint8_t* a = A + static_cast<int64_t>(row) * K;
+    const uint8_t* b = B + static_cast<int64_t>(col) * K;
+
+    // Bandwidth-bound on streaming B: 16 bytes per lane is a 512-byte wave
+    // transaction.
+    float sum = 0.0f;
+    for (int k = threadIdx.x * 16; k < K; k += kWave * 16) {
+        // K is a multiple of 16, so a 16-byte chunk never straddles the end.
+        const uint4 av = *reinterpret_cast<const uint4*>(a + k);
+        const uint4 bv = *reinterpret_cast<const uint4*>(b + k);
+        const uint8_t* ab = reinterpret_cast<const uint8_t*>(&av);
+        const uint8_t* bb = reinterpret_cast<const uint8_t*>(&bv);
+        #pragma unroll
+        for (int i = 0; i < 16; ++i) sum += fp8_to_float(ab[i]) * fp8_to_float(bb[i]);
+    }
+    sum = wave_reduce_sum(sum);
+
+    if (threadIdx.x == 0) {
+        epi.init();
+        C[static_cast<int64_t>(row) * N + col] = static_cast<OutT>(epi(row, col, sum));
+    }
+}
+
+template <typename OutT>
+static void launch_fp8(const uint8_t* A, const uint8_t* B, OutT* C, int M, int N, int K,
+                       EpiTensorwise epi, hipStream_t stream) {
+    if (M <= 8) {
+        dim3 block(kWave, 8);
+        dim3 grid((N + 7) / 8, M);
+        gemv_fp8_kernel<OutT><<<grid, block, 0, stream>>>(A, B, C, M, N, K, epi);
+        return;
+    }
+    // A 256x128 block reads (256+128)*K bytes per output tile against
+    // (128+128)*K for 128x128, i.e. 25% less global traffic per output. Selected
+    // for deep-K shapes, which are bandwidth bound; wide-N shapes have enough
+    // reuse and prefer the larger grid of the squarer tile.
+    if (M >= 512 && N >= 128 && K > N) {
+        constexpr int BM = 256, BN = 128, BKB = 64;
+        dim3 grid((N + BN - 1) / BN, (M + BM - 1) / BM);
+        gemm_wmma_kernel<MmaFp8, EpiTensorwise, OutT, BM, BN, BKB, 4, 2, 4, 4>
+            <<<grid, 256, 0, stream>>>(A, B, C, M, N, K, epi);
+    } else if (M >= 96 && N >= 96) {
+        constexpr int BM = 128, BN = 128, BKB = 64;
+        dim3 grid((N + BN - 1) / BN, (M + BM - 1) / BM);
+        gemm_wmma_kernel<MmaFp8, EpiTensorwise, OutT, BM, BN, BKB, 4, 2, 2, 4>
+            <<<grid, 256, 0, stream>>>(A, B, C, M, N, K, epi);
+    } else {
+        constexpr int BM = 64, BN = 64, BKB = 64;
+        dim3 grid((N + BN - 1) / BN, (M + BM - 1) / BM);
+        gemm_wmma_kernel<MmaFp8, EpiTensorwise, OutT, BM, BN, BKB, 2, 2, 2, 2>
+            <<<grid, 128, 0, stream>>>(A, B, C, M, N, K, epi);
+    }
+}
+
+}  // namespace comfy::hip_backend
+
+extern "C" void launch_scaled_mm_fp8_kernel(
+    const void* a, const void* b, void* c,
+    const void* scale_a, const void* scale_b, const void* bias, int bias_code,
+    int M, int N, int K, int out_code, hipStream_t stream) {
+
+    using namespace comfy::hip_backend;
+
+    if (M == 0 || N == 0) {
+        return;  // a zero-dimension grid is hipErrorInvalidConfiguration
+    }
+    // Both the tile loader and the small-M GEMV read a row 16 bytes at a time; an
+    // unaligned K would take the last chunk past the end of the row. An empty GEMM
+    // does no reads, so this only applies once there is real work above.
+    if (K % 16 != 0) {
+        throw std::runtime_error("scaled_mm_fp8: K=" + std::to_string(K) +
+                                 " must be a multiple of 16");
+    }
+
+    EpiTensorwise epi{static_cast<const float*>(scale_a), static_cast<const float*>(scale_b),
+                      bias, bias_code, 0.0f};
+
+    const uint8_t* A = static_cast<const uint8_t*>(a);
+    const uint8_t* B = static_cast<const uint8_t*>(b);
+
+    if (out_code == kBF16) {
+        launch_fp8<__bf16>(A, B, static_cast<__bf16*>(c), M, N, K, epi, stream);
+    } else if (out_code == kF16) {
+        launch_fp8<__half>(A, B, static_cast<__half*>(c), M, N, K, epi, stream);
+    } else if (out_code == kF32) {
+        launch_fp8<float>(A, B, static_cast<float*>(c), M, N, K, epi, stream);
+    } else {
+        throw std::runtime_error("scaled_mm_fp8: unsupported output dtype");
+    }
+}

--- a/comfy_kitchen/backends/hip/ops/gemm_int8.hip
+++ b/comfy_kitchen/backends/hip/ops/gemm_int8.hip
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// INT8 GEMM on WMMA (v_wmma_i32_16x16x16_iu8), gfx11 and gfx12. See mma.h.
+// C[M, N] = (A[M, K] @ B[N, K]^T) * scale_a[row] * scale_b[col] + bias
+#include <stdexcept>
+#include <string>
+
+#include "../epilogue.h"
+#include "../gemm_wmma.h"
+
+namespace comfy::hip_backend {
+
+// Small-M path: reduce K across the wave, one wave per output column.
+template <typename OutT>
+__global__ __launch_bounds__(256) void gemv_int8_kernel(
+    const int8_t* __restrict__ A, const int8_t* __restrict__ B, OutT* __restrict__ C,
+    int M, int N, int K, EpiRowwise epi) {
+
+    const int col = blockIdx.x * blockDim.y + threadIdx.y;
+    const int row = blockIdx.y;
+    if (col >= N || row >= M) return;
+
+    const int8_t* a = A + static_cast<int64_t>(row) * K;
+    const int8_t* b = B + static_cast<int64_t>(col) * K;
+
+    int sum = 0;
+    for (int k = threadIdx.x * 16; k < K; k += kWave * 16) {
+        const uint4 av = *reinterpret_cast<const uint4*>(a + k);
+        const uint4 bv = *reinterpret_cast<const uint4*>(b + k);
+        const int8_t* ab = reinterpret_cast<const int8_t*>(&av);
+        const int8_t* bb = reinterpret_cast<const int8_t*>(&bv);
+        #pragma unroll
+        for (int i = 0; i < 16; ++i) sum += ab[i] * bb[i];
+    }
+    sum = wave_reduce_sum(sum);
+
+    if (threadIdx.x == 0) {
+        epi.init();
+        C[static_cast<int64_t>(row) * N + col] =
+            static_cast<OutT>(epi(row, col, static_cast<float>(sum)));
+    }
+}
+
+template <typename OutT>
+static void launch_int8(const int8_t* A, const int8_t* B, OutT* C, int M, int N, int K,
+                        EpiRowwise epi, hipStream_t stream) {
+    const uint8_t* Au = reinterpret_cast<const uint8_t*>(A);
+    const uint8_t* Bu = reinterpret_cast<const uint8_t*>(B);
+
+    if (M <= 8) {
+        dim3 block(kWave, 8);
+        dim3 grid((N + 7) / 8, M);
+        gemv_int8_kernel<OutT><<<grid, block, 0, stream>>>(A, B, C, M, N, K, epi);
+        return;
+    }
+    if (M >= 512 && N >= 128 && K > N) {
+        constexpr int BM = 256, BN = 128, BKB = 64;
+        dim3 grid((N + BN - 1) / BN, (M + BM - 1) / BM);
+        gemm_wmma_kernel<MmaInt8, EpiRowwise, OutT, BM, BN, BKB, 4, 2, 4, 4>
+            <<<grid, 256, 0, stream>>>(Au, Bu, C, M, N, K, epi);
+    } else if (M >= 96 && N >= 96) {
+        constexpr int BM = 128, BN = 128, BKB = 64;
+        dim3 grid((N + BN - 1) / BN, (M + BM - 1) / BM);
+        gemm_wmma_kernel<MmaInt8, EpiRowwise, OutT, BM, BN, BKB, 4, 2, 2, 4>
+            <<<grid, 256, 0, stream>>>(Au, Bu, C, M, N, K, epi);
+    } else {
+        constexpr int BM = 64, BN = 64, BKB = 64;
+        dim3 grid((N + BN - 1) / BN, (M + BM - 1) / BM);
+        gemm_wmma_kernel<MmaInt8, EpiRowwise, OutT, BM, BN, BKB, 2, 2, 2, 2>
+            <<<grid, 128, 0, stream>>>(Au, Bu, C, M, N, K, epi);
+    }
+}
+
+}  // namespace comfy::hip_backend
+
+// scale_b_stride is 1 for a per-output-channel weight scale, 0 for a scalar one.
+extern "C" void launch_int8_gemm_kernel(
+    const void* a, const void* b, void* c,
+    const void* scale_a, const void* scale_b, int scale_b_stride,
+    const void* bias, int bias_code,
+    int M, int N, int K, int out_code, hipStream_t stream) {
+
+    using namespace comfy::hip_backend;
+
+    if (M == 0 || N == 0) {
+        return;  // a zero-dimension grid is hipErrorInvalidConfiguration
+    }
+    // Both the tile loader and the small-M GEMV read a row 16 bytes at a time; an
+    // unaligned K would take the last chunk past the end of the row. An empty GEMM
+    // does no reads, so this only applies once there is real work above.
+    if (K % 16 != 0) {
+        throw std::runtime_error("int8_gemm: K=" + std::to_string(K) +
+                                 " must be a multiple of 16");
+    }
+
+    EpiRowwise epi{static_cast<const float*>(scale_a), static_cast<const float*>(scale_b),
+                   scale_b_stride, bias, bias_code};
+
+    const int8_t* A = static_cast<const int8_t*>(a);
+    const int8_t* B = static_cast<const int8_t*>(b);
+
+    if (out_code == kBF16) {
+        launch_int8<__bf16>(A, B, static_cast<__bf16*>(c), M, N, K, epi, stream);
+    } else if (out_code == kF16) {
+        launch_int8<__half>(A, B, static_cast<__half*>(c), M, N, K, epi, stream);
+    } else if (out_code == kF32) {
+        launch_int8<float>(A, B, static_cast<float*>(c), M, N, K, epi, stream);
+    } else {
+        throw std::runtime_error("int8_gemm: unsupported output dtype");
+    }
+}

--- a/comfy_kitchen/backends/hip/ops/gemv_awq.hip
+++ b/comfy_kitchen/backends/hip/ops/gemv_awq.hip
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// AWQ W4A16 GEMV: 4-bit weight, bf16/fp16 activation, per-group asymmetric.
+//
+//   W[n, k] = (q[n, k] - 8) * wscale[k / G, n] + wzero[k / G, n]
+//   y       = x @ W^T + bias
+//
+// Small-batch shapes are bandwidth bound on streaming the weight and offer no
+// operand reuse for a WMMA tile, so one wave reduces one output column.
+#include <stdexcept>
+#include <string>
+
+#include "../epilogue.h"
+#include "../mma.h"
+
+namespace comfy::hip_backend {
+
+constexpr int kAwqWavesPerBlock = 8;
+
+template <typename OutT>
+__global__ __launch_bounds__(kWave* kAwqWavesPerBlock) void gemv_awq_kernel(
+    const void* __restrict__ x, const int8_t* __restrict__ qweight,
+    const void* __restrict__ wscales, const void* __restrict__ wzeros,
+    const void* __restrict__ bias, OutT* __restrict__ out,
+    int M, int N, int K, int group_size, int x_code, int s_code, int bias_code) {
+
+    const int lane = threadIdx.x;
+    const int n = blockIdx.x * kAwqWavesPerBlock + threadIdx.y;
+    const int m = blockIdx.y;
+    if (n >= N || m >= M) return;
+
+    const int8_t* wrow = qweight + static_cast<int64_t>(n) * (K / 2);
+
+    float sum = 0.0f;
+    // 4 packed bytes = 8 weights. group_size is a multiple of 8, so a chunk
+    // never straddles a group boundary and scale/zero are looked up per chunk.
+    for (int k = lane * 8; k < K; k += kWave * 8) {
+        const int g = k / group_size;
+        const float s = load_scalar(wscales, s_code, g * N + n);
+        const float z = load_scalar(wzeros, s_code, g * N + n);
+
+        const uchar4 packed = *reinterpret_cast<const uchar4*>(wrow + k / 2);
+        const uint8_t* pb = reinterpret_cast<const uint8_t*>(&packed);
+
+        #pragma unroll
+        for (int i = 0; i < 4; ++i) {
+            const int lo = pb[i] & 0x0F;
+            const int hi = (pb[i] >> 4) & 0x0F;
+            const float x0 = load_scalar(x, x_code, static_cast<int64_t>(m) * K + k + 2 * i);
+            const float x1 = load_scalar(x, x_code, static_cast<int64_t>(m) * K + k + 2 * i + 1);
+            sum += x0 * ((lo - 8.0f) * s + z);
+            sum += x1 * ((hi - 8.0f) * s + z);
+        }
+    }
+
+    sum = wave_reduce_sum(sum);
+
+    if (lane == 0) {
+        if (bias != nullptr) sum += load_scalar(bias, bias_code, n);
+        out[static_cast<int64_t>(m) * N + n] = static_cast<OutT>(sum);
+    }
+}
+
+}  // namespace comfy::hip_backend
+
+extern "C" void launch_gemv_awq_kernel(
+    const void* x, const void* qweight, const void* wscales, const void* wzeros,
+    const void* bias, void* out, int M, int N, int K, int group_size,
+    int x_code, int s_code, int bias_code, int out_code, hipStream_t stream) {
+
+    using namespace comfy::hip_backend;
+
+    if (M == 0 || N == 0) {
+        return;  // a zero-dimension grid is hipErrorInvalidConfiguration
+    }
+
+    // The kernel consumes 8 weights (4 packed bytes) per step and indexes the
+    // scale/zero rows as k / group_size. A group that is not a whole number of
+    // those chunks would straddle the boundary and pick up the wrong scale; a K
+    // that is not would read past the end of the packed row.
+    if (group_size <= 0 || group_size % 8 != 0) {
+        throw std::runtime_error("gemv_awq_w4a16: group_size must be a positive multiple of 8, got " +
+                                 std::to_string(group_size));
+    }
+    if (K % 8 != 0) {
+        throw std::runtime_error("gemv_awq_w4a16: K must be a multiple of 8, got " +
+                                 std::to_string(K));
+    }
+    if (K % group_size != 0) {
+        throw std::runtime_error("gemv_awq_w4a16: K=" + std::to_string(K) +
+                                 " must be a multiple of group_size=" + std::to_string(group_size));
+    }
+
+    dim3 block(kWave, kAwqWavesPerBlock);
+    dim3 grid((N + kAwqWavesPerBlock - 1) / kAwqWavesPerBlock, M);
+    const int8_t* q = static_cast<const int8_t*>(qweight);
+
+#define CK_AWQ_LAUNCH(T)                                                                     \
+    gemv_awq_kernel<T><<<grid, block, 0, stream>>>(x, q, wscales, wzeros, bias,               \
+                                                   static_cast<T*>(out), M, N, K, group_size, \
+                                                   x_code, s_code, bias_code)
+
+    if (out_code == kBF16) {
+        CK_AWQ_LAUNCH(__bf16);
+    } else if (out_code == kF16) {
+        CK_AWQ_LAUNCH(__half);
+    } else if (out_code == kF32) {
+        CK_AWQ_LAUNCH(float);
+    } else {
+        throw std::runtime_error("gemv_awq_w4a16: unsupported output dtype");
+    }
+#undef CK_AWQ_LAUNCH
+}

--- a/comfy_kitchen/backends/hip/ops/per_tensor_fp8.hip
+++ b/comfy_kitchen/backends/hip/ops/per_tensor_fp8.hip
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Per-tensor FP8 quantize/dequantize. The OCP encode/decode lives in fp8_utils.h
+// so this kernel and stochastic_round_fp8 cannot drift apart.
+#include <cmath>
+#include <cstdint>
+#include <stdexcept>
+
+#include <hip/hip_fp16.h>
+#include <hip/hip_runtime.h>
+
+#include "../fp8_utils.h"
+
+namespace comfy::hip_backend {
+
+constexpr int kThreads = 256;
+
+template<typename T>
+__forceinline__ __device__ void store_value(void* dst, int64_t idx, float value) {
+    reinterpret_cast<T*>(dst)[idx] = static_cast<T>(value);
+}
+
+template<>
+__forceinline__ __device__ void store_value<__half>(void* dst, int64_t idx, float value) {
+    reinterpret_cast<__half*>(dst)[idx] = __float2half(value);
+}
+
+template<typename InputType>
+__global__ void quantize_per_tensor_fp8_kernel(
+    const InputType* input,
+    const float* scale,
+    uint8_t* output,
+    int64_t numel,
+    int output_dtype_code) {
+
+    const int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (idx >= numel) {
+        return;
+    }
+    const float scaled = to_float(input[idx]) / scale[0];
+    output[idx] = pack_fp8(scaled, output_dtype_code);
+}
+
+template<typename OutputType>
+__global__ void dequantize_per_tensor_fp8_kernel(
+    const uint8_t* input,
+    const float* scale,
+    void* output,
+    int64_t numel,
+    int input_dtype_code) {
+
+    const int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (idx >= numel) {
+        return;
+    }
+    store_value<OutputType>(output, idx, unpack_fp8(input[idx], input_dtype_code) * scale[0]);
+}
+
+} // namespace comfy::hip_backend
+
+extern "C" {
+
+void launch_quantize_per_tensor_fp8_kernel(
+    const void* input,
+    const void* scale,
+    void* output,
+    int64_t numel,
+    int input_dtype_code,
+    int output_dtype_code,
+    hipStream_t stream) {
+
+    if (numel == 0) {
+        return;  // a zero-block launch is hipErrorInvalidConfiguration
+    }
+
+    const int blocks = static_cast<int>((numel + comfy::hip_backend::kThreads - 1) / comfy::hip_backend::kThreads);
+    if (input_dtype_code == 0) {
+        comfy::hip_backend::quantize_per_tensor_fp8_kernel<float><<<blocks, comfy::hip_backend::kThreads, 0, stream>>>(static_cast<const float*>(input), static_cast<const float*>(scale), static_cast<uint8_t*>(output), numel, output_dtype_code);
+    } else if (input_dtype_code == 1) {
+        comfy::hip_backend::quantize_per_tensor_fp8_kernel<__half><<<blocks, comfy::hip_backend::kThreads, 0, stream>>>(static_cast<const __half*>(input), static_cast<const float*>(scale), static_cast<uint8_t*>(output), numel, output_dtype_code);
+    } else if (input_dtype_code == 2) {
+        comfy::hip_backend::quantize_per_tensor_fp8_kernel<__bf16><<<blocks, comfy::hip_backend::kThreads, 0, stream>>>(static_cast<const __bf16*>(input), static_cast<const float*>(scale), static_cast<uint8_t*>(output), numel, output_dtype_code);
+    } else {
+        throw std::runtime_error("Unsupported input dtype for quantize_per_tensor_fp8");
+    }
+}
+
+void launch_dequantize_per_tensor_fp8_kernel(
+    const void* input,
+    const void* scale,
+    void* output,
+    int64_t numel,
+    int input_dtype_code,
+    int output_dtype_code,
+    hipStream_t stream) {
+
+    if (numel == 0) {
+        return;  // a zero-block launch is hipErrorInvalidConfiguration
+    }
+
+    const int blocks = static_cast<int>((numel + comfy::hip_backend::kThreads - 1) / comfy::hip_backend::kThreads);
+    if (output_dtype_code == 0) {
+        comfy::hip_backend::dequantize_per_tensor_fp8_kernel<float><<<blocks, comfy::hip_backend::kThreads, 0, stream>>>(static_cast<const uint8_t*>(input), static_cast<const float*>(scale), output, numel, input_dtype_code);
+    } else if (output_dtype_code == 1) {
+        comfy::hip_backend::dequantize_per_tensor_fp8_kernel<__half><<<blocks, comfy::hip_backend::kThreads, 0, stream>>>(static_cast<const uint8_t*>(input), static_cast<const float*>(scale), output, numel, input_dtype_code);
+    } else if (output_dtype_code == 2) {
+        comfy::hip_backend::dequantize_per_tensor_fp8_kernel<__bf16><<<blocks, comfy::hip_backend::kThreads, 0, stream>>>(static_cast<const uint8_t*>(input), static_cast<const float*>(scale), output, numel, input_dtype_code);
+    } else {
+        throw std::runtime_error("Unsupported output dtype for dequantize_per_tensor_fp8");
+    }
+}
+
+} // extern "C"

--- a/comfy_kitchen/backends/hip/ops/quantize_int8.hip
+++ b/comfy_kitchen/backends/hip/ops/quantize_int8.hip
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// INT8 quantization kernels for the WMMA int8 GEMM.
+#include <stdexcept>
+
+#include "../hadamard.h"
+
+namespace comfy::hip_backend {
+
+constexpr float kInt8Max = 127.0f;
+
+__forceinline__ __device__ int8_t quant_round(float v, float inv) {
+    // rintf is round-half-to-even, matching torch.round.
+    int q = static_cast<int>(rintf(v * inv));
+    q = q < -128 ? -128 : (q > 127 ? 127 : q);
+    return static_cast<int8_t>(q);
+}
+
+// One block per row: block-reduce the row absmax, then quantize the row.
+__global__ __launch_bounds__(256) void quantize_int8_rowwise_kernel(
+    const void* __restrict__ x, int in_code, int8_t* __restrict__ q,
+    float* __restrict__ scales, int M, int K) {
+
+    __shared__ float red[256];
+    const int row = blockIdx.x;
+    const int t = threadIdx.x;
+
+    float lmax = 0.0f;
+    for (int j = t; j < K; j += 256)
+        lmax = fmaxf(lmax, fabsf(load_in(x, static_cast<int64_t>(row) * K + j, in_code)));
+
+    red[t] = lmax;
+    __syncthreads();
+    for (int s = 128; s > 0; s >>= 1) {
+        if (t < s) red[t] = fmaxf(red[t], red[t + s]);
+        __syncthreads();
+    }
+
+    const float scale = fmaxf(red[0] / kInt8Max, 1e-30f);
+    if (t == 0) scales[row] = scale;
+    const float inv = 1.0f / scale;
+
+    for (int j = t; j < K; j += 256) {
+        const float v = load_in(x, static_cast<int64_t>(row) * K + j, in_code);
+        q[static_cast<int64_t>(row) * K + j] = quant_round(v, inv);
+    }
+}
+
+__global__ void absmax_kernel(const void* __restrict__ x, int in_code,
+                              unsigned int* __restrict__ out, int64_t numel) {
+    __shared__ float red[256];
+    const int t = threadIdx.x;
+
+    float lmax = 0.0f;
+    for (int64_t i = static_cast<int64_t>(blockIdx.x) * blockDim.x + t; i < numel;
+         i += static_cast<int64_t>(gridDim.x) * blockDim.x)
+        lmax = fmaxf(lmax, fabsf(load_in(x, i, in_code)));
+
+    red[t] = lmax;
+    __syncthreads();
+    for (int s = 128; s > 0; s >>= 1) {
+        if (t < s) red[t] = fmaxf(red[t], red[t + s]);
+        __syncthreads();
+    }
+    // Non-negative floats compare identically to their bit patterns as unsigned.
+    if (t == 0) atomicMax(out, __float_as_uint(red[0]));
+}
+
+__global__ void scale_from_absmax_kernel(const unsigned int* __restrict__ absmax,
+                                         float* __restrict__ scale) {
+    if (threadIdx.x == 0) *scale = fmaxf(__uint_as_float(*absmax) / kInt8Max, 1e-30f);
+}
+
+__global__ void quantize_int8_tensorwise_kernel(
+    const void* __restrict__ x, int in_code, int8_t* __restrict__ q,
+    const float* __restrict__ scale, int64_t numel) {
+
+    const int64_t i = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (i >= numel) return;
+    q[i] = quant_round(load_in(x, i, in_code), 1.0f / scale[0]);
+}
+
+}  // namespace comfy::hip_backend
+
+extern "C" void launch_quantize_int8_rowwise_kernel(
+    const void* x, int in_code, void* q, void* scales, int M, int K, hipStream_t stream) {
+
+    using namespace comfy::hip_backend;
+    if (M == 0) {
+        return;  // a zero-block launch is hipErrorInvalidConfiguration
+    }
+    quantize_int8_rowwise_kernel<<<M, 256, 0, stream>>>(
+        x, in_code, static_cast<int8_t*>(q), static_cast<float*>(scales), M, K);
+}
+
+// Fused ConvRot rotation + rowwise int8 quantize. act_code: 0 none, 1 gelu tanh.
+extern "C" void launch_quantize_int8_convrot_kernel(
+    const void* x, int in_code, void* q, void* scales,
+    int M, int K, int group_size, int act_code, hipStream_t stream) {
+
+    using namespace comfy::hip_backend;
+    check_convrot_group_size(group_size);
+    check_convrot_k(K, group_size);
+    check_convrot_act(act_code);
+    if (M == 0) {
+        return;  // a zero-block launch is hipErrorInvalidConfiguration
+    }
+    const size_t shmem = static_cast<size_t>(K) * sizeof(__bf16);
+    if (act_code == kActGeluTanh) {
+        convrot_quant_kernel<false, kActGeluTanh><<<M, 256, shmem, stream>>>(
+            x, in_code, static_cast<int8_t*>(q), static_cast<float*>(scales), M, K, group_size);
+    } else {
+        convrot_quant_kernel<false, kActNone><<<M, 256, shmem, stream>>>(
+            x, in_code, static_cast<int8_t*>(q), static_cast<float*>(scales), M, K, group_size);
+    }
+}
+
+// scratch is a 4-byte device buffer, pre-zeroed by the caller.
+extern "C" void launch_quantize_int8_tensorwise_kernel(
+    const void* x, int in_code, void* q, void* scale, void* scratch,
+    int64_t numel, hipStream_t stream) {
+
+    using namespace comfy::hip_backend;
+    const int threads = 256;
+    const int blocks = static_cast<int>((numel + threads - 1) / threads);
+    const int rblocks = blocks < 1024 ? blocks : 1024;
+
+    // An empty input has no absmax and nothing to quantize, but the scale is still
+    // an output, so only the zero-block launches are skipped. scratch is zeroed,
+    // which the scale kernel clamps.
+    if (numel > 0) {
+        absmax_kernel<<<rblocks, threads, 0, stream>>>(
+            x, in_code, static_cast<unsigned int*>(scratch), numel);
+    }
+    scale_from_absmax_kernel<<<1, 1, 0, stream>>>(
+        static_cast<const unsigned int*>(scratch), static_cast<float*>(scale));
+    if (numel > 0) {
+        quantize_int8_tensorwise_kernel<<<blocks, threads, 0, stream>>>(
+            x, in_code, static_cast<int8_t*>(q), static_cast<const float*>(scale), numel);
+    }
+}

--- a/comfy_kitchen/backends/hip/ops/rms_rope.hip
+++ b/comfy_kitchen/backends/hip/ops/rms_rope.hip
@@ -1,0 +1,156 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Fused RMSNorm + RoPE. Same operand layout as ops/apply_rope.hip. The norm
+// reduces over head_dim, the last axis in both the BHND and BNHD layouts, so the
+// kernel never has to know which of dim1/dim2 is the sequence.
+//
+// One block per row, as in ops/adaln.hip, but sized to one row rather than
+// adaln's 256 threads: rows are short and numerous, so a wider block would idle.
+// The row is re-read for the rotation rather than held in registers, which keeps
+// head_dim unbounded.
+//
+// The normalized value is rounded to x's dtype before the rotation reads it back.
+// That is the unfused contract, which every other backend matches.
+#include <stdexcept>
+
+#include "../hadamard.h"   // load_in / dtype codes
+#include "../rope_math.h"  // rope_combine / rope_store / round_to
+
+namespace comfy::hip_backend {
+
+constexpr int kRmsRopeThreads = 64;
+
+// q_scale and k_scale need not share x's dtype, so they carry their own code.
+// k is optional: rms_rope1 passes nullptr for it.
+template <typename T>
+__global__ __launch_bounds__(kRmsRopeThreads) void rms_rope_kernel(
+    const void* __restrict__ q, const void* __restrict__ k,
+    const void* __restrict__ freqs, const void* __restrict__ q_scale,
+    const void* __restrict__ k_scale, T* __restrict__ q_out, T* __restrict__ k_out,
+    int64_t dim1, int64_t dim2, int head_dim,
+    int64_t fb, int64_t fd1, int64_t fd2,
+    int64_t sx_b, int64_t sx_d1, int64_t sx_d2, int64_t sx_d,
+    int64_t so_b, int64_t so_d1, int64_t so_d2, int64_t so_d,
+    int64_t sf_b, int64_t sf_d1, int64_t sf_d2, int64_t sf_d, int64_t sf_rot,
+    int64_t sf_pair,
+    int x_code, int f_code, int s_code, float epsilon, bool split_half) {
+
+    __shared__ float red_q[kRmsRopeThreads];
+    __shared__ float red_k[kRmsRopeThreads];
+
+    const int t = threadIdx.x;
+    const int64_t row = blockIdx.x;
+    const int64_t d2 = row % dim2;
+    const int64_t d1 = (row / dim2) % dim1;
+    const int64_t b = row / (dim2 * dim1);
+
+    // Inputs keep their own strides so a qkv slice is read in place; the outputs
+    // are freshly allocated, so they carry their own set.
+    const int64_t xoff = b * sx_b + d1 * sx_d1 + d2 * sx_d2;
+    const int64_t ooff = b * so_b + d1 * so_d1 + d2 * so_d2;
+    const bool has_k = k != nullptr;
+
+    float sq_q = 0.0f;
+    float sq_k = 0.0f;
+    for (int i = t; i < head_dim; i += kRmsRopeThreads) {
+        const float v = load_in(q, xoff + i * sx_d, x_code);
+        sq_q += v * v;
+        if (has_k) {
+            const float w = load_in(k, xoff + i * sx_d, x_code);
+            sq_k += w * w;
+        }
+    }
+
+    red_q[t] = sq_q;
+    red_k[t] = sq_k;
+    __syncthreads();
+    for (int s = kRmsRopeThreads / 2; s > 0; s >>= 1) {
+        if (t < s) {
+            red_q[t] += red_q[t + s];
+            red_k[t] += red_k[t + s];
+        }
+        __syncthreads();
+    }
+
+    const float inv_d = 1.0f / static_cast<float>(head_dim);
+    const float rrms_q = rsqrtf(red_q[0] * inv_d + epsilon);
+    const float rrms_k = has_k ? rsqrtf(red_k[0] * inv_d + epsilon) : 0.0f;
+
+    const int64_t foff_row = (fb == 1 ? 0 : b) * sf_b + (fd1 == 1 ? 0 : d1) * sf_d1 +
+                             (fd2 == 1 ? 0 : d2) * sf_d2;
+
+    const int n_pairs = head_dim / 2;
+    for (int p = t; p < n_pairs; p += kRmsRopeThreads) {
+        const int64_t ia = split_half ? p : 2 * p;
+        const int64_t ib = split_half ? p + n_pairs : 2 * p + 1;
+        const int64_t ia_in = xoff + ia * sx_d;
+        const int64_t ib_in = xoff + ib * sx_d;
+        const int64_t ia_out = ooff + ia * so_d;
+        const int64_t ib_out = ooff + ib * so_d;
+
+        const int64_t foff = foff_row + static_cast<int64_t>(p) * sf_d;
+        const float f00 = load_in(freqs, foff, f_code);
+        const float f01 = load_in(freqs, foff + sf_pair, f_code);
+        const float f10 = load_in(freqs, foff + sf_rot, f_code);
+        const float f11 = load_in(freqs, foff + sf_rot + sf_pair, f_code);
+
+        const float sa = load_in(q_scale, ia, s_code);
+        const float sb = load_in(q_scale, ib, s_code);
+        const float qa = round_to<T>(load_in(q, ia_in, x_code) * rrms_q * sa);
+        const float qb = round_to<T>(load_in(q, ib_in, x_code) * rrms_q * sb);
+        rope_store<T>(q_out, ia_out, rope_combine(f00, qa, f01, qb, f_code, split_half));
+        rope_store<T>(q_out, ib_out, rope_combine(f10, qa, f11, qb, f_code, split_half));
+
+        if (has_k) {
+            const float ta = load_in(k_scale, ia, s_code);
+            const float tb = load_in(k_scale, ib, s_code);
+            const float ka = round_to<T>(load_in(k, ia_in, x_code) * rrms_k * ta);
+            const float kb = round_to<T>(load_in(k, ib_in, x_code) * rrms_k * tb);
+            rope_store<T>(k_out, ia_out, rope_combine(f00, ka, f01, kb, f_code, split_half));
+            rope_store<T>(k_out, ib_out, rope_combine(f10, ka, f11, kb, f_code, split_half));
+        }
+    }
+}
+
+}  // namespace comfy::hip_backend
+
+extern "C" void launch_rms_rope_kernel(
+    const void* q, const void* k, const void* freqs, const void* q_scale, const void* k_scale,
+    void* q_out, void* k_out,
+    int64_t batch, int64_t dim1, int64_t dim2, int64_t head_dim,
+    int64_t fb, int64_t fd1, int64_t fd2,
+    int64_t sx_b, int64_t sx_d1, int64_t sx_d2, int64_t sx_d,
+    int64_t so_b, int64_t so_d1, int64_t so_d2, int64_t so_d,
+    int64_t sf_b, int64_t sf_d1, int64_t sf_d2, int64_t sf_d, int64_t sf_rot, int64_t sf_pair,
+    int x_code, int f_code, int s_code, float epsilon, bool split_half, hipStream_t stream) {
+
+    using namespace comfy::hip_backend;
+
+    const int64_t rows = batch * dim1 * dim2;
+    // A zero-block launch is hipErrorInvalidConfiguration, and head_dim == 0 would
+    // divide by zero in the reduction.
+    if (rows == 0 || head_dim == 0) return;
+    // One block per row, and gridDim.x is 32-bit.
+    if (rows > 0xffffffffLL) {
+        throw std::runtime_error("rms_rope: too many rows for a single grid");
+    }
+
+#define CK_RMS_ROPE_LAUNCH(T)                                                                  \
+    rms_rope_kernel<T><<<static_cast<unsigned int>(rows), kRmsRopeThreads, 0, stream>>>(       \
+        q, k, freqs, q_scale, k_scale, static_cast<T*>(q_out), static_cast<T*>(k_out), dim1,   \
+        dim2, static_cast<int>(head_dim), fb, fd1, fd2, sx_b, sx_d1, sx_d2, sx_d, so_b, so_d1, \
+        so_d2, so_d, sf_b, sf_d1, sf_d2, sf_d, sf_rot, sf_pair, x_code, f_code, s_code,        \
+        epsilon, split_half)
+
+    if (x_code == 0) {
+        CK_RMS_ROPE_LAUNCH(float);
+    } else if (x_code == 1) {
+        CK_RMS_ROPE_LAUNCH(__half);
+    } else if (x_code == 2) {
+        CK_RMS_ROPE_LAUNCH(__bf16);
+    } else {
+        throw std::runtime_error("rms_rope: unsupported input dtype");
+    }
+#undef CK_RMS_ROPE_LAUNCH
+}

--- a/comfy_kitchen/backends/hip/ops/stochastic_round_fp8.hip
+++ b/comfy_kitchen/backends/hip/ops/stochastic_round_fp8.hip
@@ -1,0 +1,126 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Stochastic-rounding FP8 quantize. The OCP encode lives in fp8_utils.h so this
+// kernel and per_tensor_fp8 cannot drift apart.
+#include <cmath>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+
+#include <hip/hip_fp16.h>
+#include <hip/hip_runtime.h>
+
+#include "../fp8_utils.h"
+
+namespace comfy::hip_backend {
+
+constexpr int kMaxKernelThreads = 128;
+
+template<typename InputType>
+__global__ void stochastic_round_fp8_kernel(
+    uint8_t* rng_and_dst,
+    const InputType* src,
+    int64_t size,
+    int output_dtype_code) {
+
+    const bool e4m3 = output_dtype_code == 5;
+    const float fp8_max = e4m3 ? 448.0f : 57344.0f;
+    const int exponent_bits = e4m3 ? 4 : 5;
+    const int mantissa_bits = e4m3 ? 3 : 2;
+    const int exponent_bias = e4m3 ? 7 : 15;
+    const float mantissa_levels = static_cast<float>(1 << mantissa_bits);
+    const float subnormal_mantissa_scale = exp2f(-exponent_bias + 1 - mantissa_bits);
+    const float subnormal_value_scale = exp2f(-exponent_bias + 1);
+
+    const int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (idx >= size) {
+        return;
+    }
+
+    // Match the CUDA implementation: reduce the source value through FP16 before
+    // applying stochastic mantissa rounding.
+    const float value = __half2float(__float2half(to_float(src[idx])));
+    const float abs_value = fabsf(value);
+    const float sign = value < 0.0f ? -1.0f : (value > 0.0f ? 1.0f : 0.0f);
+
+    // log2f(0) is -inf, which -ffast-math is free to assume never happens. A NaN
+    // has to leave here too: the fp8_clamp below would drop it for a finite bound
+    // before pack_fp8 could encode it.
+    if (fp8_is_nan(value)) {
+        rng_and_dst[idx] = pack_fp8(value, output_dtype_code);
+        return;
+    }
+    if (abs_value == 0.0f) {
+        rng_and_dst[idx] = pack_fp8(0.0f, output_dtype_code);
+        return;
+    }
+
+    float exponent = floorf(log2f(abs_value)) + exponent_bias;
+    exponent = fp8_clamp(exponent, 0.0f, static_cast<float>((1 << exponent_bits) - 1));
+    const bool normal = exponent != 0.0f;
+    const float exponent_scale = exp2f(exponent - exponent_bias);
+
+    const float normal_mantissa = (abs_value / exponent_scale - 1.0f) * mantissa_levels;
+    const float subnormal_mantissa = abs_value / subnormal_mantissa_scale;
+    const float random = static_cast<float>(rng_and_dst[idx]) * (1.0f / 256.0f);
+    const float mantissa = floorf((normal ? normal_mantissa : subnormal_mantissa) + random) / mantissa_levels;
+    const float rounded = sign * (normal ? exponent_scale * (1.0f + mantissa) : subnormal_value_scale * mantissa);
+
+    rng_and_dst[idx] = pack_fp8(fp8_clamp(rounded, -fp8_max, fp8_max), output_dtype_code);
+}
+
+} // namespace comfy::hip_backend
+
+extern "C" {
+
+void launch_stochastic_round_fp8_kernel(
+    void* rng_and_output,
+    const void* input,
+    int64_t numel,
+    int rng_dtype_code,
+    int input_dtype_code,
+    int output_dtype_code,
+    hipStream_t stream) {
+
+    if (numel == 0) {
+        return;
+    }
+
+    if (rng_dtype_code != 3) {
+        throw std::runtime_error("stochastic_round_fp8 requires uint8 RNG storage");
+    }
+
+    const int blocks = static_cast<int>((numel + comfy::hip_backend::kMaxKernelThreads - 1) /
+                                        comfy::hip_backend::kMaxKernelThreads);
+
+    if (input_dtype_code == 0) {
+        comfy::hip_backend::stochastic_round_fp8_kernel<float>
+            <<<blocks, comfy::hip_backend::kMaxKernelThreads, 0, stream>>>(
+                static_cast<uint8_t*>(rng_and_output),
+                static_cast<const float*>(input),
+                numel,
+                output_dtype_code);
+    } else if (input_dtype_code == 1) {
+        comfy::hip_backend::stochastic_round_fp8_kernel<__half>
+            <<<blocks, comfy::hip_backend::kMaxKernelThreads, 0, stream>>>(
+                static_cast<uint8_t*>(rng_and_output),
+                static_cast<const __half*>(input),
+                numel,
+                output_dtype_code);
+    } else if (input_dtype_code == 2) {
+        comfy::hip_backend::stochastic_round_fp8_kernel<__bf16>
+            <<<blocks, comfy::hip_backend::kMaxKernelThreads, 0, stream>>>(
+                static_cast<uint8_t*>(rng_and_output),
+                static_cast<const __bf16*>(input),
+                numel,
+                output_dtype_code);
+    } else {
+        throw std::runtime_error("Unsupported input dtype for stochastic_round_fp8");
+    }
+    // No hipGetLastError() here: every _C entry point calls check_hip_launch()
+    // immediately after its launcher returns, and these launchers have no other
+    // caller. Checking here too would just be a second, redundant read.
+}
+
+} // extern "C"

--- a/comfy_kitchen/backends/hip/ops/svdquant_w4a4.hip
+++ b/comfy_kitchen/backends/hip/ops/svdquant_w4a4.hip
@@ -1,0 +1,316 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// SVDQuant W4A4 on WMMA (iu4: 16x16x32 on gfx12, 16x16x16 on gfx11). See mma.h.
+//
+//   out = (x/smooth quantized to int4) @ (W_int4 * wscales_group)^T
+//       + (x @ proj_down) @ proj_up^T
+//       + bias
+//
+// Both operands carry one scale per group of 64 elements along K, so the int32
+// accumulator is flushed and rescaled once per group rather than once at the end
+// of the K loop.
+//
+// The LoRA-up correction is folded into the writeback: rank R is small, so an
+// R-length dot per output is cheap relative to the K loop and avoids a second
+// pass over the output.
+#include <stdexcept>
+#include <string>
+
+#include "../epilogue.h"
+#include "../gemm_wmma.h"
+#include "../hadamard.h"  // load_in
+
+namespace comfy::hip_backend {
+
+constexpr int kSvdGroup = 64;       // quantization group, in elements
+constexpr int kSvdGroupBytes = 32;  // ... and in packed int4 bytes
+
+// x @ proj_down -> (M, R), fp32. One thread per output column: proj_down is
+// (K, R), so consecutive threads read consecutive addresses.
+__global__ __launch_bounds__(256) void lora_down_kernel(
+    const void* __restrict__ x, const void* __restrict__ lora_down,
+    float* __restrict__ lora_act, int M, int K, int R, int x_code, int d_code) {
+
+    const int m = blockIdx.x;
+    const int r = threadIdx.x;
+    if (r >= R) return;
+
+    float sum = 0.0f;
+    for (int k = 0; k < K; ++k) {
+        sum += load_in(x, static_cast<int64_t>(m) * K + k, x_code) *
+               load_in(lora_down, static_cast<int64_t>(k) * R + r, d_code);
+    }
+    lora_act[static_cast<int64_t>(m) * R + r] = sum;
+}
+
+// Smooth, then per-row per-group int4 quantize + pack. ascales is stored
+// transposed as (K/64, M_pad).
+template <bool UNSIGNED>
+__global__ __launch_bounds__(256) void svdquant_quant_kernel(
+    const void* __restrict__ x, const void* __restrict__ smooth,
+    int8_t* __restrict__ q, void* __restrict__ ascales,
+    int M, int M_pad, int K, int x_code, int s_code) {
+
+    const int m = blockIdx.x;
+    const int ngroups = K / kSvdGroup;
+
+    constexpr float kQMax = UNSIGNED ? 15.0f : 7.0f;
+    constexpr float kQMin = UNSIGNED ? 0.0f : -7.0f;
+
+    for (int g = threadIdx.x; g < ngroups; g += 256) {
+        const int64_t base = static_cast<int64_t>(m) * K + static_cast<int64_t>(g) * kSvdGroup;
+
+        float absmax = 0.0f;
+        for (int i = 0; i < kSvdGroup; ++i) {
+            const int k = g * kSvdGroup + i;
+            const float v = load_in(x, base + i, x_code) / load_in(smooth, k, s_code);
+            absmax = fmaxf(absmax, fabsf(v));
+        }
+        absmax = fmaxf(absmax, 1e-10f);
+        const float scale = absmax / kQMax;
+        const float inv = kQMax / absmax;
+
+        // (K/64, M_pad), so the group stride is M_pad.
+        store_scalar(ascales, s_code, static_cast<int64_t>(g) * M_pad + m, scale);
+
+        int8_t* qrow = q + static_cast<int64_t>(m) * (K / 2) + g * kSvdGroupBytes;
+        for (int i = 0; i < kSvdGroup; i += 2) {
+            const int k = g * kSvdGroup + i;
+            const float v0 = load_in(x, base + i, x_code) / load_in(smooth, k, s_code);
+            const float v1 = load_in(x, base + i + 1, x_code) / load_in(smooth, k + 1, s_code);
+
+            int q0 = static_cast<int>(rintf(v0 * inv));
+            int q1 = static_cast<int>(rintf(v1 * inv));
+            q0 = q0 < static_cast<int>(kQMin) ? static_cast<int>(kQMin)
+                                              : (q0 > static_cast<int>(kQMax) ? static_cast<int>(kQMax) : q0);
+            q1 = q1 < static_cast<int>(kQMin) ? static_cast<int>(kQMin)
+                                              : (q1 > static_cast<int>(kQMax) ? static_cast<int>(kQMax) : q1);
+            qrow[i / 2] = static_cast<int8_t>(((q0 & 0xF) | ((q1 & 0xF) << 4)) & 0xFF);
+        }
+    }
+}
+
+// Group-scaled int4 GEMM with the LoRA-up correction folded into the writeback.
+template <typename OutT, bool UNSIGNED>
+__global__ __launch_bounds__(256) void svdquant_gemm_kernel(
+    const uint8_t* __restrict__ A, const uint8_t* __restrict__ B, OutT* __restrict__ C,
+    const void* __restrict__ ascales, const void* __restrict__ wscales,
+    const void* __restrict__ lora_act, const void* __restrict__ lora_up,
+    const void* __restrict__ bias,
+    int M, int N, int K, int R,
+    int as_code, int ws_code, int la_code, int lu_code, int bias_code) {
+
+    constexpr int BM = 128, BN = 128, BKB = 64, TM = 2, TN = 4;
+    constexpr int kStride = BKB + kLdsPad;
+
+    // Byte arrays that TileStager::store writes through uint2, as in gemm_wmma.h.
+    __shared__ __align__(16) uint8_t As[BM * kStride];
+    __shared__ __align__(16) uint8_t Bs[BN * kStride];
+
+    const int tid = threadIdx.x;
+    const int lane = tid % kWave;
+    const int warp = tid / kWave;
+    const int wm = warp / 2;
+    const int wn = warp % 2;
+
+    const int m0 = blockIdx.y * BM;
+    const int n0 = blockIdx.x * BN;
+    const int kbytes = K / 2;
+
+    float fout[TM][TN][8] = {};
+
+    const int row = frag_row(lane);
+
+    TileStager<BM, BKB, 256> sa;
+    TileStager<BN, BKB, 256> sb;
+
+    sa.load(A, m0, M, 0, kbytes);
+    sb.load(B, n0, N, 0, kbytes);
+    sa.store(As);
+    sb.store(Bs);
+    __syncthreads();
+
+    for (int kb0 = 0; kb0 < kbytes; kb0 += BKB) {
+        const int knext = kb0 + BKB;
+        const bool has_next = knext < kbytes;
+        if (has_next) {
+            sa.load(A, m0, M, knext, kbytes);
+            sb.load(B, n0, N, knext, kbytes);
+        }
+
+        // BKB bytes = 128 elements = 2 groups of 64. A group is kSvdGroupBytes of
+        // packed int4, which is kSvdSteps MMAs: 2 on gfx12 (K=32 each), 4 on gfx11
+        // (K=16 each). The accumulator is flushed per group, so the scales apply to
+        // exactly the 64 elements they were computed for either way.
+        constexpr int kSvdSteps = kSvdGroupBytes / MmaInt4::kStepBytes;
+        static_assert(kSvdGroupBytes % MmaInt4::kStepBytes == 0,
+                      "an int4 K-step must divide the quantization group");
+
+        #pragma unroll
+        for (int grp = 0; grp < BKB / kSvdGroupBytes; ++grp) {
+            // A K that is not a multiple of the tile leaves the trailing group
+            // entirely in the zero padding; its scales do not exist.
+            if (kb0 + grp * kSvdGroupBytes >= kbytes) continue;
+
+            typename MmaInt4::Acc acc[TM][TN];
+            #pragma unroll
+            for (int i = 0; i < TM; ++i)
+                #pragma unroll
+                for (int j = 0; j < TN; ++j) acc[i][j] = MmaInt4::zero();
+
+            #pragma unroll
+            for (int s = 0; s < kSvdSteps; ++s) {
+                const int kbyte = grp * kSvdGroupBytes + s * MmaInt4::kStepBytes;
+
+                typename MmaInt4::Frag af[TM];
+                #pragma unroll
+                for (int i = 0; i < TM; ++i)
+                    af[i] = MmaInt4::load(As, wm * (TM * 16) + i * 16 + row, kbyte, kStride, lane);
+
+                typename MmaInt4::Frag bf[TN];
+                #pragma unroll
+                for (int j = 0; j < TN; ++j)
+                    bf[j] = MmaInt4::load(Bs, wn * (TN * 16) + j * 16 + row, kbyte, kStride, lane);
+
+                #pragma unroll
+                for (int i = 0; i < TM; ++i)
+                    #pragma unroll
+                    for (int j = 0; j < TN; ++j) {
+                        acc[i][j] = UNSIGNED ? MmaInt4::mma_ua(af[i], bf[j], acc[i][j])
+                                             : MmaInt4::mma(af[i], bf[j], acc[i][j]);
+                    }
+            }
+
+            // Flush the group: rescale the int32 accumulator into fp32.
+            const int g = kb0 / kSvdGroupBytes + grp;
+            #pragma unroll
+            for (int j = 0; j < TN; ++j) {
+                const int col = n0 + wn * (TN * 16) + j * 16 + acc_col(lane);
+                if (col >= N) continue;
+                const float ws = load_in(wscales, static_cast<int64_t>(g) * N + col, ws_code);
+                #pragma unroll
+                for (int i = 0; i < TM; ++i) {
+                    #pragma unroll
+                    for (int e = 0; e < 8; ++e) {
+                        const int r = m0 + wm * (TM * 16) + i * 16 + acc_row(lane, e);
+                        if (r >= M) continue;
+                        const float as =
+                            load_in(ascales, static_cast<int64_t>(g) * M + r, as_code);
+                        fout[i][j][e] += MmaInt4::get(acc[i][j], e) * as * ws;
+                    }
+                }
+            }
+        }
+
+        if (has_next) {
+            __syncthreads();
+            sa.store(As);
+            sb.store(Bs);
+            __syncthreads();
+        }
+    }
+
+    #pragma unroll
+    for (int j = 0; j < TN; ++j) {
+        const int col = n0 + wn * (TN * 16) + j * 16 + acc_col(lane);
+        if (col >= N) continue;
+        #pragma unroll
+        for (int i = 0; i < TM; ++i) {
+            #pragma unroll
+            for (int e = 0; e < 8; ++e) {
+                const int r = m0 + wm * (TM * 16) + i * 16 + acc_row(lane, e);
+                if (r >= M) continue;
+
+                float v = fout[i][j][e];
+                for (int t = 0; t < R; ++t) {
+                    v += load_in(lora_act, static_cast<int64_t>(r) * R + t, la_code) *
+                         load_in(lora_up, static_cast<int64_t>(col) * R + t, lu_code);
+                }
+                if (bias != nullptr) v += load_scalar(bias, bias_code, col);
+                C[static_cast<int64_t>(r) * N + col] = static_cast<OutT>(v);
+            }
+        }
+    }
+}
+
+}  // namespace comfy::hip_backend
+
+extern "C" void launch_svdquant_lora_down_kernel(
+    const void* x, const void* lora_down, void* lora_act, int M, int K, int R, int x_code,
+    int d_code, hipStream_t stream) {
+
+    using namespace comfy::hip_backend;
+    if (R > 256) throw std::runtime_error("svdquant: LoRA rank above 256 is not supported");
+    if (M == 0) {
+        return;  // a zero-block launch is hipErrorInvalidConfiguration
+    }
+    lora_down_kernel<<<M, 256, 0, stream>>>(x, lora_down, static_cast<float*>(lora_act), M, K, R,
+                                            x_code, d_code);
+}
+
+extern "C" void launch_svdquant_quant_kernel(
+    const void* x, const void* smooth, void* q, void* ascales, int M, int M_pad, int K,
+    int x_code, int s_code, bool act_unsigned, hipStream_t stream) {
+
+    using namespace comfy::hip_backend;
+    if (M == 0) {
+        return;  // a zero-block launch is hipErrorInvalidConfiguration
+    }
+    // The kernel writes K/64 complete groups; a partial group would leave the
+    // packed tail uninitialized. The binding checks this too, but mirror the GEMM
+    // launcher's invariant here.
+    if (K % kSvdGroup != 0) {
+        throw std::runtime_error("svdquant_quantize: K=" + std::to_string(K) +
+                                 " must be a multiple of 64");
+    }
+    if (act_unsigned) {
+        svdquant_quant_kernel<true><<<M, 256, 0, stream>>>(
+            x, smooth, static_cast<int8_t*>(q), ascales, M, M_pad, K, x_code, s_code);
+    } else {
+        svdquant_quant_kernel<false><<<M, 256, 0, stream>>>(
+            x, smooth, static_cast<int8_t*>(q), ascales, M, M_pad, K, x_code, s_code);
+    }
+}
+
+extern "C" void launch_svdquant_gemm_kernel(
+    const void* a, const void* b, void* c, const void* ascales, const void* wscales,
+    const void* lora_act, const void* lora_up, const void* bias,
+    int M, int N, int K, int R,
+    int as_code, int ws_code, int la_code, int lu_code, int bias_code, int out_code,
+    bool act_unsigned, hipStream_t stream) {
+
+    using namespace comfy::hip_backend;
+
+    if (M == 0 || N == 0) {
+        return;  // a zero-dimension grid is hipErrorInvalidConfiguration
+    }
+    // One scale per 64-element group, and the tile loader reads the packed row
+    // (K/2 bytes) in 16-byte chunks: K must be a whole number of groups. An empty
+    // GEMM reads no groups, so this only applies once there is real work above.
+    if (K % kSvdGroup != 0) {
+        throw std::runtime_error("scaled_mm_svdquant_w4a4: K=" + std::to_string(K) +
+                                 " must be a multiple of 64");
+    }
+
+    dim3 grid((N + 127) / 128, (M + 127) / 128);
+    const uint8_t* A = static_cast<const uint8_t*>(a);
+    const uint8_t* B = static_cast<const uint8_t*>(b);
+
+#define CK_SVD_LAUNCH(T, U)                                                                    \
+    svdquant_gemm_kernel<T, U><<<grid, 256, 0, stream>>>(A, B, static_cast<T*>(c), ascales,     \
+                                                         wscales, lora_act, lora_up, bias, M, N, \
+                                                         K, R, as_code, ws_code, la_code,        \
+                                                         lu_code, bias_code)
+
+    if (out_code == kBF16) {
+        if (act_unsigned) { CK_SVD_LAUNCH(__bf16, true); } else { CK_SVD_LAUNCH(__bf16, false); }
+    } else if (out_code == kF16) {
+        if (act_unsigned) { CK_SVD_LAUNCH(__half, true); } else { CK_SVD_LAUNCH(__half, false); }
+    } else if (out_code == kF32) {
+        if (act_unsigned) { CK_SVD_LAUNCH(float, true); } else { CK_SVD_LAUNCH(float, false); }
+    } else {
+        throw std::runtime_error("scaled_mm_svdquant_w4a4: unsupported output dtype");
+    }
+#undef CK_SVD_LAUNCH
+}

--- a/comfy_kitchen/backends/hip/rope_math.h
+++ b/comfy_kitchen/backends/hip/rope_math.h
@@ -1,0 +1,94 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Rounding and rotation shared by ops/apply_rope.hip and ops/rms_rope.hip.
+//
+// The rotation is evaluated in the freqs dtype, rounding after each multiply and
+// add, matching the eager reference, which upcasts x to the freqs dtype and
+// evaluates there. Doing the same makes the kernels track eager's rounding instead
+// of out-accuracy-ing it in fp32, which otherwise drifts past the comparison
+// tolerance for bf16 freqs.
+#pragma once
+
+#include <hip/hip_runtime.h>
+
+namespace comfy::hip_backend {
+
+// Round fp32 to bf16 (round to nearest, ties to even) and widen back.
+// Both callers build with -ffast-math, under which the native __bf16 type carries
+// excess precision: casting fp32 -> __bf16 -> fp32 is folded away and the
+// intermediate rounding never happens. The integer path here survives that fold
+// because it is bitwise, not floating-point.
+//
+// A NaN survives if its mantissa exceeds 0x8000, which every reachable one does
+// (torch quiets a signaling NaN on the way in). Below that it rounds to Inf, and
+// -ffinite-math-only folds a guard away, so there is no fixing it here.
+__forceinline__ __device__ float round_bf16(float x) {
+    unsigned int u = __float_as_uint(x);
+    u += 0x7fffu + ((u >> 16) & 1u);
+    return __uint_as_float(u & 0xffff0000u);
+}
+
+// Round a finite fp32 to fp16 and widen back. __float2half_rn is an intrinsic
+// conversion, so unlike a __bf16 cast it is not folded under -ffast-math.
+__forceinline__ __device__ float round_fp16(float x) {
+    return __half2float(__float2half_rn(x));
+}
+
+// Round to the storage type of T without storing. rms_rope needs this for the
+// normalized value, which the unfused contract materializes in x's dtype before
+// the rotation reads it back.
+template <typename T>
+__forceinline__ __device__ float round_to(float v);
+
+template <>
+__forceinline__ __device__ float round_to<float>(float v) {
+    return v;
+}
+template <>
+__forceinline__ __device__ float round_to<__half>(float v) {
+    return round_fp16(v);
+}
+template <>
+__forceinline__ __device__ float round_to<__bf16>(float v) {
+    return round_bf16(v);
+}
+
+template <typename T>
+__forceinline__ __device__ void rope_store(T* p, int64_t i, float v);
+
+template <>
+__forceinline__ __device__ void rope_store<float>(float* p, int64_t i, float v) {
+    p[i] = v;
+}
+template <>
+__forceinline__ __device__ void rope_store<__half>(__half* p, int64_t i, float v) {
+    p[i] = __float2half(v);
+}
+template <>
+__forceinline__ __device__ void rope_store<__bf16>(__bf16* p, int64_t i, float v) {
+    p[i] = static_cast<__bf16>(v);
+}
+
+// out = f_a * x_a + f_b * x_b, evaluated in the freqs dtype with the same rounding
+// eager applies after upcasting x to the freqs dtype. The two eager layouts round
+// differently: split-half (apply_rope_split_half1) forms both products as separate
+// tensors, so each is rounded before the add; interleaved (apply_rope1) uses
+// addcmul_, which fuses the second product into the add under one rounding. Rounding
+// inputs first mirrors eager's cast of x. f_code: 0=fp32, 1=fp16, 2=bf16.
+__forceinline__ __device__ float rope_combine(
+    float f_a, float x_a, float f_b, float x_b, int f_code, bool split_half) {
+    if (f_code == 2) {
+        const float pa = round_bf16(round_bf16(f_a) * round_bf16(x_a));
+        const float second = round_bf16(f_b) * round_bf16(x_b);
+        return round_bf16(pa + (split_half ? round_bf16(second) : second));
+    }
+    if (f_code == 1) {
+        const float pa = round_fp16(round_fp16(f_a) * round_fp16(x_a));
+        const float second = round_fp16(f_b) * round_fp16(x_b);
+        return round_fp16(pa + (split_half ? round_fp16(second) : second));
+    }
+    return f_a * x_a + f_b * x_b;
+}
+
+}  // namespace comfy::hip_backend

--- a/comfy_kitchen/scaled_mm_v2.py
+++ b/comfy_kitchen/scaled_mm_v2.py
@@ -24,6 +24,79 @@ else:
 def has_scaled_mm_v2() -> bool:
     return _HAS_SCALED_MM_V2
 
+
+_FP8_E4M3 = torch.float8_e4m3fn
+
+
+def _hip_fp8_gemm(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    scale_a: torch.Tensor,
+    scale_b: torch.Tensor,
+    bias: torch.Tensor | None,
+    out_dtype: torch.dtype | None,
+    scale_recipe_a,
+    scale_recipe_b,
+    swizzle_a,
+    swizzle_b,
+):
+    """Route an fp8 matmul to the WMMA kernel.
+
+    Returns None when the HIP backend cannot take the call or it is outside the
+    kernel's domain (non-e4m3 operands, non-tensor-wise scaling, swizzled
+    operands, K not a multiple of 16, unsupported output dtype), in which case
+    the caller falls back to torch.
+    """
+    from .backends import hip
+    from .registry import registry
+
+    if not registry.is_available("hip"):
+        return None
+    # This path skips the registry, so its per-architecture capability filter does
+    # not cover it. RDNA2 registers for the elementwise kernels but has no matrix
+    # cores and its GEMM traps, so test for WMMA rather than availability.
+    if not hip.has_wmma():
+        return None
+    # Availability is process-wide, but the kernel launches on one device and takes
+    # raw pointers: every operand has to live on the input's own GPU.
+    if input.device.type != "cuda":
+        return None
+    others = [weight, scale_a, scale_b] + ([] if bias is None else [bias])
+    if any(not torch.is_tensor(t) or t.device != input.device for t in others):
+        return None
+    # The kernel reads both operands row-major.
+    if any(s not in (None, SwizzleType.NO_SWIZZLE) for s in (swizzle_a, swizzle_b)):
+        return None
+    if input.dtype is not _FP8_E4M3 or weight.dtype is not _FP8_E4M3:
+        return None
+    if input.dim() != 2 or weight.dim() != 2:
+        return None
+    if scale_recipe_a != ScalingType.TensorWise or scale_recipe_b != ScalingType.TensorWise:
+        return None
+    if isinstance(scale_a, list) or isinstance(scale_b, list):
+        return None
+    if scale_a.numel() != 1 or scale_b.numel() != 1:
+        return None
+    # The WMMA K-step reads 16 bytes of a row at a time.
+    if input.shape[1] % 16 != 0:
+        return None
+    # out_dtype=None means "the input dtype" to torch, which for an fp8 matmul is
+    # fp8 itself. This epilogue only writes bf16/f16/f32, so substituting a default
+    # here would make the result dtype depend on whether the HIP backend took the
+    # call. Decline instead and let torch keep its own semantics.
+    if out_dtype not in (torch.bfloat16, torch.float16, torch.float32):
+        return None
+    # The epilogue indexes bias[col] with a single dtype code.
+    if bias is not None and (
+        bias.dim() != 1
+        or bias.numel() != weight.shape[1]
+        or bias.dtype not in (torch.bfloat16, torch.float16, torch.float32)
+    ):
+        return None
+
+    return hip.scaled_mm_fp8(input, weight, scale_a, scale_b, bias, out_dtype)
+
+
 def scaled_mm_v2(
     input: torch.Tensor,
     weight: torch.Tensor,
@@ -36,6 +109,13 @@ def scaled_mm_v2(
     swizzle_a: Optional['SwizzleType'] = SwizzleType.NO_SWIZZLE,
     swizzle_b: Optional['SwizzleType'] = SwizzleType.NO_SWIZZLE,
 ) -> torch.Tensor:
+
+    out = _hip_fp8_gemm(
+        input, weight, scale_a, scale_b, bias, out_dtype, scale_recipe_a, scale_recipe_b,
+        swizzle_a, swizzle_b,
+    )
+    if out is not None:
+        return out
 
     if has_scaled_mm_v2():
         return torch.nn.functional.scaled_mm(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,13 @@ requires = [
     "setuptools>=61.0",
     "wheel",
     "nanobind>=2.0.0",
+    # setup.py drives both extensions through CMake. 3.21 is the HIP language's own
+    # floor (CMAKE_HIP_ARCHITECTURES does not exist before it), but both backends
+    # ask FindPython for Development.SABIModule, which arrived in 3.26.
+    "cmake>=3.26",
+    # The HIP extension pins the Ninja generator on every platform: CMake's default
+    # generator on Windows is Visual Studio, which cannot build the HIP language.
+    "ninja",
     "tomli; python_version < '3.11'",
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,27 @@ if "--no-cuda" in sys.argv:
     print("CUDA backend excluded - only eager, triton backends")
     print("=" * 80 + "\n")
 
+# The HIP backend is built whenever a ROCm compiler is present. --hip turns a
+# missing compiler into an error rather than a skip; --no-hip suppresses it.
+BUILD_HIP = os.getenv("COMFY_KITCHEN_BUILD_HIP") == "1"
+if "--hip" in sys.argv:
+    BUILD_HIP = True
+    sys.argv.remove("--hip")
+
+BUILD_NO_HIP = os.getenv("COMFY_KITCHEN_BUILD_NO_HIP") == "1"
+if "--no-hip" in sys.argv:
+    BUILD_NO_HIP = True
+    sys.argv.remove("--no-hip")
+
+# build_ext parses --hip-archs itself, but the extension list is built before its
+# options are finalized, so the value has to be read here too. Left in argv for it.
+HIP_ARCHS_CLI = ""
+for _i, _arg in enumerate(sys.argv):
+    if _arg.startswith("--hip-archs="):
+        HIP_ARCHS_CLI = _arg.split("=", 1)[1]
+    elif _arg == "--hip-archs" and _i + 1 < len(sys.argv):
+        HIP_ARCHS_CLI = sys.argv[_i + 1]
+
 
 
 def cmake_path(path: str | os.PathLike[str]) -> str:
@@ -37,9 +58,12 @@ def cmake_path(path: str | os.PathLike[str]) -> str:
 
 
 class CMakeExtension(Extension):
-    def __init__(self, name: str, source_dir: str = ""):
+    def __init__(self, name: str, source_dir: str = "", backend: str = "cuda",
+                 hip_archs: str = ""):
         super().__init__(name, sources=[])
         self.source_dir = os.path.abspath(source_dir) if source_dir else ""
+        self.backend = backend
+        self.hip_archs = hip_archs
 
 
 class CMakeBuildExt(build_ext):
@@ -47,6 +71,7 @@ class CMakeBuildExt(build_ext):
     user_options: ClassVar = [
         *build_ext.user_options,
         ('cuda-archs=', None, 'CUDA architectures to build for (semicolon-separated, e.g., "80;89;90a")'),
+        ('hip-archs=', None, 'HIP architectures to build for (semicolon-separated, e.g., "gfx1200;gfx1201")'),
         ('debug-build', None, 'Build in debug mode with debug symbols'),
         ('lineinfo', None, 'Enable NVCC line information for profiling (adds -lineinfo flag)'),
     ]
@@ -59,6 +84,7 @@ class CMakeBuildExt(build_ext):
         super().initialize_options()
         # Set defaults - can be overridden by command-line arguments
         self.cuda_archs = None  # Will use platform-specific default in finalize_options
+        self.hip_archs = None  # None lets the HIP CMakeLists pick its default gfx list
         self.debug_build = False  # Default: Release build
         self.lineinfo = False  # Default: disabled
 
@@ -98,7 +124,11 @@ class CMakeBuildExt(build_ext):
         ext_dir = ext_fullpath.parent
         ext_dir.mkdir(parents=True, exist_ok=True)
 
-        build_temp = pathlib.Path(self.build_temp).resolve()
+        # Each backend gets its own build directory: the CUDA and HIP extensions
+        # share self.build_temp, and CMake refuses to reuse a cache generated for a
+        # different source dir ("does not match the source ... used to generate
+        # cache"), so configuring the second one into the first one's directory fails.
+        build_temp = pathlib.Path(self.build_temp).resolve() / ext.backend
         build_temp.mkdir(parents=True, exist_ok=True)
 
         # All options have been set in finalize_options with proper defaults
@@ -110,49 +140,106 @@ class CMakeBuildExt(build_ext):
             f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={cmake_path(ext_dir)}",
             f"-DCMAKE_BUILD_TYPE={config}",
             f"-DPython_EXECUTABLE={cmake_path(sys.executable)}",
-            f"-DCOMFY_CUDA_ARCHS={cuda_archs}",
             f"-DCOMFY_ENABLE_LINEINFO={'ON' if enable_lineinfo else 'OFF'}",
         ]
 
-        # Let CMake manage its own configuration cache. Reconfiguring with the
-        # explicit arguments above updates changed settings without throwing
-        # away cached compiler checks and the generated build graph.
-        generator = os.environ.get("CMAKE_GENERATOR")
-        if generator:
-            cmake_args.extend(["-G", generator])
+        if ext.backend == "hip":
+            # CMake's default generator on Windows is Visual Studio, which does
+            # not support the HIP language.
+            cmake_args.extend(["-G", "Ninja"])
 
-        # Compiler caching is opt-in. Pass project-specific variables so CMake
-        # enables the launchers after compiler identification; wrapping the
-        # identification probes is unreliable with NVCC + MSVC on Windows.
-        cuda_launcher = os.environ.get("COMFY_CUDA_COMPILER_LAUNCHER")
-        if cuda_launcher:
-            cmake_args.append(f"-DCOMFY_CUDA_COMPILER_LAUNCHER={cuda_launcher}")
-        cxx_launcher = os.environ.get("COMFY_CXX_COMPILER_LAUNCHER")
-        if cxx_launcher:
-            cmake_args.append(f"-DCOMFY_CXX_COMPILER_LAUNCHER={cxx_launcher}")
-
-        cuda_paths = get_cuda_path()
-        if cuda_paths is None:
-            raise RuntimeError(
-                "CUDA extension build requested, but nvcc could not be found. "
-                "Set CUDA_HOME to a valid CUDA toolkit or build with --no-cuda."
-            )
-        cuda_home, nvcc_bin = cuda_paths
-        cmake_args.append(f"-DCUDAToolkit_ROOT={cmake_path(cuda_home)}")
-        cmake_args.append(f"-DCMAKE_CUDA_COMPILER={cmake_path(nvcc_bin)}")
-
-        # FindCUDAToolkit only learned the Windows ARM64 library layout in
-        # CMake 4.4. Help older CMake releases find cudart under lib/arm64;
-        # once CUDA_CUDART is known, the module uses its directory for the
-        # remaining CUDA imported targets as well.
-        if os.name == "nt" and platform.machine().lower() in {"arm64", "aarch64"}:
-            arm64_cudart = pathlib.Path(cuda_home) / "lib" / "arm64" / "cudart.lib"
-            if not arm64_cudart.is_file():
+            rocm_home, hip_compiler = get_rocm_path()
+            if hip_compiler is None:
                 raise RuntimeError(
-                    f"Windows ARM64 CUDA runtime library not found: {arm64_cudart}"
+                    "HIP extension build requested, but no ROCm compiler could be found. "
+                    "Set ROCM_HOME to a valid ROCm install or build with --no-hip."
                 )
-            cmake_args.append(f"-DCUDA_CUDART={cmake_path(arm64_cudart)}")
-            cmake_args.append("-DCOMFY_MSVC_PERMISSIVE=ON")
+            cmake_args.append(f"-DCMAKE_HIP_COMPILER={hip_compiler.as_posix()}")
+
+            # CMake refuses to mix a GNU-like clang with a CL-compatible C/C++
+            # compiler, and would otherwise pick MSVC for C/C++ while using clang
+            # for HIP. Pin all three languages to the ROCm driver. The C driver
+            # drops the ++ (clang++ -> clang, amdclang++ -> amdclang); hipcc
+            # compiles both.
+            c_name = hip_compiler.stem.removesuffix("++")
+            c_compiler = hip_compiler.with_name(c_name + hip_compiler.suffix)
+            if c_compiler.is_file():
+                cmake_args.append(f"-DCMAKE_C_COMPILER={c_compiler.as_posix()}")
+            cmake_args.append(f"-DCMAKE_CXX_COMPILER={hip_compiler.as_posix()}")
+
+            # Enabling CXX pulls in the RC language, and CMake looks for the
+            # resource compiler on PATH alone. ROCm ships neither rc nor llvm-rc,
+            # so without this the configure dies in project() on any machine that
+            # is not a Visual Studio developer prompt. An explicit RC wins.
+            if os.name == "nt" and not os.environ.get("RC"):
+                rc_compiler = find_rc_compiler(hip_compiler)
+                if rc_compiler:
+                    cmake_args.append(f"-DCMAKE_RC_COMPILER={rc_compiler.as_posix()}")
+
+            if rocm_home:
+                rocm_posix = pathlib.Path(rocm_home).as_posix()
+                cmake_args.append(f"-DCMAKE_PREFIX_PATH={rocm_posix}")
+                cmake_args.append(f"-DCMAKE_HIP_COMPILER_ROCM_ROOT={rocm_posix}")
+
+            # --hip-archs beats the environment, which beats what setup_hip_extension
+            # resolved from the visible devices. The CLI value is raw, so normalize it
+            # the way ext.hip_archs already was: CMake splits its arch list on ";", and
+            # an unnormalized "gfx1100,gfx1200" would reach it as a single bad target.
+            cli_archs = ";".join(normalize_archs(self.hip_archs)) if self.hip_archs else ""
+            hip_archs = cli_archs or ext.hip_archs
+            if hip_archs:
+                cmake_args.append(f"-DCOMFY_HIP_ARCHS={hip_archs}")
+
+            # HIP is the same clang++ driver as CXX here, so the C++ launcher
+            # covers both unless a HIP-specific one is set.
+            hip_launcher = os.environ.get("COMFY_HIP_COMPILER_LAUNCHER")
+            if hip_launcher:
+                cmake_args.append(f"-DCOMFY_HIP_COMPILER_LAUNCHER={hip_launcher}")
+            cxx_launcher = os.environ.get("COMFY_CXX_COMPILER_LAUNCHER")
+            if cxx_launcher:
+                cmake_args.append(f"-DCOMFY_CXX_COMPILER_LAUNCHER={cxx_launcher}")
+        else:
+            cmake_args.append(f"-DCOMFY_CUDA_ARCHS={cuda_archs}")
+
+            # Let CMake manage its own configuration cache. Reconfiguring with the
+            # explicit arguments above updates changed settings without throwing
+            # away cached compiler checks and the generated build graph.
+            generator = os.environ.get("CMAKE_GENERATOR")
+            if generator:
+                cmake_args.extend(["-G", generator])
+
+            # Compiler caching is opt-in. Pass project-specific variables so CMake
+            # enables the launchers after compiler identification; wrapping the
+            # identification probes is unreliable with NVCC + MSVC on Windows.
+            cuda_launcher = os.environ.get("COMFY_CUDA_COMPILER_LAUNCHER")
+            if cuda_launcher:
+                cmake_args.append(f"-DCOMFY_CUDA_COMPILER_LAUNCHER={cuda_launcher}")
+            cxx_launcher = os.environ.get("COMFY_CXX_COMPILER_LAUNCHER")
+            if cxx_launcher:
+                cmake_args.append(f"-DCOMFY_CXX_COMPILER_LAUNCHER={cxx_launcher}")
+
+            cuda_paths = get_cuda_path()
+            if cuda_paths is None:
+                raise RuntimeError(
+                    "CUDA extension build requested, but nvcc could not be found. "
+                    "Set CUDA_HOME to a valid CUDA toolkit or build with --no-cuda."
+                )
+            cuda_home, nvcc_bin = cuda_paths
+            cmake_args.append(f"-DCUDAToolkit_ROOT={cmake_path(cuda_home)}")
+            cmake_args.append(f"-DCMAKE_CUDA_COMPILER={cmake_path(nvcc_bin)}")
+
+            # FindCUDAToolkit only learned the Windows ARM64 library layout in
+            # CMake 4.4. Help older CMake releases find cudart under lib/arm64;
+            # once CUDA_CUDART is known, the module uses its directory for the
+            # remaining CUDA imported targets as well.
+            if os.name == "nt" and platform.machine().lower() in {"arm64", "aarch64"}:
+                arm64_cudart = pathlib.Path(cuda_home) / "lib" / "arm64" / "cudart.lib"
+                if not arm64_cudart.is_file():
+                    raise RuntimeError(
+                        f"Windows ARM64 CUDA runtime library not found: {arm64_cudart}"
+                    )
+                cmake_args.append(f"-DCUDA_CUDART={cmake_path(arm64_cudart)}")
+                cmake_args.append("-DCOMFY_MSVC_PERMISSIVE=ON")
 
         build_args = ["--config", config]
 
@@ -217,12 +304,271 @@ def get_cuda_path() -> tuple[pathlib.Path, pathlib.Path] | None:
 
     return pathlib.Path(cuda_home), nvcc_bin
 
+# RDNA2 (gfx103x), RDNA3/3.5 (gfx11xx) and RDNA4 (gfx12xx). RDNA1 and older lack
+# even the dot-product paths, and CDNA's matrix cores are MFMA, not WMMA.
+SUPPORTED_HIP_ARCH_PREFIXES = ("gfx103", "gfx11", "gfx12")
+
+# The wheel's default fat binary: every RDNA2/3/3.5/4 target ROCm supports. RDNA2
+# carries only the elementwise kernels, so the size is dominated by the ten
+# gfx11xx/gfx12xx code objects.
+DEFAULT_HIP_ARCHS = (
+    "gfx1030;gfx1031;gfx1032;gfx1033;gfx1034;gfx1035;gfx1036"  # RDNA2
+    ";gfx1100;gfx1101;gfx1102;gfx1103"  # RDNA3
+    ";gfx1150;gfx1151;gfx1152;gfx1153"  # RDNA3.5
+    ";gfx1200;gfx1201"  # RDNA4
+)
+
+
+def hip_arch_supported(arch: str) -> bool:
+    return arch.startswith(SUPPORTED_HIP_ARCH_PREFIXES)
+
+
+def normalize_archs(value: str) -> list[str]:
+    """Split an arch list on , or ; and drop the :xnack+/-like feature suffixes."""
+    archs = []
+    for part in value.replace(";", ",").split(","):
+        arch = part.strip().split(":", 1)[0]
+        if arch and arch not in archs:
+            archs.append(arch)
+    return archs
+
+
+def get_hip_archs_override() -> list[str]:
+    if HIP_ARCHS_CLI:
+        return normalize_archs(HIP_ARCHS_CLI)
+    # PYTORCH_ROCM_ARCH and GPU_ARCHS are the conventional ROCm spellings.
+    for var in ("COMFY_HIP_ARCHS", "PYTORCH_ROCM_ARCH", "GPU_ARCHS"):
+        value = os.getenv(var)
+        if value:
+            return normalize_archs(value)
+    return []
+
+
+def detect_hip_archs() -> list[str]:
+    """gfx names of the visible AMD devices, empty when none can be enumerated."""
+    try:
+        import torch
+
+        if torch.version.hip is None or not torch.cuda.is_available():
+            return []
+        names = [
+            torch.cuda.get_device_properties(i).gcnArchName
+            for i in range(torch.cuda.device_count())
+        ]
+    except Exception:
+        return []
+    return normalize_archs(";".join(n for n in names if n))
+
+
+def rocm_sdk_root() -> str | None:
+    """Ask the pip rocm-sdk wheel for its root, if it is installed."""
+    try:
+        root = subprocess.run(
+            [sys.executable, "-m", "rocm_sdk", "path", "--root"],
+            capture_output=True,
+            check=True,
+            text=True,
+        ).stdout.strip()
+    except (subprocess.CalledProcessError, OSError):
+        return None
+    return root if root and pathlib.Path(root).exists() else None
+
+
+def find_rc_compiler(hip_compiler: pathlib.Path) -> pathlib.Path | None:
+    """Locate a Windows resource compiler, newest Windows SDK last.
+
+    CMake searches PATH for rc then llvm-rc, which finds neither outside a
+    developer prompt. The SDK is already a build requirement: clang links
+    against it, and its rc.exe sits in a directory nothing puts on PATH.
+    """
+    beside = hip_compiler.with_name("llvm-rc.exe")
+    if beside.is_file():
+        return beside
+
+    found = shutil.which("rc") or shutil.which("llvm-rc")
+    if found:
+        return pathlib.Path(found)
+
+    host = "arm64" if platform.machine().lower() in ("arm64", "aarch64") else "x64"
+    candidates = []
+    for var in ("ProgramFiles(x86)", "ProgramFiles"):
+        program_files = os.environ.get(var)
+        if program_files:
+            base = pathlib.Path(program_files) / "Windows Kits" / "10" / "bin"
+            candidates.extend(base.glob(f"*/{host}/rc.exe"))
+    if not candidates:
+        return None
+
+    def sdk_version(path: pathlib.Path) -> list[int]:
+        return [int(p) if p.isdigit() else 0 for p in path.parent.parent.name.split(".")]
+
+    return max(candidates, key=sdk_version)
+
+
+def get_rocm_path() -> tuple[str | None, pathlib.Path | None]:
+    """Locate a ROCm root and its clang driver.
+
+    Handles the pip ``rocm-sdk`` layout (site-packages/_rocm_sdk_devel) as well
+    as a system ROCm install. In precedence order: an explicit ROCM_HOME or
+    ROCM_PATH, the SDK of the interpreter running the build, then a system
+    install found through HIP_PATH, /opt/rocm or PATH.
+    """
+    # An explicit ROCM_HOME/ROCM_PATH wins, but only while it still points at a
+    # directory, so a stale value does not shadow an installed toolchain.
+    rocm_home = None
+    for var in ("ROCM_HOME", "ROCM_PATH"):
+        value = os.getenv(var)
+        if value and pathlib.Path(value).is_dir():
+            rocm_home = value
+            break
+
+    if rocm_home is None:
+        rocm_home = rocm_sdk_root()
+
+    if rocm_home is None:
+        sdk = pathlib.Path(sys.prefix) / "Lib" / "site-packages" / "_rocm_sdk_devel"
+        if not sdk.exists():
+            sdk = (
+                pathlib.Path(sys.prefix)
+                / "lib"
+                / f"python{sys.version_info.major}.{sys.version_info.minor}"
+                / "site-packages"
+                / "_rocm_sdk_devel"
+            )
+        if sdk.exists():
+            rocm_home = str(sdk)
+
+    if rocm_home is None:
+        # The Windows HIP SDK installer sets HIP_PATH itself, so it is not the
+        # deliberate choice ROCM_HOME is and ranks below the SDK installed in the
+        # interpreter running the build.
+        hip_path = os.getenv("HIP_PATH")
+        if hip_path and pathlib.Path(hip_path).is_dir():
+            rocm_home = hip_path
+
+    if rocm_home is None and pathlib.Path("/opt/rocm").exists():
+        rocm_home = "/opt/rocm"
+
+    compiler = None
+    if rocm_home:
+        root = pathlib.Path(rocm_home)
+        for candidate in (
+            root / "lib" / "llvm" / "bin" / "clang++",
+            root / "lib" / "llvm" / "bin" / "clang++.exe",
+            root / "bin" / "amdclang++",
+            # The Windows HIP SDK ships its driver as %HIP_PATH%\bin\clang++.exe.
+            root / "bin" / "clang++.exe",
+            root / "bin" / "hipcc",
+        ):
+            if candidate.is_file():
+                compiler = candidate
+                break
+
+    if compiler is None:
+        for name in ("amdclang++", "hipcc"):
+            found = shutil.which(name)
+            if found:
+                compiler = pathlib.Path(found)
+                if rocm_home is None:
+                    rocm_home = str(compiler.parent.parent)
+                break
+
+    if compiler is None and os.name == "nt":
+        # A HIP SDK whose bin is on PATH without HIP_PATH set is reachable only
+        # through its plain clang++, a name unrelated LLVM installs answer to as
+        # well. Walk PATH rather than taking shutil.which's first hit, and keep
+        # the entry that has the SDK headers beside it.
+        for entry in os.environ.get("PATH", "").split(os.pathsep):
+            found = shutil.which("clang++", path=entry) if entry else None
+            if found is None:
+                continue
+            root = pathlib.Path(found).parent.parent
+            if (root / "include" / "hip" / "hip_runtime.h").is_file():
+                compiler = pathlib.Path(found)
+                if rocm_home is None:
+                    rocm_home = str(root)
+                break
+
+    return rocm_home, compiler
+
+
+def setup_hip_extension() -> CMakeExtension | None:
+    print("=" * 80)
+    print("Checking for HIP/ROCm availability...")
+    print("=" * 80)
+
+    if BUILD_NO_HIP:
+        print("HIP extension disabled by --no-hip flag")
+        return None
+
+    rocm_home, hip_compiler = get_rocm_path()
+    if hip_compiler is None:
+        if BUILD_HIP:
+            raise RuntimeError(
+                "ERROR: --hip requested but no ROCm compiler was found "
+                "(looked for clang++/amdclang++/hipcc). Install ROCm or the rocm-sdk wheel."
+            )
+        print("No ROCm compiler detected; skipping HIP backend")
+        return None
+
+    print(f"Found ROCm root: {rocm_home or 'auto'}")
+    print(f"Found HIP compiler: {hip_compiler}")
+
+    # RDNA2 has no matrix cores, so it gets the elementwise kernels only; the GEMMs
+    # need the gfx11 or gfx12 WMMA intrinsics. Everything below RDNA2 (and CDNA,
+    # which uses MFMA rather than WMMA) has no path through these sources at all.
+    archs = get_hip_archs_override()
+    if archs:
+        unsupported = [arch for arch in archs if not hip_arch_supported(arch)]
+        if unsupported:
+            raise RuntimeError(
+                f"ERROR: the HIP backend supports RDNA2/3/4 (gfx103x, gfx11xx, gfx12xx); "
+                f"cannot build for {';'.join(unsupported)}"
+            )
+        print(f"HIP architectures from the override: {';'.join(archs)}")
+    else:
+        detected = detect_hip_archs()
+        if detected:
+            archs = [arch for arch in detected if hip_arch_supported(arch)]
+            if not archs:
+                message = (
+                    f"Visible AMD GPUs ({';'.join(detected)}) are not RDNA2/3/4; "
+                    "these kernels would not run on them."
+                )
+                if BUILD_HIP:
+                    raise RuntimeError(f"ERROR: --hip requested but {message}")
+                print(f"{message} Skipping the HIP backend.")
+                print("Set COMFY_HIP_ARCHS to build for a target anyway.")
+                return None
+            print(f"Detected supported devices: {';'.join(archs)}")
+        else:
+            archs = normalize_archs(DEFAULT_HIP_ARCHS)
+            print(f"No AMD GPU visible; building for the default {';'.join(archs)}")
+
+    root_dir = pathlib.Path(__file__).resolve().parent
+    hip_backend_dir = root_dir / "comfy_kitchen" / "backends" / "hip"
+    if not hip_backend_dir.exists():
+        raise RuntimeError(f"HIP backend directory not found: {hip_backend_dir}")
+
+    print("Building HIP extension with CMake + nanobind: comfy_kitchen.backends.hip._C")
+    return CMakeExtension(
+        name="comfy_kitchen.backends.hip._C",
+        source_dir=str(hip_backend_dir),
+        backend="hip",
+        hip_archs=";".join(archs),
+    )
+
+
 def get_cuda_version() -> tuple[int, ...] | None:
+    # get_cuda_path() returns None rather than a pair when nvcc is absent.
     cuda_paths = get_cuda_path()
     if cuda_paths is None:
         return None
 
     _cuda_home, nvcc_bin = cuda_paths
+    # A toolkit was found: absence is get_cuda_path()'s None above. A present but
+    # broken nvcc (unrunnable, or a failing -V) is a real error and must not be
+    # laundered into "no CUDA", which would silently ship a HIP-only wheel.
     try:
         output = subprocess.run(
             [nvcc_bin, "-V"],
@@ -230,8 +576,8 @@ def get_cuda_version() -> tuple[int, ...] | None:
             check=True,
             text=True,
         )
-    except (OSError, subprocess.CalledProcessError):
-        return None
+    except (OSError, subprocess.CalledProcessError) as exc:
+        raise RuntimeError(f"CUDA toolkit was found, but `{nvcc_bin} -V` failed") from exc
 
     match = re.search(r"release\s*([\d.]+)", output.stdout)
     if not match:
@@ -239,6 +585,16 @@ def get_cuda_version() -> tuple[int, ...] | None:
 
     version = tuple(map(int, match.group(1).split(".")))
     return version
+
+
+class CudaToolkitNotFoundError(RuntimeError):
+    """No CUDA toolkit on this machine.
+
+    The only CUDA failure a ROCm box is allowed to shrug off. Everything else (a
+    toolkit too old to use, a missing backend directory, a broken nanobind) means
+    a CUDA build was intended and went wrong, and must not silently degrade the
+    combined wheel to HIP-only.
+    """
 
 
 def assert_cuda_version(version: tuple[int, ...]) -> None:
@@ -266,7 +622,9 @@ def setup_cuda_extension() -> CMakeExtension | None:
 
     cuda_version = get_cuda_version()
     if cuda_version is None:
-        raise RuntimeError("ERROR: Could not detect CUDA toolkit (nvcc not found). Install CUDA toolkit and try again.")
+        raise CudaToolkitNotFoundError(
+            "ERROR: Could not detect CUDA toolkit (nvcc not found). Install CUDA toolkit and try again."
+        )
 
     print(f"Found CUDA version: {'.'.join(map(str, cuda_version))}")
 
@@ -296,19 +654,29 @@ def setup_cuda_extension() -> CMakeExtension | None:
 def get_extensions() -> list[setuptools.Extension]:
     extensions = []
 
-    if BUILD_NO_CUDA:
-        print("\n" + "=" * 80)
-        print("Building CPU-only variant (COMFY_KITCHEN_BUILD_NO_CUDA=1)")
-        print("CUDA backend excluded - only eager, triton backends")
-        print("=" * 80 + "\n")
-        return extensions
+    if not BUILD_NO_CUDA:
+        try:
+            cuda_ext = setup_cuda_extension()
+            if cuda_ext is not None:
+                extensions.append(cuda_ext)
+        except CudaToolkitNotFoundError as e:
+            # An absent toolkit is only survivable when there is a ROCm one to
+            # build instead. Any other CUDA failure propagates: silently dropping
+            # the CUDA extension would ship a HIP-only wheel under the name of a
+            # combined one.
+            _rocm_home, hip_compiler = get_rocm_path()
+            if hip_compiler is None or BUILD_NO_HIP:
+                raise
+            print(f"\nNo CUDA toolkit ({e})")
+            print("A ROCm toolchain was found, so building the HIP backend instead.\n")
 
-    cuda_ext = setup_cuda_extension()
-    if cuda_ext is not None:
-        extensions.append(cuda_ext)
-    else:
+    hip_ext = setup_hip_extension()
+    if hip_ext is not None:
+        extensions.append(hip_ext)
+
+    if not extensions:
         print("\n" + "=" * 80)
-        print("Installing comfy_kitchen without CUDA backend")
+        print("Installing comfy_kitchen without a native backend")
         print("Available backends: eager, triton (if installed)")
         print("=" * 80 + "\n")
 
@@ -324,15 +692,17 @@ def get_cmdclass(has_extensions):
     try:
         from wheel.bdist_wheel import bdist_wheel
 
-        class CUDABdistWheel(bdist_wheel):
+        class ComfyBdistWheel(bdist_wheel):
             def finalize_options(self):
                 super().finalize_options()
-                # Set stable ABI tag only for Python 3.12+ (nanobind requirement)
-                # For 3.10/3.11, leave as version-specific (cpXXX-cpXXX)
-                if not BUILD_NO_CUDA and sys.version_info >= (3, 12):
+                # Stable ABI on 3.12+ only (nanobind's floor); 3.10/3.11 stay
+                # version-specific. Both CMakeLists build against the limited API
+                # there, so a wheel carrying either or both keeps the abi3 tag and
+                # the HIP backend does not multiply the wheel matrix.
+                if has_extensions and sys.version_info >= (3, 12):
                     self.py_limited_api = "cp312"
 
-        cmdclass["bdist_wheel"] = CUDABdistWheel
+        cmdclass["bdist_wheel"] = ComfyBdistWheel
     except ImportError as e:
         print(f"Warning: Could not import wheel.bdist_wheel: {e}")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 import torch
 
@@ -8,6 +10,15 @@ def pytest_configure(config):
     config.addinivalue_line("markers", "cuda: mark test as requiring CUDA")
     config.addinivalue_line("markers", "slow: mark test as slow running")
     config.addinivalue_line("markers", "cupy: mark test as requiring CuPy")
+
+
+def pytest_sessionfinish(session, exitstatus):
+    # ROCm on Windows: pytest can hang at exit if HIP kernels left pending GPU
+    # work. See https://github.com/ROCm/TheRock/issues/999
+    if sys.platform == "win32" and torch.cuda.is_available() and getattr(
+        torch.version, "hip", None
+    ):
+        torch.cuda.synchronize()
 
 
 def cuda_backend_available() -> bool:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,10 +15,10 @@ def pytest_configure(config):
 def pytest_sessionfinish(session, exitstatus):
     # ROCm on Windows: pytest can hang at exit if HIP kernels left pending GPU
     # work. See https://github.com/ROCm/TheRock/issues/999
-    if sys.platform == "win32" and torch.cuda.is_available() and getattr(
-        torch.version, "hip", None
-    ):
-        torch.cuda.synchronize()
+    torch = sys.modules.get("torch")
+    if sys.platform == "win32" and torch is not None:
+        if torch.cuda.is_available() and getattr(torch.version, "hip", None):
+            torch.cuda.synchronize()
 
 
 def cuda_backend_available() -> bool:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,22 @@ def pytest_configure(config):
     config.addinivalue_line("markers", "cupy: mark test as requiring CuPy")
 
 
+def cuda_backend_available() -> bool:
+    """Whether the compiled CUDA backend is loadable.
+
+    Not torch.cuda.is_available(): PyTorch reports ROCm devices as "cuda", so on
+    a ROCm build that is True with no CUDA extension present. Tests that drive
+    the CUDA backend specifically must gate on this or they fail instead of
+    skipping. On a CUDA box the two are equivalent.
+    """
+    return ck.list_backends().get("cuda", {}).get("available", False)
+
+
+requires_cuda_backend = pytest.mark.skipif(
+    not cuda_backend_available(), reason="compiled CUDA backend required"
+)
+
+
 @pytest.fixture(scope="session")
 def cuda_available():
     return torch.cuda.is_available()

--- a/tests/test_convrot_w4a4.py
+++ b/tests/test_convrot_w4a4.py
@@ -15,6 +15,8 @@ from comfy_kitchen.tensor.convrot_w4a4 import (
     quantize_convrot_w4a4_weight,
 )
 
+from .conftest import cuda_backend_available
+
 
 def test_convrot_w4a4_weight_quantize_contract(seed):
     w = torch.randn(16, 256, dtype=torch.float32)
@@ -159,8 +161,8 @@ def test_convrot_w4a4_rejects_bad_groups(seed):
 
 
 def test_convrot_w4a4_cuda_smoke(seed):
-    if not torch.cuda.is_available():
-        pytest.skip("CUDA required")
+    if not cuda_backend_available():
+        pytest.skip("compiled CUDA backend required")
 
     x = torch.randn(64, 256, device="cuda", dtype=torch.bfloat16)
     w = torch.randn(128, 256, device="cuda", dtype=torch.bfloat16)
@@ -177,8 +179,8 @@ def test_convrot_w4a4_cuda_smoke(seed):
 
 
 def test_convrot_w4a4_cuda_no_bias_large_m(seed):
-    if not torch.cuda.is_available():
-        pytest.skip("CUDA required")
+    if not cuda_backend_available():
+        pytest.skip("compiled CUDA backend required")
 
     x = torch.randn(1152, 256, device="cuda", dtype=torch.bfloat16)
     w = torch.randn(128, 256, device="cuda", dtype=torch.bfloat16)
@@ -193,8 +195,8 @@ def test_convrot_w4a4_cuda_no_bias_large_m(seed):
 @pytest.mark.parametrize("with_bias", [False, True])
 @pytest.mark.parametrize("m", [64, 128, 256, 512])
 def test_turing_int4_tensor_core_gemm_matches_int8_fallback(seed, dtype, with_bias, m):
-    if not torch.cuda.is_available():
-        pytest.skip("CUDA required")
+    if not cuda_backend_available():
+        pytest.skip("compiled CUDA backend required")
     if torch.cuda.get_device_capability()[0] < 7:
         pytest.skip("INT4 tensor cores require SM75 or newer")
     if not hasattr(cuda_backend._C, "cutlass_turing_int4_dequant"):
@@ -241,8 +243,8 @@ def test_turing_int4_tensor_core_gemm_matches_int8_fallback(seed, dtype, with_bi
 
 
 def test_int4_linear_routes_turing_to_native_kernel(seed, monkeypatch):
-    if not torch.cuda.is_available():
-        pytest.skip("CUDA required")
+    if not cuda_backend_available():
+        pytest.skip("compiled CUDA backend required")
     if not hasattr(cuda_backend._C, "cutlass_turing_int4_dequant"):
         pytest.skip("CUDA extension was built without the Turing INT4 kernel")
 
@@ -276,8 +278,8 @@ def test_int4_linear_routes_turing_to_native_kernel(seed, monkeypatch):
 
 @pytest.mark.parametrize("m, expected_calls", [(8, 0), (128, 1)])
 def test_convrot_w4a4_routes_turing_to_native_kernel(seed, monkeypatch, m, expected_calls):
-    if not torch.cuda.is_available():
-        pytest.skip("CUDA required")
+    if not cuda_backend_available():
+        pytest.skip("compiled CUDA backend required")
     if torch.cuda.get_device_capability() < (7, 5):
         pytest.skip("INT4 tensor cores require SM75 or newer")
     if not hasattr(cuda_backend._C, "cutlass_turing_int4_dequant"):
@@ -303,8 +305,8 @@ def test_convrot_w4a4_routes_turing_to_native_kernel(seed, monkeypatch, m, expec
 
 
 def test_convrot_cuda_shared_memory_fit_matches_device_limit():
-    if not torch.cuda.is_available():
-        pytest.skip("CUDA required")
+    if not cuda_backend_available():
+        pytest.skip("compiled CUDA backend required")
 
     x_int8 = torch.empty((2, 65536), device="cuda", dtype=torch.float16)
     max_shared = cuda_backend._max_dynamic_shared_memory_per_block(x_int8)
@@ -330,8 +332,8 @@ def test_convrot_cuda_shared_memory_fit_matches_device_limit():
 @pytest.mark.parametrize("linear_dtype", ["int4", "int8"])
 @pytest.mark.parametrize("convrot_groupsize", [16, 64, 256])
 def test_convrot_w4a4_cuda_linear_handles_large_fp16_activations(seed, linear_dtype, convrot_groupsize):
-    if not torch.cuda.is_available():
-        pytest.skip("CUDA required")
+    if not cuda_backend_available():
+        pytest.skip("compiled CUDA backend required")
 
     torch.manual_seed(789)
     x = torch.empty(8, 256, device="cuda", dtype=torch.float16)
@@ -361,8 +363,8 @@ def test_convrot_w4a4_cuda_linear_handles_large_fp16_activations(seed, linear_dt
 @pytest.mark.parametrize("linear_dtype", ["int4", "int8"])
 @pytest.mark.parametrize(("m", "k"), [(128, 15360), (1152, 6912)])
 def test_convrot_w4a4_cuda_linear_handles_large_fp16_activation_shapes(seed, linear_dtype, m, k):
-    if not torch.cuda.is_available():
-        pytest.skip("CUDA required")
+    if not cuda_backend_available():
+        pytest.skip("compiled CUDA backend required")
 
     torch.manual_seed(790)
     x = torch.empty(m, k, device="cuda", dtype=torch.float16)
@@ -391,8 +393,8 @@ def test_convrot_w4a4_cuda_linear_handles_large_fp16_activation_shapes(seed, lin
 @pytest.mark.parametrize("linear_dtype", ["int4", "int8"])
 @pytest.mark.parametrize(("m", "k", "n"), [(4192, 6144, 1536), (4192, 16384, 512)])
 def test_convrot_w4a4_cuda_linear_handles_big_activation_tensors(seed, linear_dtype, m, k, n):
-    if not torch.cuda.is_available():
-        pytest.skip("CUDA required")
+    if not cuda_backend_available():
+        pytest.skip("compiled CUDA backend required")
 
     torch.manual_seed(791)
     x = torch.randn(m, k, device="cuda", dtype=torch.float16)
@@ -412,8 +414,8 @@ def test_convrot_w4a4_cuda_linear_handles_big_activation_tensors(seed, linear_dt
 
 
 def test_convrot_w4a4_cuda_large_k_quantize_matches_reference(seed):
-    if not torch.cuda.is_available():
-        pytest.skip("CUDA required")
+    if not cuda_backend_available():
+        pytest.skip("compiled CUDA backend required")
 
     x = torch.randn(2, 15360, device="cuda", dtype=torch.bfloat16)
     q_cuda, scale_cuda = cuda_backend.quantize_int4_rowwise_convrot64(x, 256)
@@ -431,8 +433,8 @@ def test_convrot_w4a4_cuda_large_k_quantize_matches_reference(seed):
 
 @pytest.mark.parametrize("convrot_groupsize", [16, 64, 256])
 def test_convrot_w4a4_cuda_quantize_clamps_overflow_scale(convrot_groupsize):
-    if not torch.cuda.is_available():
-        pytest.skip("CUDA required")
+    if not cuda_backend_available():
+        pytest.skip("compiled CUDA backend required")
 
     x = torch.empty(2, 256, device="cuda", dtype=torch.float16)
     pattern = torch.tensor([65504.0, 65504.0, 65504.0, -65504.0], device="cuda", dtype=torch.float16)
@@ -449,8 +451,8 @@ def test_convrot_w4a4_cuda_quantize_clamps_overflow_scale(convrot_groupsize):
 
 
 def test_convrot_w4a4_stochastic_rounding_cuda(seed):
-    if not torch.cuda.is_available():
-        pytest.skip("CUDA required")
+    if not cuda_backend_available():
+        pytest.skip("compiled CUDA backend required")
 
     torch.manual_seed(1234)
     w = torch.randn(16, 256, device="cuda", dtype=torch.bfloat16)

--- a/tests/test_hip_dispatch.py
+++ b/tests/test_hip_dispatch.py
@@ -1,0 +1,111 @@
+"""HIP dispatch and gating logic. Needs no GPU and no compiled extension.
+
+These cover which architectures the backend registers for and which ops it
+advertises on each. They are deliberately not gated on registry.is_available("hip"):
+on a CPU-only runner the kernel suite in test_hip_wmma.py skips in full, and these
+routing rules would otherwise go untested behind a green tick.
+"""
+import ast
+import pathlib
+import re
+
+import pytest
+
+from comfy_kitchen.backends import hip as hip_backend
+
+_ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+@pytest.mark.parametrize(
+    "arches",
+    [
+        [],
+        ["gfx90a"],   # CDNA: MFMA, not WMMA
+        ["gfx1010"],  # RDNA1: neither matrix cores nor the dot-product paths
+        ["gfx1201", "gfx90a"],
+    ],
+)
+def test_hip_declines_unsupported_arch(arches):
+    """The backend registers for RDNA2/3/4 and nothing else."""
+    assert hip_backend._unsupported_arch_reason(arches) is not None
+
+
+@pytest.mark.parametrize(
+    "arches",
+    [["gfx1201", "gfx1200"], ["gfx1100"], ["gfx1151"], ["gfx1030"], ["gfx1200", "gfx1030"]],
+)
+def test_hip_accepts_rdna2_through_rdna4(arches):
+    assert hip_backend._unsupported_arch_reason(arches) is None
+
+
+def test_hip_declines_when_an_arch_cannot_be_read():
+    """A device whose architecture is unknown cannot be shown to be supported."""
+    assert hip_backend._unsupported_arch_reason([None]) is not None
+    assert hip_backend._unsupported_arch_reason(["gfx1200", None]) is not None
+
+
+@pytest.mark.parametrize(
+    ("arches", "expected"),
+    [
+        (["gfx1200"], True),
+        (["gfx1201", "gfx1100"], True),
+        (["gfx1151"], True),
+        (["gfx1030"], False),             # RDNA2 has no matrix cores
+        (["gfx1200", "gfx1030"], False),  # kernels launch on the tensor's own device
+        ([None], False),
+    ],
+)
+def test_hip_wmma_capability(arches, expected):
+    """Only an all-matrix-core process may advertise the GEMMs."""
+    assert hip_backend._has_wmma(arches) is expected
+
+
+def test_hip_drops_gemms_without_matrix_cores():
+    """RDNA2 keeps the elementwise kernels and hands the GEMMs back to triton/eager."""
+    with_wmma = hip_backend._build_constraints(has_wmma=True)
+    without = hip_backend._build_constraints(has_wmma=False)
+
+    # Every WMMA-only op must be advertised with matrix cores; an intersection
+    # would pass while any single one was missing from the constraints.
+    assert set(with_wmma) >= hip_backend._WMMA_ONLY_OPS
+    assert not (hip_backend._WMMA_ONLY_OPS & set(without))
+    # The elementwise kernels need no matrix cores and must survive.
+    for op in ("apply_rope", "apply_rope_", "rms_rope", "rms_rope_split_half1_", "adaln",
+               "rms_adaln", "quantize_per_tensor_fp8", "gemv_awq_w4a16"):
+        assert op in without
+
+
+def test_hip_advertises_every_inplace_rope_entry():
+    """A missing entry routes the in-place call to eager while the functional one
+    stays on HIP: silently half the coverage rather than a failure."""
+    constraints = hip_backend._build_constraints(has_wmma=True)
+    for functional in ("apply_rope", "apply_rope1", "apply_rope_split_half",
+                       "apply_rope_split_half1", "rms_rope", "rms_rope1",
+                       "rms_rope_split_half", "rms_rope_split_half1"):
+        assert constraints[f"{functional}_"] is constraints[functional]
+
+
+def _setup_py_default_archs() -> list[str]:
+    """DEFAULT_HIP_ARCHS, read without importing setup.py (which would run setup())."""
+    tree = ast.parse((_ROOT / "setup.py").read_text(encoding="utf-8"))
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and any(
+            isinstance(t, ast.Name) and t.id == "DEFAULT_HIP_ARCHS" for t in node.targets
+        ):
+            return ast.literal_eval(node.value).split(";")
+    raise AssertionError("DEFAULT_HIP_ARCHS not found in setup.py")
+
+
+def _cmake_default_archs() -> list[str]:
+    text = (_ROOT / "comfy_kitchen" / "backends" / "hip" / "CMakeLists.txt").read_text(
+        encoding="utf-8"
+    )
+    block = re.search(r"set\(COMFY_HIP_ARCHS\s*(.*?)\)", text, re.DOTALL)
+    assert block, "COMFY_HIP_ARCHS default not found in CMakeLists.txt"
+    return re.findall(r'"(gfx\w+)"', block.group(1))
+
+
+def test_hip_default_archs_match_the_cmake_default():
+    """setup.py always passes -DCOMFY_HIP_ARCHS, so a drifted CMake default shows
+    up only in a direct cmake run, silently missing whichever target was added."""
+    assert _setup_py_default_archs() == _cmake_default_archs()

--- a/tests/test_hip_wmma.py
+++ b/tests/test_hip_wmma.py
@@ -1,0 +1,1360 @@
+"""Correctness tests for the HIP backend.
+
+Skipped unless the backend registered, which requires an RDNA2/3/4 device and the
+compiled extension. The GEMM tests need matrix cores on top of that, so they are
+skipped on RDNA2, which has none; see needs_wmma.
+"""
+import pytest
+import torch
+
+import comfy_kitchen as ck
+from comfy_kitchen.registry import registry
+
+
+def _unavailable_reason() -> str | None:
+    """None when the backend is usable, else the registry's reason for withdrawing it.
+
+    Reporting it keeps a broken build from reading as unsupported hardware.
+    """
+    if registry.is_available("hip"):
+        return None
+    reason = registry.list_backends().get("hip", {}).get("unavailable_reason")
+    return reason or "HIP backend not available"
+
+
+_UNAVAILABLE = _unavailable_reason()
+
+pytestmark = pytest.mark.skipif(_UNAVAILABLE is not None, reason=_UNAVAILABLE or "")
+
+
+def _has_wmma() -> bool:
+    # Only the backend's absence should read as "no WMMA"; a registered backend
+    # that raises here is a real failure and must surface rather than turn every
+    # needs_wmma test into a green skip.
+    if not registry.is_available("hip"):
+        return False
+    from comfy_kitchen.backends import hip as hip_backend
+
+    return hip_backend.has_wmma()
+
+
+HAS_WMMA = _has_wmma()
+
+# The GEMMs compile on RDNA2 but trap: it has no matrix cores, and the backend
+# does not advertise them there. An absent backend reports why instead.
+needs_wmma = pytest.mark.skipif(
+    not HAS_WMMA, reason=_UNAVAILABLE or "GEMM kernels need matrix cores (RDNA3/RDNA4)"
+)
+
+DEV = "cuda"
+
+
+@pytest.fixture
+def hip():
+    from comfy_kitchen.backends import hip as hip_backend
+
+    return hip_backend
+
+
+# Covers each tile path: GEMV (M <= 8), 64x64, 128x128 and 256x128 (K > N), plus
+# sizes that are not multiples of the macro tile.
+GEMM_SHAPES = [
+    (1, 256, 256),
+    (8, 512, 256),
+    (17, 256, 512),
+    (128, 512, 256),
+    (333, 1152, 1152),
+    (512, 256, 1024),
+    (1024, 2048, 512),
+]
+
+
+@pytest.mark.parametrize(("m", "n", "k"), GEMM_SHAPES)
+@pytest.mark.parametrize("bias", [False, True])
+@needs_wmma
+def test_scaled_mm_fp8_matches_reference(hip, m, n, k, bias):
+    torch.manual_seed(0)
+    a = torch.randn(m, k, device=DEV, dtype=torch.bfloat16)
+    b = torch.randn(n, k, device=DEV, dtype=torch.bfloat16)
+    sa = (a.abs().max() / 448).float()
+    sb = (b.abs().max() / 448).float()
+    aq = (a / sa).to(torch.float8_e4m3fn)
+    bq = (b / sb).to(torch.float8_e4m3fn)
+    bias_t = torch.randn(n, device=DEV, dtype=torch.bfloat16) if bias else None
+
+    out = hip.scaled_mm_fp8(aq, bq.t(), sa, sb, bias_t, torch.bfloat16)
+
+    ref = (aq.float() * sa) @ (bq.float() * sb).t()
+    if bias:
+        ref += bias_t.float()
+
+    assert out.shape == (m, n)
+    torch.testing.assert_close(out.float(), ref, rtol=2e-2, atol=2e-2)
+
+
+@pytest.mark.parametrize(("m", "n", "k"), GEMM_SHAPES)
+@pytest.mark.parametrize("per_channel", [False, True])
+@needs_wmma
+def test_int8_linear_matches_eager(m, n, k, per_channel):
+    torch.manual_seed(0)
+    x = torch.randn(m, k, device=DEV, dtype=torch.bfloat16)
+    w = torch.randn(n, k, device=DEV, dtype=torch.bfloat16)
+
+    wq, ws = ck.quantize_int8_rowwise(w)
+    ws = ws.reshape(-1) if per_channel else ws.reshape(-1)[:1]
+    bias = torch.randn(n, device=DEV, dtype=torch.bfloat16)
+
+    with ck.use_backend("hip"):
+        out = ck.int8_linear(x, wq, ws, bias, torch.bfloat16)
+    with ck.use_backend("eager"):
+        ref = ck.int8_linear(x, wq, ws, bias, torch.bfloat16)
+
+    assert out.shape == (m, n)
+    # Both paths quantize x per row and differ only in the rounding of the
+    # activation quantizer, so compare with an int8-sized tolerance.
+    scale = ref.float().abs().max().item()
+    assert (out.float() - ref.float()).abs().max().item() < 0.05 * scale
+
+
+@needs_wmma
+def test_int8_linear_convrot_matches_eager():
+    torch.manual_seed(0)
+    m, n, k = 256, 512, 512
+    x = torch.randn(m, k, device=DEV, dtype=torch.bfloat16)
+    w = torch.randn(n, k, device=DEV, dtype=torch.bfloat16)
+    wq, ws = ck.quantize_int8_rowwise(w)
+
+    with ck.use_backend("hip"):
+        out = ck.int8_linear(x, wq, ws.reshape(-1), None, torch.bfloat16, convrot=True,
+                             convrot_groupsize=256)
+    with ck.use_backend("eager"):
+        ref = ck.int8_linear(x, wq, ws.reshape(-1), None, torch.bfloat16, convrot=True,
+                             convrot_groupsize=256)
+
+    scale = ref.float().abs().max().item()
+    assert (out.float() - ref.float()).abs().max().item() < 0.05 * scale
+
+
+def _offset_copy(t: torch.Tensor) -> torch.Tensor:
+    """A contiguous copy of ``t`` deliberately based off a 16-byte boundary."""
+    flat = t.reshape(-1)
+    storage = torch.empty(flat.numel() + 16, dtype=t.dtype, device=t.device)
+    view = storage[1:1 + flat.numel()].view_as(t)
+    view.copy_(t)
+    assert view.is_contiguous() and view.data_ptr() % 16 != 0
+    return view
+
+
+@needs_wmma
+@pytest.mark.parametrize("m", [4, 256], ids=["gemv", "wmma"])
+def test_int8_linear_realigns_an_offset_weight(m):
+    """A contiguous weight can still start off a 16-byte boundary.
+
+    contiguous() is a no-op on such a slice, and the row loads are uint4, so the
+    operand has to be moved to a fresh allocation first.
+    """
+    torch.manual_seed(0)
+    n, k = 64, 256
+    aligned = torch.randint(-127, 127, (n, k), dtype=torch.int8, device=DEV)
+    offset = _offset_copy(aligned)
+
+    x = torch.randn(m, k, device=DEV, dtype=torch.bfloat16)
+    ws = torch.full((n,), 0.01, dtype=torch.float32, device=DEV)
+
+    with ck.use_backend("hip"):
+        out_aligned = ck.int8_linear(x, aligned, ws, None, torch.bfloat16)
+        out_offset = ck.int8_linear(x, offset, ws, None, torch.bfloat16)
+    assert torch.equal(out_offset, out_aligned)
+
+
+@needs_wmma
+@pytest.mark.parametrize("m", [4, 256], ids=["gemv", "wmma"])
+def test_scaled_mm_fp8_realigns_offset_operands(hip, m):
+    """Same trap on the fp8 entry, where both operands come straight from the caller."""
+    torch.manual_seed(0)
+    n, k = 64, 256
+    a = torch.randn(m, k, device=DEV, dtype=torch.bfloat16)
+    b = torch.randn(n, k, device=DEV, dtype=torch.bfloat16)
+    sa = (a.abs().max() / 448).float()
+    sb = (b.abs().max() / 448).float()
+    aq = (a / sa).to(torch.float8_e4m3fn)
+    bq = (b / sb).to(torch.float8_e4m3fn)
+
+    ref = hip.scaled_mm_fp8(aq, bq.t(), sa, sb, None, torch.bfloat16)
+    got = hip.scaled_mm_fp8(
+        _offset_copy(aq), _offset_copy(bq).t(), sa, sb, None, torch.bfloat16
+    )
+    assert torch.equal(got, ref)
+
+
+def _gelu_tanh(x):
+    return torch.nn.functional.gelu(x, approximate="tanh")
+
+
+# One shape per route: only the fused ConvRot quantizer absorbs the activation.
+@needs_wmma
+@pytest.mark.parametrize(
+    ("tag", "shape", "kwargs"),
+    [
+        ("fused convrot", (256, 1024), {"convrot": True, "convrot_groupsize": 256}),
+        ("no convrot", (256, 1024), {"convrot": False}),
+        ("K not a multiple of the group", (256, 512 + 16), {"convrot": False}),
+        ("m == 1", (1, 1024), {"convrot": True, "convrot_groupsize": 256}),
+    ],
+)
+def test_int8_linear_input_act_matches_the_eager_chain(tag, shape, kwargs):
+    """int8_linear(x, input_act=a) == int8_linear(a(x)) on every route."""
+    torch.manual_seed(0)
+    m, k = shape
+    n = 256
+    x = torch.randn(m, k, device=DEV, dtype=torch.bfloat16)
+    w = torch.randn(n, k, device=DEV, dtype=torch.bfloat16)
+    wq, ws = ck.quantize_int8_rowwise(w)
+    ws = ws.reshape(-1)
+
+    with ck.use_backend("hip"):
+        ref = ck.int8_linear(_gelu_tanh(x), wq, ws, None, torch.bfloat16, **kwargs)
+        out = ck.int8_linear(x, wq, ws, None, torch.bfloat16,
+                             input_act="gelu_tanh", **kwargs)
+
+    # An elementwise tolerance is meaningless for an int8 GEMM: one LSB in the
+    # quantized activation shifts the whole accumulated sum.
+    scale = ref.float().abs().max().item()
+    assert (out.float() - ref.float()).abs().max().item() < 0.05 * scale, tag
+
+
+@needs_wmma
+def test_int8_linear_input_act_none_is_the_identity():
+    """None and "none" must be bit-identical to omitting the argument."""
+    torch.manual_seed(0)
+    x = torch.randn(128, 1024, device=DEV, dtype=torch.bfloat16)
+    w = torch.randn(256, 1024, device=DEV, dtype=torch.bfloat16)
+    wq, ws = ck.quantize_int8_rowwise(w)
+    ws = ws.reshape(-1)
+
+    with ck.use_backend("hip"):
+        outs = [
+            ck.int8_linear(x, wq, ws, None, torch.bfloat16, convrot=True,
+                           convrot_groupsize=256, **extra)
+            for extra in ({}, {"input_act": None}, {"input_act": "none"})
+        ]
+    assert torch.equal(outs[0], outs[1])
+    assert torch.equal(outs[0], outs[2])
+
+
+@needs_wmma
+@pytest.mark.parametrize("convrot", [False, True])
+def test_int8_linear_rejects_an_unknown_input_act(convrot):
+    """Every route must reject the same way, before it picks a quantizer."""
+    x = torch.randn(128, 1024, device=DEV, dtype=torch.bfloat16)
+    wq = torch.randint(-127, 127, (256, 1024), dtype=torch.int8, device=DEV)
+    ws = torch.full((256,), 0.01, dtype=torch.float32, device=DEV)
+
+    with ck.use_backend("hip"), pytest.raises(ValueError, match="unsupported input_act"):
+        ck.int8_linear(x, wq, ws, None, torch.bfloat16, input_act="silu",
+                       convrot=convrot, convrot_groupsize=256)
+
+
+def test_convrot_quantizer_folds_the_activation_in(hip):
+    """Folding gelu into the rotation must not be worse than gelu-then-rotate.
+
+    It is normally better: the eager chain rounds gelu's output back to the input
+    dtype before the quantizer sees it, while the fold stays in fp32 throughout.
+    """
+    from comfy_kitchen.tensor.int8_utils import _build_hadamard
+
+    torch.manual_seed(0)
+    group = 256
+    x = torch.randn(512, 1024, device=DEV, dtype=torch.bfloat16) * 2.0
+    h = _build_hadamard(group, device=DEV, dtype=torch.bfloat16)
+
+    # fp64 truth, nothing rounded in between. The fused kernel synthesizes this
+    # same regular Hadamard from radix-4 butterflies.
+    xd = x.double()
+    gd = 0.5 * xd * (1 + torch.tanh(0.7978845608028654 * (xd + 0.044715 * xd**3)))
+    mat = _build_hadamard(group, device=DEV, dtype=torch.float64)
+    rot = (gd.reshape(-1, x.shape[-1] // group, group) @ mat).reshape_as(gd)
+    truth = (rot / (rot.abs().amax(-1, keepdim=True) / 127.0).clamp(min=1e-30)).round()
+
+    chain_q, _ = hip.quantize_and_rotate_rowwise(_gelu_tanh(x).contiguous(), h, group)
+    fused_q, fused_s = hip._rotate_quant_int8(x, group, "gelu_tanh")
+
+    err_chain = (chain_q.double() - truth).abs().mean().item()
+    err_fused = (fused_q.double() - truth).abs().mean().item()
+    assert err_fused <= max(err_chain * 1.05, 1e-4), (err_fused, err_chain)
+    assert fused_q.shape == x.shape
+    assert fused_s.shape == (x.shape[0],)
+
+
+@pytest.mark.parametrize("group_size", [16, 64, 256])
+def test_convrot_w4a4_weight_quant_close_to_eager(hip, group_size):
+    """The fused rotation runs in fp32; eager rotates in the weight dtype.
+
+    Codes may therefore differ by one level, but no more.
+    """
+    torch.manual_seed(0)
+    from comfy_kitchen.backends.eager.convrot_w4a4 import _unpack_int4_row_major
+
+    w = torch.randn(256, 1024, device=DEV, dtype=torch.bfloat16)
+
+    qw_h, ws_h = hip.quantize_convrot_w4a4_weight(w, group_size)
+    with ck.use_backend("eager"):
+        qw_e, ws_e = ck.quantize_convrot_w4a4_weight(w, group_size)
+
+    assert qw_h.shape == qw_e.shape
+    codes_h = _unpack_int4_row_major(qw_h).int()
+    codes_e = _unpack_int4_row_major(qw_e).int()
+
+    delta = (codes_h - codes_e).abs()
+    assert delta.max().item() <= 1
+    assert (delta > 0).float().mean().item() < 0.02
+
+    torch.testing.assert_close(ws_h, ws_e, rtol=1e-2, atol=0)
+
+
+@pytest.mark.parametrize(("m", "n", "k"), [(128, 512, 512), (512, 256, 1024), (333, 512, 512)])
+@needs_wmma
+def test_convrot_w4a4_linear_matches_eager(hip, m, n, k):
+    torch.manual_seed(0)
+    x = torch.randn(m, k, device=DEV, dtype=torch.bfloat16)
+    w = torch.randn(n, k, device=DEV, dtype=torch.bfloat16)
+
+    qw, ws = hip.quantize_convrot_w4a4_weight(w, 256)
+    out = hip.convrot_w4a4_linear(x, qw, ws, None, 256)
+
+    with ck.use_backend("eager"):
+        qw_e, ws_e = ck.quantize_convrot_w4a4_weight(w, 256)
+        ref = ck.convrot_w4a4_linear(x, qw_e, ws_e, None, 256)
+
+    assert out.shape == (m, n)
+    # W4A4 has 15 levels per operand, so agreement is coarse: this asserts the
+    # kernel computes the same function, not that it rounds identically.
+    scale = ref.float().abs().max().item()
+    assert (out.float() - ref.float()).abs().max().item() < 0.25 * scale
+
+
+def test_convrot_w4a4_roundtrip(hip):
+    torch.manual_seed(0)
+    w = torch.randn(128, 512, device=DEV, dtype=torch.bfloat16)
+
+    qw, ws = hip.quantize_convrot_w4a4_weight(w, 256)
+    deq = hip.dequantize_convrot_w4a4_weight(qw, ws, 256, output_dtype=torch.float32)
+
+    assert deq.shape == w.shape
+    rel = (deq - w.float()).norm() / w.float().norm()
+    assert rel < 0.2  # int4 weight fidelity
+
+
+def test_quantize_int8_rowwise_matches_eager():
+    torch.manual_seed(0)
+    x = torch.randn(64, 512, device=DEV, dtype=torch.bfloat16)
+
+    with ck.use_backend("hip"):
+        q, s = ck.quantize_int8_rowwise(x)
+    with ck.use_backend("eager"):
+        qe, se = ck.quantize_int8_rowwise(x)
+
+    torch.testing.assert_close(s.float(), se.float(), rtol=1e-2, atol=0)
+    assert (q.int() - qe.int()).abs().max().item() <= 1
+
+
+def test_quantize_int8_tensorwise_matches_eager():
+    torch.manual_seed(0)
+    x = torch.randn(64, 512, device=DEV, dtype=torch.bfloat16)
+
+    with ck.use_backend("hip"):
+        q, s = ck.quantize_int8_tensorwise(x)
+    with ck.use_backend("eager"):
+        qe, se = ck.quantize_int8_tensorwise(x)
+
+    torch.testing.assert_close(s.float().reshape(()), se.float().reshape(()), rtol=1e-2, atol=0)
+    assert (q.int() - qe.int()).abs().max().item() <= 1
+
+
+def test_fp8_quantize_dequantize_roundtrip():
+    torch.manual_seed(0)
+    x = torch.randn(128, 256, device=DEV, dtype=torch.bfloat16)
+    scale = (x.abs().max() / 448).float()
+
+    with ck.use_backend("hip"):
+        q = ck.quantize_per_tensor_fp8(x, scale)
+        deq = ck.dequantize_per_tensor_fp8(q, scale, torch.bfloat16)
+
+    assert q.dtype == torch.float8_e4m3fn
+    rel = (deq.float() - x.float()).norm() / x.float().norm()
+    assert rel < 0.1
+
+
+@pytest.mark.parametrize(
+    ("shape", "mshape"),
+    [((2, 4096, 3072), (2, 1, 3072)), ((4, 256, 1152), (4, 1, 1152)), ((8, 128), (8, 128))],
+)
+def test_adaln_matches_eager(shape, mshape):
+    torch.manual_seed(0)
+    x = torch.randn(*shape, device=DEV, dtype=torch.bfloat16)
+    scale = torch.randn(*mshape, device=DEV, dtype=torch.bfloat16)
+    shift = torch.randn(*mshape, device=DEV, dtype=torch.bfloat16)
+
+    with ck.use_backend("hip"):
+        out = ck.adaln(x, scale, shift)
+    with ck.use_backend("eager"):
+        ref = ck.adaln(x, scale, shift)
+
+    # Both results are bf16 and round apart by roughly a ULP regardless of
+    # correctness, so comparing them to each other measures only that rounding.
+    # Score both against an fp32 reference and require the kernel to be no worse
+    # than eager; it reduces in fp32 throughout.
+    xf = x.float()
+    truth = torch.nn.functional.layer_norm(xf, xf.shape[-1:], eps=1e-6)
+    truth = truth * (1 + scale.float()) + shift.float()
+
+    err_hip = (out.float() - truth).norm() / truth.norm()
+    err_eager = (ref.float() - truth).norm() / truth.norm()
+
+    assert err_hip < 1e-2
+    assert err_hip <= err_eager * 1.1
+
+
+@pytest.mark.parametrize(
+    ("shape", "mshape"),
+    [((2, 4096, 3072), (2, 1, 3072)), ((4, 256, 1152), (4, 1, 1152)), ((8, 128), (8, 128))],
+)
+def test_rms_adaln_matches_eager(shape, mshape):
+    """Same kernel as adaln with the mean pinned to zero. Scored the same way."""
+    torch.manual_seed(0)
+    x = torch.randn(*shape, device=DEV, dtype=torch.bfloat16)
+    scale = torch.randn(*mshape, device=DEV, dtype=torch.bfloat16)
+    shift = torch.randn(*mshape, device=DEV, dtype=torch.bfloat16)
+
+    with ck.use_backend("hip"):
+        out = ck.rms_adaln(x, scale, shift)
+    with ck.use_backend("eager"):
+        ref = ck.rms_adaln(x, scale, shift)
+
+    xf = x.float()
+    truth = torch.nn.functional.rms_norm(xf, xf.shape[-1:], eps=1e-6)
+    truth = truth * (1 + scale.float()) + shift.float()
+
+    err_hip = (out.float() - truth).norm() / truth.norm()
+    err_eager = (ref.float() - truth).norm() / truth.norm()
+
+    assert err_hip < 1e-2
+    assert err_hip <= err_eager * 1.1
+
+
+def test_rms_adaln_is_not_adaln(hip):
+    """A non-zero-mean row separates the two statistics.
+
+    An rms_adaln silently running the LayerNorm path would pass every
+    tolerance test above on zero-mean random input.
+    """
+    torch.manual_seed(0)
+    x = torch.randn(2, 32, 256, device=DEV, dtype=torch.float32) + 5.0
+    zero = torch.zeros(2, 1, 256, device=DEV, dtype=torch.float32)
+
+    rms = hip.rms_adaln(x, zero, zero, 1e-6)
+    ln = hip.adaln(x, zero, zero, 1e-6)
+
+    assert not torch.allclose(rms, ln, rtol=1e-3, atol=1e-3)
+    torch.testing.assert_close(
+        rms, torch.nn.functional.rms_norm(x, x.shape[-1:], eps=1e-6), rtol=1e-4, atol=1e-5
+    )
+
+
+@pytest.mark.parametrize("split_half", [False, True])
+@pytest.mark.parametrize("freqs_dtype", [torch.float32, torch.bfloat16])
+def test_rope_matches_eager(split_half, freqs_dtype):
+    torch.manual_seed(0)
+    batch, heads, seq, dim = 2, 8, 128, 64
+    xq = torch.randn(batch, heads, seq, dim, device=DEV, dtype=torch.bfloat16)
+    xk = torch.randn(batch, heads, seq, dim, device=DEV, dtype=torch.bfloat16)
+    freqs = torch.randn(1, 1, seq, dim // 2, 2, 2, device=DEV, dtype=freqs_dtype)
+
+    pair = ck.apply_rope_split_half if split_half else ck.apply_rope
+    with ck.use_backend("hip"):
+        q, k = pair(xq, xk, freqs)
+    with ck.use_backend("eager"):
+        qr, kr = pair(xq, xk, freqs)
+
+    torch.testing.assert_close(q.float(), qr.float(), rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(k.float(), kr.float(), rtol=2e-2, atol=2e-2)
+
+
+# (in-place name, functional sibling, takes a q/k pair, takes a norm weight)
+INPLACE_ROPE_OPS = [
+    ("apply_rope_", "apply_rope", True, False),
+    ("apply_rope1_", "apply_rope1", False, False),
+    ("apply_rope_split_half_", "apply_rope_split_half", True, False),
+    ("apply_rope_split_half1_", "apply_rope_split_half1", False, False),
+    ("rms_rope_", "rms_rope", True, True),
+    ("rms_rope1_", "rms_rope1", False, True),
+    ("rms_rope_split_half_", "rms_rope_split_half", True, True),
+    ("rms_rope_split_half1_", "rms_rope_split_half1", False, True),
+]
+
+
+@pytest.mark.parametrize(
+    ("inplace_name", "functional_name", "paired", "has_scale"),
+    INPLACE_ROPE_OPS,
+    ids=[case[0] for case in INPLACE_ROPE_OPS],
+)
+def test_rope_inplace_rotates_a_strided_view_where_it_lies(
+    hip, inplace_name, functional_name, paired, has_scale
+):
+    """The in-place entries write through the caller's view, not a copy.
+
+    The result must land on the original storage with the original strides, and
+    match the functional path bit for bit.
+    """
+    torch.manual_seed(0)
+    seq, dim = 3, 64
+    # A last-dim stride of 2 is exactly what the functional path would copy away.
+    q = torch.randn(2, 4, seq, dim * 2, device=DEV, dtype=torch.float16)[..., ::2]
+    k = torch.randn(2, 4, seq, dim * 2, device=DEV, dtype=torch.float16)[..., ::2]
+    freqs = torch.randn(1, 1, seq, dim // 2, 2, 2, device=DEV, dtype=torch.float32)
+    scale = (torch.randn(dim, device=DEV, dtype=torch.float32),) if has_scale else ()
+
+    functional = getattr(hip, functional_name)
+    inplace = getattr(hip, inplace_name)
+    operands = (q, k) if paired else (q,)
+    expected = functional(*(t.clone() for t in operands), freqs, *scale)
+    expected = expected if paired else (expected,)
+
+    pointers = tuple(t.data_ptr() for t in operands)
+    strides = tuple(t.stride() for t in operands)
+    result = inplace(*operands, freqs, *scale)
+    result = result if paired else (result,)
+
+    assert tuple(t.data_ptr() for t in result) == pointers
+    assert tuple(t.stride() for t in result) == strides
+    for got, want in zip(result, expected, strict=True):
+        assert torch.equal(got, want)
+
+
+@pytest.mark.parametrize(
+    "inplace_name", [case[0] for case in INPLACE_ROPE_OPS if not case[2]]
+)
+def test_rope_inplace_rejects_autograd(hip, inplace_name):
+    """In-place is inference-only; a grad-tracking operand must raise."""
+    x = torch.randn(1, 1, 1, 64, device=DEV, dtype=torch.float16, requires_grad=True)
+    freqs = torch.randn(1, 1, 1, 32, 2, 2, device=DEV, dtype=torch.float32)
+    extra = (
+        (torch.randn(64, device=DEV, dtype=torch.float32),)
+        if inplace_name.startswith("rms_")
+        else ()
+    )
+
+    with pytest.raises(RuntimeError, match="inference-only"):
+        getattr(hip, inplace_name)(x, freqs, *extra)
+
+
+@pytest.mark.parametrize("split_half", [False, True])
+def test_rope_inplace_splits_a_pair_the_kernel_cannot_share(hip, split_half):
+    """One stride set covers both operands, so a mismatched pair goes one at a
+    time. Out of place they would be densified into agreement instead."""
+    torch.manual_seed(0)
+    seq, dim = 5, 64
+    q = torch.randn(2, 4, seq, dim, device=DEV, dtype=torch.float16)
+    k = torch.randn(2, 4, seq, dim * 2, device=DEV, dtype=torch.float16)[..., ::2]
+    assert hip._effective_strides(q) != hip._effective_strides(k)
+    freqs = torch.randn(1, 1, seq, dim // 2, 2, 2, device=DEV, dtype=torch.float32)
+
+    one = hip.apply_rope_split_half1 if split_half else hip.apply_rope1
+    pair_ = hip.apply_rope_split_half_ if split_half else hip.apply_rope_
+    expected = (one(q.clone(), freqs), one(k.clone(), freqs))
+
+    pointers = (q.data_ptr(), k.data_ptr())
+    out_q, out_k = pair_(q, k, freqs)
+
+    assert (out_q.data_ptr(), out_k.data_ptr()) == pointers
+    assert torch.equal(out_q, expected[0])
+    assert torch.equal(out_k, expected[1])
+
+
+# BHND puts the sequence on axis 2 and BNHD on axis 1; head_dim covers the pair
+# count landing above, on and below the block width.
+RMS_ROPE_LAYOUTS = [
+    ((2, 8, 128, 128), (1, 1, 128, 64, 2, 2)),   # BHND, pairs == block
+    ((2, 128, 8, 64), (1, 128, 1, 32, 2, 2)),    # BNHD, pairs < block
+    ((1, 3, 11, 160), (1, 1, 11, 80, 2, 2)),     # head_dim neither 64 nor 128
+]
+
+
+@pytest.mark.parametrize("split_half", [False, True])
+@pytest.mark.parametrize("freqs_dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize(("shape", "freqs_shape"), RMS_ROPE_LAYOUTS, ids=["BHND", "BNHD", "D160"])
+def test_rms_rope_matches_eager(split_half, freqs_dtype, shape, freqs_shape):
+    torch.manual_seed(0)
+    head_dim = shape[-1]
+    q = torch.randn(shape, device=DEV, dtype=torch.bfloat16)
+    k = torch.randn(shape, device=DEV, dtype=torch.bfloat16)
+    freqs = torch.randn(freqs_shape, device=DEV, dtype=freqs_dtype)
+    q_scale = torch.randn(head_dim, device=DEV, dtype=torch.float32)
+    k_scale = torch.randn(head_dim, device=DEV, dtype=torch.float32)
+
+    pair = ck.rms_rope_split_half if split_half else ck.rms_rope
+    one = ck.rms_rope_split_half1 if split_half else ck.rms_rope1
+    with ck.use_backend("hip"):
+        out_q, out_k = pair(q, k, freqs, q_scale, k_scale)
+        out_one = one(q, freqs, q_scale)
+    with ck.use_backend("eager"):
+        ref_q, ref_k = pair(q, k, freqs, q_scale, k_scale)
+
+    torch.testing.assert_close(out_q.float(), ref_q.float(), rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(out_k.float(), ref_k.float(), rtol=2e-2, atol=2e-2)
+    # The fused and single-tensor entries are the same launch with k dropped.
+    assert torch.equal(out_one, out_q)
+
+
+@pytest.mark.parametrize("split_half", [False, True])
+def test_rms_rope_reads_a_qkv_slice_in_place(hip, split_half):
+    """A q/k pair sliced out of a packed qkv must match the copy bit for bit."""
+    torch.manual_seed(0)
+    b, s, h, d = 2, 96, 6, 128
+    qkv = torch.randn(b, s, 3, h, d, device=DEV, dtype=torch.bfloat16)
+    q, k, _ = qkv.unbind(dim=2)
+    assert not q.is_contiguous()
+    freqs = torch.randn(b, s, 1, d // 2, 2, 2, device=DEV, dtype=torch.float32)
+    scale = torch.randn(d, device=DEV, dtype=torch.bfloat16)
+
+    fn = hip.rms_rope_split_half if split_half else hip.rms_rope
+    out_q, out_k = fn(q, k, freqs, scale, scale)
+    ref_q, ref_k = fn(q.contiguous(), k.contiguous(), freqs, scale, scale)
+
+    assert out_q.is_contiguous() and out_k.is_contiguous()
+    assert torch.equal(out_q, ref_q)
+    assert torch.equal(out_k, ref_k)
+
+
+def test_rms_rope_takes_non_contiguous_freqs(hip):
+    """freqs is indexed through its own strides, so a sliced table needs no copy."""
+    torch.manual_seed(0)
+    b, s, h, d = 2, 64, 4, 64
+    x = torch.randn(b, s, h, d, device=DEV, dtype=torch.bfloat16)
+    table = torch.randn(b, 4 * s, 1, d // 2, 2, 2, device=DEV, dtype=torch.float32)
+    freqs = table[:, :s]
+    assert not freqs.is_contiguous()
+    scale = torch.randn(d, device=DEV, dtype=torch.bfloat16)
+
+    assert torch.equal(
+        hip.rms_rope1(x, freqs, scale), hip.rms_rope1(x, freqs.contiguous(), scale)
+    )
+
+
+def test_rms_rope_copies_when_q_and_k_disagree_on_layout(hip):
+    """One stride set covers both inputs, so a mixed pair has to be normalized first."""
+    torch.manual_seed(0)
+    b, s, h, d = 1, 64, 4, 64
+    q = torch.randn(b, s, 3, h, d, device=DEV, dtype=torch.bfloat16).unbind(dim=2)[0]
+    k = torch.randn(b, s, h, d, device=DEV, dtype=torch.bfloat16)
+    freqs = torch.randn(b, s, 1, d // 2, 2, 2, device=DEV, dtype=torch.float32)
+    scale = torch.randn(d, device=DEV, dtype=torch.bfloat16)
+
+    out_q, out_k = hip.rms_rope(q, k, freqs, scale, scale)
+
+    torch.testing.assert_close(out_q.float(), hip.rms_rope1(q, freqs, scale).float())
+    torch.testing.assert_close(out_k.float(), hip.rms_rope1(k, freqs, scale).float())
+
+
+def test_rms_rope_splits_mismatched_operands(hip):
+    """One dtype code covers both inputs and one more both weights."""
+    q = torch.randn(2, 4, 64, 64, device=DEV, dtype=torch.bfloat16)
+    k = q.to(torch.float16)
+    freqs = torch.randn(1, 1, 64, 32, 2, 2, device=DEV, dtype=torch.float32)
+    scale = torch.randn(64, device=DEV, dtype=torch.float32)
+
+    out_q, out_k = hip.rms_rope(q, k, freqs, scale)
+
+    assert out_q.dtype == torch.bfloat16
+    assert out_k.dtype == torch.float16
+    torch.testing.assert_close(out_q.float(), hip.rms_rope1(q, freqs, scale).float())
+    torch.testing.assert_close(out_k.float(), hip.rms_rope1(k, freqs, scale).float())
+
+
+def test_rms_rope_hands_back_a_weight_it_cannot_index(hip, monkeypatch):
+    """The kernel reads one weight entry per head_dim; eager broadcasts anything else."""
+    q = torch.randn(2, 4, 64, 64, device=DEV, dtype=torch.bfloat16)
+    freqs = torch.randn(1, 1, 64, 32, 2, 2, device=DEV, dtype=torch.float32)
+    scale = torch.randn(1, 64, device=DEV, dtype=torch.float32)
+
+    called = []
+    monkeypatch.setattr(
+        hip._eager, "rms_rope1", lambda *a, **kw: called.append(a) or torch.zeros_like(q)
+    )
+    hip.rms_rope1(q, freqs, scale)
+
+    assert called, "a 2D weight has no kernel and must go back to eager"
+
+
+def test_rms_rope_rejects_a_short_weight(hip):
+    """The kernel indexes the weight up to head_dim off a raw pointer."""
+    q = torch.randn(2, 4, 64, 64, device=DEV, dtype=torch.bfloat16)
+    freqs = torch.randn(1, 1, 64, 32, 2, 2, device=DEV, dtype=torch.float32)
+    q_out = torch.empty_like(q)
+
+    with pytest.raises(RuntimeError, match="q_scale"):
+        hip._C.rms_rope(
+            q.__dlpack__(stream=-1), None, freqs.__dlpack__(stream=-1),
+            torch.randn(32, device=DEV).__dlpack__(stream=-1), None,
+            q_out.__dlpack__(stream=-1), None,
+            1e-6, False, torch.cuda.current_stream(q.device).cuda_stream,
+        )
+
+
+def test_operands_that_require_grad_are_exportable(hip):
+    """Weights arrive as nn.Parameter, and neither no_grad nor inference_mode
+    clears requires_grad, which __dlpack__ refuses."""
+    torch.manual_seed(0)
+    d = 64
+    x = torch.randn(1, 4, 8, d, device=DEV, dtype=torch.bfloat16)
+    freqs = torch.randn(1, 1, 8, d // 2, 2, 2, device=DEV, dtype=torch.float32)
+    scale = torch.nn.Parameter(torch.randn(d, device=DEV, dtype=torch.bfloat16))
+    assert scale.requires_grad
+
+    with torch.inference_mode():
+        out = hip.rms_rope1(x, freqs, scale)
+    torch.testing.assert_close(out.float(), hip.rms_rope1(x, freqs, scale.detach()).float())
+
+
+@needs_wmma
+def test_bias_that_requires_grad_is_exportable(hip):
+    """The same export path carries every epilogue bias."""
+    torch.manual_seed(0)
+    m, n, k = 32, 128, 128
+    x = torch.randn(m, k, device=DEV, dtype=torch.bfloat16)
+    w = torch.randint(-8, 8, (n, k), dtype=torch.int8, device=DEV)
+    w_scale = torch.rand(n, device=DEV, dtype=torch.float32) * 0.01
+    bias = torch.nn.Parameter(torch.randn(n, device=DEV, dtype=torch.bfloat16))
+
+    with torch.inference_mode():
+        out = hip.int8_linear(x, w, w_scale, bias)
+    torch.testing.assert_close(
+        out.float(), hip.int8_linear(x, w, w_scale, bias.detach()).float()
+    )
+
+
+@pytest.mark.parametrize(("m", "n", "k"), [(1, 512, 512), (8, 1024, 1024), (64, 1152, 1152)])
+def test_gemv_awq_w4a16_matches_eager(m, n, k):
+    torch.manual_seed(0)
+    g = 64
+    x = torch.randn(m, k, device=DEV, dtype=torch.bfloat16)
+    qw = torch.randint(0, 256, (n, k // 2), dtype=torch.uint8, device=DEV).view(torch.int8)
+    ws = torch.randn(k // g, n, device=DEV, dtype=torch.bfloat16).abs() * 0.01
+    wz = torch.randn(k // g, n, device=DEV, dtype=torch.bfloat16) * 0.01
+    bias = torch.randn(n, device=DEV, dtype=torch.bfloat16)
+
+    with ck.use_backend("hip"):
+        out = ck.gemv_awq_w4a16(x, qw, ws, wz, bias, g)
+    with ck.use_backend("eager"):
+        ref = ck.gemv_awq_w4a16(x, qw, ws, wz, bias, g)
+
+    assert out.shape == (m, n)
+    # Identical dequant math on both sides; only the accumulation order differs.
+    rel = (out.float() - ref.float()).norm() / ref.float().norm()
+    assert rel < 1e-2
+
+
+@pytest.mark.parametrize("act_unsigned", [False, True])
+@pytest.mark.parametrize(("m", "n", "k", "r"), [(256, 1024, 1024, 32), (333, 512, 512, 16)])
+@needs_wmma
+def test_svdquant_w4a4_beats_eager_against_fp32_truth(m, n, k, r, act_unsigned):
+    """HIP quantizes in fp32 where eager quantizes in bf16, so the two do not
+    match bitwise. Score both against an fp32 simulation of the same W4A4 math
+    and require HIP to be no worse.
+    """
+    torch.manual_seed(0)
+    from comfy_kitchen.backends.eager.svdquant import (
+        _unpack_int4_row_major,
+        _unpack_uint4_row_major,
+    )
+
+    x = torch.randn(m, k, device=DEV, dtype=torch.bfloat16)
+    if act_unsigned:
+        x = x.abs()  # the caller pre-shifts for the unsigned path
+    smooth = torch.rand(k, device=DEV, dtype=torch.bfloat16) + 0.5
+    lora_down = torch.randn(k, r, device=DEV, dtype=torch.bfloat16) * 0.05
+    lora_up = torch.randn(n, r, device=DEV, dtype=torch.bfloat16) * 0.05
+    wgt = torch.randint(0, 256, (n, k // 2), dtype=torch.uint8, device=DEV).view(torch.int8)
+    wscales = torch.randn(k // 64, n, device=DEV, dtype=torch.bfloat16).abs() * 0.02
+    bias = torch.randn(n, device=DEV, dtype=torch.bfloat16)
+
+    qmax = 15.0 if act_unsigned else 7.0
+    qmin = 0.0 if act_unsigned else -7.0
+
+    xs = x.float() / smooth.float()
+    groups = xs.view(m, k // 64, 64)
+    scales = groups.abs().amax(-1).clamp(min=1e-10) / qmax
+    q_true = (groups / scales.unsqueeze(-1)).round().clamp(qmin, qmax)
+    act_fp = (q_true * scales.unsqueeze(-1)).view(m, k)
+
+    w_int = _unpack_int4_row_major(wgt).float().view(n, k // 64, 64)
+    w_fp = (w_int * wscales.t().float().unsqueeze(-1)).view(n, k)
+
+    truth = act_fp @ w_fp.t()
+    truth += (x.float() @ lora_down.float()) @ lora_up.float().t()
+    truth += bias.float()
+
+    with ck.use_backend("hip"):
+        q, asc, la = ck.quantize_svdquant_w4a4(x, smooth, lora_down, 256, act_unsigned)
+        out = ck.scaled_mm_svdquant_w4a4(q, wgt, asc, wscales, la, lora_up, bias, act_unsigned)
+    with ck.use_backend("eager"):
+        qe, asce, lae = ck.quantize_svdquant_w4a4(x, smooth, lora_down, 256, act_unsigned)
+        ref = ck.scaled_mm_svdquant_w4a4(qe, wgt, asce, wscales, lae, lora_up, bias, act_unsigned)
+
+    assert q.shape == qe.shape
+    assert asc.shape == asce.shape
+
+    err_hip = (out[:m].float() - truth).norm() / truth.norm()
+    err_eager = (ref[:m].float() - truth).norm() / truth.norm()
+
+    assert err_hip < 2e-2
+    assert err_hip <= err_eager * 1.1
+
+    # Activation codes must land on the fp32 grid to within one level; a larger
+    # deviation indicates the group scaling or the packing is wrong.
+    unpack = _unpack_uint4_row_major if act_unsigned else _unpack_int4_row_major
+    codes = unpack(q[:m]).int()
+    assert (codes - q_true.view(m, k).int()).abs().max() <= 1
+
+
+@needs_wmma
+def test_no_hipblaslt_on_the_quantized_paths(monkeypatch):
+    """The quantized paths must not reach hipBLASLt or fall back to a plain matmul.
+
+    torch._scaled_mm and torch._int_mm are the entry points that route to hipBLASLt,
+    and an eager fallback would reach BLAS through torch.matmul/mm/bmm. Trap all of
+    them so a silent fall-through cannot pass with an empty record.
+    """
+    from comfy_kitchen.tensor import QuantizedTensor
+
+    called = []
+
+    def trap(name):
+        # Recording and raising: the raise names the entry point at the moment it
+        # is reached, and the record still fails the assertion below if a caller
+        # swallows the exception and falls back.
+        def fn(*args, **kwargs):
+            called.append(name)
+            raise AssertionError(f"quantized path reached torch.{name}")
+
+        return fn
+
+    monkeypatch.setattr(torch, "_scaled_mm", trap("_scaled_mm"))
+    monkeypatch.setattr(torch, "_int_mm", trap("_int_mm"))
+    monkeypatch.setattr(torch, "matmul", trap("matmul"))
+    monkeypatch.setattr(torch, "mm", trap("mm"))
+    monkeypatch.setattr(torch, "bmm", trap("bmm"))
+    if hasattr(torch.nn.functional, "scaled_mm"):
+        monkeypatch.setattr(torch.nn.functional, "scaled_mm", trap("F.scaled_mm"))
+
+    torch.manual_seed(0)
+    x = torch.randn(512, 1024, device=DEV, dtype=torch.bfloat16)
+    w = torch.randn(2048, 1024, device=DEV, dtype=torch.bfloat16)
+
+    # fp8 linear via QuantizedTensor
+    xq = QuantizedTensor.from_float(x, "TensorCoreFP8Layout")
+    wq = QuantizedTensor.from_float(w, "TensorCoreFP8Layout")
+    out = torch.nn.functional.linear(xq, wq)
+    assert out.shape == (512, 2048)
+
+    # int8 linear
+    w8, ws = ck.quantize_int8_rowwise(w)
+    ck.int8_linear(x, w8, ws.reshape(-1), None, torch.bfloat16)
+
+    # int4 ConvRot
+    from comfy_kitchen.backends import hip as hip_backend
+
+    qw, wsc = hip_backend.quantize_convrot_w4a4_weight(w, 256)
+    hip_backend.convrot_w4a4_linear(x, qw, wsc, None, 256)
+
+    # AWQ W4A16 and SVDQuant W4A4 reach BLAS through eager's torch.matmul
+    qawq = torch.randint(0, 256, (2048, 512), dtype=torch.uint8, device=DEV).view(torch.int8)
+    sc = torch.ones(1024 // 64, 2048, device=DEV, dtype=torch.bfloat16)
+    ck.gemv_awq_w4a16(x, qawq, sc, sc, None, 64)
+
+    smooth = torch.ones(1024, device=DEV, dtype=torch.bfloat16)
+    ld = torch.randn(1024, 32, device=DEV, dtype=torch.bfloat16) * 0.05
+    lu = torch.randn(2048, 32, device=DEV, dtype=torch.bfloat16) * 0.05
+    q, asc, la = ck.quantize_svdquant_w4a4(x, smooth, ld)
+    ck.scaled_mm_svdquant_w4a4(q, qawq, asc, sc, la, lu, None)
+
+    assert called == [], f"quantized path fell through to hipBLASLt: {called}"
+
+
+def test_hip_registers_on_this_device():
+    """The backend registered for whatever supported AMD device is running the suite."""
+    from comfy_kitchen.backends import hip as hip_backend
+
+    arch = hip_backend._gfx_arch()
+    assert arch is not None and arch.startswith(hip_backend._ARCH_SUPPORTED)
+    assert hip_backend.is_available()
+    # has_wmma() is the intersection over every visible device, while arch names
+    # only this one; derive the expectation from the same device set. The GEMM
+    # tests below skip without it.
+    arches = hip_backend._visible_gfx_arches()
+    assert hip_backend.has_wmma() == hip_backend._has_wmma(arches)
+
+
+# The kernels are compiled with -ffast-math, under which isnan() folds to false
+# and the finite clamps drop a NaN operand. These pin the encoding of the values
+# that exercise those paths.
+FP8_EDGE_VALUES = [
+    float("nan"), -float("nan"), float("inf"), -float("inf"),
+    1e30, -1e30, 448.0, -448.0, 0.0, -0.0, 1.0, 1e-9,
+]
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("out_dtype", [torch.float8_e4m3fn, torch.float8_e5m2])
+def test_fp8_quantize_edge_values_match_eager(dtype, out_dtype):
+    x = torch.tensor(FP8_EDGE_VALUES, device=DEV, dtype=dtype)
+    scale = torch.tensor(1.0, device=DEV)
+
+    with ck.use_backend("hip"):
+        q = ck.quantize_per_tensor_fp8(x, scale, out_dtype)
+    with ck.use_backend("eager"):
+        ref = ck.quantize_per_tensor_fp8(x, scale, out_dtype)
+
+    assert torch.equal(q.view(torch.uint8), ref.view(torch.uint8))
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16, torch.float16])
+def test_stochastic_rounding_fp8_edge_values_match_eager(dtype):
+    x = torch.tensor(FP8_EDGE_VALUES, device=DEV, dtype=dtype)
+    rng = torch.randint(0, 256, (x.numel(),), dtype=torch.uint8, device=DEV)
+
+    with ck.use_backend("hip"):
+        q = ck.stochastic_rounding_fp8(x.clone(), rng.clone(), torch.float8_e4m3fn)
+    with ck.use_backend("eager"):
+        ref = ck.stochastic_rounding_fp8(x.clone(), rng.clone(), torch.float8_e4m3fn)
+
+    finite = ~torch.isnan(x.float())
+    assert torch.equal(q.view(torch.uint8)[finite], ref.view(torch.uint8)[finite])
+    # eager drops the sign of a NaN here while the kernel keeps it; both are NaN.
+    assert torch.isnan(q.float()[~finite]).all()
+
+
+# A zero-length dimension makes the grid zero-dimensional, which HIP rejects with
+# hipErrorInvalidConfiguration rather than treating as a no-op.
+@needs_wmma
+def test_empty_inputs_do_not_launch_zero_grids(hip):
+    k, n = 128, 64
+    empty = torch.empty(0, k, device=DEV, dtype=torch.bfloat16)
+    w = torch.randn(n, k, device=DEV, dtype=torch.bfloat16) / 8
+    scale = torch.tensor(1.0, device=DEV)
+
+    assert hip.quantize_per_tensor_fp8(empty, scale).shape == (0, k)
+    assert hip.quantize_int8_rowwise(empty)[0].shape == (0, k)
+    assert hip.quantize_int8_tensorwise(empty)[0].shape == (0, k)
+    assert hip.scaled_mm_fp8(
+        empty.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn).t(),
+        scale, scale, None, torch.bfloat16,
+    ).shape == (0, n)
+    assert hip.int8_linear(empty, *hip.quantize_int8_rowwise(w)).shape == (0, n)
+
+    cw, cs = hip.quantize_convrot_w4a4_weight(w, 64)
+    assert hip.convrot_w4a4_linear(empty, cw, cs, None, 64).shape == (0, n)
+
+    adaln_mod = torch.randn(1, k, device=DEV, dtype=torch.bfloat16)
+    assert hip.adaln(empty, adaln_mod, adaln_mod).shape == (0, k)
+    torch.cuda.synchronize()
+
+
+@needs_wmma
+def test_scaled_mm_v2_declines_a_bias_it_cannot_index():
+    """The epilogue indexes bias[col] with one dtype code; anything else falls back."""
+    from comfy_kitchen.scaled_mm_v2 import ScalingType, SwizzleType, _hip_fp8_gemm
+
+    a = (torch.randn(64, 128, device=DEV) / 8).to(torch.float8_e4m3fn)
+    b = (torch.randn(128, 128, device=DEV) / 8).to(torch.float8_e4m3fn)
+    scale = torch.tensor(1.0, device=DEV)
+    tw, no = ScalingType.TensorWise, SwizzleType.NO_SWIZZLE
+
+    def routes_to_hip(bias):
+        out = _hip_fp8_gemm(a, b, scale, scale, bias, torch.bfloat16, tw, tw, no, no)
+        return out is not None
+
+    assert routes_to_hip(None)
+    assert routes_to_hip(torch.randn(128, device=DEV, dtype=torch.bfloat16))
+    assert not routes_to_hip(torch.randn(8, device=DEV, dtype=torch.bfloat16))
+    assert not routes_to_hip(torch.randn(1, 128, device=DEV, dtype=torch.bfloat16))
+    assert not routes_to_hip(torch.randn(128, device=DEV, dtype=torch.float64))
+
+
+def test_rope_binding_rejects_mismatched_operands(hip):
+    """The kernel addresses xk and both outputs with xq's strides and dtype code, and
+    writes xk_out whenever xk is present."""
+    xq = torch.randn(2, 4, 64, 64, device=DEV, dtype=torch.bfloat16)
+    freqs = torch.randn(1, 1, 64, 32, 2, 2, device=DEV, dtype=torch.float32)
+    xq_out = torch.empty_like(xq)
+    xk = torch.empty_like(xq)
+    xk_out = torch.empty_like(xq)
+    dl, stream = hip._dl, hip._stream(xq)
+
+    def call(xk_a, xq_out_a, xk_out_a):
+        hip._C.apply_rope(
+            dl(xq), None if xk_a is None else dl(xk_a), dl(freqs),
+            dl(xq_out_a), None if xk_out_a is None else dl(xk_out_a), False, stream,
+        )
+
+    with pytest.raises(RuntimeError, match="together or not at all"):
+        call(xk, xq_out, None)
+    with pytest.raises(RuntimeError, match="together or not at all"):
+        call(None, xq_out, xk_out)
+    with pytest.raises(RuntimeError, match="the input's dtype"):
+        call(xk.to(torch.float16), xq_out, xk_out)
+    with pytest.raises(RuntimeError, match="the input's shape"):
+        call(None, torch.empty(2, 4, 64, 32, device=DEV, dtype=torch.bfloat16), None)
+
+    call(xk, xq_out, xk_out)
+    torch.cuda.synchronize()
+
+
+@needs_wmma
+def test_convrot_rejects_k_not_divisible_by_the_group(hip):
+    """The kernel rotates K/G groups but reads back all K, so a partial group
+    would quantize uninitialized LDS."""
+    x = torch.randn(4, 192, device=DEV, dtype=torch.bfloat16)
+    q = torch.zeros(4, 96, dtype=torch.int8, device=DEV)
+    scales = torch.zeros(4, dtype=torch.float32, device=DEV)
+
+    with pytest.raises(RuntimeError, match="divisible"):
+        hip._C.convrot_quant_int4(
+            hip._dl(x), hip._dl(q), hip._dl(scales), 4, 192, 256, hip._stream(x)
+        )
+
+    # The wrapper declines rather than reaching the kernel; a divisible K still runs.
+    with pytest.raises(ValueError, match="divisible"):
+        hip.quantize_and_rotate_rowwise(x, torch.eye(256, device=DEV, dtype=torch.bfloat16), 256)
+    qw, ws = hip.quantize_convrot_w4a4_weight(
+        torch.randn(64, 192, device=DEV, dtype=torch.bfloat16), 64
+    )
+    assert torch.isfinite(hip.convrot_w4a4_linear(x, qw, ws, None, 64)).all()
+
+
+@needs_wmma
+def test_bias_shape_is_validated(hip):
+    """The epilogue indexes bias[col], so a mis-shaped bias reads out of bounds."""
+    x = torch.randn(8, 128, device=DEV, dtype=torch.bfloat16)
+    wq, ws = hip.quantize_int8_rowwise(torch.randn(64, 128, device=DEV, dtype=torch.bfloat16))
+
+    for bad in (torch.randn(32, device=DEV), torch.randn(1, 64, device=DEV)):
+        with pytest.raises(ValueError, match="bias must be 1D"):
+            hip.int8_linear(x, wq, ws.reshape(-1), bad.bfloat16(), torch.bfloat16)
+
+    # A bias on another device is moved to the launch device, not passed as-is.
+    out = hip.int8_linear(x, wq, ws.reshape(-1), torch.randn(64).bfloat16(), torch.bfloat16)
+    assert out.shape == (8, 64)
+
+
+@needs_wmma
+def test_exported_gemms_reject_unaligned_k(hip):
+    """The tile loader and the small-M GEMV read a row 16 bytes at a time, so an
+    unaligned K reads past the end of it. The registry constraints enforce this for
+    dispatched calls; the exported helpers are reachable directly."""
+    scale = torch.tensor(1.0, device=DEV)
+
+    a = (torch.randn(4, 24, device=DEV) / 8).to(torch.float8_e4m3fn)
+    b = (torch.randn(32, 24, device=DEV) / 8).to(torch.float8_e4m3fn)
+    with pytest.raises(ValueError, match="divisible by 16"):
+        hip.scaled_mm_fp8(a, b.t(), scale, scale, None, torch.bfloat16)
+
+    x = torch.randn(4, 24, device=DEV, dtype=torch.bfloat16)
+    wq, ws = hip.quantize_int8_rowwise(torch.randn(32, 24, device=DEV, dtype=torch.bfloat16))
+    with pytest.raises(ValueError, match="divisible by 16"):
+        hip.int8_linear(x, wq, ws.reshape(-1), None, torch.bfloat16)
+
+    # int4 packs two per byte, so the packed row needs K/2 to be a whole 16-byte chunk.
+    xc = torch.randn(4, 48, device=DEV, dtype=torch.bfloat16)
+    qw = torch.zeros(32, 24, dtype=torch.int8, device=DEV)
+    with pytest.raises(ValueError, match="divisible by 32"):
+        hip.convrot_w4a4_linear(xc, qw, torch.ones(32, device=DEV), None, 16)
+
+    # The native launcher refuses too, so a C++ caller cannot slip past.
+    out = torch.empty(4, 32, dtype=torch.bfloat16, device=DEV)
+    with pytest.raises(RuntimeError, match="multiple of 16"):
+        hip._C.scaled_mm_fp8(
+            hip._dl(a.view(torch.uint8)), hip._dl(b.contiguous().view(torch.uint8)),
+            hip._dl(out), hip._dl(torch.ones(1, device=DEV)), hip._dl(torch.ones(1, device=DEV)),
+            None, 4, 32, 24, 2, hip._stream(a),
+        )
+
+
+def test_fp8_scale_must_be_a_single_element(hip):
+    """The kernels read one float off a raw pointer on the launch stream."""
+    x = torch.randn(64, device=DEV, dtype=torch.bfloat16)
+
+    with pytest.raises(ValueError, match="single per-tensor scale"):
+        hip.quantize_per_tensor_fp8(x, torch.ones(2, device=DEV))
+
+    # A scale on another device is moved to the launch device, not passed as-is.
+    assert hip.quantize_per_tensor_fp8(x, torch.tensor(1.0)).shape == (64,)
+
+
+@needs_wmma
+def test_svdquant_rejects_partial_scale_group(hip):
+    """One scale per 64-element group: a partial trailing group has no scale."""
+    act = torch.zeros(64, 48, dtype=torch.int8, device=DEV)  # K = 96, not a multiple of 64
+    wgt = torch.zeros(32, 48, dtype=torch.int8, device=DEV)
+    ascales = torch.ones(1, 64, device=DEV, dtype=torch.bfloat16)
+    wscales = torch.ones(1, 32, device=DEV, dtype=torch.bfloat16)
+    lora_act = torch.zeros(64, 8, device=DEV, dtype=torch.float32)
+    lora_up = torch.zeros(32, 8, device=DEV, dtype=torch.bfloat16)
+
+    with pytest.raises(ValueError, match="not divisible by group_size"):
+        hip.scaled_mm_svdquant_w4a4(act, wgt, ascales, wscales, lora_act, lora_up)
+
+
+@needs_wmma
+def test_scaled_mm_fp8_validates_bias(hip):
+    """scaled_mm_fp8 is public, so it enforces the same bias contract as the rest."""
+    a = (torch.randn(64, 128, device=DEV) / 8).to(torch.float8_e4m3fn)
+    b = (torch.randn(128, 128, device=DEV) / 8).to(torch.float8_e4m3fn)
+    scale = torch.tensor(1.0, device=DEV)
+
+    for bad in (
+        torch.randn(8, device=DEV, dtype=torch.bfloat16),
+        torch.randn(1, 128, device=DEV, dtype=torch.bfloat16),
+    ):
+        with pytest.raises(ValueError, match="bias must be 1D"):
+            hip.scaled_mm_fp8(a, b.t(), scale, scale, bad, torch.bfloat16)
+
+    with pytest.raises(ValueError, match="bias dtype"):
+        hip.scaled_mm_fp8(
+            a, b.t(), scale, scale, torch.randn(128, device=DEV, dtype=torch.float64),
+            torch.bfloat16,
+        )
+
+    # A bias on another device is moved to the launch device, not passed as-is.
+    out = hip.scaled_mm_fp8(
+        a, b.t(), scale, scale, torch.randn(128, dtype=torch.bfloat16), torch.bfloat16
+    )
+    assert out.shape == (64, 128)
+
+
+def test_gemv_awq_validates_its_memory_contract(hip):
+    """The inner loop decodes eight weights at a time and rescales the chunk once."""
+    k, n, g = 128, 64, 64
+    x = torch.randn(1, k, device=DEV, dtype=torch.bfloat16)
+    qw = torch.randint(-8, 8, (n, k // 2), device=DEV, dtype=torch.int8)
+    ws = torch.randn(k // g, n, device=DEV, dtype=torch.bfloat16).abs() + 0.1
+    wz = torch.zeros(k // g, n, device=DEV, dtype=torch.bfloat16)
+
+    with pytest.raises(ValueError, match="multiple of 8"):
+        hip.gemv_awq_w4a16(x, qw, ws, wz, None, 12)
+    with pytest.raises(ValueError, match="wscales must have shape"):
+        hip.gemv_awq_w4a16(x, qw, ws.reshape(-1), wz, None, g)
+    with pytest.raises(ValueError, match="bias must be 1D"):
+        hip.gemv_awq_w4a16(x, qw, ws, wz, torch.randn(8, device=DEV, dtype=torch.bfloat16), g)
+
+    assert hip.gemv_awq_w4a16(x, qw, ws, wz, None, g).shape == (1, n)
+
+
+@needs_wmma
+def test_svdquant_validates_its_operands(hip):
+    """The kernels get M, N, K and R but no tensor bounds of their own."""
+    m, k, n, r = 64, 256, 128, 16
+    x = torch.randn(m, k, device=DEV, dtype=torch.bfloat16)
+    smooth = torch.randn(k, device=DEV, dtype=torch.bfloat16).abs() + 0.1
+    lora_down = torch.randn(k, r, device=DEV, dtype=torch.bfloat16) / 8
+    lora_up = torch.randn(n, r, device=DEV, dtype=torch.bfloat16) / 8
+    wgt = torch.randint(-8, 8, (n, k // 2), device=DEV, dtype=torch.int8)
+    wscales = torch.randn(k // 64, n, device=DEV, dtype=torch.bfloat16).abs() + 0.1
+
+    with pytest.raises(ValueError, match="smooth must have shape"):
+        hip.quantize_svdquant_w4a4(x, smooth[:32], lora_down)
+    with pytest.raises(ValueError, match="lora_down must have shape"):
+        hip.quantize_svdquant_w4a4(x, smooth, lora_down[:64])
+    with pytest.raises(ValueError, match="lora_x must have shape"):
+        hip.quantize_svdquant_w4a4(x, smooth, lora_down, lora_x=x[:8])
+
+    q, ascales, lora_act = hip.quantize_svdquant_w4a4(x, smooth, lora_down)
+    with pytest.raises(ValueError, match="wscales must have shape"):
+        hip.scaled_mm_svdquant_w4a4(q, wgt, ascales, wscales.reshape(-1), lora_act, lora_up)
+    with pytest.raises(ValueError, match="lora_up must have shape"):
+        hip.scaled_mm_svdquant_w4a4(q, wgt, ascales, wscales, lora_act, lora_up[:8])
+
+    out = hip.scaled_mm_svdquant_w4a4(q, wgt, ascales, wscales, lora_act, lora_up)
+    assert torch.isfinite(out).all()
+
+
+def test_stochastic_rounding_rejects_non_contiguous_rng(hip):
+    """The kernel writes the result into rng, which a copy would silently discard."""
+    x = torch.randn(8, 16, device=DEV, dtype=torch.bfloat16)
+    rng = torch.randint(0, 256, (8, 32), dtype=torch.uint8, device=DEV)[:, ::2]
+
+    with pytest.raises(ValueError, match="contiguous"):
+        hip.stochastic_rounding_fp8(x, rng, torch.float8_e4m3fn)
+
+    rng = torch.randint(0, 256, (8, 16), dtype=torch.uint8, device=DEV)
+    out = hip.stochastic_rounding_fp8(x, rng, torch.float8_e4m3fn)
+    assert out.data_ptr() == rng.data_ptr()
+
+
+def test_fp8_nan_survives_dequantize(hip):
+    """pack_fp8 emits the NaN encoding, so unpack_fp8 has to decode it back."""
+    x = torch.tensor([float("nan"), 1.0, -448.0, 0.0], device=DEV, dtype=torch.float32)
+    scale = torch.tensor(1.0, device=DEV)
+
+    q = hip.quantize_per_tensor_fp8(x, scale)
+    deq = hip.dequantize_per_tensor_fp8(q, scale, torch.float32)
+
+    assert deq[0].isnan()
+    torch.testing.assert_close(deq[1:], x[1:])
+
+
+@pytest.mark.parametrize("offset", [0.0, 1e3, 1e4])
+def test_adaln_variance_survives_a_large_row_offset(hip, offset):
+    """E[x^2] - mean^2 cancels catastrophically once the offset dwarfs the spread."""
+    torch.manual_seed(0)
+    x = torch.randn(4, 2048, device=DEV, dtype=torch.float32) + offset
+    zeros = torch.zeros(4, 2048, device=DEV, dtype=torch.float32)
+
+    out = hip.adaln(x, zeros, zeros)
+
+    xf = x.double()
+    ref = (xf - xf.mean(-1, keepdim=True)) * (
+        xf.var(-1, unbiased=False, keepdim=True) + 1e-6
+    ).rsqrt()
+    assert (out.double() - ref).abs().max().item() < 1e-2
+
+
+# K % 128 == 64 leaves the last tile's second group entirely in the padding, and
+# its scales do not exist.
+@pytest.mark.parametrize("k", [192, 320, 576, 1088])
+@needs_wmma
+def test_svdquant_tail_group_stays_in_bounds(hip, k):
+    torch.manual_seed(0)
+    m, n, r = 64, 128, 16
+    x = torch.randn(m, k, device=DEV, dtype=torch.bfloat16)
+    smooth = torch.randn(k, device=DEV, dtype=torch.bfloat16).abs() + 0.1
+    lora_down = torch.randn(k, r, device=DEV, dtype=torch.bfloat16) / 8
+    lora_up = torch.randn(n, r, device=DEV, dtype=torch.bfloat16) / 8
+    wq = torch.randint(-8, 8, (n, k // 2), device=DEV, dtype=torch.int8)
+    wscales = torch.randn(k // 64, n, device=DEV, dtype=torch.bfloat16).abs() + 0.1
+
+    q, ascales, lora_act = hip.quantize_svdquant_w4a4(x, smooth, lora_down, pad_size=256)
+    out = hip.scaled_mm_svdquant_w4a4(q, wq, ascales, wscales, lora_act, lora_up)
+    torch.cuda.synchronize()
+
+    assert out.shape[1] == n
+    assert torch.isfinite(out).all()
+
+
+@pytest.mark.parametrize("split_half", [False, True])
+def test_rope_reads_a_permuted_qkv_in_place(hip, split_half):
+    """A q/k pair permuted out of a packed qkv must match the copy bit for bit."""
+    torch.manual_seed(0)
+    b, seq, heads, dim = 2, 96, 6, 128
+    qkv = torch.randn(b, seq, 3 * heads * dim, device=DEV, dtype=torch.bfloat16)
+    xq, xk, _ = qkv.view(b, seq, 3, heads, dim).permute(2, 0, 3, 1, 4)
+    assert not xq.is_contiguous() and xq.stride() == xk.stride()
+    freqs = torch.randn(1, 1, seq, dim // 2, 2, 2, device=DEV, dtype=torch.float32)
+
+    pair = hip.apply_rope_split_half if split_half else hip.apply_rope
+    out_q, out_k = pair(xq, xk, freqs)
+    ref_q, ref_k = pair(xq.contiguous(), xk.contiguous(), freqs)
+
+    assert out_q.is_contiguous() and out_k.is_contiguous()
+    assert torch.equal(out_q, ref_q)
+    assert torch.equal(out_k, ref_k)
+
+
+def test_rope_takes_non_contiguous_freqs(hip):
+    """freqs is indexed through its own strides, so a sliced table needs no copy."""
+    torch.manual_seed(0)
+    b, seq, heads, dim = 2, 64, 4, 64
+    x = torch.randn(b, heads, seq, dim, device=DEV, dtype=torch.bfloat16)
+    table = torch.randn(b, 1, 4 * seq, dim // 2, 2, 2, device=DEV, dtype=torch.float32)
+    freqs = table[:, :, :seq]
+    assert not freqs.is_contiguous()
+
+    assert torch.equal(
+        hip.apply_rope1(x, freqs), hip.apply_rope1(x, freqs.contiguous())
+    )
+
+
+def test_rope_copies_a_row_that_is_not_dense(hip):
+    """A last axis with a stride would scatter every load, so it is made contiguous."""
+    torch.manual_seed(0)
+    b, seq, heads, dim = 1, 64, 4, 64
+    x = torch.randn(b, heads, dim, seq, device=DEV, dtype=torch.bfloat16).transpose(-1, -2)
+    assert x.stride(-1) != 1
+    freqs = torch.randn(1, 1, seq, dim // 2, 2, 2, device=DEV, dtype=torch.float32)
+
+    out = hip.apply_rope1(x, freqs)
+
+    assert out.is_contiguous()
+    torch.testing.assert_close(out.float(), hip.apply_rope1(x.contiguous(), freqs).float())
+
+
+def test_rope_splits_mismatched_xk_dtype(hip):
+    """One dtype code is passed for both tensors, so a differing xk must not share it."""
+    xq = torch.randn(2, 4, 64, 64, device=DEV, dtype=torch.bfloat16)
+    xk = xq.to(torch.float16)
+    freqs = torch.randn(1, 1, 64, 32, 2, 2, device=DEV, dtype=torch.float32)
+
+    q, k = hip.apply_rope(xq, xk, freqs)
+
+    assert q.dtype == torch.bfloat16
+    assert k.dtype == torch.float16
+    torch.testing.assert_close(q.float(), hip.apply_rope1(xq, freqs).float())
+    torch.testing.assert_close(k.float(), hip.apply_rope1(xk, freqs).float())
+
+
+@pytest.mark.parametrize(
+    ("shape", "why"),
+    [
+        ((1, 1, 64, 16, 2, 2), "head_dim/2 too small"),
+        ((1, 1, 64, 32, 3, 2), "rotation dim is not 2"),
+        ((3, 1, 64, 32, 2, 2), "leading dim neither 1 nor the batch"),
+    ],
+)
+def test_rope_rejects_malformed_freqs(hip, shape, why):
+    """The kernel indexes the trailing dims blind, so the binding has to check them."""
+    xq = torch.randn(2, 4, 64, 64, device=DEV, dtype=torch.bfloat16)
+    freqs = torch.randn(*shape, device=DEV, dtype=torch.float32)
+
+    with pytest.raises(RuntimeError, match="freqs_cis"):
+        hip.apply_rope1(xq, freqs)
+
+
+def test_convrot_falls_back_to_eager_past_the_lds_bound(hip):
+    """The fused rotation stages a whole row in LDS, so a large K does not fit.
+
+    The launch does not fail cleanly past the budget, so the wrapper has to route
+    those shapes to eager rather than reach the kernel.
+    """
+    max_k = hip._C.convrot_max_k()
+    assert max_k > 0
+
+    k = (max_k + 1024) & ~63  # past the bound, still a multiple of the group size
+    x = torch.randn(2, k, device=DEV, dtype=torch.bfloat16)
+    h = torch.eye(64, device=DEV, dtype=torch.bfloat16)
+
+    q, scales = hip.quantize_and_rotate_rowwise(x, h, 64)
+    torch.cuda.synchronize()
+    assert q.shape == (2, k)
+    assert torch.isfinite(scales).all()
+
+    # The launcher itself still refuses, so a C++ caller cannot slip past.
+    qb = torch.zeros(2, k, dtype=torch.int8, device=DEV)
+    sb = torch.zeros(2, dtype=torch.float32, device=DEV)
+    with pytest.raises(RuntimeError, match="LDS"):
+        hip._C.quantize_int8_convrot(
+            hip._dl(x), hip._dl(qb), hip._dl(sb), 2, k, 64, 0, hip._stream(x)
+        )
+
+
+@pytest.mark.parametrize("group_size", [0, 32, 512])
+def test_convrot_launcher_rejects_unsupported_group_size(hip, group_size):
+    """The fused rotation only handles G in {16, 64, 256}; the dispatch wrappers
+    fall back to eager, so guard the launcher the C++ callers see."""
+    x = torch.randn(8, 128, device=DEV, dtype=torch.bfloat16)
+    q = torch.zeros(8, 64, dtype=torch.int8, device=DEV)
+    scales = torch.zeros(8, dtype=torch.float32, device=DEV)
+
+    with pytest.raises(RuntimeError, match="group_size"):
+        hip._C.convrot_quant_int4(
+            hip._dl(x), hip._dl(q), hip._dl(scales), 8, 128, group_size, hip._stream(x)
+        )

--- a/tests/test_int8.py
+++ b/tests/test_int8.py
@@ -11,6 +11,7 @@ from comfy_kitchen.tensor import TensorWiseINT8Layout
 
 from .conftest import (
     assert_values_close,
+    cuda_backend_available,
     get_capable_backends,
 )
 
@@ -131,8 +132,8 @@ def test_eager_int8_matmul_turing_n_alignment(monkeypatch):
 
 def test_cuda_int8_linear_does_not_retain_scratch_tensors():
     """CUDA INT8 linear uses per-call temporaries instead of retained scratch caches."""
-    if not torch.cuda.is_available():
-        pytest.skip("CUDA required")
+    if not cuda_backend_available():
+        pytest.skip("compiled CUDA backend required")
 
     x = torch.randn(16, 128, device="cuda", dtype=torch.bfloat16)
     weight = torch.randint(-128, 127, (64, 128), device="cuda", dtype=torch.int8)
@@ -248,8 +249,8 @@ def test_eager_int8_stochastic_rounding_tensorwise(seed):
 
 def test_cuda_int8_stochastic_rounding_seeded(seed):
     """CUDA stochastic INT8 rounding is seeded and unbiased."""
-    if not torch.cuda.is_available():
-        pytest.skip("CUDA required")
+    if not cuda_backend_available():
+        pytest.skip("compiled CUDA backend required")
 
     x = torch.full((4096,), 0.5, device="cuda", dtype=torch.float16)
     x[0] = 127.0
@@ -481,6 +482,8 @@ class TestTensorWiseINT8Layout:
 
     def test_int8_linear_cuda_single_row_gemv(self, seed):
         """CUDA int8_linear uses the single-row GEMV path correctly."""
+        if not cuda_backend_available():
+            pytest.skip("compiled CUDA backend required")
         import comfy_kitchen as ck
         from comfy_kitchen.backends.eager.quantization import quantize_int8_tensorwise
 
@@ -554,6 +557,8 @@ class TestTensorWiseINT8Layout:
 
     def test_dequantize_direct_output_dtype_matches_final_cast(self, seed):
         """Direct fp16/bf16 dequant output matches the prior float32-then-cast behavior."""
+        if not cuda_backend_available():
+            pytest.skip("compiled CUDA backend required")
         import comfy_kitchen as ck
 
         x = torch.randn(64, 256, device="cuda", dtype=torch.bfloat16)
@@ -643,6 +648,8 @@ class TestTensorWiseINT8Layout:
 
     def test_convrot_weight_quantize_cuda_roundtrip(self, seed):
         """CUDA ConvRot weight quantization preserves the weight after inverse rotation."""
+        if not cuda_backend_available():
+            pytest.skip("compiled CUDA backend required")
         from comfy_kitchen.backends import cuda as cuda_backend
         from comfy_kitchen.tensor.int8_utils import _build_hadamard, _rotate_weight
 
@@ -676,6 +683,8 @@ class TestTensorWiseINT8Layout:
 
     def test_convrot_int8_supports_65536_rows(self):
         """INT8 and INT4 kernels put large row counts in CUDA's grid.x dimension."""
+        if not cuda_backend_available():
+            pytest.skip("compiled CUDA backend required")
         rows, cols = 1 << 16, 256
         row = torch.linspace(-1.0, 1.0, cols, device="cuda", dtype=torch.bfloat16)
         weight = row.expand(rows, cols).contiguous()

--- a/tests/test_int8_input_act.py
+++ b/tests/test_int8_input_act.py
@@ -8,7 +8,7 @@ from torch.nn import functional
 
 import comfy_kitchen as ck
 from comfy_kitchen.tensor.int8_utils import _build_hadamard
-from tests.conftest import get_capable_backends
+from tests.conftest import cuda_backend_available, get_capable_backends
 
 _GROUP = 256
 
@@ -38,8 +38,8 @@ class TestInputActQuantizer:
         dtype before quantizing, while the fused path keeps float32 all the way
         to the int8 conversion.
         """
-        if not cuda_available:
-            pytest.skip("CUDA required")
+        if not cuda_backend_available():
+            pytest.skip("compiled CUDA backend required")
         from comfy_kitchen.backends import cuda as cuda_backend
 
         h = torch.randn(shape, dtype=dtype, device="cuda") * 2.0

--- a/tests/test_rms_rope.py
+++ b/tests/test_rms_rope.py
@@ -3,7 +3,7 @@ import torch
 
 import comfy_kitchen as ck
 
-from .conftest import assert_values_close, get_capable_backends
+from .conftest import assert_values_close, get_capable_backends, requires_cuda_backend
 
 
 def _reference_rms_rope(x, freqs_cis, scale, epsilon, *, split_half=False):
@@ -230,7 +230,7 @@ class TestRMSRopeSplitHalf:
 
 
 @pytest.mark.cuda
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+@requires_cuda_backend
 @pytest.mark.parametrize(
     "op_name",
     ["rms_rope", "rms_rope1", "rms_rope_split_half", "rms_rope_split_half1"],

--- a/tests/test_svdquant_w4a4.py
+++ b/tests/test_svdquant_w4a4.py
@@ -32,7 +32,7 @@ from comfy_kitchen.tensor import (
     svdquant_w4a4_grouped_linear,
 )
 
-from .conftest import assert_values_close
+from .conftest import assert_values_close, cuda_backend_available
 
 _GROUP = 64
 _TILE_BN = 128
@@ -319,9 +319,9 @@ class TestActUnsignedDispatch:
     """
 
     @pytest.fixture
-    def _cuda_required(self, cuda_available):
-        if not cuda_available:
-            pytest.skip("CUDA required for int4 MMA kernels")
+    def _cuda_required(self):
+        if not cuda_backend_available():
+            pytest.skip("compiled CUDA backend required for int4 MMA kernels")
 
     def _run(self, act_unsigned):
         m, n, k, r = 16, 8, 64, 16
@@ -371,8 +371,8 @@ class TestLoraXSeparation:
     @pytest.mark.parametrize("backend", ["eager", "cuda"])
     def test_lora_x_none_defaults_to_x(self, cuda_available, seed, backend):
         """Explicit lora_x=x is indistinguishable from lora_x=None (default)."""
-        if backend == "cuda" and not cuda_available:
-            pytest.skip("CUDA backend not available")
+        if backend == "cuda" and not cuda_backend_available():
+            pytest.skip("compiled CUDA backend required")
         device = "cuda" if cuda_available else "cpu"
         if backend == "eager" and device == "cpu":
             pass  # eager runs on CPU
@@ -404,8 +404,8 @@ class TestLoraXSeparation:
         not fp32-accumulate — do not interpret this as a cross-backend bit-parity
         test).
         """
-        if backend == "cuda" and not cuda_available:
-            pytest.skip("CUDA backend not available")
+        if backend == "cuda" and not cuda_backend_available():
+            pytest.skip("compiled CUDA backend required")
         device = "cuda" if cuda_available else "cpu"
         if backend != "eager" and device != "cuda":
             pytest.skip(f"backend {backend} needs cuda")
@@ -460,8 +460,8 @@ class TestSvdquantSmoke:
         (256, 128, 512, 32),
     ])
     def test_signed_forward_runs(self, cuda_available, seed, m, n, k, r):
-        if not cuda_available:
-            pytest.skip("CUDA required")
+        if not cuda_backend_available():
+            pytest.skip("compiled CUDA backend required")
         device = "cuda"
         x = torch.randn(m, k, dtype=torch.bfloat16, device=device) * 0.3
         smooth = torch.ones(k, dtype=torch.bfloat16, device=device) * 1.0
@@ -487,8 +487,8 @@ class TestSvdquantSmoke:
     @pytest.mark.parametrize("fast_accum", [False, True])
     def test_tile_packed_matches_natural_cuda(self, cuda_available, seed, monkeypatch, fast_accum):
         """Tile-packed storage should be a layout-only change vs natural CUDA."""
-        if not cuda_available:
-            pytest.skip("CUDA required")
+        if not cuda_backend_available():
+            pytest.skip("compiled CUDA backend required")
         if fast_accum:
             monkeypatch.setenv("COMFY_KITCHEN_SVDQUANT_FAST_ACCUM", "1")
         else:
@@ -529,8 +529,8 @@ class TestSvdquantSmoke:
     @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
     def test_fused_lora_epilogue_matches_unfused_cuda(self, cuda_available, seed, monkeypatch, layout, dtype):
         """Fused LoRA-up should match the old cuBLAS addmm_ epilogue to output dtype precision."""
-        if not cuda_available:
-            pytest.skip("CUDA required")
+        if not cuda_backend_available():
+            pytest.skip("compiled CUDA backend required")
 
         m, n, k, r = 64, 256, 256, 32
         device = "cuda"


### PR DESCRIPTION
Supersedes #72. That PR is sitting at ~100 review comments and is gfx12-only, so rather than force-push another rewrite on top of it I opened a fresh one. This picks up the two things that actually blocked it:

- @comfyanonymous on [#72](https://github.com/Comfy-Org/comfy-kitchen/pull/72#issuecomment-4953900342): 
> We need to figure out how to package this in the current comfy-kitchen wheels, I don't want to have separate wheels for nvidia/amd/intel/etc...

This builds one wheel with both backends in it, and keeps the `abi3` tag while doing it.

- [#72](https://github.com/Comfy-Org/comfy-kitchen/pull/72) only ran on RDNA4. 

This adds RDNA3, RDNA3.5 and RDNA2.

The kernels are #72's, rebased on current main. The packaging follows the approach in [dev/hip1](https://github.com/Comfy-Org/comfy-kitchen/tree/dev/hip1) by @rattus128.

### Packaging

`setup.py` detects both toolchains and emits `backends/cuda/_C*` and `backends/hip/_C*` into a single wheel. The Linux job installs CUDA and ROCm into the same manylinux container; the Windows job installs the ROCm toolchain from AMD's release directory (https://repo.radeon.com/), the same host the Linux job takes its RPMs from. `auditwheel` excludes the ROCm runtime libs the same way it already excludes the CUDA ones, and both jobs fail if the wheel does not contain both extensions. Each backend withdraws itself at import when its runtime is missing, so a CUDA-only or ROCm-only machine gets the same wheel and just sees one backend register.

The HIP extension is built against the Python limited API on 3.12+, like the CUDA one. That matters for the packaging goal: an extension that is not abi3 drags the whole wheel back to version-specific builds, so adding AMD would otherwise have multiplied the wheel matrix. It does not. Nothing outside `backends/hip/` changes in the build, and the wheel matrix does not grow: one wheel, both backends, same `abi3` tag as today.

### Architectures

| Generation | gfx targets         | Matrix cores | What runs                               |
|------------|---------------------|--------------|-----------------------------------------|
| RDNA4      | `gfx1200`, `gfx1201`| WMMA + fp8   | All HIP-supported kernels, fp8 GEMM natively           |
| RDNA3.5    | `gfx1150`-`gfx1153` | WMMA, no fp8 | All HIP-supported kernels; fp8 GEMM widened to bf16    |
| RDNA3      | `gfx1100`-`gfx1103` | WMMA, no fp8 | All HIP-supported kernels; fp8 GEMM widened to bf16    |
| RDNA2      | `gfx1030`-`gfx1036` | none         | Non-WMMA kernels incl. AWQ GEMV; WMMA GEMMs decline |

`v_wmma_*_w32_gfx12` has no gfx11 encoding, and the difference is not only the intrinsic name: gfx12 splits a K-step across the half-waves and takes 8-byte operands, while gfx11 gives each lane the whole K-step and duplicates it across the half-waves (rocWMMA calls this input duplication). The fragment type and the bytes of a K-row one MMA consumes therefore moved into an `Mma` policy in the new `mma.h`, and the tile GEMM stays byte-addressed and shared between the two.

gfx11 has no fp8 WMMA at all, so `MmaFp8`/`MmaBf8` widen the operands to bf16 there. The widening is exact (e4m3 and e5m2 mantissas both fit bf16's 7 bits) and both paths accumulate in f32, so RDNA3 fp8 should be as accurate as RDNA4's native path, just slower.

RDNA2 has no matrix cores. It runs the kernels that never needed them (RoPE, AdaLN, the fp8/int8 quantizers, stochastic rounding, the AWQ GEMV) and does not advertise the four GEMMs, which fall through to triton/eager. The GEMM kernels still compile for gfx103x, where they trap, so the registry gates them by architecture instead: with a mix of GPUs in one process the capability set is the intersection, since kernels launch on the tensor's own device. `scaled_mm_fp8` is reached directly rather than through the registry, so it tests `hip.has_wmma()` explicitly.

The default arch list is every RDNA2/3/3.5/4 target ROCm supports. `COMFY_HIP_ARCHS` still overrides it, and a local build for the one GPU it can see is much faster.

### Testing

- `tests/test_hip_wmma.py` passes on a gfx1200 (RX 9060 XT), Windows, ROCm 7.15, torch 2.12. The suite is arch-aware: the GEMM tests skip themselves on a device without matrix cores.
- No regressions, measured on one tree by toggling `COMFY_KITCHEN_DISABLE_HIP`.
- All 17 gfx targets compile, and I checked the generated ISA per target rather than trusting the build: for ops/gemm_int8.hip, each of the 10 gfx11xx/gfx12xx targets emits 336 `v_wmma` instructions and each of the 7 gfx103x targets emits zero plus the traps. A missing arch macro would not fail the build, it would silently drop that GPU into the no-WMMA stub, which is how I caught that `gfx1103` was missing.
- `bdist_wheel` on Windows produces a wheel containing `backends/hip/_C.abi3.pyd`, so the `abi3` tag does survive the HIP extension.
- `ruff` clean.
- The toolchain used by CI (ROCm 7.2.1 from AMD's release directory) builds every target end to end, RDNA2 through RDNA4: I built the extension against it for gfx1030;gfx1100;gfx1200 and disassembled all 17 targets - the 10 gfx11xx/gfx12xx emit `v_wmma`, the 7 gfx103x emit none, as intended.
- The Linux job builds one manylinux wheel holding both `backends/cuda/_C*.so` and `backends/hip/_C*.so`, and the "Verify Linux wheels contain CUDA and HIP extensions" step - which hard-fails if either is missing - passes; the Windows jobs do the same for `.pyd`. The CPU-only test jobs then install that wheel on runners with neither GPU runtime and pass, which exercises the "each backend withdraws itself at import" path.

Kernel changes to improve RDNA3 performance can only be properly validated on an actual RDNA3 GPU. If you have access to RDNA3 hardware and would like to help, feel free to fork the [amd/hip-backend](https://github.com/0xDELUXA/comfy-kitchen_win-rocm/tree/amd/hip-backend) branch, implement and test RDNA3-specific improvements there, and open a PR against that branch. Once those changes are merged, they'll automatically become part of this PR.

RDNA2 users should still use Triton for int8, as rocBLAS doesn't contain int kernels, and hipBLASLt doesn't support RDNA2. As things are today, the [INT8-Fast-ROCM](https://github.com/patientx/ComfyUI-INT8-Fast-ROCM) node is the best option.