### PR TITLE
Support ROCm INT8 ConvRot without CUDA backend

### DIFF
--- a/comfy_kitchen/backends/cuda/__init__.py
+++ b/comfy_kitchen/backends/cuda/__init__.py
@@ -60,33 +60,40 @@ __all__ = [
     "stochastic_rounding_fp8",
 ]
 
+_CUDA_PYTORCH_REQUIRED_REASON = "CUDA backend requires a CUDA-enabled PyTorch build"
+
+if getattr(torch.version, "cuda", None) is None:
+    _RUNTIME_UNAVAILABLE_REASON = _CUDA_PYTORCH_REQUIRED_REASON
+else:
+    _RUNTIME_UNAVAILABLE_REASON = None
 
 _dll_handle = None
 try:
-    try:
-        import nvidia.cu13
-        nvidia_cu13_path = nvidia.cu13.__path__[0]
-    except Exception:
-        nvidia_cu13_path = torch.__path__[0]
+    if _RUNTIME_UNAVAILABLE_REASON is None:
+        try:
+            import nvidia.cu13
+            nvidia_cu13_path = nvidia.cu13.__path__[0]
+        except Exception:
+            nvidia_cu13_path = torch.__path__[0]
 
-    def find_lib_dir(start_dir, lib_pattern):
-        for root, _dirs, files in os.walk(start_dir):
-            for file in files:
-                if lib_pattern in file:
-                    return root
-        return None
+        def find_lib_dir(start_dir, lib_pattern):
+            for root, _dirs, files in os.walk(start_dir):
+                for file in files:
+                    if lib_pattern in file:
+                        return root
+            return None
 
-    if sys.platform == "win32":
-        lib_dir = find_lib_dir(nvidia_cu13_path, "cublasLt64")
-        if lib_dir:
-            _dll_handle = os.add_dll_directory(lib_dir)
-    else:
-        lib_dir = find_lib_dir(nvidia_cu13_path, "libcublasLt.so")
-        if lib_dir:
-            for filename in os.listdir(lib_dir):
-                if "cublasLt" in filename and ".so" in filename:
-                    with contextlib.suppress(Exception):
-                        ctypes.CDLL(os.path.join(lib_dir, filename), mode=ctypes.RTLD_GLOBAL)
+        if sys.platform == "win32":
+            lib_dir = find_lib_dir(nvidia_cu13_path, "cublasLt64")
+            if lib_dir:
+                _dll_handle = os.add_dll_directory(lib_dir)
+        else:
+            lib_dir = find_lib_dir(nvidia_cu13_path, "libcublasLt.so")
+            if lib_dir:
+                for filename in os.listdir(lib_dir):
+                    if "cublasLt" in filename and ".so" in filename:
+                        with contextlib.suppress(Exception):
+                            ctypes.CDLL(os.path.join(lib_dir, filename), mode=ctypes.RTLD_GLOBAL)
 except Exception:
     pass  # nvidia.cu13 not installed or path doesn't exist
 
@@ -94,31 +101,40 @@ except Exception:
 # Load _C extension using importlib to avoid circular import issues on Windows
 try:
     _C = None  # type: ignore
-    _module_path = os.path.join(os.path.dirname(__file__), "_C.abi3.pyd" if sys.platform == "win32" else "_C.abi3.so")
+    if _RUNTIME_UNAVAILABLE_REASON is not None:
+        _EXT_AVAILABLE = False
+        _EXT_ERROR = _RUNTIME_UNAVAILABLE_REASON
+    else:
+        _module_path = os.path.join(os.path.dirname(__file__), "_C.abi3.pyd" if sys.platform == "win32" else "_C.abi3.so")
 
-    if not os.path.exists(_module_path):
-        ext = '.pyd' if sys.platform == 'win32' else '.so'
-        directory = os.path.dirname(__file__)
-        for filename in os.listdir(directory):
-            if filename.startswith('_C.') and filename.endswith(ext):
-                _module_path = os.path.join(directory, filename)
+        if not os.path.exists(_module_path):
+            ext = '.pyd' if sys.platform == 'win32' else '.so'
+            directory = os.path.dirname(__file__)
+            for filename in os.listdir(directory):
+                if filename.startswith('_C.') and filename.endswith(ext):
+                    _module_path = os.path.join(directory, filename)
 
-    if os.path.exists(_module_path):
-        _spec = importlib.util.spec_from_file_location(
-            "comfy_kitchen.backends.cuda._C", _module_path
-        )
-        if _spec and _spec.loader:
-            _C = importlib.util.module_from_spec(_spec)
-            sys.modules["comfy_kitchen.backends.cuda._C"] = _C
-            _spec.loader.exec_module(_C)
-            _EXT_AVAILABLE = True
-            _EXT_ERROR = None
+        if os.path.exists(_module_path):
+            _spec = importlib.util.spec_from_file_location(
+                "comfy_kitchen.backends.cuda._C", _module_path
+            )
+            if _spec and _spec.loader:
+                _C = importlib.util.module_from_spec(_spec)
+                sys.modules["comfy_kitchen.backends.cuda._C"] = _C
+                try:
+                    _spec.loader.exec_module(_C)
+                except Exception:
+                    _C = None  # type: ignore
+                    sys.modules.pop("comfy_kitchen.backends.cuda._C", None)
+                    raise
+                _EXT_AVAILABLE = True
+                _EXT_ERROR = None
+            else:
+                _EXT_AVAILABLE = False
+                _EXT_ERROR = f"Could not create module spec for {_module_path}"
         else:
             _EXT_AVAILABLE = False
-            _EXT_ERROR = f"Could not create module spec for {_module_path}"
-    else:
-        _EXT_AVAILABLE = False
-        _EXT_ERROR = f"Extension file not found: {_module_path}"
+            _EXT_ERROR = f"Extension file not found: {_module_path}"
 except ImportError as e:
     _EXT_AVAILABLE = False
     _EXT_ERROR = str(e)
@@ -3023,14 +3039,25 @@ def _build_constraints() -> dict:
     return constraints
 
 
+def _cuda_backend_unavailable_reason() -> str | None:
+    if getattr(torch.version, "cuda", None) is None:
+        return _CUDA_PYTORCH_REQUIRED_REASON
+
+    if not torch.cuda.is_available():
+        return "CUDA not available on this system"
+
+    return None
+
+
 def _register():
     """Register CUDA backend with the global registry."""
     if not _EXT_AVAILABLE:
         registry.mark_unavailable("cuda", _EXT_ERROR)
         return
 
-    if not torch.cuda.is_available():
-        registry.mark_unavailable("cuda", "CUDA not available on this system")
+    unavailable_reason = _cuda_backend_unavailable_reason()
+    if unavailable_reason is not None:
+        registry.mark_unavailable("cuda", unavailable_reason)
         return
 
     registry.register(

--- a/comfy_kitchen/backends/eager/quantization.py
+++ b/comfy_kitchen/backends/eager/quantization.py
@@ -40,6 +40,11 @@ DTYPE_CODE_TO_DTYPE = {
 
 DTYPE_TO_CODE = {v: k for k, v in DTYPE_CODE_TO_DTYPE.items()}
 
+
+def _should_use_triton_int8_convrot_on_rocm(x: torch.Tensor, convrot: bool) -> bool:
+    return bool(convrot and x.is_cuda and getattr(torch.version, "hip", None) is not None)
+
+
 def quantize_per_tensor_fp8(
     x: torch.Tensor, scale: torch.Tensor, output_type: torch.dtype = torch.float8_e4m3fn
 ) -> torch.Tensor:
@@ -975,11 +980,28 @@ def int8_linear(
             f"for weight shape {tuple(weight.shape)}"
         )
 
-    if convrot:
-        if x.shape[-1] % convrot_groupsize != 0:
-            raise ValueError(
-                f"ConvRot group size {convrot_groupsize} does not divide input features {x.shape[-1]}"
+    if convrot and x.shape[-1] % convrot_groupsize != 0:
+        raise ValueError(
+            f"ConvRot group size {convrot_groupsize} does not divide input features {x.shape[-1]}"
+        )
+
+    if _should_use_triton_int8_convrot_on_rocm(x, convrot):
+        try:
+            from comfy_kitchen.backends.triton.quantization import int8_linear as triton_int8_linear
+        except ImportError:
+            pass
+        else:
+            return triton_int8_linear(
+                x,
+                weight,
+                weight_scale,
+                bias=bias,
+                out_dtype=out_dtype,
+                convrot=convrot,
+                convrot_groupsize=convrot_groupsize,
             )
+
+    if convrot:
         h = _build_hadamard(convrot_groupsize, device=x.device, dtype=x.dtype)
         x = _rotate_activation(x, h, convrot_groupsize)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,26 @@ def device(cuda_available):
     return "cuda" if cuda_available else "cpu"
 
 
+def cuda_extension_available() -> bool:
+    from comfy_kitchen.backends import cuda as cuda_backend
+
+    return getattr(cuda_backend, "_EXT_AVAILABLE", False) and getattr(cuda_backend, "_C", None) is not None
+
+
+def cuda_extension_runtime_available() -> bool:
+    return torch.cuda.is_available() and cuda_extension_available()
+
+
+def skip_without_cuda_extension():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required")
+
+    from comfy_kitchen.backends import cuda as cuda_backend
+
+    if not cuda_extension_available():
+        pytest.skip(f"CUDA extension backend unavailable: {cuda_backend._EXT_ERROR}")
+
+
 @pytest.fixture
 def small_tensor(cuda_available):
     device = "cuda" if cuda_available else "cpu"

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -60,6 +60,42 @@ class TestBackendSystem:
             cuda_caps = backends["cuda"]["capabilities"]
             assert "int8_linear" in cuda_caps
 
+    def test_cuda_backend_rejects_non_cuda_pytorch_runtime(self, monkeypatch):
+        """CUDA extension backend must not register on non-CUDA PyTorch builds."""
+        from comfy_kitchen.backends import cuda as cuda_backend
+
+        monkeypatch.setattr(cuda_backend.torch.version, "hip", "7.2", raising=False)
+        monkeypatch.setattr(cuda_backend.torch.version, "cuda", None, raising=False)
+        monkeypatch.setattr(cuda_backend.torch.cuda, "is_available", lambda: True)
+
+        assert (
+            cuda_backend._cuda_backend_unavailable_reason()
+            == "CUDA backend requires a CUDA-enabled PyTorch build"
+        )
+
+    def test_cuda_backend_rejects_cpu_only_pytorch_build(self, monkeypatch):
+        """CUDA extension backend must not register without a CUDA PyTorch build."""
+        from comfy_kitchen.backends import cuda as cuda_backend
+
+        monkeypatch.setattr(cuda_backend.torch.version, "hip", None, raising=False)
+        monkeypatch.setattr(cuda_backend.torch.version, "cuda", None, raising=False)
+        monkeypatch.setattr(cuda_backend.torch.cuda, "is_available", lambda: True)
+
+        assert (
+            cuda_backend._cuda_backend_unavailable_reason()
+            == "CUDA backend requires a CUDA-enabled PyTorch build"
+        )
+
+    def test_cuda_backend_accepts_cuda_runtime(self, monkeypatch):
+        """CUDA extension backend remains available on CUDA PyTorch with a CUDA device."""
+        from comfy_kitchen.backends import cuda as cuda_backend
+
+        monkeypatch.setattr(cuda_backend.torch.version, "hip", None, raising=False)
+        monkeypatch.setattr(cuda_backend.torch.version, "cuda", "12.8", raising=False)
+        monkeypatch.setattr(cuda_backend.torch.cuda, "is_available", lambda: True)
+
+        assert cuda_backend._cuda_backend_unavailable_reason() is None
+
     def test_backend_context_manager_override(self, small_tensor):
         """Test that use_backend context manager correctly overrides backend selection."""
         import comfy_kitchen as ck

--- a/tests/test_convrot_w4a4.py
+++ b/tests/test_convrot_w4a4.py
@@ -15,6 +15,8 @@ from comfy_kitchen.tensor.convrot_w4a4 import (
     quantize_convrot_w4a4_weight,
 )
 
+from .conftest import skip_without_cuda_extension
+
 
 def test_convrot_w4a4_weight_quantize_contract(seed):
     w = torch.randn(16, 256, dtype=torch.float32)
@@ -193,8 +195,7 @@ def test_convrot_w4a4_cuda_no_bias_large_m(seed):
 @pytest.mark.parametrize("with_bias", [False, True])
 @pytest.mark.parametrize("m", [64, 128, 256, 512])
 def test_turing_int4_tensor_core_gemm_matches_int8_fallback(seed, dtype, with_bias, m):
-    if not torch.cuda.is_available():
-        pytest.skip("CUDA required")
+    skip_without_cuda_extension()
     if torch.cuda.get_device_capability()[0] < 7:
         pytest.skip("INT4 tensor cores require SM75 or newer")
     if not hasattr(cuda_backend._C, "cutlass_turing_int4_dequant"):
@@ -241,8 +242,7 @@ def test_turing_int4_tensor_core_gemm_matches_int8_fallback(seed, dtype, with_bi
 
 
 def test_int4_linear_routes_turing_to_native_kernel(seed, monkeypatch):
-    if not torch.cuda.is_available():
-        pytest.skip("CUDA required")
+    skip_without_cuda_extension()
     if not hasattr(cuda_backend._C, "cutlass_turing_int4_dequant"):
         pytest.skip("CUDA extension was built without the Turing INT4 kernel")
 
@@ -276,8 +276,7 @@ def test_int4_linear_routes_turing_to_native_kernel(seed, monkeypatch):
 
 @pytest.mark.parametrize("m, expected_calls", [(8, 0), (128, 1)])
 def test_convrot_w4a4_routes_turing_to_native_kernel(seed, monkeypatch, m, expected_calls):
-    if not torch.cuda.is_available():
-        pytest.skip("CUDA required")
+    skip_without_cuda_extension()
     if torch.cuda.get_device_capability() < (7, 5):
         pytest.skip("INT4 tensor cores require SM75 or newer")
     if not hasattr(cuda_backend._C, "cutlass_turing_int4_dequant"):
@@ -330,8 +329,7 @@ def test_convrot_cuda_shared_memory_fit_matches_device_limit():
 @pytest.mark.parametrize("linear_dtype", ["int4", "int8"])
 @pytest.mark.parametrize("convrot_groupsize", [16, 64, 256])
 def test_convrot_w4a4_cuda_linear_handles_large_fp16_activations(seed, linear_dtype, convrot_groupsize):
-    if not torch.cuda.is_available():
-        pytest.skip("CUDA required")
+    skip_without_cuda_extension()
 
     torch.manual_seed(789)
     x = torch.empty(8, 256, device="cuda", dtype=torch.float16)
@@ -361,8 +359,7 @@ def test_convrot_w4a4_cuda_linear_handles_large_fp16_activations(seed, linear_dt
 @pytest.mark.parametrize("linear_dtype", ["int4", "int8"])
 @pytest.mark.parametrize(("m", "k"), [(128, 15360), (1152, 6912)])
 def test_convrot_w4a4_cuda_linear_handles_large_fp16_activation_shapes(seed, linear_dtype, m, k):
-    if not torch.cuda.is_available():
-        pytest.skip("CUDA required")
+    skip_without_cuda_extension()
 
     torch.manual_seed(790)
     x = torch.empty(m, k, device="cuda", dtype=torch.float16)
@@ -412,8 +409,7 @@ def test_convrot_w4a4_cuda_linear_handles_big_activation_tensors(seed, linear_dt
 
 
 def test_convrot_w4a4_cuda_large_k_quantize_matches_reference(seed):
-    if not torch.cuda.is_available():
-        pytest.skip("CUDA required")
+    skip_without_cuda_extension()
 
     x = torch.randn(2, 15360, device="cuda", dtype=torch.bfloat16)
     q_cuda, scale_cuda = cuda_backend.quantize_int4_rowwise_convrot64(x, 256)
@@ -431,8 +427,7 @@ def test_convrot_w4a4_cuda_large_k_quantize_matches_reference(seed):
 
 @pytest.mark.parametrize("convrot_groupsize", [16, 64, 256])
 def test_convrot_w4a4_cuda_quantize_clamps_overflow_scale(convrot_groupsize):
-    if not torch.cuda.is_available():
-        pytest.skip("CUDA required")
+    skip_without_cuda_extension()
 
     x = torch.empty(2, 256, device="cuda", dtype=torch.float16)
     pattern = torch.tensor([65504.0, 65504.0, 65504.0, -65504.0], device="cuda", dtype=torch.float16)
@@ -449,8 +444,7 @@ def test_convrot_w4a4_cuda_quantize_clamps_overflow_scale(convrot_groupsize):
 
 
 def test_convrot_w4a4_stochastic_rounding_cuda(seed):
-    if not torch.cuda.is_available():
-        pytest.skip("CUDA required")
+    skip_without_cuda_extension()
 
     torch.manual_seed(1234)
     w = torch.randn(16, 256, device="cuda", dtype=torch.bfloat16)

--- a/tests/test_int8.py
+++ b/tests/test_int8.py
@@ -2,6 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for INT8 block-wise quantization."""
 
+import builtins
+import sys
+import types
+
 import pytest
 import torch
 
@@ -12,6 +16,7 @@ from comfy_kitchen.tensor import TensorWiseINT8Layout
 from .conftest import (
     assert_values_close,
     get_capable_backends,
+    skip_without_cuda_extension,
 )
 
 COMFYUI_NVIDIA_16_SERIES = (
@@ -28,7 +33,6 @@ COMFYUI_NVIDIA_16_SERIES = (
     "T1000",
     "T1200",
 )
-
 
 def test_cuda_int8_cublas_turing_n_alignment(monkeypatch):
     """CUDA cuBLAS fallback pads Turing skinny N to 32."""
@@ -129,10 +133,130 @@ def test_eager_int8_matmul_turing_n_alignment(monkeypatch):
     assert calls == [0]
 
 
+@pytest.mark.parametrize(
+    ("convrot", "is_cuda", "hip_version", "expected"),
+    [
+        (True, True, "7.2.0", True),
+        (False, True, "7.2.0", False),
+        (True, False, "7.2.0", False),
+        (True, True, None, False),
+    ],
+)
+def test_eager_int8_convrot_rocm_fast_path_detection(
+    convrot,
+    is_cuda,
+    hip_version,
+    expected,
+    monkeypatch,
+):
+    from comfy_kitchen.backends.eager import quantization
+
+    class FakeTensor:
+        def __init__(self, is_cuda):
+            self.is_cuda = is_cuda
+
+    monkeypatch.setattr(torch.version, "hip", hip_version, raising=False)
+
+    assert quantization._should_use_triton_int8_convrot_on_rocm(FakeTensor(is_cuda), convrot) is expected
+
+
+def test_eager_int8_convrot_rocm_fast_path_forwards_normalized_args(monkeypatch):
+    from comfy_kitchen.backends.eager import quantization
+
+    sentinel = torch.empty(0)
+    calls = {}
+    fake_module = types.ModuleType("comfy_kitchen.backends.triton.quantization")
+
+    def fake_triton_int8_linear(
+        x,
+        weight,
+        weight_scale,
+        *,
+        bias,
+        out_dtype,
+        convrot,
+        convrot_groupsize,
+    ):
+        calls.update(
+            x=x,
+            weight=weight,
+            weight_scale=weight_scale,
+            bias=bias,
+            out_dtype=out_dtype,
+            convrot=convrot,
+            convrot_groupsize=convrot_groupsize,
+        )
+        return sentinel
+
+    fake_module.int8_linear = fake_triton_int8_linear
+    monkeypatch.setitem(sys.modules, "comfy_kitchen.backends.triton.quantization", fake_module)
+    monkeypatch.setattr(quantization, "_should_use_triton_int8_convrot_on_rocm", lambda _x, _convrot: True)
+
+    x = torch.randn(2, 4)
+    weight = torch.randint(-4, 4, (4, 3), dtype=torch.int8).t()
+    weight_scale = torch.ones(3, 1, dtype=torch.float16)
+    bias = torch.randn(3)
+
+    result = quantization.int8_linear(
+        x,
+        weight,
+        weight_scale,
+        bias=bias,
+        out_dtype=torch.float32,
+        convrot=True,
+        convrot_groupsize=4,
+    )
+
+    assert result is sentinel
+    assert calls["x"] is x
+    assert calls["weight"].is_contiguous()
+    assert calls["weight"].device == x.device
+    assert calls["weight_scale"].shape == (3,)
+    assert calls["weight_scale"].dtype == torch.float32
+    assert calls["weight_scale"].device == x.device
+    assert calls["bias"] is bias
+    assert calls["out_dtype"] == torch.float32
+    assert calls["convrot"] is True
+    assert calls["convrot_groupsize"] == 4
+
+
+def test_eager_int8_convrot_rocm_fast_path_import_error_falls_back(monkeypatch):
+    from comfy_kitchen.backends.eager import quantization
+
+    real_import = builtins.__import__
+    import_attempted = False
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        nonlocal import_attempted
+        if name == "comfy_kitchen.backends.triton.quantization" and "int8_linear" in fromlist:
+            import_attempted = True
+            raise ImportError("forced missing triton int8_linear")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    monkeypatch.setattr(quantization, "_should_use_triton_int8_convrot_on_rocm", lambda _x, _convrot: True)
+
+    x = torch.randn(2, 4)
+    weight = torch.randint(-4, 4, (3, 4), dtype=torch.int8)
+    weight_scale = torch.ones(1, dtype=torch.float32)
+
+    result = quantization.int8_linear(
+        x,
+        weight,
+        weight_scale,
+        out_dtype=torch.float32,
+        convrot=True,
+        convrot_groupsize=4,
+    )
+
+    assert import_attempted
+    assert result.shape == (2, 3)
+    assert result.dtype == torch.float32
+
+
 def test_cuda_int8_linear_does_not_retain_scratch_tensors():
     """CUDA INT8 linear uses per-call temporaries instead of retained scratch caches."""
-    if not torch.cuda.is_available():
-        pytest.skip("CUDA required")
+    skip_without_cuda_extension()
 
     x = torch.randn(16, 128, device="cuda", dtype=torch.bfloat16)
     weight = torch.randint(-128, 127, (64, 128), device="cuda", dtype=torch.int8)
@@ -166,8 +290,7 @@ def test_turing_int8_fused_gemm_matches_reference(
     with_bias,
     scalar_weight_scale,
 ):
-    if not torch.cuda.is_available():
-        pytest.skip("CUDA required")
+    skip_without_cuda_extension()
     if not hasattr(cuda._C, "cutlass_turing_int8_dequant"):
         pytest.skip("CUDA extension was built without the Turing INT8 kernel")
 
@@ -201,8 +324,7 @@ def test_turing_int8_fused_gemm_matches_reference(
 
 
 def test_int8_linear_routes_turing_to_fused_kernel(seed, monkeypatch):
-    if not torch.cuda.is_available():
-        pytest.skip("CUDA required")
+    skip_without_cuda_extension()
     if not hasattr(cuda._C, "cutlass_turing_int8_dequant"):
         pytest.skip("CUDA extension was built without the Turing INT8 kernel")
 
@@ -248,8 +370,7 @@ def test_eager_int8_stochastic_rounding_tensorwise(seed):
 
 def test_cuda_int8_stochastic_rounding_seeded(seed):
     """CUDA stochastic INT8 rounding is seeded and unbiased."""
-    if not torch.cuda.is_available():
-        pytest.skip("CUDA required")
+    skip_without_cuda_extension()
 
     x = torch.full((4096,), 0.5, device="cuda", dtype=torch.float16)
     x[0] = 127.0
@@ -484,6 +605,8 @@ class TestTensorWiseINT8Layout:
         import comfy_kitchen as ck
         from comfy_kitchen.backends.eager.quantization import quantize_int8_tensorwise
 
+        skip_without_cuda_extension()
+
         x = torch.randn(1, 512, device="cuda", dtype=torch.bfloat16)
         w = torch.randn(384, 512, device="cuda", dtype=torch.bfloat16)
         bias = torch.randn(384, device="cuda", dtype=torch.bfloat16)
@@ -555,6 +678,8 @@ class TestTensorWiseINT8Layout:
     def test_dequantize_direct_output_dtype_matches_final_cast(self, seed):
         """Direct fp16/bf16 dequant output matches the prior float32-then-cast behavior."""
         import comfy_kitchen as ck
+
+        skip_without_cuda_extension()
 
         x = torch.randn(64, 256, device="cuda", dtype=torch.bfloat16)
 
@@ -646,6 +771,8 @@ class TestTensorWiseINT8Layout:
         from comfy_kitchen.backends import cuda as cuda_backend
         from comfy_kitchen.tensor.int8_utils import _build_hadamard, _rotate_weight
 
+        skip_without_cuda_extension()
+
         w = torch.randn(128, 256, device="cuda", dtype=torch.bfloat16)
         h = _build_hadamard(256, device=w.device, dtype=w.dtype)
 
@@ -676,6 +803,8 @@ class TestTensorWiseINT8Layout:
 
     def test_convrot_int8_supports_65536_rows(self):
         """INT8 and INT4 kernels put large row counts in CUDA's grid.x dimension."""
+        skip_without_cuda_extension()
+
         rows, cols = 1 << 16, 256
         row = torch.linspace(-1.0, 1.0, cols, device="cuda", dtype=torch.bfloat16)
         weight = row.expand(rows, cols).contiguous()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -9,7 +9,7 @@ from comfy_kitchen.tensor import (
     TensorWiseINT8Layout,
 )
 
-from .conftest import assert_values_close
+from .conftest import assert_values_close, cuda_extension_runtime_available
 
 
 class DummyQuantizedModel(torch.nn.Module):
@@ -62,7 +62,7 @@ LAYOUT_CONFIGS = [
 ]
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.skipif(not cuda_extension_runtime_available(), reason="CUDA extension backend required")
 class TestQuantizedCUDAGraph:
     """Tests for CUDA graph capture with quantized models."""
 
@@ -168,7 +168,7 @@ class TestQuantizedCUDAGraph:
         assert not torch.allclose(output1, output2, rtol=1e-5, atol=1e-5), "Outputs should differ with different inputs"
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.skipif(not cuda_extension_runtime_available(), reason="CUDA extension backend required")
 class TestQuantizedCompile:
     """Tests for torch.compile with quantized models."""
 


### PR DESCRIPTION
## Summary
- skip NVIDIA CUDA backend registration when running under non-CUDA PyTorch builds, including ROCm and CPU-only PyTorch
- keep ROCm ConvRot INT8 eager dispatch fast by routing only `convrot=True` `int8_linear` calls to the Triton fused implementation when Triton is importable
- update CUDA-extension-specific tests so ROCm systems skip native CUDA extension coverage instead of aborting

Fixes #78.

## Why this shape
Issue #78 shows that global Triton is unsafe on gfx1201/ROCm, while the narrow Triton `int8_linear` path is stable and fast for ConvRot INT8. This keeps `cuda` and global `triton` disabled in ComfyUI on ROCm, but preserves the one fast path needed by the reported workflow.

This is intentionally smaller than #74, which adds a full HIP backend and wheel packaging. It may overlap mechanically with #56 in `eager/quantization.py`, but it does not conflict conceptually: #56 improves the generic eager RDNA fallback, while this PR handles ROCm ConvRot INT8 by using the measured Triton fast path.

## Tested
- `ruff check .`
- `pytest tests/test_backends.py -q`
- `HIP_VISIBLE_DEVICES=0 ROCR_VISIBLE_DEVICES=0 pytest tests/test_int8.py -q` -> 68 passed, 39 skipped
- `HIP_VISIBLE_DEVICES=0 ROCR_VISIBLE_DEVICES=0 pytest tests/test_convrot_w4a4.py tests/test_integration.py -q` -> 41 passed, 49 skipped
- Local ComfyUI reproduction for #78 on RX 9070 XT / gfx1201 / ROCm 7.2 / PyTorch 2.12.1+rocm7.2, using a user-created Krea2 Turbo ConvRot INT8 workflow with this branch loaded via `PYTHONPATH`:
  - cold: 27.30s API / 26.98s ComfyUI log
  - warm: 8.01s API / 7.88s ComfyUI log

For comparison, the same local workflow with the previously installed workaround measured 28.35s API / 28.01s log cold and 8.01s API / 7.86s log warm.