### PR TITLE
Optimize quantize_int8_rowwise_convrot64 launch config (up to 4.9x on the generic path)

### DIFF
--- a/comfy_kitchen/backends/cuda/ops/int8_linear.cu
+++ b/comfy_kitchen/backends/cuda/ops/int8_linear.cu
@@ -1037,6 +1037,50 @@ __device__ __forceinline__ void convrot_fht_stage64_quantize(
     }
 }
 
+// Shared by both passes of quantize_int8_rowwise_convrot64_chunked_kernel
+// below: load one group-of-4 from global memory (or zero-fill if `active` is
+// false -- the group is past the row's actual group count, e.g. the partial
+// final chunk of a K not evenly divisible by the chunk width) and run the
+// first three FHT stages (S=1 inline, then S=4 and S=16 via
+// convrot_fht_stage64) on it, leaving the post-stage-2 values in buf1. Pass 1
+// and pass 2 previously duplicated this exact sequence verbatim; extracted
+// here so they cannot drift apart -- pass 2's bitwise reproduction of pass
+// 1's rotated values (the determinism this kernel's two-pass design depends
+// on) now holds by construction, not by two hand-kept-in-sync copies. Callers
+// still apply their own final S=64 stage afterward (store_absmax for pass 1,
+// fused quantize for pass 2) since that step differs between the passes.
+// Called uniformly by every thread in the block (the `active` flag only
+// gates whether x0..x3 come from memory or are zero-filled, not whether this
+// function itself is called), so the __syncthreads() calls inside are safe.
+template<typename InputType>
+__device__ __forceinline__ void convrot_load_rotate_group(
+    const InputType* __restrict__ x,
+    int64_t row_offset,
+    int group_col,
+    int base,
+    bool active,
+    float* __restrict__ buf0,
+    float* __restrict__ buf1,
+    int lane)
+{
+    const int64_t x_offset = row_offset + group_col + base;
+
+    const float x0 = active ? to_float(x[x_offset]) : 0.0f;
+    const float x1 = active ? to_float(x[x_offset + 1]) : 0.0f;
+    const float x2 = active ? to_float(x[x_offset + 2]) : 0.0f;
+    const float x3 = active ? to_float(x[x_offset + 3]) : 0.0f;
+    buf1[base] = 0.5f * (x0 + x1 + x2 - x3);
+    buf1[base + 1] = 0.5f * (x0 + x1 - x2 + x3);
+    buf1[base + 2] = 0.5f * (x0 - x1 + x2 + x3);
+    buf1[base + 3] = 0.5f * (-x0 + x1 + x2 + x3);
+    __syncthreads();
+
+    convrot_fht_stage64<4>(buf1, buf0, lane);
+    __syncthreads();
+    convrot_fht_stage64<16>(buf0, buf1, lane);
+    __syncthreads();
+}
+
 // Chunked two-pass variant of quantize_int8_rowwise_convrot64_kernel, used for
 // 2048 < K <= 4096 (see launch_quantize_int8_rowwise_convrot64_kernel's generic
 // branch -- K > 4096 deliberately does NOT use this kernel, see below) to
@@ -1114,22 +1158,8 @@ __global__ void quantize_int8_rowwise_convrot64_chunked_kernel(
         const bool active = group < n_groups;
         const int base = lane * 4;
         const int group_col = group * kConvRotGroup;
-        const int64_t x_offset = row_offset + group_col + base;
 
-        const float x0 = active ? to_float(x[x_offset]) : 0.0f;
-        const float x1 = active ? to_float(x[x_offset + 1]) : 0.0f;
-        const float x2 = active ? to_float(x[x_offset + 2]) : 0.0f;
-        const float x3 = active ? to_float(x[x_offset + 3]) : 0.0f;
-        buf1[base] = 0.5f * (x0 + x1 + x2 - x3);
-        buf1[base + 1] = 0.5f * (x0 + x1 - x2 + x3);
-        buf1[base + 2] = 0.5f * (x0 - x1 + x2 + x3);
-        buf1[base + 3] = 0.5f * (-x0 + x1 + x2 + x3);
-        __syncthreads();
-
-        convrot_fht_stage64<4>(buf1, buf0, lane);
-        __syncthreads();
-        convrot_fht_stage64<16>(buf0, buf1, lane);
-        __syncthreads();
+        convrot_load_rotate_group<InputType>(x, row_offset, group_col, base, active, buf0, buf1, lane);
 
         if (active) {
             // Discard target: buf0 is dead (already consumed above) and gets
@@ -1157,22 +1187,8 @@ __global__ void quantize_int8_rowwise_convrot64_chunked_kernel(
         const bool active = group < n_groups;
         const int base = lane * 4;
         const int group_col = group * kConvRotGroup;
-        const int64_t x_offset = row_offset + group_col + base;
 
-        const float x0 = active ? to_float(x[x_offset]) : 0.0f;
-        const float x1 = active ? to_float(x[x_offset + 1]) : 0.0f;
-        const float x2 = active ? to_float(x[x_offset + 2]) : 0.0f;
-        const float x3 = active ? to_float(x[x_offset + 3]) : 0.0f;
-        buf1[base] = 0.5f * (x0 + x1 + x2 - x3);
-        buf1[base + 1] = 0.5f * (x0 + x1 - x2 + x3);
-        buf1[base + 2] = 0.5f * (x0 - x1 + x2 + x3);
-        buf1[base + 3] = 0.5f * (-x0 + x1 + x2 + x3);
-        __syncthreads();
-
-        convrot_fht_stage64<4>(buf1, buf0, lane);
-        __syncthreads();
-        convrot_fht_stage64<16>(buf0, buf1, lane);
-        __syncthreads();
+        convrot_load_rotate_group<InputType>(x, row_offset, group_col, base, active, buf0, buf1, lane);
 
         if (active) {
             convrot_fht_stage64_quantize<64, InputType, STOCHASTIC>(

--- a/comfy_kitchen/backends/cuda/ops/int8_linear.cu
+++ b/comfy_kitchen/backends/cuda/ops/int8_linear.cu
@@ -989,6 +989,199 @@ __global__ void quantize_int8_rowwise_convrot64_kernel(
     }
 }
 
+// Final-stage (S=64) H4 butterfly fused directly with quantize-and-store, used by
+// the chunked kernel below in place of convrot_fht_stage64_store_absmax: since
+// pass 2 already knows the row's final scale, there is no need to stage the
+// rotated fp32 value through any buffer (row_buf or otherwise) before
+// quantizing it -- computing y0..y3 and immediately running them through the
+// exact same triple-roundtrip-through-InputType divide + round + clamp
+// sequence as the per-column loop above (same operations, same order) and
+// writing straight to the int8 output is bitwise identical to
+// rotate-then-buffer-then-quantize, just without the redundant store/load
+// (the buffer being skipped was already fp32 with no precision effect).
+template<int S, typename InputType, bool STOCHASTIC>
+__device__ __forceinline__ void convrot_fht_stage64_quantize(
+    const float* __restrict__ src,
+    int8_t* __restrict__ q,
+    int64_t row_offset,
+    int group_col,
+    float scale,
+    uint64_t seed,
+    int lane)
+{
+    const int base = (lane % S) + (lane / S) * (4 * S);
+    const float x0 = src[base];
+    const float x1 = src[base + S];
+    const float x2 = src[base + 2 * S];
+    const float x3 = src[base + 3 * S];
+    const float y[4] = {
+        0.5f * (x0 + x1 + x2 - x3),
+        0.5f * (x0 + x1 - x2 + x3),
+        0.5f * (x0 - x1 + x2 + x3),
+        0.5f * (-x0 + x1 + x2 + x3),
+    };
+    #pragma unroll
+    for (int d = 0; d < 4; ++d) {
+        const int col = group_col + base + d * S;
+        const int64_t idx = row_offset + col;
+        const float scaled = quant_div_float_to_float<InputType>(y[d], scale);
+        float quantized;
+        if constexpr (STOCHASTIC) {
+            const InputType noise = stochastic_rng_value<InputType>(idx, seed);
+            quantized = floorf(stochastic_sum_to_float<InputType>(scaled, noise));
+        } else {
+            quantized = nearbyintf(scaled);
+        }
+        quantized = fminf(127.0f, fmaxf(-128.0f, quantized));
+        q[idx] = static_cast<int8_t>(quantized);
+    }
+}
+
+// Chunked two-pass variant of quantize_int8_rowwise_convrot64_kernel, used for
+// 2048 < K <= 4096 (see launch_quantize_int8_rowwise_convrot64_kernel's generic
+// branch -- K > 4096 deliberately does NOT use this kernel, see below) to
+// remove the single-pass kernel's full-row shared-memory buffer (row_buf, K
+// floats) -- at K=4096 that buffer alone is 16KB, and combined with the
+// BLOCK_THREADS-independent-of-K launch it used to force, occupancy was
+// limited to roughly one block per SM. This kernel's shared-memory footprint
+// is bounded by BLOCK_THREADS alone (kGroupsInFlight * 2 * 256 floats -- 16KB
+// at BLOCK_THREADS=512), independent of K, by processing the row in
+// "chunks" of BLOCK_THREADS/64 groups (2048 elements at BLOCK_THREADS=512) and
+// never materializing more than one chunk's rotated values at a time:
+//   pass 1: for each chunk, rotate (identical 4-stage H4 butterfly, byte-for-
+//           byte the same math as the single-pass kernel) and fold its local
+//           max into the row's running abs_max (fmaxf-from-a-finite-0.0-seed,
+//           per group, exactly as the single-pass kernel's own loop already
+//           does -- NaN-safe for the same reason: an entire NaN group never
+//           corrupts a live finite accumulator), then discard the rotated
+//           values (the "store" target is scratch, immediately overwritten by
+//           the next chunk).
+//   pass 2: for each chunk again, RE-load from global (the same lines this
+//           block just read in pass 1, hopefully still L2-resident -- see the
+//           K>4096 caveat below) and RE-rotate -- deterministic fp32 math, so
+//           this reproduces pass 1's per-element rotated values exactly --
+//           then quantize using the now-final scale and store, via
+//           convrot_fht_stage64_quantize above (fusing the last butterfly
+//           stage with the quantize step so there is still no intermediate
+//           buffer in pass 2 either).
+// The recompute in pass 2 is deliberate: it roughly doubles the rotation's
+// arithmetic (already the cheaper side of this kernel's roofline -- see the
+// PR description) in exchange for cutting shared-memory pressure, which is
+// what actually gates how many blocks fit per SM.
+//
+// NOT used beyond K=4096: measured at K=8192 with M=9216 (this kernel's
+// motivating real-world shape) on an RTX 3090, this kernel is a reproducible
+// ~8% *regression* vs the old always-1024-thread single-pass kernel. With
+// 9216 blocks in flight, pass 2's re-read no longer reliably hits L2 -- the
+// resident-rows working set exceeds the card's 6MB L2 at that row count and
+// row width -- so the "recompute instead of buffer" trade that wins at
+// K<=4096 becomes a genuine second DRAM read at K=8192, which is not worth
+// the occupancy gain. See launch_quantize_int8_rowwise_convrot64_kernel's
+// K>4096 branch, which keeps using the original single-pass kernel unchanged.
+template<typename InputType, int BLOCK_THREADS, bool STOCHASTIC>
+__global__ void quantize_int8_rowwise_convrot64_chunked_kernel(
+    const InputType* __restrict__ x,
+    int8_t* __restrict__ q,
+    float* __restrict__ scales,
+    int K,
+    uint64_t seed)
+{
+    constexpr int kGroupThreads = 64;
+    constexpr int kGroupsInFlight = BLOCK_THREADS / kGroupThreads;
+    constexpr int kWarps = BLOCK_THREADS / kThreadsPerWarp;
+
+    extern __shared__ float smem[];
+    float* tmp = smem;  // kGroupsInFlight * 2 * kConvRotGroup floats -- no row_buf.
+
+    __shared__ float warp_smem[kWarps];
+    __shared__ float block_smem;
+
+    const int row = static_cast<int>(blockIdx.x);
+    const int tid = threadIdx.x;
+    const int sub = tid / kGroupThreads;
+    const int lane = tid % kGroupThreads;
+    const int64_t row_offset = static_cast<int64_t>(row) * K;
+    const int n_groups = K / kConvRotGroup;
+    const int iters = (n_groups + kGroupsInFlight - 1) / kGroupsInFlight;
+
+    float* buf0 = tmp + sub * (2 * kConvRotGroup);
+    float* buf1 = buf0 + kConvRotGroup;
+
+    // ---- Pass 1: rotate each chunk, fold abs-max, discard rotated values. ----
+    float abs_max = 0.0f;
+    for (int it = 0; it < iters; ++it) {
+        const int group = it * kGroupsInFlight + sub;
+        const bool active = group < n_groups;
+        const int base = lane * 4;
+        const int group_col = group * kConvRotGroup;
+        const int64_t x_offset = row_offset + group_col + base;
+
+        const float x0 = active ? to_float(x[x_offset]) : 0.0f;
+        const float x1 = active ? to_float(x[x_offset + 1]) : 0.0f;
+        const float x2 = active ? to_float(x[x_offset + 2]) : 0.0f;
+        const float x3 = active ? to_float(x[x_offset + 3]) : 0.0f;
+        buf1[base] = 0.5f * (x0 + x1 + x2 - x3);
+        buf1[base + 1] = 0.5f * (x0 + x1 - x2 + x3);
+        buf1[base + 2] = 0.5f * (x0 - x1 + x2 + x3);
+        buf1[base + 3] = 0.5f * (-x0 + x1 + x2 + x3);
+        __syncthreads();
+
+        convrot_fht_stage64<4>(buf1, buf0, lane);
+        __syncthreads();
+        convrot_fht_stage64<16>(buf0, buf1, lane);
+        __syncthreads();
+
+        if (active) {
+            // Discard target: buf0 is dead (already consumed above) and gets
+            // overwritten again next iteration -- only the returned local max
+            // is used.
+            abs_max = fmaxf(
+                abs_max,
+                convrot_fht_stage64_store_absmax<64, float>(buf1, buf0, lane));
+        }
+        __syncthreads();
+    }
+
+    abs_max = block_reduce_max_t<kWarps>(abs_max, warp_smem, &block_smem);
+    const float scale = fmaxf(
+        finite_absmax_for_int8_scale<InputType>(abs_max) * (1.0f / 127.0f),
+        1.0e-30f);
+    if (tid == 0) {
+        scales[row] = scale;
+    }
+    __syncthreads();  // all threads must see `scale` before pass 2 reuses smem.
+
+    // ---- Pass 2: re-load + re-rotate (identical math -> identical values) + quantize. ----
+    for (int it = 0; it < iters; ++it) {
+        const int group = it * kGroupsInFlight + sub;
+        const bool active = group < n_groups;
+        const int base = lane * 4;
+        const int group_col = group * kConvRotGroup;
+        const int64_t x_offset = row_offset + group_col + base;
+
+        const float x0 = active ? to_float(x[x_offset]) : 0.0f;
+        const float x1 = active ? to_float(x[x_offset + 1]) : 0.0f;
+        const float x2 = active ? to_float(x[x_offset + 2]) : 0.0f;
+        const float x3 = active ? to_float(x[x_offset + 3]) : 0.0f;
+        buf1[base] = 0.5f * (x0 + x1 + x2 - x3);
+        buf1[base + 1] = 0.5f * (x0 + x1 - x2 + x3);
+        buf1[base + 2] = 0.5f * (x0 - x1 + x2 + x3);
+        buf1[base + 3] = 0.5f * (-x0 + x1 + x2 + x3);
+        __syncthreads();
+
+        convrot_fht_stage64<4>(buf1, buf0, lane);
+        __syncthreads();
+        convrot_fht_stage64<16>(buf0, buf1, lane);
+        __syncthreads();
+
+        if (active) {
+            convrot_fht_stage64_quantize<64, InputType, STOCHASTIC>(
+                buf1, q, row_offset, group_col, scale, seed, lane);
+        }
+        __syncthreads();
+    }
+}
+
 } // namespace
 
 } // namespace comfy
@@ -1282,7 +1475,6 @@ void launch_quantize_int8_rowwise_convrot64_kernel(
 
     DISPATCH_FP_DTYPE(input_dtype_code, InputType, [&] {
         constexpr int block_threads_single = 512;
-        constexpr int block_threads_multi = 1024;
         auto launch = [&](auto kernel, int block_threads) {
             const int groups_in_flight = block_threads / 64;
             const size_t smem_bytes =
@@ -1293,6 +1485,28 @@ void launch_quantize_int8_rowwise_convrot64_kernel(
             if (attr_err != cudaSuccess) {
                 throw std::runtime_error(
                     std::string("convrot64 fused kernel shared memory request (") +
+                    std::to_string(smem_bytes) + " bytes) failed: " +
+                    cudaGetErrorString(attr_err));
+            }
+            kernel<<<static_cast<unsigned int>(num_rows), block_threads, smem_bytes, stream>>>(
+                static_cast<const InputType*>(input),
+                static_cast<int8_t*>(output),
+                static_cast<float*>(scales),
+                static_cast<int>(num_cols),
+                seed);
+        };
+        // Chunked kernel's shared memory is bounded by block_threads alone (no
+        // row_buf, so no num_cols term) -- see quantize_int8_rowwise_convrot64_chunked_kernel.
+        auto launch_chunked = [&](auto kernel, int block_threads) {
+            const int groups_in_flight = block_threads / 64;
+            const size_t smem_bytes =
+                static_cast<size_t>(groups_in_flight) * 2 * comfy::kConvRotGroup * sizeof(float);
+            cudaError_t attr_err = cudaFuncSetAttribute(
+                kernel, cudaFuncAttributeMaxDynamicSharedMemorySize,
+                static_cast<int>(smem_bytes));
+            if (attr_err != cudaSuccess) {
+                throw std::runtime_error(
+                    std::string("convrot64 chunked kernel shared memory request (") +
                     std::to_string(smem_bytes) + " bytes) failed: " +
                     cudaGetErrorString(attr_err));
             }
@@ -1339,7 +1553,95 @@ void launch_quantize_int8_rowwise_convrot64_kernel(
                 launch(comfy::quantize_int8_rowwise_convrot64_kernel<InputType, block_threads_6144, false>,
                        block_threads_6144);
             }
+        } else if (num_cols <= 2048) {
+            // Right-sized launch: threads = min(1024, (K/256)*64), realized
+            // below as an explicit switch over n_groups (2..8) rather than a
+            // literal min() -- for K in this branch (a multiple of 256, > 256,
+            // <= 2048, and not one of the other special-cased widths above)
+            // (K/256)*64 always lands at or under 512, so the min(1024, ...)
+            // never actually clamps for any K reaching this switch. That min()
+            // is NOT what the branches below this one use, despite the
+            // similar-looking numbers: the 2048 < K <= 4096 branch launches
+            // the chunked kernel at a hardcoded 512 threads (independent of
+            // K, by construction -- see that kernel's docstring), and the
+            // K > 4096 branch launches the original single-pass kernel at a
+            // hardcoded 1024 threads unconditionally (matching stock's prior
+            // behavior verbatim, not derived from this formula, even though
+            // it happens to equal what the formula would produce there).
+            // Was previously ALWAYS 1024 threads regardless of K (e.g. 768 of
+            // 1024 threads sit idle every iteration at K=1024, since only
+            // (K/256)*64 = 256 of them ever have `active` true) -- see the PR
+            // description for the roofline analysis this fixes.
+            const int n_groups = static_cast<int>(num_cols / comfy::kConvRotGroup);
+            switch (n_groups) {
+                case 2:  // K=512
+                    if (stochastic) launch(comfy::quantize_int8_rowwise_convrot64_kernel<InputType, 128, true>, 128);
+                    else launch(comfy::quantize_int8_rowwise_convrot64_kernel<InputType, 128, false>, 128);
+                    break;
+                case 3:  // K=768
+                    if (stochastic) launch(comfy::quantize_int8_rowwise_convrot64_kernel<InputType, 192, true>, 192);
+                    else launch(comfy::quantize_int8_rowwise_convrot64_kernel<InputType, 192, false>, 192);
+                    break;
+                case 4:  // K=1024
+                    if (stochastic) launch(comfy::quantize_int8_rowwise_convrot64_kernel<InputType, 256, true>, 256);
+                    else launch(comfy::quantize_int8_rowwise_convrot64_kernel<InputType, 256, false>, 256);
+                    break;
+                case 5:  // K=1280
+                    if (stochastic) launch(comfy::quantize_int8_rowwise_convrot64_kernel<InputType, 320, true>, 320);
+                    else launch(comfy::quantize_int8_rowwise_convrot64_kernel<InputType, 320, false>, 320);
+                    break;
+                case 6:  // K=1536
+                    if (stochastic) launch(comfy::quantize_int8_rowwise_convrot64_kernel<InputType, 384, true>, 384);
+                    else launch(comfy::quantize_int8_rowwise_convrot64_kernel<InputType, 384, false>, 384);
+                    break;
+                case 7:  // K=1792
+                    if (stochastic) launch(comfy::quantize_int8_rowwise_convrot64_kernel<InputType, 448, true>, 448);
+                    else launch(comfy::quantize_int8_rowwise_convrot64_kernel<InputType, 448, false>, 448);
+                    break;
+                default:  // K=2048 (n_groups == 8); n_groups < 2 (K < 512) can't reach
+                          // this branch (K==256 is the block_threads_256 special case
+                          // above, and K must be a multiple of 256 and > 256 here).
+                    if (stochastic) launch(comfy::quantize_int8_rowwise_convrot64_kernel<InputType, 512, true>, 512);
+                    else launch(comfy::quantize_int8_rowwise_convrot64_kernel<InputType, 512, false>, 512);
+                    break;
+            }
+        } else if (num_cols <= 4096) {
+            // 2048 < K <= 4096: chunked two-pass kernel, fixed at 512 threads
+            // (CHUNK = (512/64)*256 = 2048 elements/iteration).
+            //
+            // Gated to K <= 4096, NOT "K > 2048" unconditionally: measured at
+            // K=8192 (M=9216, RTX 3090) this kernel is a reproducible ~8%
+            // *regression* vs the old always-1024-thread single-pass kernel,
+            // not the win the occupancy math predicts. Root cause: with 9216
+            // blocks in flight, pass 2's re-read of global memory (deliberately
+            // redundant with pass 1 -- see the kernel's docstring) no longer
+            // reliably hits L2 at that row count -- the resident-rows working
+            // set exceeds the RTX 3090's 6MB L2 -- so at K=8192 the "recompute
+            // instead of buffer" trade becomes a genuine second DRAM read
+            // instead of an L2-served one, which is not worth the occupancy
+            // gain. At K<=4096 the smaller per-row footprint keeps enough of
+            // the working set L2-resident for pass 2 to still win. See the PR
+            // description for the measured numbers at both sizes. Lifting this
+            // cap (e.g. occupancy/L2-aware chunk sizing that adapts to M, not
+            // just K) is noted there as future work, not attempted here.
+            constexpr int block_threads_chunked = 512;
+            if (stochastic) {
+                launch_chunked(comfy::quantize_int8_rowwise_convrot64_chunked_kernel<InputType, block_threads_chunked, true>,
+                                block_threads_chunked);
+            } else {
+                launch_chunked(comfy::quantize_int8_rowwise_convrot64_chunked_kernel<InputType, block_threads_chunked, false>,
+                                block_threads_chunked);
+            }
         } else {
+            // K > 4096: EXISTING full-row generic path, UNCHANGED -- same
+            // kernel, same fixed 1024-thread launch, same `launch` lambda (with
+            // its num_cols-dependent smem formula) stock already used for every
+            // K in this else-branch before this PR. Verified byte-identical
+            // dispatch to stock for these K (same template instantiation, same
+            // block_threads, same smem_bytes computation) -- this branch exists
+            // only so the right-sized (<=2048) and chunked (<=4096) branches
+            // above don't have to special-case "was this K already covered".
+            constexpr int block_threads_multi = 1024;
             if (stochastic) {
                 launch(comfy::quantize_int8_rowwise_convrot64_kernel<InputType, block_threads_multi, true>,
                        block_threads_multi);

--- a/comfy_kitchen/backends/cuda/ops/int8_linear.cu
+++ b/comfy_kitchen/backends/cuda/ops/int8_linear.cu
@@ -989,9 +989,9 @@ __global__ void quantize_int8_rowwise_convrot64_kernel(
     }
 }
 
-// Final-stage (S=64) H4 butterfly fused directly with quantize-and-store, so
-// the chunked kernel's pass 2 never stages the rotated value through a
-// buffer -- same divide/round/clamp sequence as the per-column loop above.
+// S=64 H4 butterfly with quantize+store fused into the final stage. The
+// divide/round/clamp sequence must match the per-column quantize loop in
+// quantize_int8_rowwise_convrot64_kernel.
 template<int S, typename InputType, bool STOCHASTIC>
 __device__ __forceinline__ void convrot_fht_stage64_quantize(
     const float* __restrict__ src,
@@ -1030,10 +1030,9 @@ __device__ __forceinline__ void convrot_fht_stage64_quantize(
     }
 }
 
-// Shared by both passes of the chunked kernel below: load one group-of-4
-// (zero-filled if `active` is false, e.g. a partial final chunk) and run the
-// first three FHT stages, leaving the result in buf1. Extracted so pass 1 and
-// pass 2 cannot drift apart -- their bitwise agreement is now by construction.
+// Load one group-of-4 (zero-filled when inactive) and run the first three FHT
+// stages, leaving the result in buf1. Both passes of the chunked kernel must
+// go through this helper so their rotated values agree bitwise.
 template<typename InputType>
 __device__ __forceinline__ void convrot_load_rotate_group(
     const InputType* __restrict__ x,
@@ -1063,15 +1062,12 @@ __device__ __forceinline__ void convrot_load_rotate_group(
     __syncthreads();
 }
 
-// Chunked two-pass variant of quantize_int8_rowwise_convrot64_kernel, used for
-// 2048 < K <= 4096. Shared memory is bounded by BLOCK_THREADS alone
-// (kGroupsInFlight * 2 * 256 floats, independent of K) by processing the row
-// in chunks and never materializing more than one chunk's rotated values:
-// pass 1 rotates each chunk and folds its max into abs_max, discarding the
-// values; pass 2 re-loads and re-rotates (deterministic fp32 math, so this
-// reproduces pass 1 exactly) and quantizes with the final scale. Not used
-// beyond K=4096: at K=8192/M=9216 the re-read in pass 2 stops hitting L2 and
-// this kernel regresses ~8% vs the single-pass kernel (see PR description).
+// Two-pass variant for 2048 < K <= 4096: shared memory holds only one chunk's
+// scratch (independent of K). Pass 1 rotates each chunk and folds its abs-max;
+// pass 2 re-loads and re-rotates -- fp32 math is deterministic, so the values
+// match pass 1 -- and quantizes with the final scale. Above K=4096 the pass-2
+// re-read no longer stays L2-resident at large row counts and the single-pass
+// kernel is faster.
 template<typename InputType, int BLOCK_THREADS, bool STOCHASTIC>
 __global__ void quantize_int8_rowwise_convrot64_chunked_kernel(
     const InputType* __restrict__ x,
@@ -1085,7 +1081,7 @@ __global__ void quantize_int8_rowwise_convrot64_chunked_kernel(
     constexpr int kWarps = BLOCK_THREADS / kThreadsPerWarp;
 
     extern __shared__ float smem[];
-    float* tmp = smem;  // kGroupsInFlight * 2 * kConvRotGroup floats -- no row_buf.
+    float* tmp = smem;  // kGroupsInFlight * 2 * kConvRotGroup floats.
 
     __shared__ float warp_smem[kWarps];
     __shared__ float block_smem;
@@ -1112,9 +1108,8 @@ __global__ void quantize_int8_rowwise_convrot64_chunked_kernel(
         convrot_load_rotate_group<InputType>(x, row_offset, group_col, base, active, buf0, buf1, lane);
 
         if (active) {
-            // buf0 is scratch here (dead value, reused next iteration).
-            // fmaxf ignores NaN against a finite abs_max, so an all-NaN
-            // group (huge-magnitude row) can't corrupt the running max.
+            // fmaxf ignores NaN against a finite accumulator, so an all-NaN
+            // group (huge-magnitude row) cannot corrupt the running max.
             abs_max = fmaxf(
                 abs_max,
                 convrot_fht_stage64_store_absmax<64, float>(buf1, buf0, lane));
@@ -1129,7 +1124,6 @@ __global__ void quantize_int8_rowwise_convrot64_chunked_kernel(
     if (tid == 0) {
         scales[row] = scale;
     }
-    __syncthreads();  // all threads must see `scale` before pass 2 reuses smem.
 
     // ---- Pass 2: re-load + re-rotate (identical math -> identical values) + quantize. ----
     for (int it = 0; it < iters; ++it) {
@@ -1461,21 +1455,11 @@ void launch_quantize_int8_rowwise_convrot64_kernel(
                 static_cast<int>(num_cols),
                 seed);
         };
-        // Chunked kernel's shared memory is bounded by block_threads alone (no
-        // row_buf, so no num_cols term) -- see quantize_int8_rowwise_convrot64_chunked_kernel.
+        // Dynamic smem here is at most 16 KiB -- under the default limit, no opt-in attribute needed.
         auto launch_chunked = [&](auto kernel, int block_threads) {
             const int groups_in_flight = block_threads / 64;
             const size_t smem_bytes =
                 static_cast<size_t>(groups_in_flight) * 2 * comfy::kConvRotGroup * sizeof(float);
-            cudaError_t attr_err = cudaFuncSetAttribute(
-                kernel, cudaFuncAttributeMaxDynamicSharedMemorySize,
-                static_cast<int>(smem_bytes));
-            if (attr_err != cudaSuccess) {
-                throw std::runtime_error(
-                    std::string("convrot64 chunked kernel shared memory request (") +
-                    std::to_string(smem_bytes) + " bytes) failed: " +
-                    cudaGetErrorString(attr_err));
-            }
             kernel<<<static_cast<unsigned int>(num_rows), block_threads, smem_bytes, stream>>>(
                 static_cast<const InputType*>(input),
                 static_cast<int8_t*>(output),
@@ -1520,10 +1504,7 @@ void launch_quantize_int8_rowwise_convrot64_kernel(
                        block_threads_6144);
             }
         } else if (num_cols <= 2048) {
-            // Right-sized launch: threads = min(1024, (K/256)*64) via the
-            // switch below (always <= 512 here, so the min never clamps).
-            // The chunked and K>4096 branches below use their own hardcoded
-            // thread counts, not this formula.
+            // One 64-thread group per 256-column block: threads = n_groups * 64.
             const int n_groups = static_cast<int>(num_cols / comfy::kConvRotGroup);
             switch (n_groups) {
                 case 2:  // K=512
@@ -1550,18 +1531,18 @@ void launch_quantize_int8_rowwise_convrot64_kernel(
                     if (stochastic) launch(comfy::quantize_int8_rowwise_convrot64_kernel<InputType, 448, true>, 448);
                     else launch(comfy::quantize_int8_rowwise_convrot64_kernel<InputType, 448, false>, 448);
                     break;
-                default:  // K=2048 (n_groups == 8); n_groups < 2 (K < 512) can't reach
-                          // this branch (K==256 is the block_threads_256 special case
-                          // above, and K must be a multiple of 256 and > 256 here).
+                case 8:  // K=2048
                     if (stochastic) launch(comfy::quantize_int8_rowwise_convrot64_kernel<InputType, 512, true>, 512);
                     else launch(comfy::quantize_int8_rowwise_convrot64_kernel<InputType, 512, false>, 512);
                     break;
+                default:
+                    if (stochastic) launch(comfy::quantize_int8_rowwise_convrot64_kernel<InputType, 1024, true>, 1024);
+                    else launch(comfy::quantize_int8_rowwise_convrot64_kernel<InputType, 1024, false>, 1024);
+                    break;
             }
         } else if (num_cols <= 4096) {
-            // Chunked two-pass kernel, fixed at 512 threads. Gated to K<=4096
-            // (not all K>2048): at K=8192/M=9216, pass 2's re-read stops
-            // hitting L2 and this kernel regresses ~8% vs the single-pass
-            // kernel below -- see the PR description.
+            // Above K=4096 the chunked kernel's pass-2 re-read falls out of L2 at large
+            // row counts and loses to the single-pass kernel below.
             constexpr int block_threads_chunked = 512;
             if (stochastic) {
                 launch_chunked(comfy::quantize_int8_rowwise_convrot64_chunked_kernel<InputType, block_threads_chunked, true>,
@@ -1571,8 +1552,6 @@ void launch_quantize_int8_rowwise_convrot64_kernel(
                                 block_threads_chunked);
             }
         } else {
-            // K > 4096: unchanged from stock -- same kernel, same fixed
-            // 1024-thread launch.
             constexpr int block_threads_multi = 1024;
             if (stochastic) {
                 launch(comfy::quantize_int8_rowwise_convrot64_kernel<InputType, block_threads_multi, true>,

--- a/comfy_kitchen/backends/cuda/ops/int8_linear.cu
+++ b/comfy_kitchen/backends/cuda/ops/int8_linear.cu
@@ -989,16 +989,9 @@ __global__ void quantize_int8_rowwise_convrot64_kernel(
     }
 }
 
-// Final-stage (S=64) H4 butterfly fused directly with quantize-and-store, used by
-// the chunked kernel below in place of convrot_fht_stage64_store_absmax: since
-// pass 2 already knows the row's final scale, there is no need to stage the
-// rotated fp32 value through any buffer (row_buf or otherwise) before
-// quantizing it -- computing y0..y3 and immediately running them through the
-// exact same triple-roundtrip-through-InputType divide + round + clamp
-// sequence as the per-column loop above (same operations, same order) and
-// writing straight to the int8 output is bitwise identical to
-// rotate-then-buffer-then-quantize, just without the redundant store/load
-// (the buffer being skipped was already fp32 with no precision effect).
+// Final-stage (S=64) H4 butterfly fused directly with quantize-and-store, so
+// the chunked kernel's pass 2 never stages the rotated value through a
+// buffer -- same divide/round/clamp sequence as the per-column loop above.
 template<int S, typename InputType, bool STOCHASTIC>
 __device__ __forceinline__ void convrot_fht_stage64_quantize(
     const float* __restrict__ src,
@@ -1037,21 +1030,10 @@ __device__ __forceinline__ void convrot_fht_stage64_quantize(
     }
 }
 
-// Shared by both passes of quantize_int8_rowwise_convrot64_chunked_kernel
-// below: load one group-of-4 from global memory (or zero-fill if `active` is
-// false -- the group is past the row's actual group count, e.g. the partial
-// final chunk of a K not evenly divisible by the chunk width) and run the
-// first three FHT stages (S=1 inline, then S=4 and S=16 via
-// convrot_fht_stage64) on it, leaving the post-stage-2 values in buf1. Pass 1
-// and pass 2 previously duplicated this exact sequence verbatim; extracted
-// here so they cannot drift apart -- pass 2's bitwise reproduction of pass
-// 1's rotated values (the determinism this kernel's two-pass design depends
-// on) now holds by construction, not by two hand-kept-in-sync copies. Callers
-// still apply their own final S=64 stage afterward (store_absmax for pass 1,
-// fused quantize for pass 2) since that step differs between the passes.
-// Called uniformly by every thread in the block (the `active` flag only
-// gates whether x0..x3 come from memory or are zero-filled, not whether this
-// function itself is called), so the __syncthreads() calls inside are safe.
+// Shared by both passes of the chunked kernel below: load one group-of-4
+// (zero-filled if `active` is false, e.g. a partial final chunk) and run the
+// first three FHT stages, leaving the result in buf1. Extracted so pass 1 and
+// pass 2 cannot drift apart -- their bitwise agreement is now by construction.
 template<typename InputType>
 __device__ __forceinline__ void convrot_load_rotate_group(
     const InputType* __restrict__ x,
@@ -1082,46 +1064,14 @@ __device__ __forceinline__ void convrot_load_rotate_group(
 }
 
 // Chunked two-pass variant of quantize_int8_rowwise_convrot64_kernel, used for
-// 2048 < K <= 4096 (see launch_quantize_int8_rowwise_convrot64_kernel's generic
-// branch -- K > 4096 deliberately does NOT use this kernel, see below) to
-// remove the single-pass kernel's full-row shared-memory buffer (row_buf, K
-// floats) -- at K=4096 that buffer alone is 16KB, and combined with the
-// BLOCK_THREADS-independent-of-K launch it used to force, occupancy was
-// limited to roughly one block per SM. This kernel's shared-memory footprint
-// is bounded by BLOCK_THREADS alone (kGroupsInFlight * 2 * 256 floats -- 16KB
-// at BLOCK_THREADS=512), independent of K, by processing the row in
-// "chunks" of BLOCK_THREADS/64 groups (2048 elements at BLOCK_THREADS=512) and
-// never materializing more than one chunk's rotated values at a time:
-//   pass 1: for each chunk, rotate (identical 4-stage H4 butterfly, byte-for-
-//           byte the same math as the single-pass kernel) and fold its local
-//           max into the row's running abs_max (fmaxf-from-a-finite-0.0-seed,
-//           per group, exactly as the single-pass kernel's own loop already
-//           does -- NaN-safe for the same reason: an entire NaN group never
-//           corrupts a live finite accumulator), then discard the rotated
-//           values (the "store" target is scratch, immediately overwritten by
-//           the next chunk).
-//   pass 2: for each chunk again, RE-load from global (the same lines this
-//           block just read in pass 1, hopefully still L2-resident -- see the
-//           K>4096 caveat below) and RE-rotate -- deterministic fp32 math, so
-//           this reproduces pass 1's per-element rotated values exactly --
-//           then quantize using the now-final scale and store, via
-//           convrot_fht_stage64_quantize above (fusing the last butterfly
-//           stage with the quantize step so there is still no intermediate
-//           buffer in pass 2 either).
-// The recompute in pass 2 is deliberate: it roughly doubles the rotation's
-// arithmetic (already the cheaper side of this kernel's roofline -- see the
-// PR description) in exchange for cutting shared-memory pressure, which is
-// what actually gates how many blocks fit per SM.
-//
-// NOT used beyond K=4096: measured at K=8192 with M=9216 (this kernel's
-// motivating real-world shape) on an RTX 3090, this kernel is a reproducible
-// ~8% *regression* vs the old always-1024-thread single-pass kernel. With
-// 9216 blocks in flight, pass 2's re-read no longer reliably hits L2 -- the
-// resident-rows working set exceeds the card's 6MB L2 at that row count and
-// row width -- so the "recompute instead of buffer" trade that wins at
-// K<=4096 becomes a genuine second DRAM read at K=8192, which is not worth
-// the occupancy gain. See launch_quantize_int8_rowwise_convrot64_kernel's
-// K>4096 branch, which keeps using the original single-pass kernel unchanged.
+// 2048 < K <= 4096. Shared memory is bounded by BLOCK_THREADS alone
+// (kGroupsInFlight * 2 * 256 floats, independent of K) by processing the row
+// in chunks and never materializing more than one chunk's rotated values:
+// pass 1 rotates each chunk and folds its max into abs_max, discarding the
+// values; pass 2 re-loads and re-rotates (deterministic fp32 math, so this
+// reproduces pass 1 exactly) and quantizes with the final scale. Not used
+// beyond K=4096: at K=8192/M=9216 the re-read in pass 2 stops hitting L2 and
+// this kernel regresses ~8% vs the single-pass kernel (see PR description).
 template<typename InputType, int BLOCK_THREADS, bool STOCHASTIC>
 __global__ void quantize_int8_rowwise_convrot64_chunked_kernel(
     const InputType* __restrict__ x,
@@ -1162,9 +1112,9 @@ __global__ void quantize_int8_rowwise_convrot64_chunked_kernel(
         convrot_load_rotate_group<InputType>(x, row_offset, group_col, base, active, buf0, buf1, lane);
 
         if (active) {
-            // Discard target: buf0 is dead (already consumed above) and gets
-            // overwritten again next iteration -- only the returned local max
-            // is used.
+            // buf0 is scratch here (dead value, reused next iteration).
+            // fmaxf ignores NaN against a finite abs_max, so an all-NaN
+            // group (huge-magnitude row) can't corrupt the running max.
             abs_max = fmaxf(
                 abs_max,
                 convrot_fht_stage64_store_absmax<64, float>(buf1, buf0, lane));
@@ -1570,24 +1520,10 @@ void launch_quantize_int8_rowwise_convrot64_kernel(
                        block_threads_6144);
             }
         } else if (num_cols <= 2048) {
-            // Right-sized launch: threads = min(1024, (K/256)*64), realized
-            // below as an explicit switch over n_groups (2..8) rather than a
-            // literal min() -- for K in this branch (a multiple of 256, > 256,
-            // <= 2048, and not one of the other special-cased widths above)
-            // (K/256)*64 always lands at or under 512, so the min(1024, ...)
-            // never actually clamps for any K reaching this switch. That min()
-            // is NOT what the branches below this one use, despite the
-            // similar-looking numbers: the 2048 < K <= 4096 branch launches
-            // the chunked kernel at a hardcoded 512 threads (independent of
-            // K, by construction -- see that kernel's docstring), and the
-            // K > 4096 branch launches the original single-pass kernel at a
-            // hardcoded 1024 threads unconditionally (matching stock's prior
-            // behavior verbatim, not derived from this formula, even though
-            // it happens to equal what the formula would produce there).
-            // Was previously ALWAYS 1024 threads regardless of K (e.g. 768 of
-            // 1024 threads sit idle every iteration at K=1024, since only
-            // (K/256)*64 = 256 of them ever have `active` true) -- see the PR
-            // description for the roofline analysis this fixes.
+            // Right-sized launch: threads = min(1024, (K/256)*64) via the
+            // switch below (always <= 512 here, so the min never clamps).
+            // The chunked and K>4096 branches below use their own hardcoded
+            // thread counts, not this formula.
             const int n_groups = static_cast<int>(num_cols / comfy::kConvRotGroup);
             switch (n_groups) {
                 case 2:  // K=512
@@ -1622,24 +1558,10 @@ void launch_quantize_int8_rowwise_convrot64_kernel(
                     break;
             }
         } else if (num_cols <= 4096) {
-            // 2048 < K <= 4096: chunked two-pass kernel, fixed at 512 threads
-            // (CHUNK = (512/64)*256 = 2048 elements/iteration).
-            //
-            // Gated to K <= 4096, NOT "K > 2048" unconditionally: measured at
-            // K=8192 (M=9216, RTX 3090) this kernel is a reproducible ~8%
-            // *regression* vs the old always-1024-thread single-pass kernel,
-            // not the win the occupancy math predicts. Root cause: with 9216
-            // blocks in flight, pass 2's re-read of global memory (deliberately
-            // redundant with pass 1 -- see the kernel's docstring) no longer
-            // reliably hits L2 at that row count -- the resident-rows working
-            // set exceeds the RTX 3090's 6MB L2 -- so at K=8192 the "recompute
-            // instead of buffer" trade becomes a genuine second DRAM read
-            // instead of an L2-served one, which is not worth the occupancy
-            // gain. At K<=4096 the smaller per-row footprint keeps enough of
-            // the working set L2-resident for pass 2 to still win. See the PR
-            // description for the measured numbers at both sizes. Lifting this
-            // cap (e.g. occupancy/L2-aware chunk sizing that adapts to M, not
-            // just K) is noted there as future work, not attempted here.
+            // Chunked two-pass kernel, fixed at 512 threads. Gated to K<=4096
+            // (not all K>2048): at K=8192/M=9216, pass 2's re-read stops
+            // hitting L2 and this kernel regresses ~8% vs the single-pass
+            // kernel below -- see the PR description.
             constexpr int block_threads_chunked = 512;
             if (stochastic) {
                 launch_chunked(comfy::quantize_int8_rowwise_convrot64_chunked_kernel<InputType, block_threads_chunked, true>,
@@ -1649,14 +1571,8 @@ void launch_quantize_int8_rowwise_convrot64_kernel(
                                 block_threads_chunked);
             }
         } else {
-            // K > 4096: EXISTING full-row generic path, UNCHANGED -- same
-            // kernel, same fixed 1024-thread launch, same `launch` lambda (with
-            // its num_cols-dependent smem formula) stock already used for every
-            // K in this else-branch before this PR. Verified byte-identical
-            // dispatch to stock for these K (same template instantiation, same
-            // block_threads, same smem_bytes computation) -- this branch exists
-            // only so the right-sized (<=2048) and chunked (<=4096) branches
-            // above don't have to special-case "was this K already covered".
+            // K > 4096: unchanged from stock -- same kernel, same fixed
+            // 1024-thread launch.
             constexpr int block_threads_multi = 1024;
             if (stochastic) {
                 launch(comfy::quantize_int8_rowwise_convrot64_kernel<InputType, block_threads_multi, true>,

--- a/tests/test_convrot64_quantize.py
+++ b/tests/test_convrot64_quantize.py
@@ -1,0 +1,203 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Direct coverage for comfy_kitchen.backends.cuda.quantize_int8_rowwise_convrot64
+(the fused online-ConvRot-rotation + row-wise-INT8-quantize CUDA kernel).
+
+This kernel previously had no direct test coverage (it was only exercised
+indirectly through int8_linear / TensorWiseINT8Layout convrot weight-quantize
+tests). Added alongside the kernel launch-config fix (right-sized thread count
+for K <= 2048, chunked two-pass for 2048 < K <= 4096, original always-1024-
+thread single-pass kernel unchanged for K > 4096 -- see
+launch_quantize_int8_rowwise_convrot64_kernel's docstring in int8_linear.cu for
+why the chunked kernel is deliberately NOT used beyond K=4096) to pin down its
+documented contract: rotation math, scale computation, rounding, and dtype
+dispatch.
+"""
+
+import pytest
+import torch
+
+from comfy_kitchen.backends import cuda
+from comfy_kitchen.tensor.int8_utils import _build_hadamard
+
+from .conftest import assert_values_close
+
+GROUP_SIZE = 256
+
+
+@pytest.fixture(autouse=True)
+def cuda_only():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required for quantize_int8_rowwise_convrot64 tests")
+
+
+class TestConvrot64QuantizeShapes:
+    """Shape/dtype coverage across the launcher's special cases, the
+    right-sized generic branch (K <= 2048, single-pass), the chunked branch
+    (2048 < K <= 4096, two-pass), and the K > 4096 branch (original
+    always-1024-thread single-pass kernel, unchanged -- the chunked kernel
+    regressed ~8% at K=8192/M=9216 on an RTX 3090 due to pass 2's re-read no
+    longer reliably hitting L2 at that row count, so it is gated off beyond
+    K=4096; see int8_linear.cu's launcher docstring)."""
+
+    @pytest.mark.parametrize("k", [256, 512, 1024, 1536, 2048, 2560, 3072, 3584, 4096, 6144, 8192])
+    @pytest.mark.parametrize("m", [1, 4, 63, 9216])
+    @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
+    def test_shape_dtype_matrix(self, k, m, dtype):
+        """Every (M, K, dtype) combination returns correctly-shaped, finite,
+        in-range int8 output and a positive finite per-row scale. Covers the
+        M==1 single-row-GEMV passthrough (untouched by the launch-config
+        change), the num_cols in {256, 2560, 6144} special cases (also
+        untouched), the right-sized single-pass branch (K in {512, 1024,
+        1536, 2048}), the chunked two-pass branch (K in {3072, 3584, 4096} --
+        3072/256=12 and 3584/256=14 groups are NOT multiples of the chunked
+        kernel's 8-groups-per-chunk width, so these two specifically exercise
+        the partial-last-chunk path where some of the 8 "sub" lanes in the
+        final chunk iteration are masked `active=false`, unlike 4096's exact
+        2-chunks-of-8-groups split), and K=8192 (back to the original
+        always-1024-thread single-pass kernel, byte-identical dispatch to
+        stock -- deliberately NOT chunked, see the class docstring)."""
+        torch.manual_seed(m * 100_000 + k)
+        x = torch.randn(m, k, device="cuda", dtype=dtype)
+
+        q, scale = cuda.quantize_int8_rowwise_convrot64(x, GROUP_SIZE)
+
+        assert q.shape == (m, k)
+        assert q.dtype == torch.int8
+        assert scale.shape == (m, 1)
+        assert scale.dtype == torch.float32
+        assert q.min() >= -128
+        assert q.max() <= 127
+        assert torch.isfinite(scale).all()
+        assert (scale > 0).all()
+
+    def test_k_not_divisible_by_group_size_raises(self):
+        x = torch.randn(4, 300, device="cuda", dtype=torch.bfloat16)
+        with pytest.raises(RuntimeError, match="divisible by 256"):
+            cuda.quantize_int8_rowwise_convrot64(x, GROUP_SIZE)
+
+
+class TestConvrot64QuantizeDeterminism:
+    """Rotation + quantization is a pure function of the input values (no
+    randomness in the non-stochastic path) -- two calls on the same input
+    must be bitwise identical, including across the resident/chunked boundary
+    at K=2048/2304, the chunked partial-last-chunk cases at K=3072/3584, and
+    the chunked/original-single-pass boundary at K=4096/4352 (the latter
+    tested implicitly via K=4096 vs K=8192 here)."""
+
+    @pytest.mark.parametrize("k", [1024, 2048, 3072, 3584, 4096, 8192])
+    def test_two_calls_bitwise_equal(self, k):
+        torch.manual_seed(0)
+        x = torch.randn(512, k, device="cuda", dtype=torch.bfloat16)
+
+        q1, s1 = cuda.quantize_int8_rowwise_convrot64(x, GROUP_SIZE)
+        q2, s2 = cuda.quantize_int8_rowwise_convrot64(x, GROUP_SIZE)
+
+        assert torch.equal(q1, q2)
+        assert torch.equal(s1, s2)
+
+
+class TestConvrot64QuantizeScaleFloor:
+    """An all-zero row rotates to all-zero (H4 is linear), so its abs-max is
+    0 and the scale must floor at 1e-30 (guards div-by-zero on dequant/re-use)
+    rather than collapsing to 0 itself."""
+
+    @pytest.mark.parametrize("k", [1024, 3072, 4096])
+    def test_all_zero_row_floors_scale(self, k):
+        x = torch.zeros(8, k, device="cuda", dtype=torch.bfloat16)
+
+        q, scale = cuda.quantize_int8_rowwise_convrot64(x, GROUP_SIZE)
+
+        assert torch.equal(scale, torch.full_like(scale, 1.0e-30))
+        assert torch.equal(q, torch.zeros_like(q))
+
+    @pytest.mark.parametrize("k", [1024, 3072, 4096])
+    def test_all_zero_row_among_normal_rows(self, k):
+        """A single all-zero row's degenerate scale must not affect any other
+        row's (rows are independent -- one block per row)."""
+        torch.manual_seed(1)
+        x = torch.randn(8, k, device="cuda", dtype=torch.bfloat16)
+        x[3, :] = 0.0
+
+        q, scale = cuda.quantize_int8_rowwise_convrot64(x, GROUP_SIZE)
+
+        # Compare as float32 tensors (not scale[3].item() == 1e-30 as Python
+        # floats): .item() upconverts to float64 first, and float32(1e-30)
+        # upcast to float64 is not exactly the float64 literal 1e-30, so that
+        # comparison would spuriously fail despite the kernel producing
+        # exactly its own "1.0e-30f" floor literal.
+        assert torch.equal(scale[3], torch.full_like(scale[3], 1.0e-30))
+        assert torch.equal(q[3], torch.zeros(k, dtype=torch.int8, device="cuda"))
+        assert (scale[torch.arange(8) != 3] > 1.0e-30).all()
+
+
+class TestConvrot64QuantizeOverflowClamp:
+    """A row whose magnitude is close enough to the input dtype's finite max
+    that intermediate Hadamard-butterfly sums overflow to +/-Inf (and a later
+    stage's Inf - Inf produces NaN) must still produce a finite, in-range
+    scale and int8 output -- this is the PR #66 clamp
+    (finite_absmax_for_int8_scale) this change does not touch, exercised here
+    for the K shapes/launch configs this change DOES touch."""
+
+    @pytest.mark.parametrize("k", [1024, 3072, 4096])
+    def test_near_dtype_max_row_stays_finite(self, k):
+        bf16_max = 3.38953139e38
+        x = torch.randn(8, k, device="cuda", dtype=torch.bfloat16)
+        x[0, :] = bf16_max * 0.99
+        x[1, :] = -bf16_max * 0.99
+
+        q, scale = cuda.quantize_int8_rowwise_convrot64(x, GROUP_SIZE)
+
+        assert torch.isfinite(scale).all()
+        assert (scale > 0).all()
+        assert torch.isfinite(q.float()).all()
+        assert q.min() >= -128
+        assert q.max() <= 127
+
+
+class TestConvrot64QuantizeEagerReference:
+    """CUDA kernel vs the eager backend's reference implementation
+    (rotate-then-quantize as two separate ops, dense H @ x matmul for the
+    rotation). NOT compared bitwise: the eager path builds the full
+    normalized Hadamard matrix via torch.kron and rotates with a dense
+    matmul, which sums the same terms in a different order (and in the
+    dense-matmul epilogue's own accumulation, not the CUDA kernel's explicit
+    4-stage radix-4 butterfly with a 0.5x scale per stage) than the CUDA
+    kernel's fast Hadamard transform -- floating-point addition is not
+    associative, so a different summation order can differ in the last few
+    bits even though both are mathematically the same rotation. Compared
+    with a tolerance loose enough to absorb that (not the rotation's
+    correctness, which is exact up to associativity) while still catching a
+    genuinely wrong rotation/quantization.
+    """
+
+    @pytest.mark.parametrize("k", [1024, 2048, 3072, 3584, 4096, 8192])
+    def test_cuda_matches_eager_within_tolerance(self, k):
+        torch.manual_seed(3)
+        x = torch.randn(32, k, device="cuda", dtype=torch.bfloat16)
+
+        q_cuda, scale_cuda = cuda.quantize_int8_rowwise_convrot64(x, GROUP_SIZE)
+
+        h = _build_hadamard(GROUP_SIZE, device=x.device, dtype=x.dtype)
+        from comfy_kitchen.backends.eager.quantization import quantize_and_rotate_rowwise
+
+        q_eager, scale_eager = quantize_and_rotate_rowwise(x, h, GROUP_SIZE)
+
+        assert_values_close(
+            scale_cuda, scale_eager, rtol=1.0e-2, atol=1.0e-4, name="convrot64_scale"
+        )
+        # Individual int8 codes can land on either side of a rounding boundary
+        # under a different summation order; measured empirically (see the PR
+        # description) at ~2-4% of codes differing by at most +/-2, stable
+        # across K -- allow comfortable headroom above that while still
+        # catching a genuinely wrong rotation/quantization (which would push
+        # both numbers far higher, not shift them by a couple percent).
+        max_code_diff = (q_cuda.to(torch.int32) - q_eager.to(torch.int32)).abs().max().item()
+        n_mismatch = (q_cuda != q_eager).sum().item()
+        mismatch_ratio = n_mismatch / q_cuda.numel()
+        assert max_code_diff <= 3, (
+            f"max int8 code diff {max_code_diff} too large vs eager reference"
+        )
+        assert mismatch_ratio <= 0.06, (
+            f"{mismatch_ratio:.4%} of int8 codes differ from eager reference"
+        )

--- a/tests/test_convrot64_quantize.py
+++ b/tests/test_convrot64_quantize.py
@@ -1,18 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Direct coverage for comfy_kitchen.backends.cuda.quantize_int8_rowwise_convrot64
-(the fused online-ConvRot-rotation + row-wise-INT8-quantize CUDA kernel).
-
-This kernel previously had no direct test coverage (it was only exercised
-indirectly through int8_linear / TensorWiseINT8Layout convrot weight-quantize
-tests). Added alongside the kernel launch-config fix (right-sized thread count
-for K <= 2048, chunked two-pass for 2048 < K <= 4096, original always-1024-
-thread single-pass kernel unchanged for K > 4096 -- see
-launch_quantize_int8_rowwise_convrot64_kernel's docstring in int8_linear.cu for
-why the chunked kernel is deliberately NOT used beyond K=4096) to pin down its
-documented contract: rotation math, scale computation, rounding, and dtype
-dispatch.
-"""
+"""Tests for the fused ConvRot rotate + row-wise INT8 quantize CUDA kernel."""
 
 import pytest
 import torch
@@ -32,13 +20,7 @@ def cuda_only():
 
 
 class TestConvrot64QuantizeShapes:
-    """Shape/dtype coverage across the launcher's special cases, the
-    right-sized generic branch (K <= 2048, single-pass), the chunked branch
-    (2048 < K <= 4096, two-pass), and the K > 4096 branch (original
-    always-1024-thread single-pass kernel, unchanged -- the chunked kernel
-    regressed ~8% at K=8192/M=9216 on an RTX 3090 due to pass 2's re-read no
-    longer reliably hitting L2 at that row count, so it is gated off beyond
-    K=4096; see int8_linear.cu's launcher docstring)."""
+    """Shape/dtype coverage across the launcher's special cases and branches."""
 
     @pytest.mark.parametrize(
         "k", [256, 512, 1024, 1536, 2048, 2304, 2560, 3072, 3584, 4096, 6144, 8192]
@@ -46,21 +28,7 @@ class TestConvrot64QuantizeShapes:
     @pytest.mark.parametrize("m", [1, 4, 63, 9216])
     @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
     def test_shape_dtype_matrix(self, k, m, dtype):
-        """Every (M, K, dtype) combination returns correctly-shaped, finite,
-        in-range int8 output and a positive finite per-row scale. Covers the
-        M==1 single-row-GEMV passthrough (untouched by the launch-config
-        change), the num_cols in {256, 2560, 6144} special cases (also
-        untouched), the right-sized single-pass branch (K in {512, 1024,
-        1536, 2048}), the chunked two-pass branch (K in {2304, 3072, 3584,
-        4096} -- 2304/256=9, 3072/256=12, and 3584/256=14 groups are NOT
-        multiples of the chunked kernel's 8-groups-per-chunk width, so these
-        three specifically exercise the partial-last-chunk path where some of
-        the 8 "sub" lanes in the final chunk iteration are masked
-        `active=false` (2304 is the most extreme case: only 1 of 8 lanes
-        active in the second chunk), unlike 4096's exact 2-chunks-of-8-groups
-        split), and K=8192 (back to the original always-1024-thread
-        single-pass kernel, byte-identical dispatch to
-        stock -- deliberately NOT chunked, see the class docstring)."""
+        """Every (M, K, dtype) combination returns valid shape/dtype/range output."""
         torch.manual_seed(m * 100_000 + k)
         x = torch.randn(m, k, device="cuda", dtype=dtype)
 
@@ -82,12 +50,7 @@ class TestConvrot64QuantizeShapes:
 
 
 class TestConvrot64QuantizeDeterminism:
-    """Rotation + quantization is a pure function of the input values (no
-    randomness in the non-stochastic path) -- two calls on the same input
-    must be bitwise identical, including across the resident/chunked boundary
-    at K=2048/2304, the chunked partial-last-chunk cases at K=3072/3584, and
-    the chunked/original-single-pass boundary at K=4096/4352 (the latter
-    tested implicitly via K=4096 vs K=8192 here)."""
+    """Non-stochastic quantize is a pure function -- two calls must match bitwise."""
 
     @pytest.mark.parametrize("k", [1024, 2048, 2304, 3072, 3584, 4096, 8192])
     def test_two_calls_bitwise_equal(self, k):
@@ -102,9 +65,7 @@ class TestConvrot64QuantizeDeterminism:
 
 
 class TestConvrot64QuantizeScaleFloor:
-    """An all-zero row rotates to all-zero (H4 is linear), so its abs-max is
-    0 and the scale must floor at 1e-30 (guards div-by-zero on dequant/re-use)
-    rather than collapsing to 0 itself."""
+    """An all-zero row's scale must floor at 1e-30, not collapse to 0."""
 
     @pytest.mark.parametrize("k", [1024, 3072, 4096])
     def test_all_zero_row_floors_scale(self, k):
@@ -117,31 +78,21 @@ class TestConvrot64QuantizeScaleFloor:
 
     @pytest.mark.parametrize("k", [1024, 3072, 4096])
     def test_all_zero_row_among_normal_rows(self, k):
-        """A single all-zero row's degenerate scale must not affect any other
-        row's (rows are independent -- one block per row)."""
+        """A degenerate row's scale must not affect any other row's."""
         torch.manual_seed(1)
         x = torch.randn(8, k, device="cuda", dtype=torch.bfloat16)
         x[3, :] = 0.0
 
         q, scale = cuda.quantize_int8_rowwise_convrot64(x, GROUP_SIZE)
 
-        # Compare as float32 tensors (not scale[3].item() == 1e-30 as Python
-        # floats): .item() upconverts to float64 first, and float32(1e-30)
-        # upcast to float64 is not exactly the float64 literal 1e-30, so that
-        # comparison would spuriously fail despite the kernel producing
-        # exactly its own "1.0e-30f" floor literal.
+        # float32-vs-float32 compare, not .item(): avoids a float64 literal mismatch.
         assert torch.equal(scale[3], torch.full_like(scale[3], 1.0e-30))
         assert torch.equal(q[3], torch.zeros(k, dtype=torch.int8, device="cuda"))
         assert (scale[torch.arange(8) != 3] > 1.0e-30).all()
 
 
 class TestConvrot64QuantizeOverflowClamp:
-    """A row whose magnitude is close enough to the input dtype's finite max
-    that intermediate Hadamard-butterfly sums overflow to +/-Inf (and a later
-    stage's Inf - Inf produces NaN) must still produce a finite, in-range
-    scale and int8 output -- this is the PR #66 clamp
-    (finite_absmax_for_int8_scale) this change does not touch, exercised here
-    for the K shapes/launch configs this change DOES touch."""
+    """A near-dtype-max row (NaN mid-butterfly) must still yield finite output."""
 
     @pytest.mark.parametrize("k", [1024, 3072, 4096])
     def test_near_dtype_max_row_stays_finite(self, k):
@@ -160,20 +111,7 @@ class TestConvrot64QuantizeOverflowClamp:
 
 
 class TestConvrot64QuantizeEagerReference:
-    """CUDA kernel vs the eager backend's reference implementation
-    (rotate-then-quantize as two separate ops, dense H @ x matmul for the
-    rotation). NOT compared bitwise: the eager path builds the full
-    normalized Hadamard matrix via torch.kron and rotates with a dense
-    matmul, which sums the same terms in a different order (and in the
-    dense-matmul epilogue's own accumulation, not the CUDA kernel's explicit
-    4-stage radix-4 butterfly with a 0.5x scale per stage) than the CUDA
-    kernel's fast Hadamard transform -- floating-point addition is not
-    associative, so a different summation order can differ in the last few
-    bits even though both are mathematically the same rotation. Compared
-    with a tolerance loose enough to absorb that (not the rotation's
-    correctness, which is exact up to associativity) while still catching a
-    genuinely wrong rotation/quantization.
-    """
+    """CUDA kernel vs the eager (dense-matmul rotation) reference, within tolerance."""
 
     @pytest.mark.parametrize("k", [1024, 2048, 3072, 3584, 4096, 8192])
     def test_cuda_matches_eager_within_tolerance(self, k):
@@ -190,12 +128,7 @@ class TestConvrot64QuantizeEagerReference:
         assert_values_close(
             scale_cuda, scale_eager, rtol=1.0e-2, atol=1.0e-4, name="convrot64_scale"
         )
-        # Individual int8 codes can land on either side of a rounding boundary
-        # under a different summation order; measured empirically (see the PR
-        # description) at ~2-4% of codes differing by at most +/-2, stable
-        # across K -- allow comfortable headroom above that while still
-        # catching a genuinely wrong rotation/quantization (which would push
-        # both numbers far higher, not shift them by a couple percent).
+        # Rounding-boundary drift under a different summation order: ~2-4% of codes, max +/-2.
         max_code_diff = (q_cuda.to(torch.int32) - q_eager.to(torch.int32)).abs().max().item()
         n_mismatch = (q_cuda != q_eager).sum().item()
         mismatch_ratio = n_mismatch / q_cuda.numel()

--- a/tests/test_convrot64_quantize.py
+++ b/tests/test_convrot64_quantize.py
@@ -23,7 +23,7 @@ class TestConvrot64QuantizeShapes:
     """Shape/dtype coverage across the launcher's special cases and branches."""
 
     @pytest.mark.parametrize(
-        "k", [256, 512, 1024, 1536, 2048, 2304, 2560, 3072, 3584, 4096, 6144, 8192]
+        "k", [256, 512, 768, 1024, 1280, 1536, 1792, 2048, 2304, 2560, 3072, 3584, 4096, 6144, 8192]
     )
     @pytest.mark.parametrize("m", [1, 4, 63, 9216])
     @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
@@ -52,7 +52,7 @@ class TestConvrot64QuantizeShapes:
 class TestConvrot64QuantizeDeterminism:
     """Non-stochastic quantize is a pure function -- two calls must match bitwise."""
 
-    @pytest.mark.parametrize("k", [1024, 2048, 2304, 3072, 3584, 4096, 8192])
+    @pytest.mark.parametrize("k", [768, 1024, 1280, 1792, 2048, 2304, 3072, 3584, 4096, 8192])
     def test_two_calls_bitwise_equal(self, k):
         torch.manual_seed(0)
         x = torch.randn(512, k, device="cuda", dtype=torch.bfloat16)
@@ -62,6 +62,25 @@ class TestConvrot64QuantizeDeterminism:
 
         assert torch.equal(q1, q2)
         assert torch.equal(s1, s2)
+
+
+class TestConvrot64QuantizeStochasticRounding:
+    """Stochastic path (seeded) must be deterministic and produce valid output."""
+
+    @pytest.mark.parametrize("k", [768, 1024, 1280, 1792, 2048, 3072])
+    def test_seeded_calls_bitwise_equal_and_valid(self, k):
+        torch.manual_seed(0)
+        x = torch.randn(512, k, device="cuda", dtype=torch.bfloat16)
+
+        q1, s1 = cuda.quantize_int8_rowwise_convrot64(x, GROUP_SIZE, stochastic_rounding=424242)
+        q2, s2 = cuda.quantize_int8_rowwise_convrot64(x, GROUP_SIZE, stochastic_rounding=424242)
+
+        assert torch.equal(q1, q2)
+        assert torch.equal(s1, s2)
+        assert q1.min() >= -128
+        assert q1.max() <= 127
+        assert torch.isfinite(s1).all()
+        assert (s1 > 0).all()
 
 
 class TestConvrot64QuantizeScaleFloor:

--- a/tests/test_convrot64_quantize.py
+++ b/tests/test_convrot64_quantize.py
@@ -40,7 +40,9 @@ class TestConvrot64QuantizeShapes:
     longer reliably hitting L2 at that row count, so it is gated off beyond
     K=4096; see int8_linear.cu's launcher docstring)."""
 
-    @pytest.mark.parametrize("k", [256, 512, 1024, 1536, 2048, 2560, 3072, 3584, 4096, 6144, 8192])
+    @pytest.mark.parametrize(
+        "k", [256, 512, 1024, 1536, 2048, 2304, 2560, 3072, 3584, 4096, 6144, 8192]
+    )
     @pytest.mark.parametrize("m", [1, 4, 63, 9216])
     @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
     def test_shape_dtype_matrix(self, k, m, dtype):
@@ -49,13 +51,15 @@ class TestConvrot64QuantizeShapes:
         M==1 single-row-GEMV passthrough (untouched by the launch-config
         change), the num_cols in {256, 2560, 6144} special cases (also
         untouched), the right-sized single-pass branch (K in {512, 1024,
-        1536, 2048}), the chunked two-pass branch (K in {3072, 3584, 4096} --
-        3072/256=12 and 3584/256=14 groups are NOT multiples of the chunked
-        kernel's 8-groups-per-chunk width, so these two specifically exercise
-        the partial-last-chunk path where some of the 8 "sub" lanes in the
-        final chunk iteration are masked `active=false`, unlike 4096's exact
-        2-chunks-of-8-groups split), and K=8192 (back to the original
-        always-1024-thread single-pass kernel, byte-identical dispatch to
+        1536, 2048}), the chunked two-pass branch (K in {2304, 3072, 3584,
+        4096} -- 2304/256=9, 3072/256=12, and 3584/256=14 groups are NOT
+        multiples of the chunked kernel's 8-groups-per-chunk width, so these
+        three specifically exercise the partial-last-chunk path where some of
+        the 8 "sub" lanes in the final chunk iteration are masked
+        `active=false` (2304 is the most extreme case: only 1 of 8 lanes
+        active in the second chunk), unlike 4096's exact 2-chunks-of-8-groups
+        split), and K=8192 (back to the original always-1024-thread
+        single-pass kernel, byte-identical dispatch to
         stock -- deliberately NOT chunked, see the class docstring)."""
         torch.manual_seed(m * 100_000 + k)
         x = torch.randn(m, k, device="cuda", dtype=dtype)
@@ -85,7 +89,7 @@ class TestConvrot64QuantizeDeterminism:
     the chunked/original-single-pass boundary at K=4096/4352 (the latter
     tested implicitly via K=4096 vs K=8192 here)."""
 
-    @pytest.mark.parametrize("k", [1024, 2048, 3072, 3584, 4096, 8192])
+    @pytest.mark.parametrize("k", [1024, 2048, 2304, 3072, 3584, 4096, 8192])
     def test_two_calls_bitwise_equal(self, k):
         torch.manual_seed(0)
         x = torch.randn(512, k, device="cuda", dtype=torch.bfloat16)


### PR DESCRIPTION
The generic launch path of `quantize_int8_rowwise_convrot64` used a fixed 1024-thread block and a full-row shared-memory buffer for every K, reaching only 9–35% of peak bandwidth on Ampere (75% of lanes idle at K=1024). This PR right-sizes the block to the actual group count for K≤2048 and adds a two-pass chunked kernel with bounded shared memory for 2048<K≤4096, while K>4096 keeps the existing path unchanged (chunking measured ~8% slower at K=8192 — the second pass's re-read loses L2 residency at high row counts — so it is gated off there). Outputs are bitwise-identical to the current kernel, verified against the shipped v0.2.22 wheel across K∈{1024, 2048, 2304, 3072, 3584, 4096, 8192}, fp32/fp16/bf16, and adversarial inputs (all-zero rows, near-dtype-max NaN cascades — preserving the overflow-clamp semantics from #66), and the kernel gains direct test coverage it previously lacked. Measured on an RTX 3090: 4.9x at K=1024, 2.5x at K=2048, 1.12x at K=4096 standalone; end-to-end on an int8 ConvRot checkpoint (Anima) at 1536x1536 this is 0.842→0.777 s/it eager and 0.797→0.729 s/it with torch.compile.
