### PR TITLE
Speed up native builds with portable compiler caching

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -29,9 +29,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .ccache
-          key: ccache-linux-x86_64-cuda13-${{ hashFiles('setup.py', 'comfy_kitchen/backends/cuda/**', 'third_party/cutlass/.git') }}
+          key: ccache-4.13.6-linux-x86_64-cuda13-${{ hashFiles('setup.py', 'comfy_kitchen/backends/cuda/**', 'third_party/cutlass/.git') }}
           restore-keys: |
-            ccache-linux-x86_64-cuda13-
+            ccache-4.13.6-linux-x86_64-cuda13-
       - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
@@ -60,9 +60,24 @@ jobs:
             # Install ONLY the minimal CUDA packages needed for compilation (not the full toolkit)
             dnf install -y cuda-nvcc-13-0 cuda-cudart-devel-13-0 libcublas-devel-13-0 libnvjitlink-devel-13-0
             # Install Python development headers (fallback for CMake FindPython)
-            dnf install -y python3-devel ccache ninja-build
+            dnf install -y python3-devel curl ninja-build tar xz
+            # EL8 ships ccache 3.7.7, which predates NVCC -x cu handling.
+            # Use the same pinned modern ccache release on both Linux architectures.
+            CCACHE_VERSION=4.13.6
+            CCACHE_ARCH=$(uname -m)
+            case "$CCACHE_ARCH" in
+              x86_64) CCACHE_SHA256=156ec57c5198cc849d92834023d09910b83dc5504c6cf405d09e6ae7b208a3e5 ;;
+              aarch64) CCACHE_SHA256=2098d561e4a8e36bd06a29aedce53ea90c7e365f9573a93d91c230efbf96a958 ;;
+              *) echo "Unsupported ccache architecture: $CCACHE_ARCH" >&2; exit 1 ;;
+            esac
+            CCACHE_ARCHIVE="ccache-$CCACHE_VERSION-linux-$CCACHE_ARCH-musl-static.tar.xz"
+            curl --fail --location --retry 3 --silent --show-error "https://github.com/ccache/ccache/releases/download/v$CCACHE_VERSION/$CCACHE_ARCHIVE" --output "/tmp/$CCACHE_ARCHIVE"
+            echo "$CCACHE_SHA256  /tmp/$CCACHE_ARCHIVE" | sha256sum --check
+            tar -xJf "/tmp/$CCACHE_ARCHIVE" -C /tmp
+            install -m 755 "/tmp/${CCACHE_ARCHIVE%.tar.xz}/ccache" /usr/local/bin/ccache
+            ccache --version
             # Reset counters, but retain restored compiler objects.
-            CCACHE_DIR=/project/.ccache ccache --zero-stats
+            CCACHE_DIR=/host${{ github.workspace }}/.ccache ccache --zero-stats
             # Verify CUDA installation
             /usr/local/cuda-13.0/bin/nvcc --version
 
@@ -75,7 +90,7 @@ jobs:
             CMAKE_GENERATOR=Ninja
             COMFY_CUDA_COMPILER_LAUNCHER=ccache
             COMFY_CXX_COMPILER_LAUNCHER=ccache
-            CCACHE_DIR=/project/.ccache
+            CCACHE_DIR=/host${{ github.workspace }}/.ccache
             CCACHE_BASEDIR=/project
             CCACHE_COMPILERCHECK=content
 
@@ -98,6 +113,16 @@ jobs:
 
         with:
           output-dir: wheelhouse
+
+      - name: Report final compiler-cache statistics
+        shell: bash
+        run: |
+          ccache_version=4.13.6
+          archive="$RUNNER_TEMP/ccache-$ccache_version-linux-x86_64-musl-static.tar.xz"
+          curl --fail --location --retry 3 --silent --show-error "https://github.com/ccache/ccache/releases/download/v$ccache_version/ccache-$ccache_version-linux-x86_64-musl-static.tar.xz" --output "$archive"
+          echo "156ec57c5198cc849d92834023d09910b83dc5504c6cf405d09e6ae7b208a3e5  $archive" | sha256sum --check
+          tar -xJf "$archive" -C "$RUNNER_TEMP"
+          CCACHE_DIR="$GITHUB_WORKSPACE/.ccache" "$RUNNER_TEMP/ccache-$ccache_version-linux-x86_64-musl-static/ccache" --show-stats
 
       - name: Build CPU-only wheel (py3-none-any)
         shell: bash
@@ -144,9 +169,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .ccache
-          key: ccache-linux-aarch64-cuda13-${{ hashFiles('setup.py', 'comfy_kitchen/backends/cuda/**', 'third_party/cutlass/.git') }}
+          key: ccache-4.13.6-linux-aarch64-cuda13-${{ hashFiles('setup.py', 'comfy_kitchen/backends/cuda/**', 'third_party/cutlass/.git') }}
           restore-keys: |
-            ccache-linux-aarch64-cuda13-
+            ccache-4.13.6-linux-aarch64-cuda13-
       - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
@@ -176,9 +201,24 @@ jobs:
             # Install ONLY the minimal CUDA packages needed for compilation (not the full toolkit)
             dnf install -y cuda-nvcc-13-0 cuda-cudart-devel-13-0 libcublas-devel-13-0 libnvjitlink-devel-13-0
             # Install Python development headers (fallback for CMake FindPython)
-            dnf install -y python3-devel ccache ninja-build
+            dnf install -y python3-devel curl ninja-build tar xz
+            # EL8 ships ccache 3.7.7, which predates NVCC -x cu handling.
+            # Use the same pinned modern ccache release on both Linux architectures.
+            CCACHE_VERSION=4.13.6
+            CCACHE_ARCH=$(uname -m)
+            case "$CCACHE_ARCH" in
+              x86_64) CCACHE_SHA256=156ec57c5198cc849d92834023d09910b83dc5504c6cf405d09e6ae7b208a3e5 ;;
+              aarch64) CCACHE_SHA256=2098d561e4a8e36bd06a29aedce53ea90c7e365f9573a93d91c230efbf96a958 ;;
+              *) echo "Unsupported ccache architecture: $CCACHE_ARCH" >&2; exit 1 ;;
+            esac
+            CCACHE_ARCHIVE="ccache-$CCACHE_VERSION-linux-$CCACHE_ARCH-musl-static.tar.xz"
+            curl --fail --location --retry 3 --silent --show-error "https://github.com/ccache/ccache/releases/download/v$CCACHE_VERSION/$CCACHE_ARCHIVE" --output "/tmp/$CCACHE_ARCHIVE"
+            echo "$CCACHE_SHA256  /tmp/$CCACHE_ARCHIVE" | sha256sum --check
+            tar -xJf "/tmp/$CCACHE_ARCHIVE" -C /tmp
+            install -m 755 "/tmp/${CCACHE_ARCHIVE%.tar.xz}/ccache" /usr/local/bin/ccache
+            ccache --version
             # Reset counters, but retain restored compiler objects.
-            CCACHE_DIR=/project/.ccache ccache --zero-stats
+            CCACHE_DIR=/host${{ github.workspace }}/.ccache ccache --zero-stats
             # Verify CUDA installation
             /usr/local/cuda-13.0/bin/nvcc --version
 
@@ -191,7 +231,7 @@ jobs:
             CMAKE_GENERATOR=Ninja
             COMFY_CUDA_COMPILER_LAUNCHER=ccache
             COMFY_CXX_COMPILER_LAUNCHER=ccache
-            CCACHE_DIR=/project/.ccache
+            CCACHE_DIR=/host${{ github.workspace }}/.ccache
             CCACHE_BASEDIR=/project
             CCACHE_COMPILERCHECK=content
 
@@ -214,6 +254,16 @@ jobs:
 
         with:
           output-dir: wheelhouse
+
+      - name: Report final compiler-cache statistics
+        shell: bash
+        run: |
+          ccache_version=4.13.6
+          archive="$RUNNER_TEMP/ccache-$ccache_version-linux-aarch64-musl-static.tar.xz"
+          curl --fail --location --retry 3 --silent --show-error "https://github.com/ccache/ccache/releases/download/v$ccache_version/ccache-$ccache_version-linux-aarch64-musl-static.tar.xz" --output "$archive"
+          echo "2098d561e4a8e36bd06a29aedce53ea90c7e365f9573a93d91c230efbf96a958  $archive" | sha256sum --check
+          tar -xJf "$archive" -C "$RUNNER_TEMP"
+          CCACHE_DIR="$GITHUB_WORKSPACE/.ccache" "$RUNNER_TEMP/ccache-$ccache_version-linux-aarch64-musl-static/ccache" --show-stats
 
       - name: List built wheels
         shell: bash

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -61,6 +61,8 @@ jobs:
             dnf install -y cuda-nvcc-13-0 cuda-cudart-devel-13-0 libcublas-devel-13-0 libnvjitlink-devel-13-0
             # Install Python development headers (fallback for CMake FindPython)
             dnf install -y python3-devel ccache ninja-build
+            # Reset counters, but retain restored compiler objects.
+            CCACHE_DIR=/project/.ccache ccache --zero-stats
             # Verify CUDA installation
             /usr/local/cuda-13.0/bin/nvcc --version
 
@@ -71,14 +73,17 @@ jobs:
             LD_LIBRARY_PATH=/usr/local/cuda-13.0/lib64:$LD_LIBRARY_PATH
             LIBRARY_PATH=/usr/local/cuda-13.0/lib64/stubs:$LIBRARY_PATH
             CMAKE_GENERATOR=Ninja
-            CMAKE_CUDA_COMPILER_LAUNCHER=ccache
-            CMAKE_CXX_COMPILER_LAUNCHER=ccache
+            COMFY_CUDA_COMPILER_LAUNCHER=ccache
+            COMFY_CXX_COMPILER_LAUNCHER=ccache
             CCACHE_DIR=/project/.ccache
             CCACHE_BASEDIR=/project
             CCACHE_COMPILERCHECK=content
 
-          # Install Python build dependencies
-          CIBW_BEFORE_BUILD: "pip install nanobind cmake setuptools wheel"
+          # Report the previous interpreter build's cache result, then install build dependencies.
+          CIBW_BEFORE_BUILD: |
+            python --version
+            ccache --show-stats
+            pip install nanobind cmake setuptools wheel
 
           # Repair wheel for manylinux compliance, excluding CUDA runtime libs
           # Users must have CUDA installed on their system
@@ -172,6 +177,8 @@ jobs:
             dnf install -y cuda-nvcc-13-0 cuda-cudart-devel-13-0 libcublas-devel-13-0 libnvjitlink-devel-13-0
             # Install Python development headers (fallback for CMake FindPython)
             dnf install -y python3-devel ccache ninja-build
+            # Reset counters, but retain restored compiler objects.
+            CCACHE_DIR=/project/.ccache ccache --zero-stats
             # Verify CUDA installation
             /usr/local/cuda-13.0/bin/nvcc --version
 
@@ -182,14 +189,17 @@ jobs:
             LD_LIBRARY_PATH=/usr/local/cuda-13.0/lib64:$LD_LIBRARY_PATH
             LIBRARY_PATH=/usr/local/cuda-13.0/lib64/stubs:$LIBRARY_PATH
             CMAKE_GENERATOR=Ninja
-            CMAKE_CUDA_COMPILER_LAUNCHER=ccache
-            CMAKE_CXX_COMPILER_LAUNCHER=ccache
+            COMFY_CUDA_COMPILER_LAUNCHER=ccache
+            COMFY_CXX_COMPILER_LAUNCHER=ccache
             CCACHE_DIR=/project/.ccache
             CCACHE_BASEDIR=/project
             CCACHE_COMPILERCHECK=content
 
-          # Install Python build dependencies
-          CIBW_BEFORE_BUILD: "pip install nanobind cmake setuptools wheel"
+          # Report the previous interpreter build's cache result, then install build dependencies.
+          CIBW_BEFORE_BUILD: |
+            python --version
+            ccache --show-stats
+            pip install nanobind cmake setuptools wheel
 
           # Repair wheel for manylinux compliance, excluding CUDA runtime libs
           # Users must have CUDA installed on their system
@@ -257,8 +267,8 @@ jobs:
         run: |
           echo "CUDA_PATH_V13_0=$env:CUDA_PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           echo "CMAKE_GENERATOR=Ninja" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          echo "CMAKE_CUDA_COMPILER_LAUNCHER=ccache" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          echo "CMAKE_CXX_COMPILER_LAUNCHER=ccache" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "COMFY_CUDA_COMPILER_LAUNCHER=ccache" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "COMFY_CXX_COMPILER_LAUNCHER=ccache" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           echo "CCACHE_DIR=$env:GITHUB_WORKSPACE\.ccache" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           echo "CCACHE_BASEDIR=$env:GITHUB_WORKSPACE" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           echo "CCACHE_COMPILERCHECK=content" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -25,6 +25,13 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Restore compiler cache
+        uses: actions/cache@v4
+        with:
+          path: .ccache
+          key: ccache-linux-x86_64-cuda13-${{ hashFiles('setup.py', 'comfy_kitchen/backends/cuda/**', 'third_party/cutlass/.git') }}
+          restore-keys: |
+            ccache-linux-x86_64-cuda13-
       - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
@@ -53,7 +60,7 @@ jobs:
             # Install ONLY the minimal CUDA packages needed for compilation (not the full toolkit)
             dnf install -y cuda-nvcc-13-0 cuda-cudart-devel-13-0 libcublas-devel-13-0 libnvjitlink-devel-13-0
             # Install Python development headers (fallback for CMake FindPython)
-            dnf install -y python3-devel
+            dnf install -y python3-devel ccache ninja-build
             # Verify CUDA installation
             /usr/local/cuda-13.0/bin/nvcc --version
 
@@ -63,6 +70,12 @@ jobs:
             PATH=/usr/local/cuda-13.0/bin:$PATH
             LD_LIBRARY_PATH=/usr/local/cuda-13.0/lib64:$LD_LIBRARY_PATH
             LIBRARY_PATH=/usr/local/cuda-13.0/lib64/stubs:$LIBRARY_PATH
+            CMAKE_GENERATOR=Ninja
+            CMAKE_CUDA_COMPILER_LAUNCHER=ccache
+            CMAKE_CXX_COMPILER_LAUNCHER=ccache
+            CCACHE_DIR=/project/.ccache
+            CCACHE_BASEDIR=/project
+            CCACHE_COMPILERCHECK=content
 
           # Install Python build dependencies
           CIBW_BEFORE_BUILD: "pip install nanobind cmake setuptools wheel"
@@ -122,6 +135,13 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Restore compiler cache
+        uses: actions/cache@v4
+        with:
+          path: .ccache
+          key: ccache-linux-aarch64-cuda13-${{ hashFiles('setup.py', 'comfy_kitchen/backends/cuda/**', 'third_party/cutlass/.git') }}
+          restore-keys: |
+            ccache-linux-aarch64-cuda13-
       - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
@@ -151,7 +171,7 @@ jobs:
             # Install ONLY the minimal CUDA packages needed for compilation (not the full toolkit)
             dnf install -y cuda-nvcc-13-0 cuda-cudart-devel-13-0 libcublas-devel-13-0 libnvjitlink-devel-13-0
             # Install Python development headers (fallback for CMake FindPython)
-            dnf install -y python3-devel
+            dnf install -y python3-devel ccache ninja-build
             # Verify CUDA installation
             /usr/local/cuda-13.0/bin/nvcc --version
 
@@ -161,6 +181,12 @@ jobs:
             PATH=/usr/local/cuda-13.0/bin:$PATH
             LD_LIBRARY_PATH=/usr/local/cuda-13.0/lib64:$LD_LIBRARY_PATH
             LIBRARY_PATH=/usr/local/cuda-13.0/lib64/stubs:$LIBRARY_PATH
+            CMAKE_GENERATOR=Ninja
+            CMAKE_CUDA_COMPILER_LAUNCHER=ccache
+            CMAKE_CXX_COMPILER_LAUNCHER=ccache
+            CCACHE_DIR=/project/.ccache
+            CCACHE_BASEDIR=/project
+            CCACHE_COMPILERCHECK=content
 
           # Install Python build dependencies
           CIBW_BEFORE_BUILD: "pip install nanobind cmake setuptools wheel"
@@ -206,6 +232,17 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Restore compiler cache
+        uses: actions/cache@v4
+        with:
+          path: .ccache
+          key: ccache-windows-x86_64-cuda13-${{ hashFiles('setup.py', 'comfy_kitchen/backends/cuda/**', 'third_party/cutlass/.git') }}
+          restore-keys: |
+            ccache-windows-x86_64-cuda13-
+
+      - name: Install compiler cache and Ninja
+        shell: pwsh
+        run: choco install ccache ninja --no-progress --yes
       - name: Install CUDA Toolkit 13.0.2
         uses: Jimver/cuda-toolkit@v0.2.29
         id: cuda-toolkit
@@ -215,10 +252,16 @@ jobs:
           use-github-cache: 'true'
           log-file-suffix: 'windows-2022.txt'
 
-      - name: Set additional CUDA environment variables
+      - name: Set compiler-cache and CUDA environment
         shell: pwsh
         run: |
           echo "CUDA_PATH_V13_0=$env:CUDA_PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "CMAKE_GENERATOR=Ninja" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "CMAKE_CUDA_COMPILER_LAUNCHER=ccache" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "CMAKE_CXX_COMPILER_LAUNCHER=ccache" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "CCACHE_DIR=$env:GITHUB_WORKSPACE\.ccache" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "CCACHE_BASEDIR=$env:GITHUB_WORKSPACE" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "CCACHE_COMPILERCHECK=content" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Verify CUDA installation
         shell: bash
@@ -229,85 +272,6 @@ jobs:
 
       - name: Setup MSVC
         uses: ilammy/msvc-dev-cmd@v1
-
-      - name: Setup CUDA MSBuild integration
-        shell: pwsh
-        run: |
-          # Copy CUDA MSBuild integration files to Visual Studio directory
-          $cudaPath = $env:CUDA_PATH
-          $cudaMSBuildSource = Join-Path $cudaPath "extras\visual_studio_integration\MSBuildExtensions"
-          
-          if (-not (Test-Path $cudaMSBuildSource)) {
-            Write-Error "CUDA MSBuild extensions not found at $cudaMSBuildSource"
-            exit 1
-          }
-          
-          # Find Visual Studio installation
-          $vsBasePaths = @(
-            "C:\Program Files (x86)\Microsoft Visual Studio",
-            "C:\Program Files\Microsoft Visual Studio"
-          )
-          
-          $vsVersions = @("2022", "2019")
-          $vsEditions = @("BuildTools", "Enterprise", "Professional", "Community")
-          $toolsets = @("v170", "v160")
-          
-          $destinations = @()
-          
-          foreach ($basePath in $vsBasePaths) {
-            if (Test-Path $basePath) {
-              foreach ($version in $vsVersions) {
-                foreach ($edition in $vsEditions) {
-                  foreach ($toolset in $toolsets) {
-                    $vsPath = Join-Path $basePath "$version\$edition\MSBuild\Microsoft\VC\$toolset\BuildCustomizations"
-                    if (Test-Path $vsPath) {
-                      $destinations += $vsPath
-                    }
-                  }
-                }
-              }
-            }
-          }
-          
-          if ($destinations.Count -eq 0) {
-            Write-Error "Could not find Visual Studio MSBuild directory"
-            exit 1
-          }
-          
-          # CUDA 13.0 uses versioned filenames that need to be copied as both versioned and standard names
-          $fileMapping = @{
-            "CUDA 13.0.props" = @("CUDA 13.0.props", "CUDA.props")
-            "CUDA 13.0.targets" = @("CUDA 13.0.targets", "CUDA.targets")
-            "CUDA 13.0.xml" = @("CUDA 13.0.xml", "CUDA.xml")
-            "Nvda.Build.CudaTasks.v13.0.dll" = @("Nvda.Build.CudaTasks.v13.0.dll")
-          }
-          
-          $copySuccess = $false
-          
-          foreach ($destDir in $destinations) {
-            try {
-              foreach ($srcFileName in $fileMapping.Keys) {
-                $srcFile = Join-Path $cudaMSBuildSource $srcFileName
-                
-                if (Test-Path $srcFile) {
-                  foreach ($destFileName in $fileMapping[$srcFileName]) {
-                    $destFile = Join-Path $destDir $destFileName
-                    Copy-Item -Path $srcFile -Destination $destFile -Force
-                  }
-                }
-              }
-              $copySuccess = $true
-            } catch {
-              Write-Warning "Failed to copy to $destDir : $_"
-            }
-          }
-          
-          if (-not $copySuccess) {
-            Write-Error "Failed to copy CUDA MSBuild files to any destination"
-            exit 1
-          }
-          
-          Write-Host "CUDA MSBuild integration configured successfully"
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
@@ -351,6 +315,10 @@ jobs:
           # Build with default platform-specific CUDA architectures from setup.py
           # Python 3.12 will produce abi3 wheel, 3.10/3.11 will be version-specific
           python setup.py bdist_wheel
+
+      - name: Report compiler-cache statistics
+        shell: pwsh
+        run: ccache --show-stats
 
       - name: List built wheels
         shell: bash

--- a/comfy_kitchen/__init__.py
+++ b/comfy_kitchen/__init__.py
@@ -23,8 +23,6 @@ from .tensor.convrot_w4a4 import (
     quantize_convrot_w4a4_weight,
 )
 
-__version__ = "0.2.19"
-
 __all__ = [
     # Normalization
     "adaln",

--- a/comfy_kitchen/__init__.py
+++ b/comfy_kitchen/__init__.py
@@ -23,7 +23,7 @@ from .tensor.convrot_w4a4 import (
     quantize_convrot_w4a4_weight,
 )
 
-__version__ = "0.1.0"
+__version__ = "0.2.19"
 
 __all__ = [
     # Normalization

--- a/comfy_kitchen/backends/cuda/CMakeLists.txt
+++ b/comfy_kitchen/backends/cuda/CMakeLists.txt
@@ -99,10 +99,6 @@ if(COMFY_ENABLE_LINEINFO OR CMAKE_BUILD_TYPE STREQUAL "Debug")
     list(APPEND CUDA_NVCC_FLAGS -lineinfo)
 endif()
 
-if(NOT DEFINED COMFY_KITCHEN_VERSION)
-    message(FATAL_ERROR "COMFY_KITCHEN_VERSION must be passed by setup.py")
-endif()
-
 # Source files
 set(CUDA_SOURCES
     ops/per_tensor_quantize.cu
@@ -174,10 +170,7 @@ endif()
 
 target_sources(_C PRIVATE $<TARGET_OBJECTS:comfy_kitchen_cuda_kernels>)
 
-target_compile_definitions(_C PRIVATE
-    NB_STATIC
-    COMFY_KITCHEN_VERSION="${COMFY_KITCHEN_VERSION}"
-)
+target_compile_definitions(_C PRIVATE NB_STATIC)
 
 # Include directories
 target_include_directories(_C PRIVATE

--- a/comfy_kitchen/backends/cuda/CMakeLists.txt
+++ b/comfy_kitchen/backends/cuda/CMakeLists.txt
@@ -99,6 +99,10 @@ if(COMFY_ENABLE_LINEINFO OR CMAKE_BUILD_TYPE STREQUAL "Debug")
     list(APPEND CUDA_NVCC_FLAGS -lineinfo)
 endif()
 
+if(NOT DEFINED COMFY_KITCHEN_VERSION)
+    message(FATAL_ERROR "COMFY_KITCHEN_VERSION must be passed by setup.py")
+endif()
+
 # Source files
 set(CUDA_SOURCES
     ops/per_tensor_quantize.cu
@@ -123,33 +127,15 @@ set(CPP_SOURCES
     dlpack_bindings.cpp
 )
 
-# Create the nanobind module
-# Python 3.12+: Use stable ABI (abi3) for forward compatibility with 3.13+
-# Python 3.10/3.11: Version-specific module (nanobind stable ABI requires 3.12+)
-if(Python_VERSION VERSION_GREATER_EQUAL "3.12")
-    message(STATUS "Python ${Python_VERSION} detected - enabling stable ABI (abi3)")
-    nanobind_add_module(_C NB_STATIC STABLE_ABI LTO ${CPP_SOURCES} ${CUDA_SOURCES})
-    # Explicitly set abi3 suffix
-    if(WIN32)
-        set_target_properties(_C PROPERTIES SUFFIX ".abi3.pyd")
-    else()
-        set_target_properties(_C PROPERTIES SUFFIX ".abi3.so")
-    endif()
-    target_compile_definitions(_C PRIVATE Py_LIMITED_API=0x030C0000)
-else()
-    message(STATUS "Python ${Python_VERSION} detected - building version-specific wheel")
-    nanobind_add_module(_C NB_STATIC LTO ${CPP_SOURCES} ${CUDA_SOURCES})
-endif()
-
-target_compile_definitions(_C PRIVATE NB_STATIC)
-
-# Set target properties
-target_compile_options(_C PRIVATE
+# Keep CUDA compilation independent of the Python extension target. The
+# kernels consume CUDA, DLPack, and project headers only, so a compiler cache
+# can reuse their fatbin objects across CPython wheel builds. _C remains the
+# only Python-facing shared library.
+add_library(comfy_kitchen_cuda_kernels OBJECT ${CUDA_SOURCES})
+target_compile_options(comfy_kitchen_cuda_kernels PRIVATE
     $<$<COMPILE_LANGUAGE:CUDA>:${CUDA_NVCC_FLAGS}>
 )
-
-# Include directories
-target_include_directories(_C PRIVATE
+target_include_directories(comfy_kitchen_cuda_kernels PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CUDAToolkit_INCLUDE_DIRS}
 )
@@ -162,11 +148,42 @@ if(NOT DEFINED COMFY_CUTLASS_DIR)
 endif()
 if(EXISTS "${COMFY_CUTLASS_DIR}/cutlass/version.h")
     message(STATUS "CUTLASS found: ${COMFY_CUTLASS_DIR}")
-    target_include_directories(_C PRIVATE ${COMFY_CUTLASS_DIR})
-    target_compile_definitions(_C PRIVATE COMFY_HAVE_CUTLASS)
+    target_include_directories(comfy_kitchen_cuda_kernels PRIVATE ${COMFY_CUTLASS_DIR})
+    target_compile_definitions(comfy_kitchen_cuda_kernels PRIVATE COMFY_HAVE_CUTLASS)
 else()
     message(STATUS "CUTLASS not found at ${COMFY_CUTLASS_DIR} - int8 GEMM uses cuBLAS only")
 endif()
+
+# Create the nanobind module
+# Python 3.12+: Use stable ABI (abi3) for forward compatibility with 3.13+
+# Python 3.10/3.11: Version-specific module (nanobind stable ABI requires 3.12+)
+if(Python_VERSION VERSION_GREATER_EQUAL "3.12")
+    message(STATUS "Python ${Python_VERSION} detected - enabling stable ABI (abi3)")
+    nanobind_add_module(_C NB_STATIC STABLE_ABI LTO ${CPP_SOURCES})
+    # Explicitly set abi3 suffix
+    if(WIN32)
+        set_target_properties(_C PROPERTIES SUFFIX ".abi3.pyd")
+    else()
+        set_target_properties(_C PROPERTIES SUFFIX ".abi3.so")
+    endif()
+    target_compile_definitions(_C PRIVATE Py_LIMITED_API=0x030C0000)
+else()
+    message(STATUS "Python ${Python_VERSION} detected - building version-specific wheel")
+    nanobind_add_module(_C NB_STATIC LTO ${CPP_SOURCES})
+endif()
+
+target_sources(_C PRIVATE $<TARGET_OBJECTS:comfy_kitchen_cuda_kernels>)
+
+target_compile_definitions(_C PRIVATE
+    NB_STATIC
+    COMFY_KITCHEN_VERSION="${COMFY_KITCHEN_VERSION}"
+)
+
+# Include directories
+target_include_directories(_C PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CUDAToolkit_INCLUDE_DIRS}
+)
 
 # Link libraries
 # Note: cuBLASLt is loaded dynamically at runtime via dlopen/LoadLibrary

--- a/comfy_kitchen/backends/cuda/CMakeLists.txt
+++ b/comfy_kitchen/backends/cuda/CMakeLists.txt
@@ -4,6 +4,19 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 project(comfy_kitchen_cuda LANGUAGES CXX CUDA)
+
+# Enable compiler launchers only after CMake identifies the host and CUDA
+# compilers. This keeps ccache out of the MSVC/NVCC detection probes on
+# Windows, while still wrapping all target compilation commands.
+if(DEFINED COMFY_CXX_COMPILER_LAUNCHER)
+    set(CMAKE_CXX_COMPILER_LAUNCHER "${COMFY_CXX_COMPILER_LAUNCHER}")
+    message(STATUS "C++ compiler launcher: ${CMAKE_CXX_COMPILER_LAUNCHER}")
+endif()
+if(DEFINED COMFY_CUDA_COMPILER_LAUNCHER)
+    set(CMAKE_CUDA_COMPILER_LAUNCHER "${COMFY_CUDA_COMPILER_LAUNCHER}")
+    message(STATUS "CUDA compiler launcher: ${CMAKE_CUDA_COMPILER_LAUNCHER}")
+endif()
+
 find_package(CUDAToolkit REQUIRED)
 
 if(MSVC)

--- a/comfy_kitchen/backends/cuda/dlpack_bindings.cpp
+++ b/comfy_kitchen/backends/cuda/dlpack_bindings.cpp
@@ -2167,10 +2167,6 @@ void dequantize_int8_convrot_weight(
         stream);
 }
 
-#ifndef COMFY_KITCHEN_VERSION
-#error "COMFY_KITCHEN_VERSION must be defined by CMake"
-#endif
-
 NB_MODULE(_C, m) {
     m.doc() = "comfy_kitchen CUDA kernels - nanobind + DLPack interface (NO PyTorch C++ dependencies)";
     
@@ -2558,8 +2554,6 @@ NB_MODULE(_C, m) {
     // Feature availability flag (computed at module load time)
     m.attr("HAS_CUBLASLT") = comfy::CublasLtRuntime::instance().is_available();
 
-    // Add version info
-    m.attr("__version__") = COMFY_KITCHEN_VERSION;
     m.attr("__nanobind__") = true;
     m.attr("__stable_abi__") = true;
 }

--- a/comfy_kitchen/backends/cuda/dlpack_bindings.cpp
+++ b/comfy_kitchen/backends/cuda/dlpack_bindings.cpp
@@ -2167,6 +2167,10 @@ void dequantize_int8_convrot_weight(
         stream);
 }
 
+#ifndef COMFY_KITCHEN_VERSION
+#error "COMFY_KITCHEN_VERSION must be defined by CMake"
+#endif
+
 NB_MODULE(_C, m) {
     m.doc() = "comfy_kitchen CUDA kernels - nanobind + DLPack interface (NO PyTorch C++ dependencies)";
     
@@ -2555,7 +2559,7 @@ NB_MODULE(_C, m) {
     m.attr("HAS_CUBLASLT") = comfy::CublasLtRuntime::instance().is_available();
 
     // Add version info
-    m.attr("__version__") = "0.1.0";
+    m.attr("__version__") = COMFY_KITCHEN_VERSION;
     m.attr("__nanobind__") = true;
     m.attr("__stable_abi__") = true;
 }

--- a/setup.py
+++ b/setup.py
@@ -29,11 +29,6 @@ if "--no-cuda" in sys.argv:
     print("=" * 80 + "\n")
 
 
-_PROJECT_TOML = pathlib.Path(__file__).with_name("pyproject.toml")
-with _PROJECT_TOML.open("rb") as _project_file:
-    PROJECT_METADATA = tomllib.load(_project_file).get("project", {})
-PROJECT_VERSION = PROJECT_METADATA["version"]
-
 
 class CMakeExtension(Extension):
     def __init__(self, name: str, source_dir: str = ""):
@@ -109,7 +104,6 @@ class CMakeBuildExt(build_ext):
             f"-DPython_EXECUTABLE={sys.executable}",
             f"-DCOMFY_CUDA_ARCHS={cuda_archs}",
             f"-DCOMFY_ENABLE_LINEINFO={'ON' if enable_lineinfo else 'OFF'}",
-            f"-DCOMFY_KITCHEN_VERSION={PROJECT_VERSION}",
         ]
 
         # Let CMake manage its own configuration cache. Reconfiguring with the
@@ -346,8 +340,12 @@ setup_kwargs = {
 }
 
 if BUILD_NO_CUDA:
-    version = PROJECT_VERSION
-    description = PROJECT_METADATA.get("description", "")
+    with open("pyproject.toml", "rb") as f:
+        pyproject = tomllib.load(f)
+
+    project_meta = pyproject.get("project", {})
+    version = project_meta["version"]
+    description = project_meta.get("description", "")
 
     setup_kwargs.update({
         "packages": get_packages(),

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,12 @@ if "--no-cuda" in sys.argv:
     print("=" * 80 + "\n")
 
 
+_PROJECT_TOML = pathlib.Path(__file__).with_name("pyproject.toml")
+with _PROJECT_TOML.open("rb") as _project_file:
+    PROJECT_METADATA = tomllib.load(_project_file).get("project", {})
+PROJECT_VERSION = PROJECT_METADATA["version"]
+
+
 class CMakeExtension(Extension):
     def __init__(self, name: str, source_dir: str = ""):
         super().__init__(name, sources=[])
@@ -92,12 +98,6 @@ class CMakeBuildExt(build_ext):
         build_temp = pathlib.Path(self.build_temp).resolve()
         build_temp.mkdir(parents=True, exist_ok=True)
 
-        # Clean CMake cache if it exists (to avoid stale configuration)
-        cmake_cache = build_temp / "CMakeCache.txt"
-        if cmake_cache.exists():
-            cmake_cache.unlink()
-            print(f"Cleaned stale CMake cache: {cmake_cache}")
-
         # All options have been set in finalize_options with proper defaults
         config = "Debug" if self.debug_build else "Release"
         cuda_archs = self.cuda_archs
@@ -109,7 +109,24 @@ class CMakeBuildExt(build_ext):
             f"-DPython_EXECUTABLE={sys.executable}",
             f"-DCOMFY_CUDA_ARCHS={cuda_archs}",
             f"-DCOMFY_ENABLE_LINEINFO={'ON' if enable_lineinfo else 'OFF'}",
+            f"-DCOMFY_KITCHEN_VERSION={PROJECT_VERSION}",
         ]
+
+        # Let CMake manage its own configuration cache. Reconfiguring with the
+        # explicit arguments above updates changed settings without throwing
+        # away cached compiler checks and the generated build graph.
+        generator = os.environ.get("CMAKE_GENERATOR")
+        if generator:
+            cmake_args.extend(["-G", generator])
+
+        # ccache/sccache are opt-in: ordinary source builds gain no dependency,
+        # while release builders can share expensive fatbin compilation results.
+        cuda_launcher = os.environ.get("CMAKE_CUDA_COMPILER_LAUNCHER")
+        if cuda_launcher:
+            cmake_args.append(f"-DCMAKE_CUDA_COMPILER_LAUNCHER={cuda_launcher}")
+        cxx_launcher = os.environ.get("CMAKE_CXX_COMPILER_LAUNCHER")
+        if cxx_launcher:
+            cmake_args.append(f"-DCMAKE_CXX_COMPILER_LAUNCHER={cxx_launcher}")
 
         cuda_home, nvcc_bin = get_cuda_path()
         cmake_args.append(f"-DCUDAToolkit_ROOT={cuda_home}")
@@ -329,12 +346,8 @@ setup_kwargs = {
 }
 
 if BUILD_NO_CUDA:
-    with open("pyproject.toml", "rb") as f:
-        pyproject = tomllib.load(f)
-
-    project_meta = pyproject.get("project", {})
-    version = project_meta.get("version", "0.1.0")
-    description = project_meta.get("description", "")
+    version = PROJECT_VERSION
+    description = PROJECT_METADATA.get("description", "")
 
     setup_kwargs.update({
         "packages": get_packages(),

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,11 @@ if "--no-cuda" in sys.argv:
 
 
 
+def cmake_path(path: str | os.PathLike[str]) -> str:
+    """Return a CMake-safe path with forward slashes on every platform."""
+    return os.fspath(path).replace("\\", "/")
+
+
 class CMakeExtension(Extension):
     def __init__(self, name: str, source_dir: str = ""):
         super().__init__(name, sources=[])
@@ -99,9 +104,9 @@ class CMakeBuildExt(build_ext):
         enable_lineinfo = self.lineinfo
 
         cmake_args = [
-            f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={ext_dir}",
+            f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={cmake_path(ext_dir)}",
             f"-DCMAKE_BUILD_TYPE={config}",
-            f"-DPython_EXECUTABLE={sys.executable}",
+            f"-DPython_EXECUTABLE={cmake_path(sys.executable)}",
             f"-DCOMFY_CUDA_ARCHS={cuda_archs}",
             f"-DCOMFY_ENABLE_LINEINFO={'ON' if enable_lineinfo else 'OFF'}",
         ]
@@ -124,8 +129,8 @@ class CMakeBuildExt(build_ext):
             cmake_args.append(f"-DCOMFY_CXX_COMPILER_LAUNCHER={cxx_launcher}")
 
         cuda_home, nvcc_bin = get_cuda_path()
-        cmake_args.append(f"-DCUDAToolkit_ROOT={cuda_home}")
-        cmake_args.append(f"-DCMAKE_CUDA_COMPILER={nvcc_bin}")
+        cmake_args.append(f"-DCUDAToolkit_ROOT={cmake_path(cuda_home)}")
+        cmake_args.append(f"-DCMAKE_CUDA_COMPILER={cmake_path(nvcc_bin)}")
 
         build_args = ["--config", config]
 
@@ -135,7 +140,7 @@ class CMakeBuildExt(build_ext):
         build_args.extend(["--parallel", str(max_jobs)])
 
         # Run CMake configure
-        source_dir = ext.source_dir if ext.source_dir else os.path.dirname(os.path.abspath(__file__))
+        source_dir = cmake_path(ext.source_dir if ext.source_dir else os.path.dirname(os.path.abspath(__file__)))
 
         print(f"Configuring CMake for {ext.name}...")
         print(f"  Source directory: {source_dir}")

--- a/setup.py
+++ b/setup.py
@@ -128,15 +128,19 @@ class CMakeBuildExt(build_ext):
         if cxx_launcher:
             cmake_args.append(f"-DCOMFY_CXX_COMPILER_LAUNCHER={cxx_launcher}")
 
-        cuda_home, nvcc_bin = get_cuda_path()
+        cuda_paths = get_cuda_path()
+        if cuda_paths is None:
+            raise RuntimeError(
+                "CUDA extension build requested, but nvcc could not be found. "
+                "Set CUDA_HOME to a valid CUDA toolkit or build with --no-cuda."
+            )
+        cuda_home, nvcc_bin = cuda_paths
         cmake_args.append(f"-DCUDAToolkit_ROOT={cmake_path(cuda_home)}")
         cmake_args.append(f"-DCMAKE_CUDA_COMPILER={cmake_path(nvcc_bin)}")
 
         build_args = ["--config", config]
 
         max_jobs = os.cpu_count() or 1
-        # Let CMake translate parallelism for the selected generator. In
-        # particular, Ninja does not accept MSBuild's /m:N syntax.
         build_args.extend(["--parallel", str(max_jobs)])
 
         # Run CMake configure
@@ -175,7 +179,7 @@ class CMakeBuildExt(build_ext):
 
         print(f"Successfully built {ext.name}")
 
-def get_cuda_path():
+def get_cuda_path() -> tuple[pathlib.Path, pathlib.Path] | None:
     nvcc_bin = None
     cuda_home = os.getenv("CUDA_HOME")
     if cuda_home:
@@ -193,12 +197,16 @@ def get_cuda_path():
         return None
 
     if cuda_home is None:
-        cuda_home = str(nvcc_bin.parent.parent)
+        cuda_home = nvcc_bin.parent.parent
 
-    return cuda_home, nvcc_bin
+    return pathlib.Path(cuda_home), nvcc_bin
 
 def get_cuda_version() -> tuple[int, ...] | None:
-    _cuda_home, nvcc_bin = get_cuda_path()
+    cuda_paths = get_cuda_path()
+    if cuda_paths is None:
+        return None
+
+    _cuda_home, nvcc_bin = cuda_paths
     try:
         output = subprocess.run(
             [nvcc_bin, "-V"],
@@ -206,7 +214,7 @@ def get_cuda_version() -> tuple[int, ...] | None:
             check=True,
             text=True,
         )
-    except subprocess.CalledProcessError:
+    except (OSError, subprocess.CalledProcessError):
         return None
 
     match = re.search(r"release\s*([\d.]+)", output.stdout)

--- a/setup.py
+++ b/setup.py
@@ -113,14 +113,15 @@ class CMakeBuildExt(build_ext):
         if generator:
             cmake_args.extend(["-G", generator])
 
-        # ccache/sccache are opt-in: ordinary source builds gain no dependency,
-        # while release builders can share expensive fatbin compilation results.
-        cuda_launcher = os.environ.get("CMAKE_CUDA_COMPILER_LAUNCHER")
+        # Compiler caching is opt-in. Pass project-specific variables so CMake
+        # enables the launchers after compiler identification; wrapping the
+        # identification probes is unreliable with NVCC + MSVC on Windows.
+        cuda_launcher = os.environ.get("COMFY_CUDA_COMPILER_LAUNCHER")
         if cuda_launcher:
-            cmake_args.append(f"-DCMAKE_CUDA_COMPILER_LAUNCHER={cuda_launcher}")
-        cxx_launcher = os.environ.get("CMAKE_CXX_COMPILER_LAUNCHER")
+            cmake_args.append(f"-DCOMFY_CUDA_COMPILER_LAUNCHER={cuda_launcher}")
+        cxx_launcher = os.environ.get("COMFY_CXX_COMPILER_LAUNCHER")
         if cxx_launcher:
-            cmake_args.append(f"-DCMAKE_CXX_COMPILER_LAUNCHER={cxx_launcher}")
+            cmake_args.append(f"-DCOMFY_CXX_COMPILER_LAUNCHER={cxx_launcher}")
 
         cuda_home, nvcc_bin = get_cuda_path()
         cmake_args.append(f"-DCUDAToolkit_ROOT={cuda_home}")
@@ -129,13 +130,9 @@ class CMakeBuildExt(build_ext):
         build_args = ["--config", config]
 
         max_jobs = os.cpu_count() or 1
-        # Use appropriate parallel build syntax for the platform
-        if os.name == "nt":
-            # Windows MSBuild uses /m:N for parallel builds
-            build_args.extend(["--", f"/m:{max_jobs}"])
-        else:
-            # Unix make uses -jN for parallel builds
-            build_args.extend(["--", f"-j{max_jobs}"])
+        # Let CMake translate parallelism for the selected generator. In
+        # particular, Ninja does not accept MSBuild's /m:N syntax.
+        build_args.extend(["--parallel", str(max_jobs)])
 
         # Run CMake configure
         source_dir = ext.source_dir if ext.source_dir else os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
This reduces CUDA wheel build time by using Ninja and ccache in Linux and Windows CI.

CUDA kernels now build as a separate object target. This keeps the expensive CUTLASS translation units independent of the Python/nanobind extension target, allowing ccache to reuse kernel fatbins across wheel builds when Python-specific build inputs change.

Also removes forced CMake-cache deletion so CMake can reuse its generated build graph.
Measured locally on Linux with the default fatbin architecture set:
- Build from scratch: 447.30 s (7m 27s)
- Rebuild after touching only ops/apply_rope.cu: 6.44 s

The RoPE-only rebuild compiled apply_rope.cu and relinked _C; all other CUDA translation units were unchanged.

CI cache-hit rates will be reported through ccache --show-stats.