### PR TITLE
Support int8 convrot embedding lookup

### DIFF
--- a/comfy_kitchen/backends/eager/__init__.py
+++ b/comfy_kitchen/backends/eager/__init__.py
@@ -15,6 +15,7 @@ __all__ = [
     "dequantize_int8_simple_dtype",
     "dequantize_int8_convrot_weight",
     "dequantize_int8_convrot_weight_dtype",
+    "dequantize_int8_embedding",
     "dequantize_convrot_w4a4_weight",
     "gemv_awq_w4a16",
     "convrot_w4a4_linear",
@@ -55,6 +56,7 @@ from .convrot_w4a4 import (
 from .quantization import (
     dequantize_int8_convrot_weight,
     dequantize_int8_convrot_weight_dtype,
+    dequantize_int8_embedding,
     dequantize_int8_simple,
     dequantize_int8_simple_dtype,
     dequantize_mxfp8,
@@ -397,6 +399,16 @@ def _build_constraints() -> dict:
         params={
             "q": ParamConstraint(dtypes=frozenset({torch.int8}), shape_rules=(ExactDims(2),)),
             "scale": ParamConstraint(dtypes=standard_floats),
+            "group_size": ParamConstraint(dtypes=frozenset({int})),
+            "output_dtype_code": ParamConstraint(dtypes=frozenset({int})),
+        },
+        default_devices=all_devices,
+    )
+    out["dequantize_int8_embedding"] = FunctionConstraints(
+        params={
+            "q": ParamConstraint(dtypes=frozenset({torch.int8}), shape_rules=(ExactDims(2),)),
+            "scale": ParamConstraint(dtypes=standard_floats),
+            "indices": ParamConstraint(dtypes=frozenset({torch.int64, torch.int32})),
             "group_size": ParamConstraint(dtypes=frozenset({int})),
             "output_dtype_code": ParamConstraint(dtypes=frozenset({int})),
         },

--- a/comfy_kitchen/backends/eager/quantization.py
+++ b/comfy_kitchen/backends/eager/quantization.py
@@ -931,6 +931,31 @@ def dequantize_int8_simple(q: torch.Tensor, scale: torch.Tensor) -> torch.Tensor
     return q.float() * scale
 
 
+def dequantize_int8_embedding(
+    q: torch.Tensor,
+    scale: torch.Tensor,
+    indices: torch.Tensor,
+    group_size: int,
+    output_dtype_code: int,
+) -> torch.Tensor:
+    """Gather rows from an INT8 embedding table ``[vocab, dim]`` and dequantize only those rows.
+
+    Indexes first, unlike ``dequantize_int8_convrot_weight*`` which materializes the whole table.
+    ``scale`` is per-row ``[vocab, 1]`` or scalar. ``group_size <= 0`` means the table is not
+    ConvRot-rotated; if it is, the rows are un-rotated after the lookup (a Linear folds that into
+    its GEMM, a lookup has no GEMM). Returns ``[*indices.shape, dim]``.
+    """
+    x = torch.nn.functional.embedding(indices, q).to(torch.float32)
+    if scale.dim() >= 2:
+        x = x * torch.nn.functional.embedding(indices, scale).to(torch.float32)
+    else:
+        x = x * scale.to(torch.float32)
+    if group_size > 0:
+        h = _build_hadamard(group_size, device=q.device, dtype=torch.float32)
+        x = _rotate_weight(x.reshape(-1, x.shape[-1]), h, group_size).reshape(x.shape)
+    return x.to(DTYPE_CODE_TO_DTYPE[output_dtype_code])
+
+
 def dequantize_int8_simple_dtype(q: torch.Tensor, scale: torch.Tensor, output_dtype_code: int) -> torch.Tensor:
     """Dequantize INT8 tensor with scale into a requested floating dtype."""
     return dequantize_int8_simple(q, scale).to(DTYPE_CODE_TO_DTYPE[output_dtype_code])
@@ -1107,6 +1132,34 @@ def _op_dequantize_int8_convrot_weight_dtype(
 @_op_dequantize_int8_convrot_weight_dtype.register_fake
 def _op_dequantize_int8_convrot_weight_dtype_fake(q, scale, group_size, output_dtype_code):
     return torch.empty_like(q, dtype=DTYPE_CODE_TO_DTYPE[output_dtype_code])
+
+
+@torch.library.custom_op("comfy_kitchen::dequantize_int8_embedding", mutates_args=())
+def _op_dequantize_int8_embedding(
+    q: torch.Tensor,
+    scale: torch.Tensor,
+    indices: torch.Tensor,
+    group_size: int,
+    output_dtype_code: int,
+) -> torch.Tensor:
+    kwargs = {
+        "q": q,
+        "scale": scale,
+        "indices": indices,
+        "group_size": group_size,
+        "output_dtype_code": output_dtype_code,
+    }
+    impl = registry.get_implementation("dequantize_int8_embedding", kwargs=kwargs)
+    return impl(**kwargs)
+
+
+@_op_dequantize_int8_embedding.register_fake
+def _op_dequantize_int8_embedding_fake(q, scale, indices, group_size, output_dtype_code):
+    return torch.empty(
+        (*indices.shape, q.shape[-1]),
+        dtype=DTYPE_CODE_TO_DTYPE[output_dtype_code],
+        device=q.device,
+    )
 
 
 @torch.library.custom_op("comfy_kitchen::dequantize_int8_simple", mutates_args=())

--- a/comfy_kitchen/backends/triton/__init__.py
+++ b/comfy_kitchen/backends/triton/__init__.py
@@ -55,8 +55,8 @@ try:
     from .quantization import (
         triton_quantize_rowwise as _triton_quantize_int8_rowwise,
     )
-    from .rope import apply_rope, apply_rope1, apply_rope_split_half, apply_rope_split_half1
     from .rms_rope import rms_rope, rms_rope1, rms_rope_split_half, rms_rope_split_half1
+    from .rope import apply_rope, apply_rope1, apply_rope_split_half, apply_rope_split_half1
 except ImportError as e:
     _TRITON_AVAILABLE = False
     _TRITON_ERROR = f"ImportError: {e!s}"

--- a/comfy_kitchen/tensor/int8.py
+++ b/comfy_kitchen/tensor/int8.py
@@ -177,6 +177,20 @@ class TensorWiseINT8Layout(QuantizedLayout):
         return result.to(params.orig_dtype)
 
     @classmethod
+    def dequantize_embedding(cls, qdata: torch.Tensor, params: Params, indices: torch.Tensor) -> torch.Tensor:
+        """Gather rows from an INT8 embedding table and dequantize only those rows.
+
+        Embedding counterpart of ``dequantize``, which would materialize the whole ``[vocab, dim]``
+        table to read a few rows. Un-rotates if ``params.convrot``. Returns ``[*indices.shape, dim]``.
+        """
+        output_dtype_code = _INT8_DEQUANT_DTYPE_TO_CODE.get(params.orig_dtype, 0)
+        group_size = params.convrot_groupsize if getattr(params, "convrot", False) else 0
+        result = torch.ops.comfy_kitchen.dequantize_int8_embedding(
+            qdata, params.scale, indices, group_size, output_dtype_code
+        )
+        return result.to(params.orig_dtype)
+
+    @classmethod
     def get_plain_tensors(cls, qtensor: QuantizedTensor) -> tuple[torch.Tensor, torch.Tensor]:
         """Extract raw tensors for computation.
 


### PR DESCRIPTION
Adds support for int8 embedding lookup, useful for text generation models with lm_head or embed_tokens layers such as used in Gemma4.

Compared to the fp8 scaled (the only previously supported quant format for embed lookup), int8 with convrot reaches much lower relative error at ~0.8% vs ~2.6% of fp8_scaled.

Since the embedding lookup is only ~0.10% of the token time, speed is not an issue and I only included the eager backend.

Paired core PR: https://github.com/Comfy-Org/ComfyUI/pull/15035