### PR TITLE
Fix HIP backend device detection on ROCm lazy initialization

### DIFF
--- a/comfy_kitchen/backends/hip/__init__.py
+++ b/comfy_kitchen/backends/hip/__init__.py
@@ -121,6 +121,10 @@ def _visible_gfx_arches() -> tuple[str | None, ...]:
     """
     if not torch.cuda.is_available() or not getattr(torch.version, "hip", None):
         return ()
+
+    # ROCm lazy initialization: device_count() may return 0 until HIP is initialized.
+    torch.cuda.current_device()
+
     return tuple(_gfx_arch(i) for i in range(torch.cuda.device_count()))
 
 


### PR DESCRIPTION
Don't know if I missed this when I tested https://github.com/Comfy-Org/comfy-kitchen/pull/74, but with the current build, it fails to detect my 6800xt (RDNA2) card, as it returned a device count of 0.
> [INFO] Found comfy_kitchen backend hip: {'available': False, 'disabled': False, 'unavailable_reason': 'no HIP device available', 'capabilities': []}

The fix seems to relatively easy to initialize the device before counting. I've tested it on my machine and it now correctly returns 
> [INFO] Found comfy_kitchen backend hip: {'available': True, 'disabled': False, 'unavailable_reason': None, 'capabilities': ['adaln', 'apply_rope', 'apply_rope1', 'apply_rope1_', 'apply_rope_', 'apply_rope_split_half', 'apply_rope_split_half1', 'apply_rope_split_half1_', 'apply_rope_split_half_', 'dequantize_convrot_w4a4_weight', 'dequantize_int8_convrot_weight_dtype', 'dequantize_int8_simple_dtype', 'dequantize_per_tensor_fp8', 'gemv_awq_w4a16', 'quantize_and_rotate_rowwise', 'quantize_convrot_w4a4_weight', 'quantize_int8_convrot_weight', 'quantize_int8_rowwise', 'quantize_int8_tensorwise', 'quantize_per_tensor_fp8', 'quantize_svdquant_w4a4', 'rms_adaln', 'rms_rope', 'rms_rope1', 'rms_rope1_', 'rms_rope_', 'rms_rope_split_half', 'rms_rope_split_half1', 'rms_rope_split_half1_', 'rms_rope_split_half_', 'stochastic_rounding_fp8']}

I have read and agree to the DCO, although this fix doesn't really have much intellectual property going for it.