### PR TITLE
Add swiglu input_act and partial-rotary rot_dim for rms_rope

### DIFF
--- a/comfy_kitchen/__init__.py
+++ b/comfy_kitchen/__init__.py
@@ -549,7 +549,7 @@ def rms_rope_split_half(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Apply per-head RMSNorm and split-half RoPE to query and key tensors.
 
-    Split-half layout: pair k uses elements [k] and [k + rot_dim//2]. rot_dim
+    Split-half layout: pair i uses elements [i] and [i + rot_dim//2]. rot_dim
     restricts the rotation to a head-dim prefix (partial rotary; the norm
     always spans the full head_dim); 0 rotates everything.
     """

--- a/comfy_kitchen/__init__.py
+++ b/comfy_kitchen/__init__.py
@@ -545,22 +545,29 @@ def rms_rope_split_half(
     q_scale: torch.Tensor,
     k_scale: torch.Tensor | None = None,
     epsilon: float = 1e-6,
+    rot_dim: int = 0,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Apply per-head RMSNorm and split-half RoPE to query and key tensors.
 
-    Split-half layout: pair k uses elements [k] and [k + head_dim//2].
+    Split-half layout: pair k uses elements [k] and [k + rot_dim//2]. rot_dim
+    restricts the rotation to a head-dim prefix (partial rotary; the norm
+    always spans the full head_dim); 0 rotates everything.
     """
-    return torch.ops.comfy_kitchen.rms_rope_split_half(q, k, freqs_cis, q_scale, k_scale, epsilon)
+    return torch.ops.comfy_kitchen.rms_rope_split_half(q, k, freqs_cis, q_scale, k_scale, epsilon, rot_dim)
 
 
 def rms_rope_split_half_(
     q: torch.Tensor, k: torch.Tensor, freqs_cis: torch.Tensor,
     q_scale: torch.Tensor, k_scale: torch.Tensor | None = None,
-    epsilon: float = 1e-6,
+    epsilon: float = 1e-6, rot_dim: int = 0,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    """Apply RMSNorm and split-half RoPE in place (inference only)."""
+    """Apply RMSNorm and split-half RoPE in place (inference only).
+
+    rot_dim restricts the rotation to a head-dim prefix (partial rotary; the
+    norm always spans the full head_dim); 0 rotates everything.
+    """
     torch.ops.comfy_kitchen.rms_rope_split_half_(
-        q, k, freqs_cis, q_scale, k_scale, epsilon
+        q, k, freqs_cis, q_scale, k_scale, epsilon, rot_dim
     )
     return q, k
 

--- a/comfy_kitchen/_rope_utils.py
+++ b/comfy_kitchen/_rope_utils.py
@@ -23,6 +23,33 @@ def _storage_bounds(x: torch.Tensor) -> tuple[int, int]:
     return lo * element_size, (hi + 1) * element_size - 1
 
 
+def _interleaved_disjoint(x: torch.Tensor, y: torch.Tensor) -> bool:
+    """True for same-layout views whose rows sit side by side within a shared
+    period — the packed-QKV case, where q and k are strided slices of one fused
+    projection: bounds overlap but the element sets never do."""
+    if x.shape != y.shape or x.stride() != y.stride():
+        return False
+    strides = x.stride()
+    if not strides or strides[-1] != 1:
+        return False
+    # fold the contiguous suffix into one row extent
+    extent = 1
+    i = len(strides)
+    while i > 0 and strides[i - 1] == extent:
+        extent *= x.shape[i - 1]
+        i -= 1
+    outer = [s for size, s in zip(x.shape[:i], strides[:i], strict=True) if size > 1]
+    if not outer:
+        return False
+    period = min(outer)
+    if period <= 0 or any(s % period != 0 for s in outer):
+        # index combinations of non-multiple strides can land inside the
+        # collision window; only the hierarchical layout is provably disjoint
+        return False
+    delta = abs(x.storage_offset() - y.storage_offset())
+    return delta >= extent and delta + extent <= period
+
+
 def _tensors_overlap(x: torch.Tensor, y: torch.Tensor) -> bool:
     if x.numel() == 0 or y.numel() == 0 or x.device != y.device:
         return False
@@ -30,21 +57,28 @@ def _tensors_overlap(x: torch.Tensor, y: torch.Tensor) -> bool:
         return False
     x0, x1 = _storage_bounds(x)
     y0, y1 = _storage_bounds(y)
-    return max(x0, y0) <= min(x1, y1)
+    if max(x0, y0) > min(x1, y1):
+        return False
+    return not _interleaved_disjoint(x, y)
 
 
-def detect_rms_rope_bnhd(x: torch.Tensor, freqs_cis: torch.Tensor) -> bool | None:
+def detect_rms_rope_bnhd(
+    x: torch.Tensor, freqs_cis: torch.Tensor, rot_dim: int = 0
+) -> bool | None:
     if x.ndim != 4 or freqs_cis.ndim != 6:
         return None
 
     x_shape = x.shape
     freqs_shape = freqs_cis.shape
     head_dim = x_shape[3]
+    rot = rot_dim if rot_dim else head_dim
     if (
         head_dim == 0
         or head_dim % 2 != 0
+        or rot % 2 != 0
+        or rot > head_dim
+        or freqs_shape[3:] != (rot // 2, 2, 2)
         or freqs_shape[0] not in (1, x_shape[0])
-        or freqs_shape[3:] != (head_dim // 2, 2, 2)
     ):
         return None
     if freqs_shape[1] == 1 and freqs_shape[2] in (1, x_shape[2]):

--- a/comfy_kitchen/backends/_activations.py
+++ b/comfy_kitchen/backends/_activations.py
@@ -14,9 +14,8 @@ quantized row is half as wide as the raw input row.
 
 import torch
 
-# Must match the kActNone / kActGeluTanh / kActSwiGLU enum in
-# backends/cuda/ops/int8_linear.cu; the CUDA backend passes these codes
-# straight to the kernel.
+# Must match the enum in backends/cuda/input_act_codes.h; the CUDA backend
+# passes these codes straight to the kernel.
 INPUT_ACT_TO_CODE: dict[str | None, int] = {
     None: 0,
     "none": 0,

--- a/comfy_kitchen/backends/_activations.py
+++ b/comfy_kitchen/backends/_activations.py
@@ -1,21 +1,27 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Elementwise activations that a quantizer can absorb on the way in.
+"""Activations that a quantizer can absorb on the way in.
 
 An MLP's ``linear(act(proj(x)))`` otherwise writes act's output to HBM and reads
 it straight back to quantize it. Backends that can fold the activation into the
 quantizer do so; the rest apply it here first and then quantize unchanged, so
 every path produces the same result.
+
+``swiglu`` is the gated pair variant: the input carries ``[gate | up]`` halves
+on the last dim and the activation ``silu(gate) * up`` halves it, so the
+quantized row is half as wide as the raw input row.
 """
 
 import torch
 
-# Must match the kActNone / kActGeluTanh enum in backends/cuda/ops/int8_linear.cu
-# the CUDA backend passes these codes straight to the kernel.
+# Must match the kActNone / kActGeluTanh / kActSwiGLU enum in
+# backends/cuda/ops/int8_linear.cu; the CUDA backend passes these codes
+# straight to the kernel.
 INPUT_ACT_TO_CODE: dict[str | None, int] = {
     None: 0,
     "none": 0,
     "gelu_tanh": 1,
+    "swiglu": 2,
 }
 
 
@@ -25,6 +31,11 @@ def input_act_code(input_act: str | None) -> int:
         return INPUT_ACT_TO_CODE[input_act]
     except KeyError:
         raise ValueError(_unsupported(input_act)) from None
+
+
+def input_act_width(input_act: str | None) -> int:
+    """How many input columns produce one activated column (1, or 2 for swiglu)."""
+    return 2 if input_act == "swiglu" else 1
 
 
 def apply_input_act(x: torch.Tensor, input_act: str | None) -> torch.Tensor:
@@ -37,6 +48,9 @@ def apply_input_act(x: torch.Tensor, input_act: str | None) -> torch.Tensor:
         return x
     if input_act == "gelu_tanh":
         return torch.nn.functional.gelu(x, approximate="tanh")
+    if input_act == "swiglu":
+        gate, up = x.chunk(2, dim=-1)
+        return torch.nn.functional.silu(gate).mul_(up)
     raise ValueError(_unsupported(input_act))
 
 

--- a/comfy_kitchen/backends/cuda/__init__.py
+++ b/comfy_kitchen/backends/cuda/__init__.py
@@ -145,6 +145,7 @@ except Exception as e:
 
 from comfy_kitchen.backends._activations import (  # noqa: E402
     apply_input_act as _apply_input_act,
+    input_act_width as _input_act_width,
 )
 from comfy_kitchen.backends._activations import (  # noqa: E402
     input_act_code as _input_act_code,
@@ -160,6 +161,7 @@ from comfy_kitchen.backends.eager.quantization import (  # noqa: E402
 from comfy_kitchen.backends.eager.quantization import (  # noqa: E402
     quantize_int8_tensorwise as eager_quantize_int8_tensorwise,
 )
+from comfy_kitchen.backends.eager import rope as _eager_rope  # noqa: E402
 from comfy_kitchen.backends.eager.svdquant import (  # noqa: E402
     _INT4_GROUP_SIZE,
     _unpack_int4_row_major,
@@ -1367,10 +1369,14 @@ def quantize_int8_rowwise_convrot64(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Fused ConvRot row-wise INT8 quantization using 64-lane groups.
 
-    input_act applies an elementwise activation on the way in, so an MLP's
-    `linear(act(proj(x)))` never materializes act's output in bf16.
+    input_act applies an activation on the way in, so an MLP's
+    `linear(act(proj(x)))` never materializes act's output in bf16. For the
+    gated "swiglu" pair the input rows are [gate | up] and the quantized rows
+    are half as wide.
     """
-    q_2d = torch.empty_like(weight_2d, dtype=torch.int8)
+    q_2d = torch.empty(
+        (weight_2d.shape[0], weight_2d.shape[1] // _input_act_width(input_act)),
+        dtype=torch.int8, device=weight_2d.device)
     scales_2d = torch.empty((weight_2d.shape[0], 1), dtype=torch.float32, device=weight_2d.device)
     stream_ptr = torch.cuda.current_stream(weight_2d.device).cuda_stream
     _C.quantize_int8_rowwise_convrot64(
@@ -1740,18 +1746,21 @@ def int8_linear(
 
     # Only the fused ConvRot quantizer can absorb the activation; every other
     # route applies it eagerly here and proceeds unchanged, so all paths agree.
+    # k_act is the activated (quantized) row width: swiglu halves the raw row.
+    k_act = x_2d.shape[-1] // _input_act_width(input_act)
     _fused_convrot_ok = (
         convrot
         and convrot_groupsize == 256
-        and x_2d.shape[-1] % 256 == 0
-        and 256 <= x_2d.shape[-1] <= _CONVROT_FUSED_MAX_K
-        and _convrot_fused_shared_memory_fits(x_2d, x_2d.shape[-1], convrot_groupsize)
+        and k_act % 256 == 0
+        and 256 <= k_act <= _CONVROT_FUSED_MAX_K
+        and _convrot_fused_shared_memory_fits(x_2d, k_act, convrot_groupsize)
     )
     if input_act not in (None, "none") and not (_fused_convrot_ok and x_2d.shape[0] > 1):
         x_2d = _apply_input_act(x_2d, input_act)
         input_act = None
 
-    m, k = x_2d.shape
+    m = x_2d.shape[0]
+    k = k_act
     n, k_w = weight.shape
     assert k == k_w, "Input and weight inner dimensions must match"
 
@@ -1797,7 +1806,6 @@ def int8_linear(
 
     # cuBLAS INT8 GEMM requires row-wise quantized activations and tensor-wise quantized weights.
     if convrot:
-        k = x_2d.shape[-1]
         # Fused wins for small K (narrow block) and large K (wide block); the
         # 5120 < K < 8192 band loses to the rotate-matmul path on both, so skip
         # it. (Real model hidden dims avoid that band anyway.)
@@ -2062,12 +2070,13 @@ def _validate_cuda_rms_rope(kwargs: dict[str, object]) -> ValidationResult:
         k_scale = q_scale
     assert all(isinstance(value, torch.Tensor) for value in (q, k, q_scale, k_scale))
     freqs_cis = kwargs["freqs_cis"]
+    rot_dim = int(kwargs.get("rot_dim") or 0)
     extension_op = "rms_rope" if k.shape == q.shape else "rms_rope1"
-    if _native_rms_rope_layout(q, freqs_cis, extension_op=extension_op) is None:
+    if _native_rms_rope_layout(q, freqs_cis, extension_op=extension_op, rot_dim=rot_dim) is None:
         return ValidationResult.fail("q", "CUDA fused RMS-RoPE requires a supported native layout")
     if k.dtype != q.dtype:
         return ValidationResult.fail("k", "must have the same dtype as q for fused CUDA RMS-RoPE")
-    if k.shape != q.shape and _native_rms_rope_layout(k, freqs_cis, extension_op="rms_rope1") is None:
+    if k.shape != q.shape and _native_rms_rope_layout(k, freqs_cis, extension_op="rms_rope1", rot_dim=rot_dim) is None:
         return ValidationResult.fail("k", "CUDA fused RMS-RoPE requires a supported native layout")
     if q_scale.ndim != 1 or q_scale.numel() != q.shape[-1]:
         return ValidationResult.fail("q_scale", "must be a 1D tensor matching q head_dim")
@@ -2083,8 +2092,9 @@ def _native_rms_rope_layout(
     freqs_cis: torch.Tensor,
     *,
     extension_op: str,
+    rot_dim: int = 0,
 ) -> bool | None:
-    bnhd = detect_rms_rope_bnhd(x, freqs_cis)
+    bnhd = detect_rms_rope_bnhd(x, freqs_cis, rot_dim=rot_dim)
     if bnhd is None or not (
         _C is not None
         and hasattr(_C, extension_op)
@@ -2131,11 +2141,15 @@ def _rms_rope_cuda(
     *,
     split_half: bool,
     inplace: bool,
+    rot_dim: int = 0,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     if k_scale is None:
         k_scale = q_scale
 
     if q.shape != k.shape:
+        if rot_dim:
+            return _eager_rope.rms_rope_split_half(
+                q, k, freqs_cis, q_scale, k_scale, epsilon, rot_dim=rot_dim)
         return (
             _rms_rope1_cuda(
                 q, freqs_cis, q_scale, epsilon,
@@ -2147,7 +2161,7 @@ def _rms_rope_cuda(
             ),
         )
 
-    assert _native_rms_rope_layout(q, freqs_cis, extension_op="rms_rope") is not None
+    assert _native_rms_rope_layout(q, freqs_cis, extension_op="rms_rope", rot_dim=rot_dim) is not None
 
     q_out = q if inplace else torch.empty_like(q)
     k_out = k if inplace else torch.empty_like(k)
@@ -2163,6 +2177,7 @@ def _rms_rope_cuda(
         epsilon,
         stream_ptr,
         split_half,
+        rot_dim,
     )
     return q_out, k_out
 
@@ -2243,10 +2258,11 @@ def rms_rope_split_half(
     q_scale: torch.Tensor,
     k_scale: torch.Tensor | None = None,
     epsilon: float = 1e-6,
+    rot_dim: int = 0,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     return _rms_rope_cuda(
         q, k, freqs_cis, q_scale, k_scale, epsilon,
-        split_half=True, inplace=False,
+        split_half=True, inplace=False, rot_dim=rot_dim,
     )
 
 
@@ -2257,13 +2273,14 @@ def rms_rope_split_half_(
     q_scale: torch.Tensor,
     k_scale: torch.Tensor | None = None,
     epsilon: float = 1e-6,
+    rot_dim: int = 0,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     if k_scale is None:
         k_scale = q_scale
     check_rope_inplace(q, k, readonly=(freqs_cis, q_scale, k_scale))
     return _rms_rope_cuda(
         q, k, freqs_cis, q_scale, k_scale, epsilon,
-        split_half=True, inplace=True,
+        split_half=True, inplace=True, rot_dim=rot_dim,
     )
 
 

--- a/comfy_kitchen/backends/cuda/__init__.py
+++ b/comfy_kitchen/backends/cuda/__init__.py
@@ -145,12 +145,15 @@ except Exception as e:
 
 from comfy_kitchen.backends._activations import (  # noqa: E402
     apply_input_act as _apply_input_act,
-    input_act_width as _input_act_width,
 )
 from comfy_kitchen.backends._activations import (  # noqa: E402
     input_act_code as _input_act_code,
 )
+from comfy_kitchen.backends._activations import (  # noqa: E402
+    input_act_width as _input_act_width,
+)
 from comfy_kitchen.backends._modulation import adaln_prep_modulation  # noqa: E402
+from comfy_kitchen.backends.eager import rope as _eager_rope  # noqa: E402
 from comfy_kitchen.backends.eager.quantization import (  # noqa: E402
     DTYPE_CODE_TO_DTYPE,
     DTYPE_TO_CODE,
@@ -161,7 +164,6 @@ from comfy_kitchen.backends.eager.quantization import (  # noqa: E402
 from comfy_kitchen.backends.eager.quantization import (  # noqa: E402
     quantize_int8_tensorwise as eager_quantize_int8_tensorwise,
 )
-from comfy_kitchen.backends.eager import rope as _eager_rope  # noqa: E402
 from comfy_kitchen.backends.eager.svdquant import (  # noqa: E402
     _INT4_GROUP_SIZE,
     _unpack_int4_row_major,

--- a/comfy_kitchen/backends/cuda/__init__.py
+++ b/comfy_kitchen/backends/cuda/__init__.py
@@ -2148,8 +2148,9 @@ def _rms_rope_cuda(
 
     if q.shape != k.shape:
         if rot_dim:
-            return _eager_rope.rms_rope_split_half(
-                q, k, freqs_cis, q_scale, k_scale, epsilon, rot_dim=rot_dim)
+            fallback = (_eager_rope.rms_rope_split_half_ if inplace
+                        else _eager_rope.rms_rope_split_half)
+            return fallback(q, k, freqs_cis, q_scale, k_scale, epsilon, rot_dim=rot_dim)
         return (
             _rms_rope1_cuda(
                 q, freqs_cis, q_scale, epsilon,

--- a/comfy_kitchen/backends/cuda/dlpack_bindings.cpp
+++ b/comfy_kitchen/backends/cuda/dlpack_bindings.cpp
@@ -128,6 +128,7 @@ extern "C" {
         void* q_out,
         void* k_out,
         int64_t batch, int64_t dim1, int64_t dim2, int64_t head_dim,
+        int64_t rot_dim,
         int64_t freqs_batch, int64_t freqs_dim1, int64_t freqs_dim2,
         int64_t q_s0, int64_t q_s1, int64_t q_s2, int64_t q_s3,
         int64_t k_s0, int64_t k_s1, int64_t k_s2, int64_t k_s3,
@@ -648,7 +649,8 @@ void rms_rope(nb::ndarray<nb::device::cuda> q, nb::ndarray<nb::device::cuda> k,
               nb::ndarray<nb::device::cuda> k_scale,
               nb::ndarray<nb::device::cuda> q_out,
               nb::ndarray<nb::device::cuda> k_out, float epsilon,
-              uintptr_t stream_ptr, bool split_half = false) {
+              uintptr_t stream_ptr, bool split_half = false,
+              int64_t rot_dim = 0) {
 
   if (q.ndim() != 4 || k.ndim() != 4 || q_out.ndim() != 4 ||
       k_out.ndim() != 4) {
@@ -671,10 +673,17 @@ void rms_rope(nb::ndarray<nb::device::cuda> q, nb::ndarray<nb::device::cuda> k,
     throw std::runtime_error(
         "native rms_rope requires head_dim to be a positive multiple of 32");
   }
+  // rot_dim restricts the rotation to a head-dim prefix (partial rotary); the
+  // norm always spans the full head_dim. 0 means rotate everything.
+  const int64_t rot = rot_dim > 0 ? rot_dim : head_dim;
+  if (rot % 2 != 0 || rot > head_dim) {
+    throw std::runtime_error(
+        "rms_rope rot_dim must be an even value <= head_dim");
+  }
   if (freqs.ndim() != 6 || (freqs.shape(0) != 1 && freqs.shape(0) != batch) ||
       (freqs.shape(1) != 1 && freqs.shape(1) != dim1) ||
       (freqs.shape(2) != 1 && freqs.shape(2) != dim2) ||
-      freqs.shape(3) != head_dim / 2 || freqs.shape(4) != 2 ||
+      freqs.shape(3) != rot / 2 || freqs.shape(4) != 2 ||
       freqs.shape(5) != 2) {
     throw std::runtime_error(
         "rms_rope freqs shape must broadcast to Q/K");
@@ -707,7 +716,7 @@ void rms_rope(nb::ndarray<nb::device::cuda> q, nb::ndarray<nb::device::cuda> k,
 
   launch_rms_rope_kernel(
       q.data(), k.data(), freqs.data(), q_scale.data(), k_scale.data(),
-      q_out.data(), k_out.data(), batch, dim1, dim2, head_dim,
+      q_out.data(), k_out.data(), batch, dim1, dim2, head_dim, rot,
       freqs.shape(0), freqs.shape(1), freqs.shape(2),
       q.stride(0), q.stride(1), q.stride(2), q.stride(3),
       k.stride(0), k.stride(1), k.stride(2), k.stride(3),
@@ -774,7 +783,7 @@ void rms_rope1(nb::ndarray<nb::device::cuda> q,
 
   launch_rms_rope_kernel(
       q.data(), nullptr, freqs.data(), q_scale.data(), nullptr, q_out.data(),
-      nullptr, batch, dim1, dim2, head_dim,
+      nullptr, batch, dim1, dim2, head_dim, head_dim,
       freqs.shape(0), freqs.shape(1), freqs.shape(2),
       q.stride(0), q.stride(1), q.stride(2), q.stride(3),
       0, 0, 0, 0,
@@ -1981,9 +1990,12 @@ void quantize_int8_rowwise_convrot64(
     uintptr_t stream_ptr) {
 
     const int64_t M = input.shape(0);
-    const int64_t K = input.shape(1);
+    // K is the activated (quantized) row width; the SwiGLU pair reads a
+    // [gate | up] input row twice as wide.
+    const int64_t K = output.shape(1);
+    const int64_t in_width = (act_code == 2) ? 2 : 1;
 
-    if (output.shape(0) != M || output.shape(1) != K) {
+    if (output.shape(0) != M || input.shape(1) != K * in_width) {
         throw std::runtime_error("INT8 rowwise convrot64 output shape mismatch");
     }
     if (scales.shape(0) != M || scales.shape(1) != 1) {
@@ -2605,7 +2617,7 @@ NB_MODULE(_C, m) {
           nb::arg("k"), nb::arg("freqs"), nb::arg("q_scale"),
           nb::arg("k_scale"), nb::arg("q_out"), nb::arg("k_out"),
           nb::arg("epsilon"), nb::arg("stream_ptr"),
-          nb::arg("split_half") = false);
+          nb::arg("split_half") = false, nb::arg("rot_dim") = 0);
 
     m.def("rms_rope1", &rms_rope1, "Fused RMSNorm and RoPE for a single tensor",
           nb::arg("q"), nb::arg("freqs"), nb::arg("q_scale"), nb::arg("q_out"),

--- a/comfy_kitchen/backends/cuda/dlpack_bindings.cpp
+++ b/comfy_kitchen/backends/cuda/dlpack_bindings.cpp
@@ -20,6 +20,7 @@
 #include <cstring>
 
 #include "cublaslt_runtime.h"
+#include "input_act_codes.h"
 
 namespace nb = nanobind;
 
@@ -1993,7 +1994,7 @@ void quantize_int8_rowwise_convrot64(
     // K is the activated (quantized) row width; the SwiGLU pair reads a
     // [gate | up] input row twice as wide.
     const int64_t K = output.shape(1);
-    const int64_t in_width = (act_code == 2) ? 2 : 1;
+    const int64_t in_width = (act_code == comfy::kActSwiGLU) ? 2 : 1;
 
     if (output.shape(0) != M || input.shape(1) != K * in_width) {
         throw std::runtime_error("INT8 rowwise convrot64 output shape mismatch");

--- a/comfy_kitchen/backends/cuda/input_act_codes.h
+++ b/comfy_kitchen/backends/cuda/input_act_codes.h
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Codes for the optional activation a quantizer absorbs on the way in. Shared
+// by the CUDA kernels and the nanobind layer; must match INPUT_ACT_TO_CODE in
+// comfy_kitchen/backends/_activations.py.
+#pragma once
+
+namespace comfy {
+
+// SwiGLU is the gated pair: the raw row is [gate | up] (2*K wide) and the
+// activated row silu(gate) * up is K wide; the others are elementwise.
+enum : int { kActNone = 0, kActGeluTanh = 1, kActSwiGLU = 2 };
+
+}  // namespace comfy

--- a/comfy_kitchen/backends/cuda/ops/int8_linear.cu
+++ b/comfy_kitchen/backends/cuda/ops/int8_linear.cu
@@ -5,6 +5,7 @@
 
 #include "utils.cuh"
 #include "dtype_dispatch.cuh"
+#include "input_act_codes.h"
 
 #include <cmath>
 #include <cfloat>
@@ -907,11 +908,8 @@ __global__ void quantize_int8_rowwise_from_partials_kernel(
 
 // Optional activation applied on the way into the quantizer, so an MLP's
 // `linear(act(proj(x)))` never writes act's output to HBM just to read it
-// straight back. No reduction is involved, so it is nearly free here. SwiGLU
-// is the gated pair: the raw row is [gate | up] (2*K wide) and the activated
-// row silu(gate) * up is K wide.
-enum : int { kActNone = 0, kActGeluTanh = 1, kActSwiGLU = 2 };
-
+// straight back. No reduction is involved, so it is nearly free here. The
+// codes live in input_act_codes.h, shared with the nanobind layer.
 template<int ACT>
 __device__ __forceinline__ float apply_input_act(float v) {
     if constexpr (ACT == kActGeluTanh) {

--- a/comfy_kitchen/backends/cuda/ops/int8_linear.cu
+++ b/comfy_kitchen/backends/cuda/ops/int8_linear.cu
@@ -905,10 +905,12 @@ __global__ void quantize_int8_rowwise_from_partials_kernel(
     }
 }
 
-// Optional elementwise activation applied on the way into the quantizer, so an
-// MLP's `linear(act(proj(x)))` never writes act's output to HBM just to read it
-// straight back. Elementwise means no reduction, so it is nearly free here.
-enum : int { kActNone = 0, kActGeluTanh = 1 };
+// Optional activation applied on the way into the quantizer, so an MLP's
+// `linear(act(proj(x)))` never writes act's output to HBM just to read it
+// straight back. No reduction is involved, so it is nearly free here. SwiGLU
+// is the gated pair: the raw row is [gate | up] (2*K wide) and the activated
+// row silu(gate) * up is K wide.
+enum : int { kActNone = 0, kActGeluTanh = 1, kActSwiGLU = 2 };
 
 template<int ACT>
 __device__ __forceinline__ float apply_input_act(float v) {
@@ -920,6 +922,23 @@ __device__ __forceinline__ float apply_input_act(float v) {
         return 0.5f * v * (1.0f + tanhf(inner));
     }
     return v;
+}
+
+// Reads one activated value: column `col` of the K-wide activated row starting
+// at `in_row`. For SwiGLU the raw row is 2*K wide with the gate in the first
+// half; every other activation reads the same K-wide row it writes.
+template<int ACT, typename InputType>
+__device__ __forceinline__ float load_input_act(
+    const InputType* __restrict__ x, int64_t in_row, int col, int K)
+{
+    if constexpr (ACT == kActSwiGLU) {
+        // Matches torch silu(gate) * up.
+        const float gate = to_float(x[in_row + col]);
+        const float up = to_float(x[in_row + K + col]);
+        return (gate / (1.0f + expf(-gate))) * up;
+    } else {
+        return apply_input_act<ACT>(to_float(x[in_row + col]));
+    }
 }
 
 template<typename InputType, int BLOCK_THREADS, bool STOCHASTIC, int ACT = kActNone>
@@ -946,6 +965,9 @@ __global__ void quantize_int8_rowwise_convrot64_kernel(
     const int sub = tid / kGroupThreads;
     const int lane = tid % kGroupThreads;
     const int64_t row_offset = static_cast<int64_t>(row) * K;
+    // SwiGLU reads a [gate | up] raw row twice as wide as the K it writes.
+    constexpr int kInWidth = (ACT == kActSwiGLU) ? 2 : 1;
+    const int64_t in_row_offset = row_offset * kInWidth;
     const int n_groups = K / kConvRotGroup;
 
     float* buf0 = tmp + sub * (2 * kConvRotGroup);
@@ -958,12 +980,12 @@ __global__ void quantize_int8_rowwise_convrot64_kernel(
         const bool active = group < n_groups;
         const int base = lane * 4;
         const int group_col = group * kConvRotGroup;
-        const int64_t x_offset = row_offset + group_col + base;
+        const int col = group_col + base;
 
-        const float x0 = active ? apply_input_act<ACT>(to_float(x[x_offset])) : 0.0f;
-        const float x1 = active ? apply_input_act<ACT>(to_float(x[x_offset + 1])) : 0.0f;
-        const float x2 = active ? apply_input_act<ACT>(to_float(x[x_offset + 2])) : 0.0f;
-        const float x3 = active ? apply_input_act<ACT>(to_float(x[x_offset + 3])) : 0.0f;
+        const float x0 = active ? load_input_act<ACT>(x, in_row_offset, col, K) : 0.0f;
+        const float x1 = active ? load_input_act<ACT>(x, in_row_offset, col + 1, K) : 0.0f;
+        const float x2 = active ? load_input_act<ACT>(x, in_row_offset, col + 2, K) : 0.0f;
+        const float x3 = active ? load_input_act<ACT>(x, in_row_offset, col + 3, K) : 0.0f;
         buf1[base] = 0.5f * (x0 + x1 + x2 - x3);
         buf1[base + 1] = 0.5f * (x0 + x1 - x2 + x3);
         buf1[base + 2] = 0.5f * (x0 - x1 + x2 + x3);
@@ -1297,7 +1319,7 @@ void launch_quantize_int8_rowwise_convrot64_kernel(
     if (num_cols > static_cast<int64_t>(std::numeric_limits<int>::max())) {
         throw std::runtime_error("convrot64 fused kernel only supports K <= INT_MAX");
     }
-    if (act_code != comfy::kActNone && act_code != comfy::kActGeluTanh) {
+    if (act_code != comfy::kActNone && act_code != comfy::kActGeluTanh && act_code != comfy::kActSwiGLU) {
         throw std::runtime_error("convrot64 fused kernel: unsupported input activation code");
     }
 
@@ -1332,9 +1354,9 @@ void launch_quantize_int8_rowwise_convrot64_kernel(
                                 : 1024;
 
         DISPATCH_BOOL(stochastic, kStoch, [&] {
-            DISPATCH_BOOL(act_code == comfy::kActGeluTanh, kGelu, [&] {
-                constexpr int kAct = kGelu ? comfy::kActGeluTanh : comfy::kActNone;
-                switch (block_threads) {
+            auto launch_act = [&](auto act_tag, int bt) {
+                constexpr int kAct = decltype(act_tag)::value;
+                switch (bt) {
                     case 64:
                         launch(comfy::quantize_int8_rowwise_convrot64_kernel<InputType, 64, kStoch, kAct>, 64);
                         break;
@@ -1351,7 +1373,18 @@ void launch_quantize_int8_rowwise_convrot64_kernel(
                         launch(comfy::quantize_int8_rowwise_convrot64_kernel<InputType, 1024, kStoch, kAct>, 1024);
                         break;
                 }
-            });
+            };
+            switch (act_code) {
+                case comfy::kActGeluTanh:
+                    launch_act(std::integral_constant<int, comfy::kActGeluTanh>{}, block_threads);
+                    break;
+                case comfy::kActSwiGLU:
+                    launch_act(std::integral_constant<int, comfy::kActSwiGLU>{}, block_threads);
+                    break;
+                default:
+                    launch_act(std::integral_constant<int, comfy::kActNone>{}, block_threads);
+                    break;
+            }
         });
     });
 
@@ -1677,7 +1710,10 @@ void launch_dequantize_int8_convrot_kernel(
     if (num_cols >= comfy::kConvRotGroup) {
         auto launch_groups = [&](auto groups_tag) {
             constexpr int groups_per_block = decltype(groups_tag)::value;
-            constexpr int block_threads = groups_per_block * 64;
+            // const (not constexpr): MSVC 14.42 rejects capturing a constexpr
+            // local into the nested dispatch lambda (C3495); it is only a
+            // runtime launch dimension here.
+            const int block_threads = groups_per_block * 64;
             const int group_blocks =
                 static_cast<int>((num_cols / comfy::kConvRotGroup + groups_per_block - 1) / groups_per_block);
             const size_t smem_bytes = groups_per_block * 2 * comfy::kConvRotGroup * sizeof(float);
@@ -1685,7 +1721,10 @@ void launch_dequantize_int8_convrot_kernel(
                 static_cast<unsigned int>(num_rows),
                 static_cast<unsigned int>(group_blocks));
             DISPATCH_FP_DTYPE(output_dtype_code, OutputType, [&] {
-                comfy::dequantize_int8_convrot_groups64_kernel<groups_per_block, OutputType>
+                // Re-derived from the tag: MSVC 14.42 refuses to capture the
+                // enclosing lambda's constexpr local (C3495).
+                constexpr int kGroupsPerBlock = decltype(groups_tag)::value;
+                comfy::dequantize_int8_convrot_groups64_kernel<kGroupsPerBlock, OutputType>
                     <<<grid, block_threads, smem_bytes, stream>>>(
                         static_cast<const int8_t*>(input),
                         static_cast<const float*>(scales),

--- a/comfy_kitchen/backends/cuda/ops/rms_rope.cu
+++ b/comfy_kitchen/backends/cuda/ops/rms_rope.cu
@@ -41,7 +41,7 @@ __global__ __launch_bounds__(kThreads) void rope_kernel(
     const ScaleType *__restrict__ q_scale,
     const ScaleType *__restrict__ k_scale, InputType *q_out,
     InputType *k_out, int64_t batch, int64_t dim1, int64_t dim2,
-    int head_dim, int64_t freqs_batch, int64_t freqs_dim1,
+    int head_dim, int rot_dim, int64_t freqs_batch, int64_t freqs_dim1,
     int64_t freqs_dim2, int64_t q_s0, int64_t q_s1, int64_t q_s2,
     int64_t q_s3, int64_t k_s0, int64_t k_s1, int64_t k_s2, int64_t k_s3,
     int64_t qo_s0, int64_t qo_s1, int64_t qo_s2, int64_t qo_s3,
@@ -91,7 +91,9 @@ __global__ __launch_bounds__(kThreads) void rope_kernel(
   const int64_t fi1 = freqs_dim1 == 1 ? 0 : i1;
   const int64_t fi2 = freqs_dim2 == 1 ? 0 : i2;
   const int64_t freq_row = fi0 * f_s0 + fi1 * f_s1 + fi2 * f_s2;
-  const int pairs = head_dim / 2;
+  // Rotation covers the first rot_dim dims (split-half pairs (i, i + rot_dim/2));
+  // the RMS reduction above always spans the full head_dim.
+  const int pairs = rot_dim / 2;
   constexpr int kPairsPerLane = SplitHalf && ContigHead ? 2 : 1;
 
   for (int pair_base = lane * kPairsPerLane; pair_base < pairs;
@@ -201,6 +203,29 @@ __global__ __launch_bounds__(kThreads) void rope_kernel(
       }
     }
   }
+
+  // Norm-only tail: dims beyond rot_dim are normalized and scaled but never
+  // rotated. Empty in the common rot_dim == head_dim case.
+  const int64_t qo_s3_eff = InPlace ? q_s3 : qo_s3;
+  const int64_t ko_s3_eff = InPlace ? k_s3 : ko_s3;
+  for (int d = rot_dim + lane; d < head_dim; d += kThreadsPerWarp) {
+    InputType qv = q[q_base + static_cast<int64_t>(d) * q_s3];
+    if constexpr (HasRms) {
+      qv = static_cast<InputType>(
+          static_cast<float>(qv) * q_rrms *
+          static_cast<float>(q_scale[static_cast<int64_t>(d) * qs_stride]));
+    }
+    q_out[qo_base + static_cast<int64_t>(d) * qo_s3_eff] = qv;
+    if constexpr (HasK) {
+      InputType kv = k[k_base + static_cast<int64_t>(d) * k_s3];
+      if constexpr (HasRms) {
+        kv = static_cast<InputType>(
+            static_cast<float>(kv) * k_rrms *
+            static_cast<float>(k_scale[static_cast<int64_t>(d) * ks_stride]));
+      }
+      k_out[ko_base + static_cast<int64_t>(d) * ko_s3_eff] = kv;
+    }
+  }
 }
 
 template <typename T>
@@ -215,6 +240,7 @@ void launch_config(
     const InputType *q, const InputType *k, const FreqsType *freqs,
     const ScaleType *q_scale, const ScaleType *k_scale, InputType *q_out,
     InputType *k_out, int64_t batch, int64_t dim1, int64_t dim2, int head_dim,
+    int rot_dim,
     int64_t freqs_batch, int64_t freqs_dim1, int64_t freqs_dim2, int64_t q_s0,
     int64_t q_s1, int64_t q_s2, int64_t q_s3, int64_t k_s0, int64_t k_s1,
     int64_t k_s2, int64_t k_s3, int64_t qo_s0, int64_t qo_s1, int64_t qo_s2,
@@ -231,6 +257,7 @@ void launch_config(
   rope_kernel<InputType, FreqsType, ScaleType, HasRms, SplitHalf, HasK, InPlace,
               ContigHead><<<blocks, kThreads, 0, stream>>>(
       q, k, freqs, q_scale, k_scale, q_out, k_out, batch, dim1, dim2, head_dim,
+      rot_dim,
       freqs_batch, freqs_dim1, freqs_dim2, q_s0, q_s1, q_s2, q_s3, k_s0, k_s1,
       k_s2, k_s3, qo_s0, qo_s1, qo_s2, qo_s3, ko_s0, ko_s1, ko_s2, ko_s3,
       f_s0, f_s1, f_s2, f_s3, f_s4, f_s5, qs_stride, ks_stride, epsilon);
@@ -242,6 +269,7 @@ void rope_launcher(
     const InputType *q, const InputType *k, const FreqsType *freqs,
     const ScaleType *q_scale, const ScaleType *k_scale, InputType *q_out,
     InputType *k_out, int64_t batch, int64_t dim1, int64_t dim2, int head_dim,
+    int rot_dim,
     int64_t freqs_batch, int64_t freqs_dim1, int64_t freqs_dim2, int64_t q_s0,
     int64_t q_s1, int64_t q_s2, int64_t q_s3, int64_t k_s0, int64_t k_s1,
     int64_t k_s2, int64_t k_s3, int64_t qo_s0, int64_t qo_s1, int64_t qo_s2,
@@ -259,13 +287,15 @@ void rope_launcher(
              pair_aligned(k_out, ko_s0, ko_s1, ko_s2);
   }
   // Split-half packs adjacent values independently in each half. Both half
-  // starts must therefore be pair-aligned.
-  contig = contig && (!split_half || head_dim % 4 == 0);
+  // starts must therefore be pair-aligned (the rotated prefix for partial
+  // rotary).
+  contig = contig && (!split_half || (head_dim % 4 == 0 && rot_dim % 4 == 0));
 
 #define LAUNCH(HAS_K, SPLIT, INPLACE, CONTIG)                                  \
   launch_config<InputType, FreqsType, ScaleType, HasRms, SPLIT, HAS_K,         \
                 INPLACE, CONTIG>(                                               \
       q, k, freqs, q_scale, k_scale, q_out, k_out, batch, dim1, dim2, head_dim, \
+      rot_dim,                                                                  \
       freqs_batch, freqs_dim1, freqs_dim2, q_s0, q_s1, q_s2, q_s3, k_s0, k_s1, \
       k_s2, k_s3, qo_s0, qo_s1, qo_s2, qo_s3, ko_s0, ko_s1, ko_s2, ko_s3,      \
       f_s0, f_s1, f_s2, f_s3, f_s4, f_s5, qs_stride, ks_stride, epsilon, stream)
@@ -312,7 +342,8 @@ extern "C" void launch_apply_rope_kernel(
         static_cast<const InputType *>(q), static_cast<const InputType *>(k),
         static_cast<const FreqsType *>(freqs), nullptr, nullptr,
         static_cast<InputType *>(q_out), static_cast<InputType *>(k_out), batch,
-        dim1, dim2, static_cast<int>(head_dim), freqs_batch, freqs_dim1,
+        dim1, dim2, static_cast<int>(head_dim), static_cast<int>(head_dim),
+        freqs_batch, freqs_dim1,
         freqs_dim2, q_s0, q_s1, q_s2, q_s3, k_s0, k_s1, k_s2, k_s3, qo_s0,
         qo_s1, qo_s2, qo_s3, ko_s0, ko_s1, ko_s2, ko_s3, f_s0, f_s1, f_s2,
         f_s3, f_s4, f_s5, 0, 0, 0.0f, has_k, split_half, stream);
@@ -322,7 +353,8 @@ extern "C" void launch_apply_rope_kernel(
 extern "C" void launch_rms_rope_kernel(
     const void *q, const void *k, const void *freqs, const void *q_scale,
     const void *k_scale, void *q_out, void *k_out, int64_t batch, int64_t dim1,
-    int64_t dim2, int64_t head_dim, int64_t freqs_batch, int64_t freqs_dim1,
+    int64_t dim2, int64_t head_dim, int64_t rot_dim,
+    int64_t freqs_batch, int64_t freqs_dim1,
     int64_t freqs_dim2, int64_t q_s0, int64_t q_s1, int64_t q_s2, int64_t q_s3,
     int64_t k_s0, int64_t k_s1, int64_t k_s2, int64_t k_s3, int64_t qo_s0,
     int64_t qo_s1, int64_t qo_s2, int64_t qo_s3, int64_t ko_s0, int64_t ko_s1,
@@ -340,7 +372,8 @@ extern "C" void launch_rms_rope_kernel(
             static_cast<const ScaleType *>(q_scale),
             static_cast<const ScaleType *>(k_scale),
             static_cast<InputType *>(q_out), static_cast<InputType *>(k_out),
-            batch, dim1, dim2, static_cast<int>(head_dim), freqs_batch,
+            batch, dim1, dim2, static_cast<int>(head_dim),
+            static_cast<int>(rot_dim), freqs_batch,
             freqs_dim1, freqs_dim2, q_s0, q_s1, q_s2, q_s3, k_s0, k_s1, k_s2,
             k_s3, qo_s0, qo_s1, qo_s2, qo_s3, ko_s0, ko_s1, ko_s2, ko_s3,
             f_s0, f_s1, f_s2, f_s3, f_s4, f_s5, qs_stride, ks_stride, epsilon,

--- a/comfy_kitchen/backends/eager/rope.py
+++ b/comfy_kitchen/backends/eager/rope.py
@@ -71,6 +71,7 @@ def _rms_rope1(
     epsilon: float,
     *,
     split_half: bool,
+    rot_dim: int = 0,
 ) -> torch.Tensor:
     x_norm = torch.nn.functional.rms_norm(
         x,
@@ -78,6 +79,14 @@ def _rms_rope1(
         weight=scale,
         eps=epsilon,
     )
+    if rot_dim and rot_dim != x.shape[-1]:
+        # partial rotary: rotate the first rot_dim dims, pass the rest through
+        rotated = x_norm[..., :rot_dim]
+        if split_half:
+            rotated = apply_rope_split_half1(rotated, freqs_cis)
+        else:
+            rotated = apply_rope1(rotated, freqs_cis)
+        return torch.cat((rotated, x_norm[..., rot_dim:]), dim=-1)
     if split_half:
         return apply_rope_split_half1(x_norm, freqs_cis)
     return apply_rope1(x_norm, freqs_cis)
@@ -124,12 +133,13 @@ def rms_rope_split_half(
     q_scale: torch.Tensor,
     k_scale: torch.Tensor | None = None,
     epsilon: float = 1e-6,
+    rot_dim: int = 0,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     if k_scale is None:
         k_scale = q_scale
     return (
-        _rms_rope1(q, freqs_cis, q_scale, epsilon, split_half=True),
-        _rms_rope1(k, freqs_cis, k_scale, epsilon, split_half=True),
+        _rms_rope1(q, freqs_cis, q_scale, epsilon, split_half=True, rot_dim=rot_dim),
+        _rms_rope1(k, freqs_cis, k_scale, epsilon, split_half=True, rot_dim=rot_dim),
     )
 
 
@@ -168,12 +178,12 @@ def rms_rope_split_half1_(
 def rms_rope_split_half_(
     q: torch.Tensor, k: torch.Tensor, freqs_cis: torch.Tensor,
     q_scale: torch.Tensor, k_scale: torch.Tensor | None = None,
-    epsilon: float = 1e-6,
+    epsilon: float = 1e-6, rot_dim: int = 0,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     if k_scale is None:
         k_scale = q_scale
     check_rope_inplace(q, k, readonly=(freqs_cis, q_scale, k_scale))
-    q_out, k_out = rms_rope_split_half(q, k, freqs_cis, q_scale, k_scale, epsilon)
+    q_out, k_out = rms_rope_split_half(q, k, freqs_cis, q_scale, k_scale, epsilon, rot_dim=rot_dim)
     q.copy_(q_out)
     k.copy_(k_out)
     return q, k
@@ -256,6 +266,7 @@ def _op_rms_rope_split_half(
     q_scale: torch.Tensor,
     k_scale: torch.Tensor | None = None,
     epsilon: float = 1e-6,
+    rot_dim: int = 0,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     kwargs = {
         "q": q,
@@ -264,6 +275,7 @@ def _op_rms_rope_split_half(
         "q_scale": q_scale,
         "k_scale": k_scale,
         "epsilon": epsilon,
+        "rot_dim": rot_dim,
     }
     impl = registry.get_implementation("rms_rope_split_half", kwargs=kwargs)
     return impl(**kwargs)
@@ -271,7 +283,7 @@ def _op_rms_rope_split_half(
 
 @_op_rms_rope_split_half.register_fake
 def _op_rms_rope_split_half_fake(
-    q, k, freqs_cis, q_scale, k_scale=None, epsilon=1e-6
+    q, k, freqs_cis, q_scale, k_scale=None, epsilon=1e-6, rot_dim=0
 ):
     return torch.empty_like(q), torch.empty_like(k)
 
@@ -386,18 +398,18 @@ def _op_rms_rope1_fake_(x, freqs_cis, scale, epsilon=1e-6):
 def _op_rms_rope_split_half_(
     q: torch.Tensor, k: torch.Tensor, freqs_cis: torch.Tensor,
     q_scale: torch.Tensor, k_scale: torch.Tensor | None = None,
-    epsilon: float = 1e-6,
+    epsilon: float = 1e-6, rot_dim: int = 0,
 ) -> None:
     kwargs = {
         "q": q, "k": k, "freqs_cis": freqs_cis, "q_scale": q_scale,
-        "k_scale": k_scale, "epsilon": epsilon,
+        "k_scale": k_scale, "epsilon": epsilon, "rot_dim": rot_dim,
     }
     registry.get_implementation("rms_rope_split_half_", kwargs=kwargs)(**kwargs)
 
 
 @_op_rms_rope_split_half_.register_fake
 def _op_rms_rope_split_half_fake_(
-    q, k, freqs_cis, q_scale, k_scale=None, epsilon=1e-6
+    q, k, freqs_cis, q_scale, k_scale=None, epsilon=1e-6, rot_dim=0
 ):
     return None
 

--- a/comfy_kitchen/backends/hip/__init__.py
+++ b/comfy_kitchen/backends/hip/__init__.py
@@ -589,6 +589,11 @@ def int8_linear(
     """INT8 linear with dynamic row-wise activation quantization, on WMMA."""
     # Rejected here so every route fails the same way, not just the fused one.
     _input_act_code(input_act)
+    if input_act == "swiglu":
+        # The WMMA quantizer does not fuse the gated pair; apply it eagerly so
+        # the row width and result match the fused backends.
+        x = _apply_input_act(x, input_act)
+        input_act = None
     if x.shape[-1] != weight.shape[-1]:
         raise ValueError(
             f"Input and weight inner dimensions must match, got {x.shape[-1]} and {weight.shape[-1]}"
@@ -1223,7 +1228,12 @@ def rms_rope_split_half(
     q_scale: torch.Tensor,
     k_scale: torch.Tensor | None = None,
     epsilon: float = 1e-6,
+    rot_dim: int = 0,
 ) -> tuple[torch.Tensor, torch.Tensor]:
+    if rot_dim and rot_dim != q.shape[-1]:
+        # partial rotary is not fused in the WMMA kernel
+        return _eager.rms_rope_split_half(
+            q, k, freqs_cis, q_scale, k_scale, epsilon, rot_dim=rot_dim)
     return _rms_rope_pair(q, k, freqs_cis, q_scale, k_scale, epsilon, True)
 
 
@@ -1234,9 +1244,14 @@ def rms_rope_split_half_(
     q_scale: torch.Tensor,
     k_scale: torch.Tensor | None = None,
     epsilon: float = 1e-6,
+    rot_dim: int = 0,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     if k_scale is None:
         k_scale = q_scale
+    if rot_dim and rot_dim != q.shape[-1]:
+        # partial rotary is not fused in the WMMA kernel
+        return _eager.rms_rope_split_half_(
+            q, k, freqs_cis, q_scale, k_scale, epsilon, rot_dim=rot_dim)
     check_rope_inplace(q, k, readonly=(freqs_cis, q_scale, k_scale))
     return _rms_rope_pair(q, k, freqs_cis, q_scale, k_scale, epsilon, True, inplace=True)
 

--- a/comfy_kitchen/backends/triton/rms_rope.py
+++ b/comfy_kitchen/backends/triton/rms_rope.py
@@ -3,6 +3,7 @@ import torch
 import triton
 import triton.language as tl
 from comfy_kitchen._rope_utils import check_rope_inplace, detect_rms_rope_bnhd
+from comfy_kitchen.backends.eager import rope as _eager_rope
 
 
 @triton.jit
@@ -235,9 +236,14 @@ def rms_rope_split_half(
     q_scale: torch.Tensor,
     k_scale: torch.Tensor | None = None,
     epsilon: float = 1e-6,
+    rot_dim: int = 0,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     if k_scale is None:
         k_scale = q_scale
+    if rot_dim and rot_dim != q.shape[-1]:
+        # partial rotary is not fused in the triton kernel
+        return _eager_rope.rms_rope_split_half(
+            q, k, freqs_cis, q_scale, k_scale, epsilon, rot_dim=rot_dim)
     return (
         _rms_rope(q, freqs_cis, q_scale, epsilon, split_half=True),
         _rms_rope(k, freqs_cis, k_scale, epsilon, split_half=True),
@@ -251,9 +257,14 @@ def rms_rope_split_half_(
     q_scale: torch.Tensor,
     k_scale: torch.Tensor | None = None,
     epsilon: float = 1e-6,
+    rot_dim: int = 0,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     if k_scale is None:
         k_scale = q_scale
+    if rot_dim and rot_dim != q.shape[-1]:
+        # partial rotary is not fused in the triton kernel
+        return _eager_rope.rms_rope_split_half_(
+            q, k, freqs_cis, q_scale, k_scale, epsilon, rot_dim=rot_dim)
     check_rope_inplace(q, k, readonly=(freqs_cis, q_scale, k_scale))
     return (
         _rms_rope(q, freqs_cis, q_scale, epsilon, split_half=True, inplace=True),

--- a/tests/test_int8_input_act.py
+++ b/tests/test_int8_input_act.py
@@ -174,3 +174,100 @@ class TestInt8LinearInputAct:
         denom = ref.float().abs().max()
         rel = ((got.float() - ref.float()).abs().max() / denom).item()
         assert rel < 0.05, f"3d: rel={rel:.3e}"
+
+
+def _swiglu(x):
+    gate, up = x.chunk(2, dim=-1)
+    return functional.silu(gate) * up
+
+
+class TestSwiGLUInputAct:
+    """swiglu is the gated pair: input rows are [gate | up], the activated row
+    silu(gate) * up is half as wide, and the weight matches the halved width."""
+
+    @pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+    @pytest.mark.parametrize("shape", [(512, 256), (1024, 4096), (37, 14336)])
+    def test_at_least_as_accurate_as_eager_chain(self, dtype, shape, seed, cuda_available):
+        if not cuda_backend_available():
+            pytest.skip("compiled CUDA backend required")
+        from comfy_kitchen.backends import cuda as cuda_backend
+
+        m, k = shape
+        h = torch.randn((m, 2 * k), dtype=dtype, device="cuda") * 2.0
+
+        hd = h.double()
+        g = functional.silu(hd[:, :k]) * hd[:, k:]
+        mat = _build_hadamard(_GROUP, device=h.device, dtype=torch.float64)
+        rot = (g.reshape(-1, k // _GROUP, _GROUP) @ mat).reshape(-1, k)
+        scale = (rot.abs().amax(-1, keepdim=True) / 127.0).clamp(min=1e-30)
+        exact_q = (rot / scale).round().clamp(-128, 127)
+
+        chain_q, _ = cuda_backend.quantize_int8_rowwise_convrot64(
+            _swiglu(h).contiguous(), _GROUP
+        )
+        fused_q, fused_s = cuda_backend.quantize_int8_rowwise_convrot64(
+            h, _GROUP, input_act="swiglu"
+        )
+
+        err_chain = (chain_q.double() - exact_q).abs().mean().item()
+        err_fused = (fused_q.double() - exact_q).abs().mean().item()
+        assert err_fused <= max(err_chain * 1.05, 1e-4), (
+            f"fused ({err_fused:.6f}) less accurate than chain ({err_chain:.6f})"
+        )
+        assert fused_q.shape == (m, k)
+        assert fused_q.dtype == torch.int8
+        assert fused_s.shape == (m, 1)
+
+    @pytest.mark.parametrize("backend", ["cuda", "triton", "eager"])
+    def test_matches_eager_activation(self, backend, seed, cuda_available):
+        """int8_linear(x, input_act="swiglu") == int8_linear(swiglu(x)) everywhere."""
+        device = "cuda" if cuda_available else "cpu"
+        if backend not in get_capable_backends("int8_linear", device):
+            pytest.skip(f"backend '{backend}' not capable")
+
+        m, k, n = 1024, 4096, 512
+        h = torch.randn(m, 2 * k, dtype=torch.bfloat16, device=device)
+        weight = torch.randint(-127, 127, (n, k), dtype=torch.int8, device=device)
+        wscale = torch.tensor(0.01, dtype=torch.float32, device=device)
+
+        with ck.use_backend(backend):
+            ref = ck.int8_linear(
+                _swiglu(h), weight, wscale, None, torch.bfloat16,
+                convrot=True, convrot_groupsize=_GROUP,
+            )
+            got = ck.int8_linear(
+                h, weight, wscale, None, torch.bfloat16,
+                convrot=True, convrot_groupsize=_GROUP, input_act="swiglu",
+            )
+
+        assert got.shape == (m, n)
+        denom = ref.float().abs().max()
+        rel = ((got.float() - ref.float()).abs().max() / denom).item()
+        assert rel < 0.05, f"{backend}: rel={rel:.3e}"
+
+    @pytest.mark.parametrize(
+        "tag,shape,kwargs",
+        [
+            ("no convrot", (1024, 2 * 4096), {"convrot": False}),
+            ("K over smem cap", (64, 2 * 256 * 72), {"convrot": True, "convrot_groupsize": 256}),
+            ("m == 1", (1, 2 * 4096), {"convrot": True, "convrot_groupsize": 256}),
+        ],
+    )
+    def test_fallback_paths_agree(self, tag, shape, kwargs, seed, cuda_available):
+        """Paths the fused kernel cannot serve must still apply the activation."""
+        if not cuda_available:
+            pytest.skip("CUDA required")
+
+        m, k2 = shape
+        k = k2 // 2
+        h = torch.randn(m, k2, dtype=torch.bfloat16, device="cuda")
+        weight = torch.randint(-127, 127, (256, k), dtype=torch.int8, device="cuda")
+        wscale = torch.tensor(0.01, dtype=torch.float32, device="cuda")
+
+        ref = ck.int8_linear(_swiglu(h), weight, wscale, None, torch.bfloat16, **kwargs)
+        got = ck.int8_linear(
+            h, weight, wscale, None, torch.bfloat16, input_act="swiglu", **kwargs
+        )
+        denom = ref.float().abs().max().clamp(min=1e-9)
+        rel = ((got.float() - ref.float()).abs().max() / denom).item()
+        assert rel < 0.05, f"{tag}: rel={rel:.3e}"

--- a/tests/test_rms_rope.py
+++ b/tests/test_rms_rope.py
@@ -417,3 +417,103 @@ def test_rms_rope_inplace_storage(op_name, backend, device, monkeypatch):
     refs = reference if paired else (reference,)
     for actual, expected in zip(outputs, refs, strict=True):
         torch.testing.assert_close(actual, expected, rtol=2e-3, atol=2e-3)
+
+
+class TestPartialRotary:
+    """rot_dim rotates a head-dim prefix in split-half pairs (i, i + rot_dim//2);
+    the RMS norm always spans the full head_dim and the tail passes through."""
+
+    _S, _H, _D, _ROT = 333, 8, 128, 96
+
+    def _reference(self, x, freqs_cis, scale, epsilon, rot_dim):
+        x_float = x.float()
+        rrms = torch.rsqrt(x_float.square().mean(dim=-1, keepdim=True) + epsilon)
+        x_norm = (x_float * rrms * scale.float()).to(x.dtype).float()
+        half = rot_dim // 2
+        x1, x2 = x_norm[..., :half], x_norm[..., half:rot_dim]
+        f = freqs_cis.float()
+        o1 = f[..., 0, 0] * x1 + f[..., 0, 1] * x2
+        o2 = f[..., 1, 0] * x1 + f[..., 1, 1] * x2
+        return torch.cat([o1, o2, x_norm[..., rot_dim:]], dim=-1).to(x.dtype)
+
+    def _inputs(self, device, dtype):
+        q = torch.randn(1, self._S, self._H, self._D, dtype=dtype, device=device)
+        k = torch.randn(1, self._S, self._H, self._D, dtype=dtype, device=device)
+        freqs = torch.randn(1, self._S, 1, self._ROT // 2, 2, 2, dtype=torch.float32, device=device)
+        q_scale = torch.randn(self._D, dtype=torch.float32, device=device)
+        k_scale = torch.randn(self._D, dtype=torch.float32, device=device)
+        return q, k, freqs, q_scale, k_scale
+
+    @pytest.mark.parametrize("backend", ["cuda", "triton", "eager"])
+    @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16], ids=["bf16", "fp16"])
+    def test_partial_vs_reference(self, backend, device, seed, dtype, monkeypatch):
+        if backend not in get_capable_backends("rms_rope_split_half", device):
+            pytest.skip(f"{backend} does not support rms_rope_split_half on {device}")
+        q, k, freqs, q_scale, k_scale = self._inputs(device, dtype)
+        if backend == "cuda":
+            # the fused kernel must serve partial rotary itself, not fall back
+            q_out, k_out = _run_backend(
+                "rms_rope_split_half", backend,
+                (q, k, freqs, q_scale, k_scale, 1e-6, self._ROT), monkeypatch)
+        else:
+            with ck.use_backend(backend):
+                q_out, k_out = ck.rms_rope_split_half(
+                    q, k, freqs, q_scale, k_scale, rot_dim=self._ROT)
+        for name, out, x, scale in (("q", q_out, q, q_scale), ("k", k_out, k, k_scale)):
+            ref = self._reference(x, freqs, scale, 1e-6, self._ROT)
+            assert_values_close(out, ref, rtol=1e-3, atol=1e-3,
+                                max_mismatch_ratio=_max_mismatch(torch.float32, dtype),
+                                name=f"partial rotary {name} ({backend})")
+
+    @pytest.mark.parametrize("backend", ["cuda", "eager"])
+    def test_full_rot_dim_matches_default(self, backend, device, seed, monkeypatch):
+        """rot_dim == head_dim must be bit-identical to the default full rotation."""
+        if backend not in get_capable_backends("rms_rope_split_half", device):
+            pytest.skip(f"{backend} does not support rms_rope_split_half on {device}")
+        q, k, _, q_scale, k_scale = self._inputs(device, torch.bfloat16)
+        freqs = torch.randn(1, self._S, 1, self._D // 2, 2, 2, dtype=torch.float32, device=device)
+        with ck.use_backend(backend):
+            full = ck.rms_rope_split_half(q, k, freqs, q_scale, k_scale, rot_dim=self._D)
+            default = ck.rms_rope_split_half(q, k, freqs, q_scale, k_scale)
+        assert torch.equal(full[0], default[0]) and torch.equal(full[1], default[1])
+
+    @pytest.mark.parametrize("backend", ["cuda", "triton", "eager"])
+    def test_inplace_packed_qkv(self, backend, device, seed, monkeypatch):
+        """In-place on q/k slices of a fused QKV projection: interleaved views of
+        one buffer, bounds overlap but the element sets are disjoint."""
+        if backend not in get_capable_backends("rms_rope_split_half_", device):
+            pytest.skip(f"{backend} does not support rms_rope_split_half_ on {device}")
+        S, H, D, ROT = self._S, self._H, self._D, self._ROT
+        qkv = torch.randn(S, 3 * H * D, dtype=torch.bfloat16, device=device)
+        qkv_ref = qkv.clone()
+        freqs = torch.randn(1, S, 1, ROT // 2, 2, 2, dtype=torch.float32, device=device)
+        q_scale = torch.randn(D, dtype=torch.float32, device=device)
+        k_scale = torch.randn(D, dtype=torch.float32, device=device)
+        q, k, v = (t.view(1, S, H, D) for t in qkv.split(H * D, dim=-1))
+        qr, kr, vr = (t.view(1, S, H, D) for t in qkv_ref.split(H * D, dim=-1))
+        with ck.use_backend(backend):
+            ck.rms_rope_split_half_(q, k, freqs, q_scale, k_scale, rot_dim=ROT)
+            q_ref, k_ref = ck.rms_rope_split_half(qr, kr, freqs, q_scale, k_scale, rot_dim=ROT)
+        assert torch.equal(q, q_ref) and torch.equal(k, k_ref)
+        assert torch.equal(v, vr), "v must not be touched by in-place q/k rope"
+
+    def test_inplace_rejects_true_overlap(self, device, seed):
+        """Views that genuinely share elements must still be rejected."""
+        buf = torch.randn(64, 256, dtype=torch.bfloat16, device=device)
+        q = buf[:, :128].view(1, 64, 1, 128)
+        k = buf[:, 64:192].view(1, 64, 1, 128)  # overlaps q's second half
+        freqs = torch.randn(1, 64, 1, 64, 2, 2, dtype=torch.float32, device=device)
+        scale = torch.randn(128, dtype=torch.float32, device=device)
+        with pytest.raises(ValueError, match="non-overlapping"):
+            ck.rms_rope_split_half_(q, k, freqs, scale, scale)
+
+    def test_inplace_rejects_nonmultiple_strides(self, device, seed):
+        """Same-layout views whose outer strides are not multiples of each other
+        can collide through index combinations; the check stays conservative."""
+        base = torch.randn(4096, dtype=torch.bfloat16, device=device)
+        x = base.as_strided((3, 4, 20), (1000, 130, 1), 0).unsqueeze(0)
+        y = base.as_strided((3, 4, 20), (1000, 130, 1), 40).unsqueeze(0)
+        freqs = torch.randn(1, 3, 1, 10, 2, 2, dtype=torch.float32, device=device)
+        scale = torch.randn(20, dtype=torch.float32, device=device)
+        with pytest.raises(ValueError, match="non-overlapping"):
+            ck.rms_rope_split_half_(x, y, freqs, scale, scale)

--- a/tests/test_rms_rope.py
+++ b/tests/test_rms_rope.py
@@ -465,7 +465,7 @@ class TestPartialRotary:
                                 max_mismatch_ratio=_max_mismatch(torch.float32, dtype),
                                 name=f"partial rotary {name} ({backend})")
 
-    @pytest.mark.parametrize("backend", ["cuda", "eager"])
+    @pytest.mark.parametrize("backend", ["cuda", "triton", "eager"])
     def test_full_rot_dim_matches_default(self, backend, device, seed, monkeypatch):
         """rot_dim == head_dim must be bit-identical to the default full rotation."""
         if backend not in get_capable_backends("rms_rope_split_half", device):
@@ -483,17 +483,17 @@ class TestPartialRotary:
         one buffer, bounds overlap but the element sets are disjoint."""
         if backend not in get_capable_backends("rms_rope_split_half_", device):
             pytest.skip(f"{backend} does not support rms_rope_split_half_ on {device}")
-        S, H, D, ROT = self._S, self._H, self._D, self._ROT
-        qkv = torch.randn(S, 3 * H * D, dtype=torch.bfloat16, device=device)
+        seq_len, heads, head_dim, rot = self._S, self._H, self._D, self._ROT
+        qkv = torch.randn(seq_len, 3 * heads * head_dim, dtype=torch.bfloat16, device=device)
         qkv_ref = qkv.clone()
-        freqs = torch.randn(1, S, 1, ROT // 2, 2, 2, dtype=torch.float32, device=device)
-        q_scale = torch.randn(D, dtype=torch.float32, device=device)
-        k_scale = torch.randn(D, dtype=torch.float32, device=device)
-        q, k, v = (t.view(1, S, H, D) for t in qkv.split(H * D, dim=-1))
-        qr, kr, vr = (t.view(1, S, H, D) for t in qkv_ref.split(H * D, dim=-1))
+        freqs = torch.randn(1, seq_len, 1, rot // 2, 2, 2, dtype=torch.float32, device=device)
+        q_scale = torch.randn(head_dim, dtype=torch.float32, device=device)
+        k_scale = torch.randn(head_dim, dtype=torch.float32, device=device)
+        q, k, v = (t.view(1, seq_len, heads, head_dim) for t in qkv.split(heads * head_dim, dim=-1))
+        qr, kr, vr = (t.view(1, seq_len, heads, head_dim) for t in qkv_ref.split(heads * head_dim, dim=-1))
         with ck.use_backend(backend):
-            ck.rms_rope_split_half_(q, k, freqs, q_scale, k_scale, rot_dim=ROT)
-            q_ref, k_ref = ck.rms_rope_split_half(qr, kr, freqs, q_scale, k_scale, rot_dim=ROT)
+            ck.rms_rope_split_half_(q, k, freqs, q_scale, k_scale, rot_dim=rot)
+            q_ref, k_ref = ck.rms_rope_split_half(qr, kr, freqs, q_scale, k_scale, rot_dim=rot)
         assert torch.equal(q, q_ref) and torch.equal(k, k_ref)
         assert torch.equal(v, vr), "v must not be touched by in-place q/k rope"
 
@@ -517,3 +517,24 @@ class TestPartialRotary:
         scale = torch.randn(20, dtype=torch.float32, device=device)
         with pytest.raises(ValueError, match="non-overlapping"):
             ck.rms_rope_split_half_(x, y, freqs, scale, scale)
+
+    @pytest.mark.parametrize("backend", ["cuda", "triton", "eager"])
+    def test_inplace_partial_gqa_shapes(self, backend, device, seed):
+        """Mismatched Q/K head counts route through a fallback that must still
+        honor the in-place contract: the caller's buffers get written even if
+        the return value is ignored."""
+        if backend not in get_capable_backends("rms_rope_split_half_", device):
+            pytest.skip(f"{backend} does not support rms_rope_split_half_ on {device}")
+        seq_len, head_dim, rot = 65, self._D, self._ROT
+        q = torch.randn(1, seq_len, 8, head_dim, dtype=torch.bfloat16, device=device)
+        k = torch.randn(1, seq_len, 2, head_dim, dtype=torch.bfloat16, device=device)
+        q_orig, k_orig = q.clone(), k.clone()
+        freqs = torch.randn(1, seq_len, 1, rot // 2, 2, 2, dtype=torch.float32, device=device)
+        q_scale = torch.randn(head_dim, dtype=torch.float32, device=device)
+        k_scale = torch.randn(head_dim, dtype=torch.float32, device=device)
+        with ck.use_backend(backend):
+            q_ref, k_ref = ck.rms_rope_split_half(q, k, freqs, q_scale, k_scale, rot_dim=rot)
+            ck.rms_rope_split_half_(q, k, freqs, q_scale, k_scale, rot_dim=rot)
+        assert torch.equal(q, q_ref) and torch.equal(k, k_ref)
+        assert not torch.equal(q, q_orig), "q buffer was never written in place"
+        assert not torch.equal(k, k_orig), "k buffer was never written in place"


### PR DESCRIPTION
Two additions for packed single-stream DiTs, plus build fixes:

- int8_linear input_act gains "swiglu": the quantizer reads a [gate | up] row
  (2*K wide) and absorbs silu(gate) * up on the way in, so the MLP intermediate
  never round-trips through HBM. 

- rms_rope_split_half(_) gains rot_dim: partial rotary that rotates only a
  head-dim prefix (pairs (i, i + rot_dim/2)) while the RMS norm spans the full
  head dim. In-place now also accepts q/k slices of a fused QKV projection
  (interleaved views were rejected by the conservative overlap check).

- And building on Windows surfaced two MSVC 14.42 C3495 errors (constexpr locals captured into nested
  dispatch lambdas) that broke the CUDA build, should be behavior-neutral fix.

Tests:
- swiglu cases added to test_int8_input_act.py 
- TestPartialRotary added to test_rms_rope.py
