### PR TITLE
Add optimized w4a8 with int8 codebook

### DIFF
--- a/comfy_kitchen/__init__.py
+++ b/comfy_kitchen/__init__.py
@@ -20,6 +20,11 @@ from .tensor.convrot_w4a4 import (
     dequantize_convrot_w4a4_weight,
     quantize_convrot_w4a4_weight,
 )
+from .tensor.w4a8_int8 import (
+    dequantize_w4a8_int8_weight,
+    quantize_w4a8_int8_weight,
+    w4a8_int8_linear,
+)
 
 # Loading the HIP extension also loads the ROCm runtime. Do that only under a
 # ROCm PyTorch build so CUDA/CPU processes do not pay the import cost or acquire
@@ -47,6 +52,7 @@ __all__ = [
     "dequantize_mxfp8",
     "quantize_svdquant_w4a4",
     "quantize_convrot_w4a4_weight",
+    "quantize_w4a8_int8_weight",
     "quantize_int8_rowwise",
     "quantize_int8_tensorwise",
     "dequantize_int8_simple",
@@ -56,8 +62,10 @@ __all__ = [
     "scaled_mm_svdquant_w4a4",
     "convrot_w4a4_linear",
     "dequantize_convrot_w4a4_weight",
+    "dequantize_w4a8_int8_weight",
     "gemv_awq_w4a16",
     "int8_linear",
+    "w4a8_int8_linear",
     # Positional encoding
     "apply_rope",
     "apply_rope_",

--- a/comfy_kitchen/backends/cuda/CMakeLists.txt
+++ b/comfy_kitchen/backends/cuda/CMakeLists.txt
@@ -134,6 +134,7 @@ set(CUDA_SOURCES
     ops/quantize_svdquant_w4a4.cu
     ops/scaled_mm_svdquant_w4a4.cu
     ops/awq_w4a16.cu
+    ops/w4a8_gemm.cu
     ops/adaln.cu
 )
 

--- a/comfy_kitchen/backends/cuda/__init__.py
+++ b/comfy_kitchen/backends/cuda/__init__.py
@@ -52,7 +52,9 @@ __all__ = [
     "dequantize_int8_convrot_weight",
     "dequantize_int8_convrot_weight_dtype",
     "dequantize_convrot_w4a4_weight",
+    "dequantize_w4a8_int8_weight",
     "int8_linear",
+    "w4a8_int8_linear",
     "int4_linear",
     "convrot_w4a4_linear",
     "prepare_int4_weight_for_int8_linear",
@@ -62,7 +64,9 @@ __all__ = [
     "quantize_int4_rowwise_convrot64",
     "quantize_int4_rowwise_convrot64_to_int8",
     "quantize_convrot_w4a4_weight",
+    "quantize_w4a8_int8_weight",
     "quantize_int8_convrot_weight",
+    "rotate_int8_convrot_weight",
     "quantize_int8_rowwise_convrot64",
     "quantize_and_rotate_rowwise",
     "gemv_awq_w4a16",
@@ -168,6 +172,15 @@ from comfy_kitchen.backends.eager.svdquant import (  # noqa: E402
     _INT4_GROUP_SIZE,
     _unpack_int4_row_major,
 )
+from comfy_kitchen.backends.eager.w4a8_int8 import (  # noqa: E402
+    _dequantize_w4a8_int8_weight_from_int8,
+    _quantize_rotated_w4a8_int8_weight,
+    validate_w4a8_operands,
+    validate_w4a8_weight_shape,
+)
+from comfy_kitchen.backends.eager.w4a8_int8 import (  # noqa: E402
+    w4a8_int8_linear as eager_w4a8_int8_linear,
+)
 from comfy_kitchen.constraints import (  # noqa: E402
     DivisibleBy,
     ExactDims,
@@ -195,6 +208,7 @@ _device_multiprocessor_count_cache: dict[int, int] = {}
 _FORCE_INT4_INT8_FALLBACK = os.environ.get("COMFY_KITCHEN_FORCE_INT4_INT8_FALLBACK", "0") == "1"
 _INT4_PACKED_WEIGHT_SMALL_M_MAX = 8
 _INT4_INT8_WEIGHT_CHUNK_N = max(1, int(os.environ.get("COMFY_KITCHEN_INT4_INT8_WEIGHT_CHUNK_N", "4096")))
+_W4A8_CHUNKED = os.environ.get("COMFY_KITCHEN_W4A8_CHUNKED", "1") != "0"
 _NVIDIA_16_SERIES = (
     "1660",
     "1650",
@@ -1324,17 +1338,43 @@ def quantize_int8_rowwise_convrot(
     return q_2d, scales_2d
 
 
-def rotate_int8_convrot_weight(weight_2d: torch.Tensor, group_size: int) -> torch.Tensor:
+def rotate_int8_convrot_weight(weight: torch.Tensor, group_size: int) -> torch.Tensor:
     """ConvRot weight rotation using the CUDA FHT kernel."""
-    output = torch.empty_like(weight_2d)
-    stream_ptr = torch.cuda.current_stream(weight_2d.device).cuda_stream
+    output = torch.empty_like(weight)
+    stream_ptr = torch.cuda.current_stream(weight.device).cuda_stream
     _C.rotate_int8_convrot_weight(
-        _wrap_for_dlpack(weight_2d),
+        _wrap_for_dlpack(weight),
         _wrap_for_dlpack(output),
         group_size,
         stream_ptr,
     )
     return output
+
+
+def quantize_w4a8_int8_weight(
+    weight: torch.Tensor,
+    group_size: int = 16,
+    convrot_groupsize: int = 256,
+    symmetric: bool = True,
+    scale_dtype: torch.dtype = torch.float8_e4m3fn,
+    codebook: bool = True,
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor | None,
+    torch.Tensor | None,
+]:
+    """Prepare W4A8 weights using native CUDA ConvRot and eager packing math."""
+    validate_w4a8_weight_shape(weight, group_size, convrot_groupsize)
+    rotated = rotate_int8_convrot_weight(weight.contiguous(), convrot_groupsize)
+    return _quantize_rotated_w4a8_int8_weight(
+        rotated,
+        group_size=group_size,
+        symmetric=symmetric,
+        scale_dtype=scale_dtype,
+        codebook=codebook,
+    )
 
 
 def quantize_int8_convrot_staged(
@@ -1941,6 +1981,223 @@ def int8_linear(
         )
 
     return out if is_2d_output else out.reshape(*orig_shape[:-1], n)
+
+
+def dequantize_w4a8_int8_weight(
+    qdata: torch.Tensor,
+    s_rel: torch.Tensor,
+    s_channel: torch.Tensor,
+    codebook: torch.Tensor | None = None,
+    correction: torch.Tensor | None = None,
+    group_size: int = 16,
+    convrot_groupsize: int = 256,
+    output_dtype: torch.dtype = torch.bfloat16,
+) -> torch.Tensor:
+    """Dequantize W4A8 weights with native CUDA decode and ConvRot operations."""
+    validate_w4a8_operands(
+        qdata,
+        s_rel,
+        s_channel,
+        codebook,
+        correction,
+        group_size,
+        convrot_groupsize,
+    )
+    qdata_arg = qdata.contiguous()
+    s_rel_arg = s_rel.contiguous()
+    codebook_arg = codebook.contiguous() if codebook is not None else None
+    n, k_half = qdata_arg.shape
+    int8_weight = torch.empty(n, k_half * 2, dtype=torch.int8, device=qdata.device)
+    stream_ptr = torch.cuda.current_stream(qdata.device).cuda_stream
+    wrapped_codebook = _wrap_for_dlpack(codebook_arg) if codebook_arg is not None else None
+    if s_rel_arg.dtype == torch.float8_e4m3fn:
+        _C.dequant_int4_grouped_to_int8_e4m3(
+            _wrap_for_dlpack(qdata_arg),
+            _wrap_for_dlpack(s_rel_arg.view(torch.uint8)),
+            wrapped_codebook,
+            _wrap_for_dlpack(int8_weight),
+            group_size,
+            stream_ptr,
+        )
+    else:
+        _C.dequant_int4_grouped_to_int8(
+            _wrap_for_dlpack(qdata_arg),
+            _wrap_for_dlpack(s_rel_arg),
+            wrapped_codebook,
+            _wrap_for_dlpack(int8_weight),
+            group_size,
+            stream_ptr,
+        )
+    weight_rotated = _dequantize_w4a8_int8_weight_from_int8(
+        int8_weight,
+        s_channel,
+        correction,
+        group_size,
+        output_dtype,
+    )
+    return rotate_int8_convrot_weight(weight_rotated.contiguous(), convrot_groupsize).to(output_dtype)
+
+
+def w4a8_int8_linear(
+    x: torch.Tensor,
+    qdata: torch.Tensor,
+    s_rel: torch.Tensor,
+    s_channel: torch.Tensor,
+    codebook: torch.Tensor | None = None,
+    correction: torch.Tensor | None = None,
+    bias: torch.Tensor | None = None,
+    group_size: int = 16,
+    convrot_groupsize: int = 256,
+    out_dtype: torch.dtype = torch.bfloat16,
+) -> torch.Tensor:
+    """CUDA W4A8 linear using chunked INT4 decode and the tuned INT8 GEMM."""
+    validate_w4a8_operands(
+        qdata,
+        s_rel,
+        s_channel,
+        codebook,
+        correction,
+        group_size,
+        convrot_groupsize,
+    )
+    n, k_half = qdata.shape
+    k = k_half * 2
+    if x.shape[-1] != k:
+        raise ValueError(f"Input K={x.shape[-1]} does not match qdata K={k}")
+    groups = k // group_size
+    x_2d = x.reshape(-1, k).contiguous()
+    m = x_2d.shape[0]
+    output_dtype_code = DTYPE_TO_CODE[out_dtype]
+    stream_ptr = torch.cuda.current_stream(x.device).cuda_stream
+
+    def wrap_codebook():
+        return _wrap_for_dlpack(codebook) if codebook is not None else None
+
+    xq = torch.empty(m, k, dtype=torch.int8, device=x.device)
+    xs = torch.empty(m, 1, dtype=torch.float32, device=x.device)
+    out = torch.empty(m, n, dtype=out_dtype, device=x.device)
+    bias_float = bias.float().contiguous() if bias is not None else None
+
+    chunked = (
+        _W4A8_CHUNKED
+        and correction is None
+        and s_rel.dtype == torch.float8_e4m3fn
+    )
+    if chunked:
+        chunk_cols = _int4_int8_weight_chunk_cols(m, n)
+        workspace = torch.empty(
+            min(chunk_cols, n), k, dtype=torch.int8, device=x.device
+        )
+        if hasattr(_C, "w4a8_codebook_linear_chunked"):
+            used = _C.w4a8_codebook_linear_chunked(
+                _wrap_for_dlpack(x_2d),
+                _wrap_for_dlpack(xq),
+                _wrap_for_dlpack(xs),
+                _wrap_for_dlpack(qdata),
+                _wrap_for_dlpack(s_rel.view(torch.uint8)),
+                wrap_codebook(),
+                _wrap_for_dlpack(s_channel),
+                _wrap_for_dlpack(bias_float) if bias_float is not None else None,
+                _wrap_for_dlpack(workspace),
+                _wrap_for_dlpack(out),
+                convrot_groupsize,
+                group_size,
+                chunk_cols,
+                output_dtype_code,
+                stream_ptr,
+            )
+        else:
+            _C.quantize_int8_rowwise_convrot(
+                _wrap_for_dlpack(x_2d),
+                _wrap_for_dlpack(xq),
+                _wrap_for_dlpack(xs),
+                convrot_groupsize,
+                False,
+                0,
+                stream_ptr,
+            )
+            used = _C.w4a8_codebook_gemm_chunked(
+                _wrap_for_dlpack(xq),
+                _wrap_for_dlpack(qdata),
+                _wrap_for_dlpack(s_rel.view(torch.uint8)),
+                wrap_codebook(),
+                _wrap_for_dlpack(s_channel),
+                _wrap_for_dlpack(xs.reshape(m)),
+                _wrap_for_dlpack(bias_float) if bias_float is not None else None,
+                _wrap_for_dlpack(workspace),
+                _wrap_for_dlpack(out),
+                group_size,
+                chunk_cols,
+                output_dtype_code,
+                stream_ptr,
+            )
+        if used:
+            return out.reshape(*x.shape[:-1], n)
+    else:
+        _C.quantize_int8_rowwise_convrot(
+            _wrap_for_dlpack(x_2d),
+            _wrap_for_dlpack(xq),
+            _wrap_for_dlpack(xs),
+            convrot_groupsize,
+            False,
+            0,
+            stream_ptr,
+        )
+
+    int8_weight = torch.empty(n, k, dtype=torch.int8, device=x.device)
+    if s_rel.dtype == torch.float8_e4m3fn:
+        _C.dequant_int4_grouped_to_int8_e4m3(
+            _wrap_for_dlpack(qdata),
+            _wrap_for_dlpack(s_rel.view(torch.uint8)),
+            wrap_codebook(),
+            _wrap_for_dlpack(int8_weight),
+            group_size,
+            stream_ptr,
+        )
+    else:
+        _C.dequant_int4_grouped_to_int8(
+            _wrap_for_dlpack(qdata),
+            _wrap_for_dlpack(s_rel),
+            wrap_codebook(),
+            _wrap_for_dlpack(int8_weight),
+            group_size,
+            stream_ptr,
+        )
+
+    bias_arg = (
+        bias_float
+        if bias_float is not None
+        else _empty_cuda_tensor(x.device, torch.float32)
+    )
+    used = _C.cutlass_int8_dequant(
+        _wrap_for_dlpack(xq),
+        _wrap_for_dlpack(int8_weight),
+        _wrap_for_dlpack(xs),
+        _wrap_for_dlpack(s_channel),
+        _wrap_for_dlpack(bias_arg),
+        _wrap_for_dlpack(out),
+        output_dtype_code,
+        stream_ptr,
+    )
+    if not used:
+        return eager_w4a8_int8_linear(
+            x,
+            qdata,
+            s_rel,
+            s_channel,
+            codebook=codebook,
+            correction=correction,
+            bias=bias,
+            group_size=group_size,
+            convrot_groupsize=convrot_groupsize,
+            out_dtype=out_dtype,
+        )
+
+    if correction is not None:
+        sx = xq.view(m, groups, group_size).sum(-1, dtype=torch.int32).to(out_dtype)
+        sx = sx * xs.to(out_dtype)
+        out.addmm_(sx, correction.to(out_dtype))
+    return out.reshape(*x.shape[:-1], n)
 
 
 def _adaln_impl(kernel, x: torch.Tensor, scale: torch.Tensor, shift: torch.Tensor, eps: float):
@@ -2897,6 +3154,99 @@ def _build_constraints() -> dict:
                 "stochastic_rounding": ParamConstraint(dtypes=frozenset({int})),
             },
             default_devices=cuda_devices,
+        ),
+        "rotate_int8_convrot_weight": FunctionConstraints(
+            params={
+                "weight": ParamConstraint(
+                    dtypes=frozenset({torch.float32, torch.float16, torch.bfloat16}),
+                    shape_rules=(ExactDims(2),),
+                ),
+                "group_size": ParamConstraint(dtypes=frozenset({int})),
+            },
+            default_devices=cuda_devices,
+        ),
+        "quantize_w4a8_int8_weight": FunctionConstraints(
+            params={
+                "weight": ParamConstraint(
+                    dtypes=frozenset({torch.float32, torch.float16, torch.bfloat16}),
+                    shape_rules=(ExactDims(2),),
+                ),
+                "group_size": ParamConstraint(dtypes=frozenset({int})),
+                "convrot_groupsize": ParamConstraint(dtypes=frozenset({int})),
+                "symmetric": ParamConstraint(dtypes=frozenset({bool})),
+                "scale_dtype": ParamConstraint(dtypes=frozenset({torch.float8_e4m3fn, torch.float32})),
+                "codebook": ParamConstraint(dtypes=frozenset({bool})),
+            },
+            default_devices=cuda_devices,
+            min_compute_capability=(8, 0),
+        ),
+        "dequantize_w4a8_int8_weight": FunctionConstraints(
+            params={
+                "qdata": ParamConstraint(
+                    dtypes=frozenset({torch.int8}),
+                    shape_rules=(ExactDims(2),),
+                ),
+                "s_rel": ParamConstraint(
+                    dtypes=frozenset({torch.float8_e4m3fn, torch.float32}),
+                    shape_rules=(ExactDims(2),),
+                ),
+                "s_channel": ParamConstraint(
+                    dtypes=frozenset({torch.float32}),
+                    shape_rules=(ExactDims(1),),
+                ),
+                "codebook": ParamConstraint(
+                    dtypes=frozenset({torch.float32}),
+                    shape_rules=(ExactDims(1),),
+                ),
+                "correction": ParamConstraint(
+                    dtypes=frozenset({torch.float32, torch.float16, torch.bfloat16}),
+                    shape_rules=(ExactDims(2),),
+                ),
+                "group_size": ParamConstraint(dtypes=frozenset({int})),
+                "convrot_groupsize": ParamConstraint(dtypes=frozenset({int})),
+                "output_dtype": ParamConstraint(
+                    dtypes=frozenset({torch.float32, torch.float16, torch.bfloat16}),
+                ),
+            },
+            default_devices=cuda_devices,
+            min_compute_capability=(8, 0),
+        ),
+        "w4a8_int8_linear": FunctionConstraints(
+            params={
+                "x": ParamConstraint(
+                    dtypes=frozenset({torch.float32, torch.float16, torch.bfloat16}),
+                ),
+                "qdata": ParamConstraint(
+                    dtypes=frozenset({torch.int8}),
+                    shape_rules=(ExactDims(2),),
+                ),
+                "s_rel": ParamConstraint(
+                    dtypes=frozenset({torch.float8_e4m3fn, torch.float32}),
+                    shape_rules=(ExactDims(2),),
+                ),
+                "s_channel": ParamConstraint(
+                    dtypes=frozenset({torch.float32}),
+                    shape_rules=(ExactDims(1),),
+                ),
+                "codebook": ParamConstraint(
+                    dtypes=frozenset({torch.float32}),
+                    shape_rules=(ExactDims(1),),
+                ),
+                "correction": ParamConstraint(
+                    dtypes=frozenset({torch.float32, torch.float16, torch.bfloat16}),
+                    shape_rules=(ExactDims(2),),
+                ),
+                "bias": ParamConstraint(
+                    dtypes=frozenset({torch.float32, torch.float16, torch.bfloat16}),
+                ),
+                "group_size": ParamConstraint(dtypes=frozenset({int})),
+                "convrot_groupsize": ParamConstraint(dtypes=frozenset({int})),
+                "out_dtype": ParamConstraint(
+                    dtypes=frozenset({torch.float32, torch.float16, torch.bfloat16}),
+                ),
+            },
+            default_devices=cuda_devices,
+            min_compute_capability=(8, 0),
         ),
         "dequantize_int8_convrot_weight": FunctionConstraints(
             params={

--- a/comfy_kitchen/backends/cuda/dlpack_bindings.cpp
+++ b/comfy_kitchen/backends/cuda/dlpack_bindings.cpp
@@ -16,8 +16,10 @@
  */
 #include <nanobind/nanobind.h>
 #include <nanobind/ndarray.h>
+#include <nanobind/stl/optional.h>
 #include <cuda_runtime.h>
 #include <cstring>
+#include <optional>
 
 #include "cublaslt_runtime.h"
 #include "input_act_codes.h"
@@ -1147,6 +1149,26 @@ extern "C" {
         int out_dtype_code,
         cudaStream_t stream);
 
+    void launch_dequant_int4_grouped_to_int8(
+        const void* qw,
+        const void* s_rel,
+        const void* codebook,
+        void* out,
+        int64_t N,
+        int64_t K,
+        int64_t G,
+        cudaStream_t stream);
+
+    void launch_dequant_int4_grouped_to_int8_e4m3(
+        const void* qw,
+        const void* s_rel,
+        const void* codebook,
+        void* out,
+        int64_t N,
+        int64_t K,
+        int64_t G,
+        cudaStream_t stream);
+
     void launch_quantize_int8_rowwise_convrot_kernel(
         const void* input,
         void* output,
@@ -1864,6 +1886,36 @@ bool cutlass_turing_int4_dequant(
         a.data(), b.data(), xs.data(), ws.data(), bias_ptr, d.data(), M, N, K, out_dtype_code, stream);
 }
 
+// Grouped int4 -> int8 dequant (group scale folded; per-channel scale applied in GEMM).
+void dequant_int4_grouped_to_int8(
+    nb::ndarray<int8_t, nb::ndim<2>, nb::device::cuda> qw,     // [N, K/2]
+    nb::ndarray<float, nb::ndim<2>, nb::device::cuda> s_rel,   // [N, K/G]
+    std::optional<nb::ndarray<float, nb::ndim<1>, nb::device::cuda>> codebook,  // [16] or None
+    nb::ndarray<int8_t, nb::ndim<2>, nb::device::cuda> out,    // [N, K]
+    int64_t G, uintptr_t stream_ptr) {
+    const int64_t N = qw.shape(0);
+    const int64_t K = out.shape(1);
+    if (qw.shape(1) != K / 2) throw std::runtime_error("dequant_int4_grouped: K/2 mismatch");
+    cudaStream_t stream = reinterpret_cast<cudaStream_t>(stream_ptr);
+    const void* cb = codebook.has_value() ? codebook->data() : nullptr;
+    launch_dequant_int4_grouped_to_int8(qw.data(), s_rel.data(), cb, out.data(), N, K, G, stream);
+}
+
+// fp8 (e4m3) per-group scale: s_rel passed as raw uint8 bits.
+void dequant_int4_grouped_to_int8_e4m3(
+    nb::ndarray<int8_t, nb::ndim<2>, nb::device::cuda> qw,     // [N, K/2]
+    nb::ndarray<uint8_t, nb::ndim<2>, nb::device::cuda> s_rel, // [N, K/G] e4m3 bits
+    std::optional<nb::ndarray<float, nb::ndim<1>, nb::device::cuda>> codebook,  // [16] or None
+    nb::ndarray<int8_t, nb::ndim<2>, nb::device::cuda> out,    // [N, K]
+    int64_t G, uintptr_t stream_ptr) {
+    const int64_t N = qw.shape(0);
+    const int64_t K = out.shape(1);
+    if (qw.shape(1) != K / 2) throw std::runtime_error("dequant_int4_grouped: K/2 mismatch");
+    cudaStream_t stream = reinterpret_cast<cudaStream_t>(stream_ptr);
+    const void* cb = codebook.has_value() ? codebook->data() : nullptr;
+    launch_dequant_int4_grouped_to_int8_e4m3(qw.data(), s_rel.data(), cb, out.data(), N, K, G, stream);
+}
+
 void quantize_int8_rowwise_convrot(
     nb::ndarray<nb::ndim<2>, nb::device::cuda> input,
     nb::ndarray<int8_t, nb::ndim<2>, nb::device::cuda> output,
@@ -2507,6 +2559,16 @@ NB_MODULE(_C, m) {
           nb::arg("d"),
           nb::arg("out_dtype_code"),
           nb::arg("stream_ptr"));
+
+    m.def("dequant_int4_grouped_to_int8", &dequant_int4_grouped_to_int8,
+          "Grouped int4 -> int8 dequant (group scale folded into int8); optional 16-entry codebook",
+          nb::arg("qw"), nb::arg("s_rel"), nb::arg("codebook").none(), nb::arg("out"),
+          nb::arg("g"), nb::arg("stream_ptr"));
+
+    m.def("dequant_int4_grouped_to_int8_e4m3", &dequant_int4_grouped_to_int8_e4m3,
+          "Grouped int4 -> int8 dequant with fp8 e4m3 per-group scale; optional 16-entry codebook",
+          nb::arg("qw"), nb::arg("s_rel"), nb::arg("codebook").none(), nb::arg("out"),
+          nb::arg("g"), nb::arg("stream_ptr"));
 
     m.def("quantize_int8_rowwise_convrot", &quantize_int8_rowwise_convrot,
           "Fused ConvRot Hadamard rotation + rowwise INT8 quantization",

--- a/comfy_kitchen/backends/cuda/dlpack_bindings.cpp
+++ b/comfy_kitchen/backends/cuda/dlpack_bindings.cpp
@@ -1752,16 +1752,16 @@ bool cutlass_int8_dequant(
     const int64_t N = b.shape(0);
     if (b.shape(1) != K) throw std::runtime_error("cutlass_int8_dequant: K mismatch");
     if (d.shape(0) != M || d.shape(1) != N) throw std::runtime_error("cutlass_int8_dequant: D shape mismatch");
-    // Per-row (xs) and per-column (ws) scales, and the optional bias, are read as contiguous
-    // [M]/[N] vectors; validate lengths + out dtype so a bad call errors instead of reading OOB.
-    if (static_cast<int64_t>(xs.shape(0)) != M) throw std::runtime_error("cutlass_int8_dequant: xs must have M rows");
-    if (static_cast<int64_t>(ws.shape(0)) != N) throw std::runtime_error("cutlass_int8_dequant: ws must have N entries");
-    if (bias.size() > 0 && static_cast<int64_t>(bias.shape(0)) != N)
-        throw std::runtime_error("cutlass_int8_dequant: bias must be [N]");
-    if (out_dtype_code < 0 || out_dtype_code > 2)
-        throw std::runtime_error("cutlass_int8_dequant: out_dtype_code must be 0 (fp32), 1 (fp16), or 2 (bf16)");
-    if (d.itemsize() != (out_dtype_code == 0 ? 4u : 2u))
-        throw std::runtime_error("cutlass_int8_dequant: d.itemsize() does not match out_dtype_code");
+    // xs/ws/bias are read as contiguous [M]/[N] vectors; check element counts (via size(),
+    // which tolerates the [M,1] scale the int8 caller passes but rejects degenerate shapes
+    // like [M,0]). Match the output dtype exactly (fp16 and bf16 share itemsize but the
+    // launch selects half_t vs bfloat16_t) so a mismatched code can't reinterpret the buffer.
+    if (static_cast<int64_t>(xs.size()) != M) throw std::runtime_error("cutlass_int8_dequant: xs must be a length-M vector");
+    if (static_cast<int64_t>(ws.size()) != N) throw std::runtime_error("cutlass_int8_dequant: ws must be a length-N vector");
+    if (bias.size() != 0 && static_cast<int64_t>(bias.size()) != N)
+        throw std::runtime_error("cutlass_int8_dequant: bias must be empty or a length-N vector");
+    if (map_dtype_to_code(d.dtype()) != out_dtype_code)
+        throw std::runtime_error("cutlass_int8_dequant: output dtype does not match out_dtype_code (0=fp32, 1=fp16, 2=bf16)");
     cudaStream_t stream = reinterpret_cast<cudaStream_t>(stream_ptr);
     const void* bias_ptr = bias.size() > 0 ? bias.data() : nullptr;
     return launch_cutlass_int8_dequant(a.data(), b.data(), xs.data(), ws.data(),
@@ -2002,11 +2002,10 @@ bool w4a8_codebook_gemm_chunked(
     // each chunk by n0*itemsize. Verify the code and the buffer agree, and the out/workspace
     // geometry the chunk loop indexes, so a mismatch errors here instead of scribbling past
     // the allocation.
-    if (out_dtype_code < 0 || out_dtype_code > 2)
-        throw std::runtime_error("w4a8_codebook_gemm: out_dtype_code must be 0 (fp32), 1 (fp16), or 2 (bf16)");
-    const size_t expect_osz = (out_dtype_code == 0) ? 4u : 2u;
-    if (out.itemsize() != expect_osz)
-        throw std::runtime_error("w4a8_codebook_gemm: out.itemsize() does not match out_dtype_code");
+    // Exact dtype match: fp16 and bf16 share itemsize but the launch selects half_t vs
+    // bfloat16_t, so a mismatched code would reinterpret the buffer.
+    if (map_dtype_to_code(out.dtype()) != out_dtype_code)
+        throw std::runtime_error("w4a8_codebook_gemm: out dtype does not match out_dtype_code (0=fp32, 1=fp16, 2=bf16)");
     if (static_cast<int64_t>(out.shape(0)) != M || static_cast<int64_t>(out.shape(1)) != N)
         throw std::runtime_error("w4a8_codebook_gemm: out must be [M, N]");
     if (chunk_cols > 0) {  // chunk_cols <= 0 is handled (2-pass fallback) in the launcher

--- a/comfy_kitchen/backends/cuda/dlpack_bindings.cpp
+++ b/comfy_kitchen/backends/cuda/dlpack_bindings.cpp
@@ -1950,6 +1950,23 @@ bool w4a8_codebook_gemm_chunked(
     const int64_t K = xq.shape(1);
     const int64_t N = weight.shape(0);
     if (weight.shape(1) != K / 2) throw std::runtime_error("w4a8_codebook_gemm: K/2 mismatch");
+    // out is untyped; the kernel derives its element size from out_dtype_code and offsets
+    // each chunk by n0*itemsize. Verify the code and the buffer agree, and the out/workspace
+    // geometry the chunk loop indexes, so a mismatch errors here instead of scribbling past
+    // the allocation.
+    if (out_dtype_code < 0 || out_dtype_code > 2)
+        throw std::runtime_error("w4a8_codebook_gemm: out_dtype_code must be 0 (fp32), 1 (fp16), or 2 (bf16)");
+    const size_t expect_osz = (out_dtype_code == 0) ? 4u : 2u;
+    if (out.itemsize() != expect_osz)
+        throw std::runtime_error("w4a8_codebook_gemm: out.itemsize() does not match out_dtype_code");
+    if (static_cast<int64_t>(out.shape(0)) != M || static_cast<int64_t>(out.shape(1)) != N)
+        throw std::runtime_error("w4a8_codebook_gemm: out must be [M, N]");
+    if (chunk_cols > 0) {  // chunk_cols <= 0 is handled (2-pass fallback) in the launcher
+        const int64_t ws_rows = (chunk_cols < N) ? chunk_cols : N;
+        if (static_cast<int64_t>(workspace.shape(1)) != K
+                || static_cast<int64_t>(workspace.shape(0)) < ws_rows)
+            throw std::runtime_error("w4a8_codebook_gemm: workspace must be [>=min(chunk_cols,N), K] int8");
+    }
     cudaStream_t stream = reinterpret_cast<cudaStream_t>(stream_ptr);
     const void* cb = codebook.has_value() ? codebook->data() : nullptr;
     const void* bs = bias.has_value() ? bias->data() : nullptr;

--- a/comfy_kitchen/backends/cuda/dlpack_bindings.cpp
+++ b/comfy_kitchen/backends/cuda/dlpack_bindings.cpp
@@ -1931,7 +1931,7 @@ void dequant_int4_grouped_to_int8(
         throw std::runtime_error("dequant_int4_grouped: G must be >=4 and divide 16 or be a multiple of 16");
     if (K % G != 0) throw std::runtime_error("dequant_int4_grouped: K must be divisible by G");
     if (static_cast<int64_t>(s_rel.shape(0)) != N || static_cast<int64_t>(s_rel.shape(1)) != K / G)
-        throw std::runtime_error("dequant_int4_grouped: s_rel must be [N, K/G]");
+        throw std::runtime_error("dequant_int4_grouped: s_rel must have shape [N, K/G]");
     if (static_cast<int64_t>(out.shape(0)) != N)
         throw std::runtime_error("dequant_int4_grouped: out must be [N, K]");
     if (codebook.has_value() && static_cast<int64_t>(codebook->shape(0)) != 16)
@@ -1956,7 +1956,7 @@ void dequant_int4_grouped_to_int8_e4m3(
         throw std::runtime_error("dequant_int4_grouped: G must be >=4 and divide 16 or be a multiple of 16");
     if (K % G != 0) throw std::runtime_error("dequant_int4_grouped: K must be divisible by G");
     if (static_cast<int64_t>(s_rel.shape(0)) != N || static_cast<int64_t>(s_rel.shape(1)) != K / G)
-        throw std::runtime_error("dequant_int4_grouped: s_rel must be [N, K/G]");
+        throw std::runtime_error("dequant_int4_grouped: s_rel must have shape [N, K/G]");
     if (static_cast<int64_t>(out.shape(0)) != N)
         throw std::runtime_error("dequant_int4_grouped: out must be [N, K]");
     if (codebook.has_value() && static_cast<int64_t>(codebook->shape(0)) != 16)
@@ -1964,6 +1964,47 @@ void dequant_int4_grouped_to_int8_e4m3(
     cudaStream_t stream = reinterpret_cast<cudaStream_t>(stream_ptr);
     const void* cb = codebook.has_value() ? codebook->data() : nullptr;
     launch_dequant_int4_grouped_to_int8_e4m3(qw.data(), s_rel.data(), cb, out.data(), N, K, G, stream);
+}
+
+static void validate_w4a8_codebook_gemm_contract(
+    int64_t M, int64_t N, int64_t K,
+    int64_t weight_khalf,
+    int64_t s_rel_n, int64_t s_rel_groups,
+    int64_t s_channel_size, int64_t xs_size,
+    int64_t codebook_size, int64_t bias_size,
+    int64_t workspace_rows, int64_t workspace_cols,
+    int64_t out_rows, int64_t out_cols,
+    const nb::dlpack::dtype& out_dtype,
+    int64_t G, int64_t chunk_cols, int out_dtype_code) {
+    if (weight_khalf != K / 2)
+        throw std::runtime_error("w4a8_codebook_gemm: K/2 mismatch");
+    if (K % 16 != 0)
+        throw std::runtime_error("w4a8_codebook_gemm: K must be a multiple of 16");
+    if (G < 4 || (16 % G != 0 && G % 16 != 0))
+        throw std::runtime_error("w4a8_codebook_gemm: G must be >=4 and divide 16 or be a multiple of 16");
+    if (K % G != 0)
+        throw std::runtime_error("w4a8_codebook_gemm: K must be divisible by G");
+    if (xs_size != M)
+        throw std::runtime_error("w4a8_codebook_gemm: xs must have M values");
+    if (s_rel_n != N || s_rel_groups != K / G)
+        throw std::runtime_error("w4a8_codebook_gemm: s_rel must be [N, K/G]");
+    if (s_channel_size != N)
+        throw std::runtime_error("w4a8_codebook_gemm: s_channel must be [N]");
+    if (codebook_size >= 0 && codebook_size != 16)
+        throw std::runtime_error("w4a8_codebook_gemm: codebook must be [16]");
+    if (bias_size >= 0 && bias_size != N)
+        throw std::runtime_error("w4a8_codebook_gemm: bias must be [N]");
+    if (out_dtype_code < 0 || out_dtype_code > 2)
+        throw std::runtime_error("w4a8_codebook_gemm: out_dtype_code must be 0 (fp32), 1 (fp16), or 2 (bf16)");
+    if (map_dtype_to_code(out_dtype) != out_dtype_code)
+        throw std::runtime_error("w4a8_codebook_gemm: out dtype does not match out_dtype_code (0=fp32, 1=fp16, 2=bf16)");
+    if (out_rows != M || out_cols != N)
+        throw std::runtime_error("w4a8_codebook_gemm: out must be [M, N]");
+    if (chunk_cols > 0) {
+        const int64_t required_rows = (chunk_cols < N) ? chunk_cols : N;
+        if (workspace_cols != K || workspace_rows < required_rows)
+            throw std::runtime_error("w4a8_codebook_gemm: workspace must be [>=min(chunk_cols,N), K] int8");
+    }
 }
 
 // Chunked fused W4A8: per-chunk (codebook+s_rel) dequant -> L2-hot int8 -> strided int8 GEMM.
@@ -1981,44 +2022,77 @@ bool w4a8_codebook_gemm_chunked(
     const int64_t M = xq.shape(0);
     const int64_t K = xq.shape(1);
     const int64_t N = weight.shape(0);
-    if (weight.shape(1) != K / 2) throw std::runtime_error("w4a8_codebook_gemm: K/2 mismatch");
-    // Grouping contract: the dequant kernel is 16-wide vectorized (K % 16), and G must be a
-    // supported group size (>=4, divides 16 or a multiple of 16) that divides K so K/G groups
-    // are exact. A bad G/K silently truncates or misaligns the kernel.
-    if (K % 16 != 0) throw std::runtime_error("w4a8_codebook_gemm: K must be a multiple of 16");
-    if (G < 4 || (16 % G != 0 && G % 16 != 0))
-        throw std::runtime_error("w4a8_codebook_gemm: G must be >=4 and divide 16 or be a multiple of 16");
-    if (K % G != 0) throw std::runtime_error("w4a8_codebook_gemm: K must be divisible by G");
-    // The launcher reads these as contiguous metadata; a wrong length reads past the buffer.
-    if (static_cast<int64_t>(xq.shape(1)) != K || static_cast<int64_t>(xs.shape(0)) != M)
-        throw std::runtime_error("w4a8_codebook_gemm: xq must be [M, K] and xs [M]");
-    if (static_cast<int64_t>(s_rel.shape(0)) != N || static_cast<int64_t>(s_rel.shape(1)) != K / G)
-        throw std::runtime_error("w4a8_codebook_gemm: s_rel must be [N, K/G]");
-    if (static_cast<int64_t>(s_channel.shape(0)) != N)
-        throw std::runtime_error("w4a8_codebook_gemm: s_channel must be [N]");
-    if (codebook.has_value() && static_cast<int64_t>(codebook->shape(0)) != 16)
-        throw std::runtime_error("w4a8_codebook_gemm: codebook must be [16]");
-    if (bias.has_value() && static_cast<int64_t>(bias->shape(0)) != N)
-        throw std::runtime_error("w4a8_codebook_gemm: bias must be [N]");
-    // out is untyped; the kernel derives its element size from out_dtype_code and offsets
-    // each chunk by n0*itemsize. Verify the code and the buffer agree, and the out/workspace
-    // geometry the chunk loop indexes, so a mismatch errors here instead of scribbling past
-    // the allocation.
-    // Exact dtype match: fp16 and bf16 share itemsize but the launch selects half_t vs
-    // bfloat16_t, so a mismatched code would reinterpret the buffer.
-    if (out_dtype_code < 0 || out_dtype_code > 2)  // allow-list: the launch only supports these
-        throw std::runtime_error("w4a8_codebook_gemm: out_dtype_code must be 0 (fp32), 1 (fp16), or 2 (bf16)");
-    if (map_dtype_to_code(out.dtype()) != out_dtype_code)
-        throw std::runtime_error("w4a8_codebook_gemm: out dtype does not match out_dtype_code (0=fp32, 1=fp16, 2=bf16)");
-    if (static_cast<int64_t>(out.shape(0)) != M || static_cast<int64_t>(out.shape(1)) != N)
-        throw std::runtime_error("w4a8_codebook_gemm: out must be [M, N]");
-    if (chunk_cols > 0) {  // chunk_cols <= 0 is handled (2-pass fallback) in the launcher
-        const int64_t ws_rows = (chunk_cols < N) ? chunk_cols : N;
-        if (static_cast<int64_t>(workspace.shape(1)) != K
-                || static_cast<int64_t>(workspace.shape(0)) < ws_rows)
-            throw std::runtime_error("w4a8_codebook_gemm: workspace must be [>=min(chunk_cols,N), K] int8");
-    }
+    validate_w4a8_codebook_gemm_contract(
+        M, N, K,
+        weight.shape(1),
+        s_rel.shape(0), s_rel.shape(1),
+        s_channel.size(), xs.size(),
+        codebook.has_value() ? static_cast<int64_t>(codebook->size()) : -1,
+        bias.has_value() ? static_cast<int64_t>(bias->size()) : -1,
+        workspace.shape(0), workspace.shape(1),
+        out.shape(0), out.shape(1), out.dtype(),
+        G, chunk_cols, out_dtype_code);
     cudaStream_t stream = reinterpret_cast<cudaStream_t>(stream_ptr);
+    const void* cb = codebook.has_value() ? codebook->data() : nullptr;
+    const void* bs = bias.has_value() ? bias->data() : nullptr;
+    return launch_w4a8_codebook_gemm_chunked(
+        xq.data(), weight.data(), s_rel.data(), cb, s_channel.data(), xs.data(), bs,
+        workspace.data(), out.data(), M, N, K, G, chunk_cols, out_dtype_code, stream);
+}
+
+// Common W4A8 inference path: online ConvRot activation quantization followed by the
+// chunked int4 decode + strided INT8 GEMM, coordinated through one Python/native call.
+bool w4a8_codebook_linear_chunked(
+    nb::ndarray<nb::ndim<2>, nb::device::cuda> input,             // [M, K] fp32/fp16/bf16
+    nb::ndarray<int8_t, nb::ndim<2>, nb::device::cuda> xq,       // [M, K]
+    nb::ndarray<float, nb::ndim<2>, nb::device::cuda> xs,        // [M, 1]
+    nb::ndarray<int8_t, nb::ndim<2>, nb::device::cuda> weight,   // [N, K/2]
+    nb::ndarray<uint8_t, nb::ndim<2>, nb::device::cuda> s_rel,   // [N, K/G]
+    std::optional<nb::ndarray<float, nb::ndim<1>, nb::device::cuda>> codebook,
+    nb::ndarray<float, nb::ndim<1>, nb::device::cuda> s_channel, // [N]
+    std::optional<nb::ndarray<float, nb::ndim<1>, nb::device::cuda>> bias,
+    nb::ndarray<int8_t, nb::ndim<2>, nb::device::cuda> workspace,
+    nb::ndarray<nb::ndim<2>, nb::device::cuda> out,
+    int64_t convrot_group_size, int64_t G, int64_t chunk_cols,
+    int out_dtype_code, uintptr_t stream_ptr) {
+    const int64_t M = input.shape(0);
+    const int64_t K = input.shape(1);
+    const int64_t N = weight.shape(0);
+    if (xq.shape(0) != M || xq.shape(1) != K)
+        throw std::runtime_error("w4a8_codebook_linear: xq must be [M, K]");
+    if (xs.shape(0) != M || xs.shape(1) != 1)
+        throw std::runtime_error("w4a8_codebook_linear: xs must be [M, 1]");
+    if (input.stride(1) != 1 || input.stride(0) != K
+            || xq.stride(1) != 1 || xq.stride(0) != K
+            || xs.stride(1) != 1 || xs.stride(0) != 1)
+        throw std::runtime_error("w4a8_codebook_linear: input, xq, and xs must be contiguous");
+    if (weight.stride(1) != 1 || weight.stride(0) != weight.shape(1)
+            || s_rel.stride(1) != 1 || s_rel.stride(0) != s_rel.shape(1)
+            || s_channel.stride(0) != 1
+            || workspace.stride(1) != 1 || workspace.stride(0) != workspace.shape(1)
+            || out.stride(1) != 1 || out.stride(0) != out.shape(1)
+            || (codebook.has_value() && codebook->stride(0) != 1)
+            || (bias.has_value() && bias->stride(0) != 1))
+        throw std::runtime_error("w4a8_codebook_linear: weight metadata, workspace, and out must be contiguous");
+    const int input_dtype_code = map_dtype_to_code(input.dtype());
+    if (input_dtype_code < 0 || input_dtype_code > 2)
+        throw std::runtime_error("w4a8_codebook_linear: input must be fp32, fp16, or bf16");
+    validate_w4a8_codebook_gemm_contract(
+        M, N, K,
+        weight.shape(1),
+        s_rel.shape(0), s_rel.shape(1),
+        s_channel.size(), xs.size(),
+        codebook.has_value() ? static_cast<int64_t>(codebook->size()) : -1,
+        bias.has_value() ? static_cast<int64_t>(bias->size()) : -1,
+        workspace.shape(0), workspace.shape(1),
+        out.shape(0), out.shape(1), out.dtype(),
+        G, chunk_cols, out_dtype_code);
+
+    cudaStream_t stream = reinterpret_cast<cudaStream_t>(stream_ptr);
+    launch_quantize_int8_rowwise_convrot_kernel(
+        input.data(), xq.data(), xs.data(), M, K,
+        static_cast<int>(convrot_group_size), input_dtype_code,
+        false, 0, stream);
     const void* cb = codebook.has_value() ? codebook->data() : nullptr;
     const void* bs = bias.has_value() ? bias->data() : nullptr;
     return launch_w4a8_codebook_gemm_chunked(
@@ -2686,6 +2760,14 @@ NB_MODULE(_C, m) {
           nb::arg("s_channel"), nb::arg("xs"), nb::arg("bias").none(), nb::arg("workspace"),
           nb::arg("out"), nb::arg("g"), nb::arg("chunk_cols"), nb::arg("out_dtype_code"),
           nb::arg("stream_ptr"));
+
+    m.def("w4a8_codebook_linear_chunked", &w4a8_codebook_linear_chunked,
+          "Fused W4A8 inference orchestration: ConvRot activation quantization followed by chunked decode/GEMM",
+          nb::arg("input"), nb::arg("xq"), nb::arg("xs"), nb::arg("weight"),
+          nb::arg("s_rel"), nb::arg("codebook").none(), nb::arg("s_channel"),
+          nb::arg("bias").none(), nb::arg("workspace"), nb::arg("out"),
+          nb::arg("convrot_group_size"), nb::arg("g"), nb::arg("chunk_cols"),
+          nb::arg("out_dtype_code"), nb::arg("stream_ptr"));
 
     m.def("quantize_int8_rowwise_convrot", &quantize_int8_rowwise_convrot,
           "Fused ConvRot Hadamard rotation + rowwise INT8 quantization",

--- a/comfy_kitchen/backends/cuda/dlpack_bindings.cpp
+++ b/comfy_kitchen/backends/cuda/dlpack_bindings.cpp
@@ -1760,6 +1760,8 @@ bool cutlass_int8_dequant(
     if (static_cast<int64_t>(ws.size()) != N) throw std::runtime_error("cutlass_int8_dequant: ws must be a length-N vector");
     if (bias.size() != 0 && static_cast<int64_t>(bias.size()) != N)
         throw std::runtime_error("cutlass_int8_dequant: bias must be empty or a length-N vector");
+    if (out_dtype_code < 0 || out_dtype_code > 2)  // allow-list: the launch only supports these
+        throw std::runtime_error("cutlass_int8_dequant: out_dtype_code must be 0 (fp32), 1 (fp16), or 2 (bf16)");
     if (map_dtype_to_code(d.dtype()) != out_dtype_code)
         throw std::runtime_error("cutlass_int8_dequant: output dtype does not match out_dtype_code (0=fp32, 1=fp16, 2=bf16)");
     cudaStream_t stream = reinterpret_cast<cudaStream_t>(stream_ptr);
@@ -2004,6 +2006,8 @@ bool w4a8_codebook_gemm_chunked(
     // the allocation.
     // Exact dtype match: fp16 and bf16 share itemsize but the launch selects half_t vs
     // bfloat16_t, so a mismatched code would reinterpret the buffer.
+    if (out_dtype_code < 0 || out_dtype_code > 2)  // allow-list: the launch only supports these
+        throw std::runtime_error("w4a8_codebook_gemm: out_dtype_code must be 0 (fp32), 1 (fp16), or 2 (bf16)");
     if (map_dtype_to_code(out.dtype()) != out_dtype_code)
         throw std::runtime_error("w4a8_codebook_gemm: out dtype does not match out_dtype_code (0=fp32, 1=fp16, 2=bf16)");
     if (static_cast<int64_t>(out.shape(0)) != M || static_cast<int64_t>(out.shape(1)) != N)

--- a/comfy_kitchen/backends/cuda/dlpack_bindings.cpp
+++ b/comfy_kitchen/backends/cuda/dlpack_bindings.cpp
@@ -1752,6 +1752,16 @@ bool cutlass_int8_dequant(
     const int64_t N = b.shape(0);
     if (b.shape(1) != K) throw std::runtime_error("cutlass_int8_dequant: K mismatch");
     if (d.shape(0) != M || d.shape(1) != N) throw std::runtime_error("cutlass_int8_dequant: D shape mismatch");
+    // Per-row (xs) and per-column (ws) scales, and the optional bias, are read as contiguous
+    // [M]/[N] vectors; validate lengths + out dtype so a bad call errors instead of reading OOB.
+    if (static_cast<int64_t>(xs.shape(0)) != M) throw std::runtime_error("cutlass_int8_dequant: xs must have M rows");
+    if (static_cast<int64_t>(ws.shape(0)) != N) throw std::runtime_error("cutlass_int8_dequant: ws must have N entries");
+    if (bias.size() > 0 && static_cast<int64_t>(bias.shape(0)) != N)
+        throw std::runtime_error("cutlass_int8_dequant: bias must be [N]");
+    if (out_dtype_code < 0 || out_dtype_code > 2)
+        throw std::runtime_error("cutlass_int8_dequant: out_dtype_code must be 0 (fp32), 1 (fp16), or 2 (bf16)");
+    if (d.itemsize() != (out_dtype_code == 0 ? 4u : 2u))
+        throw std::runtime_error("cutlass_int8_dequant: d.itemsize() does not match out_dtype_code");
     cudaStream_t stream = reinterpret_cast<cudaStream_t>(stream_ptr);
     const void* bias_ptr = bias.size() > 0 ? bias.data() : nullptr;
     return launch_cutlass_int8_dequant(a.data(), b.data(), xs.data(), ws.data(),
@@ -1914,6 +1924,16 @@ void dequant_int4_grouped_to_int8(
     const int64_t N = qw.shape(0);
     const int64_t K = out.shape(1);
     if (qw.shape(1) != K / 2) throw std::runtime_error("dequant_int4_grouped: K/2 mismatch");
+    if (K % 16 != 0) throw std::runtime_error("dequant_int4_grouped: K must be a multiple of 16");
+    if (G < 4 || (16 % G != 0 && G % 16 != 0))
+        throw std::runtime_error("dequant_int4_grouped: G must be >=4 and divide 16 or be a multiple of 16");
+    if (K % G != 0) throw std::runtime_error("dequant_int4_grouped: K must be divisible by G");
+    if (static_cast<int64_t>(s_rel.shape(0)) != N || static_cast<int64_t>(s_rel.shape(1)) != K / G)
+        throw std::runtime_error("dequant_int4_grouped: s_rel must be [N, K/G]");
+    if (static_cast<int64_t>(out.shape(0)) != N)
+        throw std::runtime_error("dequant_int4_grouped: out must be [N, K]");
+    if (codebook.has_value() && static_cast<int64_t>(codebook->shape(0)) != 16)
+        throw std::runtime_error("dequant_int4_grouped: codebook must be [16]");
     cudaStream_t stream = reinterpret_cast<cudaStream_t>(stream_ptr);
     const void* cb = codebook.has_value() ? codebook->data() : nullptr;
     launch_dequant_int4_grouped_to_int8(qw.data(), s_rel.data(), cb, out.data(), N, K, G, stream);
@@ -1929,6 +1949,16 @@ void dequant_int4_grouped_to_int8_e4m3(
     const int64_t N = qw.shape(0);
     const int64_t K = out.shape(1);
     if (qw.shape(1) != K / 2) throw std::runtime_error("dequant_int4_grouped: K/2 mismatch");
+    if (K % 16 != 0) throw std::runtime_error("dequant_int4_grouped: K must be a multiple of 16");
+    if (G < 4 || (16 % G != 0 && G % 16 != 0))
+        throw std::runtime_error("dequant_int4_grouped: G must be >=4 and divide 16 or be a multiple of 16");
+    if (K % G != 0) throw std::runtime_error("dequant_int4_grouped: K must be divisible by G");
+    if (static_cast<int64_t>(s_rel.shape(0)) != N || static_cast<int64_t>(s_rel.shape(1)) != K / G)
+        throw std::runtime_error("dequant_int4_grouped: s_rel must be [N, K/G]");
+    if (static_cast<int64_t>(out.shape(0)) != N)
+        throw std::runtime_error("dequant_int4_grouped: out must be [N, K]");
+    if (codebook.has_value() && static_cast<int64_t>(codebook->shape(0)) != 16)
+        throw std::runtime_error("dequant_int4_grouped: codebook must be [16]");
     cudaStream_t stream = reinterpret_cast<cudaStream_t>(stream_ptr);
     const void* cb = codebook.has_value() ? codebook->data() : nullptr;
     launch_dequant_int4_grouped_to_int8_e4m3(qw.data(), s_rel.data(), cb, out.data(), N, K, G, stream);
@@ -1950,6 +1980,24 @@ bool w4a8_codebook_gemm_chunked(
     const int64_t K = xq.shape(1);
     const int64_t N = weight.shape(0);
     if (weight.shape(1) != K / 2) throw std::runtime_error("w4a8_codebook_gemm: K/2 mismatch");
+    // Grouping contract: the dequant kernel is 16-wide vectorized (K % 16), and G must be a
+    // supported group size (>=4, divides 16 or a multiple of 16) that divides K so K/G groups
+    // are exact. A bad G/K silently truncates or misaligns the kernel.
+    if (K % 16 != 0) throw std::runtime_error("w4a8_codebook_gemm: K must be a multiple of 16");
+    if (G < 4 || (16 % G != 0 && G % 16 != 0))
+        throw std::runtime_error("w4a8_codebook_gemm: G must be >=4 and divide 16 or be a multiple of 16");
+    if (K % G != 0) throw std::runtime_error("w4a8_codebook_gemm: K must be divisible by G");
+    // The launcher reads these as contiguous metadata; a wrong length reads past the buffer.
+    if (static_cast<int64_t>(xq.shape(1)) != K || static_cast<int64_t>(xs.shape(0)) != M)
+        throw std::runtime_error("w4a8_codebook_gemm: xq must be [M, K] and xs [M]");
+    if (static_cast<int64_t>(s_rel.shape(0)) != N || static_cast<int64_t>(s_rel.shape(1)) != K / G)
+        throw std::runtime_error("w4a8_codebook_gemm: s_rel must be [N, K/G]");
+    if (static_cast<int64_t>(s_channel.shape(0)) != N)
+        throw std::runtime_error("w4a8_codebook_gemm: s_channel must be [N]");
+    if (codebook.has_value() && static_cast<int64_t>(codebook->shape(0)) != 16)
+        throw std::runtime_error("w4a8_codebook_gemm: codebook must be [16]");
+    if (bias.has_value() && static_cast<int64_t>(bias->shape(0)) != N)
+        throw std::runtime_error("w4a8_codebook_gemm: bias must be [N]");
     // out is untyped; the kernel derives its element size from out_dtype_code and offsets
     // each chunk by n0*itemsize. Verify the code and the buffer agree, and the out/workspace
     // geometry the chunk loop indexes, so a mismatch errors here instead of scribbling past

--- a/comfy_kitchen/backends/cuda/dlpack_bindings.cpp
+++ b/comfy_kitchen/backends/cuda/dlpack_bindings.cpp
@@ -1169,6 +1169,24 @@ extern "C" {
         int64_t G,
         cudaStream_t stream);
 
+    bool launch_w4a8_codebook_gemm_chunked(
+        const void* xq,
+        const void* weight,
+        const void* s_rel,
+        const void* codebook,
+        const void* s_channel,
+        const void* xs,
+        const void* bias,
+        void* workspace,
+        void* out,
+        int64_t M,
+        int64_t N,
+        int64_t K,
+        int64_t G,
+        int64_t chunk_cols,
+        int out_dtype_code,
+        cudaStream_t stream);
+
     void launch_quantize_int8_rowwise_convrot_kernel(
         const void* input,
         void* output,
@@ -1916,6 +1934,30 @@ void dequant_int4_grouped_to_int8_e4m3(
     launch_dequant_int4_grouped_to_int8_e4m3(qw.data(), s_rel.data(), cb, out.data(), N, K, G, stream);
 }
 
+// Chunked fused W4A8: per-chunk (codebook+s_rel) dequant -> L2-hot int8 -> strided int8 GEMM.
+bool w4a8_codebook_gemm_chunked(
+    nb::ndarray<int8_t, nb::ndim<2>, nb::device::cuda> xq,        // [M, K] int8 act
+    nb::ndarray<int8_t, nb::ndim<2>, nb::device::cuda> weight,    // [N, K/2] packed uint4
+    nb::ndarray<uint8_t, nb::ndim<2>, nb::device::cuda> s_rel,    // [N, K/G] e4m3 bits
+    std::optional<nb::ndarray<float, nb::ndim<1>, nb::device::cuda>> codebook,  // [16] or None
+    nb::ndarray<float, nb::ndim<1>, nb::device::cuda> s_channel,  // [N] fp32
+    nb::ndarray<float, nb::ndim<1>, nb::device::cuda> xs,         // [M] fp32
+    std::optional<nb::ndarray<float, nb::ndim<1>, nb::device::cuda>> bias,  // [N] or None
+    nb::ndarray<int8_t, nb::ndim<2>, nb::device::cuda> workspace, // [chunk_cols, K] int8
+    nb::ndarray<nb::ndim<2>, nb::device::cuda> out,               // [M, N] out_dtype
+    int64_t G, int64_t chunk_cols, int out_dtype_code, uintptr_t stream_ptr) {
+    const int64_t M = xq.shape(0);
+    const int64_t K = xq.shape(1);
+    const int64_t N = weight.shape(0);
+    if (weight.shape(1) != K / 2) throw std::runtime_error("w4a8_codebook_gemm: K/2 mismatch");
+    cudaStream_t stream = reinterpret_cast<cudaStream_t>(stream_ptr);
+    const void* cb = codebook.has_value() ? codebook->data() : nullptr;
+    const void* bs = bias.has_value() ? bias->data() : nullptr;
+    return launch_w4a8_codebook_gemm_chunked(
+        xq.data(), weight.data(), s_rel.data(), cb, s_channel.data(), xs.data(), bs,
+        workspace.data(), out.data(), M, N, K, G, chunk_cols, out_dtype_code, stream);
+}
+
 void quantize_int8_rowwise_convrot(
     nb::ndarray<nb::ndim<2>, nb::device::cuda> input,
     nb::ndarray<int8_t, nb::ndim<2>, nb::device::cuda> output,
@@ -2569,6 +2611,13 @@ NB_MODULE(_C, m) {
           "Grouped int4 -> int8 dequant with fp8 e4m3 per-group scale; optional 16-entry codebook",
           nb::arg("qw"), nb::arg("s_rel"), nb::arg("codebook").none(), nb::arg("out"),
           nb::arg("g"), nb::arg("stream_ptr"));
+
+    m.def("w4a8_codebook_gemm_chunked", &w4a8_codebook_gemm_chunked,
+          "Chunked fused W4A8: per-chunk codebook+s_rel dequant -> L2-hot int8 -> strided int8 GEMM",
+          nb::arg("xq"), nb::arg("weight"), nb::arg("s_rel"), nb::arg("codebook").none(),
+          nb::arg("s_channel"), nb::arg("xs"), nb::arg("bias").none(), nb::arg("workspace"),
+          nb::arg("out"), nb::arg("g"), nb::arg("chunk_cols"), nb::arg("out_dtype_code"),
+          nb::arg("stream_ptr"));
 
     m.def("quantize_int8_rowwise_convrot", &quantize_int8_rowwise_convrot,
           "Fused ConvRot Hadamard rotation + rowwise INT8 quantization",

--- a/comfy_kitchen/backends/cuda/ops/w4a8_gemm.cu
+++ b/comfy_kitchen/backends/cuda/ops/w4a8_gemm.cu
@@ -3,11 +3,10 @@
 //
 // W4A8 weight dequant: grouped int4 -> int8 for the tuned int8-GEMM path.
 //
-// The AsymW4A8Int8Layout dequantizes int4 weights to the "grouped int8"
-// representation (per-group scale folded in, per-channel scale left for the int8
-// GEMM epilogue) and runs comfy's tuned int8 CUTLASS GEMM -- so this file only
-// needs the memory-bound int4->int8 dequant kernel (fp32 and fp8/e4m3 group
-// scales, optional Lloyd-Max codebook). The matmul itself is cutlass_gemm_int8.
+// AsymW4A8Int8Layout dequantizes int4 weights to "grouped int8" (per-group scale
+// folded in, per-channel scale left for the int8 GEMM epilogue), then runs comfy's
+// tuned int8 CUTLASS GEMM. So this file is just the memory-bound int4->int8 dequant
+// kernel (fp32/fp8-e4m3 group scales, optional codebook); the matmul is cutlass_gemm_int8.
 
 #include <cuda_runtime.h>
 #include <cuda_fp8.h>
@@ -18,9 +17,8 @@
 // s_rel = per-group scale / per-channel scale (so the int8 range is used). The
 // per-channel scale is applied later in the int8 GEMM epilogue. Memory-bound.
 namespace {
-// Per-group scale may be stored fp32 or fp8 (e4m3). fp8 halves the scale
-// metadata (g16 fp32 -> 0.75 B/elem; fp8 -> ~0.56, ~half int8) at a tiny
-// quality cost (still beats NVFP4). uint8_t storage == e4m3 raw bits.
+// Per-group scale is fp32 or fp8 (e4m3). fp8 halves the scale metadata at a tiny
+// quality cost. uint8_t storage == e4m3 raw bits.
 template <typename ScaleT> __device__ __forceinline__ float load_scale(ScaleT v);
 template <> __device__ __forceinline__ float load_scale<float>(float v) { return v; }
 template <> __device__ __forceinline__ float load_scale<uint8_t>(uint8_t v) {
@@ -29,8 +27,9 @@ template <> __device__ __forceinline__ float load_scale<uint8_t>(uint8_t v) {
 
 // Each thread: 8 packed bytes (uint2) -> 16 int8 (uint4 store). The 16 output
 // cols may span multiple groups when G<16 (finer groups = better int4 quality),
-// so the scale is (re)loaded per output pair from its own group. G must be even
-// and either divide 16 or be a multiple of 16 (so groups stay pair-aligned).
+// so the scale is (re)loaded per output pair from its own group. Only 4 group
+// scales (sc0..sc3) are loaded, so a 16-col vec may span at most 4 groups: G must
+// be in {4, 8, 16} or a multiple of 16 (G<4 would span >4 groups and mis-scale).
 // If codebook != nullptr, the 4-bit code indexes a shared 16-entry non-uniform
 // codebook (Lloyd-Max on the rotated-Gaussian weight) instead of the uniform
 // level (q-8); same storage/speed, ~14% lower weight error at coarse groups.

--- a/comfy_kitchen/backends/cuda/ops/w4a8_gemm.cu
+++ b/comfy_kitchen/backends/cuda/ops/w4a8_gemm.cu
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// W4A8 weight dequant: grouped int4 -> int8 for the tuned int8-GEMM path.
+//
+// The AsymW4A8Int8Layout dequantizes int4 weights to the "grouped int8"
+// representation (per-group scale folded in, per-channel scale left for the int8
+// GEMM epilogue) and runs comfy's tuned int8 CUTLASS GEMM -- so this file only
+// needs the memory-bound int4->int8 dequant kernel (fp32 and fp8/e4m3 group
+// scales, optional Lloyd-Max codebook). The matmul itself is cutlass_gemm_int8.
+
+#include <cuda_runtime.h>
+#include <cuda_fp8.h>
+#include <cstdint>
+
+// Grouped int4 -> int8 dequant for the int8-GEMM W4A8 path: out[n,k] =
+// round((q_u[n,k]-8) * s_rel[n, k/G]), q_u packed uint4 (even col=low nibble).
+// s_rel = per-group scale / per-channel scale (so the int8 range is used). The
+// per-channel scale is applied later in the int8 GEMM epilogue. Memory-bound.
+namespace {
+// Per-group scale may be stored fp32 or fp8 (e4m3). fp8 halves the scale
+// metadata (g16 fp32 -> 0.75 B/elem; fp8 -> ~0.56, ~half int8) at a tiny
+// quality cost (still beats NVFP4). uint8_t storage == e4m3 raw bits.
+template <typename ScaleT> __device__ __forceinline__ float load_scale(ScaleT v);
+template <> __device__ __forceinline__ float load_scale<float>(float v) { return v; }
+template <> __device__ __forceinline__ float load_scale<uint8_t>(uint8_t v) {
+    return __half2float(__nv_cvt_fp8_to_halfraw(v, __NV_E4M3));
+}
+
+// Each thread: 8 packed bytes (uint2) -> 16 int8 (uint4 store). The 16 output
+// cols may span multiple groups when G<16 (finer groups = better int4 quality),
+// so the scale is (re)loaded per output pair from its own group. G must be even
+// and either divide 16 or be a multiple of 16 (so groups stay pair-aligned).
+// If codebook != nullptr, the 4-bit code indexes a shared 16-entry non-uniform
+// codebook (Lloyd-Max on the rotated-Gaussian weight) instead of the uniform
+// level (q-8); same storage/speed, ~14% lower weight error at coarse groups.
+template <typename ScaleT>
+__global__ void dequant_int4_grouped_to_int8_kernel(
+    const int8_t* __restrict__ qw,   // (N, K/2) packed uint4
+    const ScaleT* __restrict__ s_rel,// (N, K/G) fp32 or e4m3 raw
+    const float*  __restrict__ codebook, // 16 floats or nullptr
+    int8_t*       __restrict__ out,  // (N, K)
+    long n_vec, int Khalf, int K, int G)
+{
+    __shared__ float cb[16];
+    if (codebook && threadIdx.x < 16) cb[threadIdx.x] = codebook[threadIdx.x];
+    if (codebook) __syncthreads();
+    long v = (long)blockIdx.x * blockDim.x + threadIdx.x;
+    if (v >= n_vec) return;                       // n_vec = N*Khalf/8
+    const int vec_per_row = Khalf / 8;
+    const int n = v / vec_per_row;
+    const int hv = v % vec_per_row;               // which uint2 in the row
+    const int kh = hv * 8;                        // packed byte offset
+    const int k0 = kh * 2;                         // output col base (16 wide)
+    const int nG = K / G;
+    const long srow = (long)n * nG;
+    const uint2 pk = *reinterpret_cast<const uint2*>(&qw[(long)n * Khalf + kh]);
+    const unsigned words[2] = {pk.x, pk.y};
+    char4 o4[4];
+    #pragma unroll
+    for (int w = 0; w < 2; ++w) {
+        const unsigned bb = words[w];
+        #pragma unroll
+        for (int bi = 0; bi < 4; ++bi) {
+            const int oo = w * 4 + bi;             // 0..7 -> cols oo*2, oo*2+1
+            // q0/q1 are consecutive cols (same group since G>=2 even).
+            const float s = load_scale<ScaleT>(s_rel[srow + (k0 + oo * 2) / G]);
+            const unsigned byte = (bb >> (bi * 8)) & 0xFF;
+            const unsigned c0 = byte & 0xF, c1 = (byte >> 4) & 0xF;
+            const float v0 = codebook ? cb[c0] : (static_cast<float>(c0) - 8.0f);
+            const float v1 = codebook ? cb[c1] : (static_cast<float>(c1) - 8.0f);
+            reinterpret_cast<int8_t*>(&o4[oo / 2])[(oo % 2) * 2]     =
+                static_cast<int8_t>(max(-127, min(127, __float2int_rn(v0 * s))));
+            reinterpret_cast<int8_t*>(&o4[oo / 2])[(oo % 2) * 2 + 1] =
+                static_cast<int8_t>(max(-127, min(127, __float2int_rn(v1 * s))));
+        }
+    }
+    *reinterpret_cast<uint4*>(&out[(long)n * K + k0]) = *reinterpret_cast<uint4*>(o4);
+}
+}  // namespace
+
+// codebook: 16 floats (non-uniform levels) or nullptr for uniform (q-8).
+extern "C" void launch_dequant_int4_grouped_to_int8(
+    const void* qw, const void* s_rel, const void* codebook, void* out,
+    int64_t N, int64_t K, int64_t G, cudaStream_t stream)
+{
+    const int Khalf = K / 2;
+    const long n_vec = (long)N * Khalf / 8;
+    const int block = 256;
+    const long grid = (n_vec + block - 1) / block;
+    dequant_int4_grouped_to_int8_kernel<float><<<grid, block, 0, stream>>>(
+        static_cast<const int8_t*>(qw), static_cast<const float*>(s_rel),
+        static_cast<const float*>(codebook),
+        static_cast<int8_t*>(out), n_vec, Khalf, static_cast<int>(K), static_cast<int>(G));
+}
+
+// fp8 (e4m3) per-group scale variant; s_rel passed as raw uint8 bits.
+extern "C" void launch_dequant_int4_grouped_to_int8_e4m3(
+    const void* qw, const void* s_rel, const void* codebook, void* out,
+    int64_t N, int64_t K, int64_t G, cudaStream_t stream)
+{
+    const int Khalf = K / 2;
+    const long n_vec = (long)N * Khalf / 8;
+    const int block = 256;
+    const long grid = (n_vec + block - 1) / block;
+    dequant_int4_grouped_to_int8_kernel<uint8_t><<<grid, block, 0, stream>>>(
+        static_cast<const int8_t*>(qw), static_cast<const uint8_t*>(s_rel),
+        static_cast<const float*>(codebook),
+        static_cast<int8_t*>(out), n_vec, Khalf, static_cast<int>(K), static_cast<int>(G));
+}
+

--- a/comfy_kitchen/backends/cuda/ops/w4a8_gemm.cu
+++ b/comfy_kitchen/backends/cuda/ops/w4a8_gemm.cu
@@ -56,6 +56,18 @@ __global__ void dequant_int4_grouped_to_int8_kernel(
     const long srow = (long)n * nG;
     const uint2 pk = *reinterpret_cast<const uint2*>(&qw[(long)n * Khalf + kh]);
     const unsigned words[2] = {pk.x, pk.y};
+    // The 16-col vec spans 1 group (G>=16, the common case), 2 (G=8), or 4 (G=4).
+    // Load+decode each distinct group scale ONCE instead of per output pair.
+    const int base_g = k0 / G;
+    float sc0 = load_scale<ScaleT>(s_rel[srow + base_g]);
+    float sc1 = sc0, sc2 = sc0, sc3 = sc0;
+    if (G < 16) {
+        sc1 = load_scale<ScaleT>(s_rel[srow + base_g + 1]);
+        if (G < 8) {  // G == 4
+            sc2 = load_scale<ScaleT>(s_rel[srow + base_g + 2]);
+            sc3 = load_scale<ScaleT>(s_rel[srow + base_g + 3]);
+        }
+    }
     char4 o4[4];
     #pragma unroll
     for (int w = 0; w < 2; ++w) {
@@ -63,8 +75,8 @@ __global__ void dequant_int4_grouped_to_int8_kernel(
         #pragma unroll
         for (int bi = 0; bi < 4; ++bi) {
             const int oo = w * 4 + bi;             // 0..7 -> cols oo*2, oo*2+1
-            // q0/q1 are consecutive cols (same group since G>=2 even).
-            const float s = load_scale<ScaleT>(s_rel[srow + (k0 + oo * 2) / G]);
+            const int lg = (G >= 16) ? 0 : ((oo * 2) / G);  // local group in the vec
+            const float s = (lg == 0) ? sc0 : (lg == 1 ? sc1 : (lg == 2 ? sc2 : sc3));
             const unsigned byte = (bb >> (bi * 8)) & 0xFF;
             const unsigned c0 = byte & 0xF, c1 = (byte >> 4) & 0xF;
             const float v0 = codebook ? cb[c0] : (static_cast<float>(c0) - 8.0f);
@@ -107,5 +119,45 @@ extern "C" void launch_dequant_int4_grouped_to_int8_e4m3(
         static_cast<const int8_t*>(qw), static_cast<const uint8_t*>(s_rel),
         static_cast<const float*>(codebook),
         static_cast<int8_t*>(out), n_vec, Khalf, static_cast<int>(K), static_cast<int>(G));
+}
+
+// Fused-quality W4A8: dequant int4 -> int8 in column chunks (codebook + per-group
+// s_rel) feeding the tuned STRIDED int8 GEMM, so each int8 weight chunk stays
+// L2-resident instead of the full [N,K] round-tripping global (the convrot_w4a4
+// chunking trick, run at our group-16 codebook quality). Returns false if the
+// strided GEMM rejects a chunk config -> caller falls back to the 2-pass path.
+extern "C" bool launch_cutlass_int8_dequant_strided(
+    const void* A, const void* B, const void* xs, const void* ws, const void* bias,
+    void* D, int64_t M, int64_t N, int64_t K, int64_t output_stride, int out_dtype_code,
+    cudaStream_t stream);
+
+extern "C" bool launch_w4a8_codebook_gemm_chunked(
+    const void* xq,        // [M, K] int8 activation
+    const void* weight,    // [N, K/2] packed uint4
+    const void* s_rel,     // [N, K/G] fp8 (e4m3) per-group scale
+    const void* codebook,  // [16] fp32 or nullptr
+    const void* s_channel, // [N] fp32 per-channel scale
+    const void* xs,        // [M] fp32 per-row activation scale
+    const void* bias,      // [N] fp32 or nullptr
+    void* workspace,       // [chunk_cols, K] int8 scratch (preallocated, reused)
+    void* out,             // [M, N] output (out_dtype)
+    int64_t M, int64_t N, int64_t K, int64_t G, int64_t chunk_cols,
+    int out_dtype_code, cudaStream_t stream)
+{
+    const int64_t Khalf = K / 2, KG = K / G, osz = (out_dtype_code == 0) ? 4 : 2;
+    for (int64_t n0 = 0; n0 < N; n0 += chunk_cols) {
+        const int64_t cols = (chunk_cols < N - n0) ? chunk_cols : (N - n0);
+        launch_dequant_int4_grouped_to_int8_e4m3(
+            static_cast<const int8_t*>(weight) + n0 * Khalf,
+            static_cast<const uint8_t*>(s_rel) + n0 * KG,
+            codebook, workspace, cols, K, G, stream);
+        const void* bias_chunk = bias ? static_cast<const float*>(bias) + n0 : nullptr;
+        void* out_chunk = static_cast<char*>(out) + n0 * osz;
+        if (!launch_cutlass_int8_dequant_strided(
+                xq, workspace, xs, static_cast<const float*>(s_channel) + n0, bias_chunk,
+                out_chunk, M, cols, K, N /*output_stride*/, out_dtype_code, stream))
+            return false;
+    }
+    return true;
 }
 

--- a/comfy_kitchen/backends/cuda/ops/w4a8_gemm.cu
+++ b/comfy_kitchen/backends/cuda/ops/w4a8_gemm.cu
@@ -143,6 +143,9 @@ extern "C" bool launch_w4a8_codebook_gemm_chunked(
     int64_t M, int64_t N, int64_t K, int64_t G, int64_t chunk_cols,
     int out_dtype_code, cudaStream_t stream)
 {
+    // A non-positive chunk stride never advances n0 -> would loop forever; a non-positive
+    // K/G would divide by zero below. Bail so the caller uses the 2-pass path.
+    if (chunk_cols <= 0 || K <= 0 || G <= 0) return false;
     const int64_t Khalf = K / 2, KG = K / G, osz = (out_dtype_code == 0) ? 4 : 2;
     for (int64_t n0 = 0; n0 < N; n0 += chunk_cols) {
         const int64_t cols = (chunk_cols < N - n0) ? chunk_cols : (N - n0);

--- a/comfy_kitchen/backends/eager/__init__.py
+++ b/comfy_kitchen/backends/eager/__init__.py
@@ -26,6 +26,7 @@ __all__ = [
     "dequantize_int8_convrot_weight_dtype",
     "dequantize_int8_embedding",
     "dequantize_convrot_w4a4_weight",
+    "dequantize_w4a8_int8_weight",
     "gemv_awq_w4a16",
     "convrot_w4a4_linear",
     "prepare_int4_weight_for_int8_linear",
@@ -33,8 +34,10 @@ __all__ = [
     "quantize_nvfp4",
     "quantize_per_tensor_fp8",
     "quantize_convrot_w4a4_weight",
+    "quantize_w4a8_int8_weight",
     "quantize_int8_rowwise",
     "quantize_int8_convrot_weight",
+    "rotate_int8_convrot_weight",
     "quantize_and_rotate_rowwise",
     "quantize_int8_tensorwise",
     "quantize_svdquant_w4a4",
@@ -80,6 +83,7 @@ from .quantization import (
     quantize_mxfp8,
     quantize_nvfp4,
     quantize_per_tensor_fp8,
+    rotate_int8_convrot_weight,
     scaled_mm_mxfp8,
     scaled_mm_nvfp4,
     stochastic_rounding_fp8,
@@ -103,7 +107,11 @@ from .rope import (
     rms_rope_split_half_,
 )
 from .svdquant import quantize_svdquant_w4a4, scaled_mm_svdquant_w4a4
-from .w4a8_int8 import w4a8_int8_linear
+from .w4a8_int8 import (
+    dequantize_w4a8_int8_weight,
+    quantize_w4a8_int8_weight,
+    w4a8_int8_linear,
+)
 
 
 def _build_constraints() -> dict:
@@ -362,15 +370,42 @@ def _build_constraints() -> dict:
             },
             default_devices=all_devices,
         ),
+        "quantize_w4a8_int8_weight": FunctionConstraints(
+            params={
+                "weight": ParamConstraint(dtypes=standard_floats, shape_rules=(ExactDims(2),)),
+                "group_size": ParamConstraint(dtypes=frozenset({int})),
+                "convrot_groupsize": ParamConstraint(dtypes=frozenset({int})),
+                "symmetric": ParamConstraint(dtypes=frozenset({bool})),
+                "scale_dtype": ParamConstraint(dtypes=frozenset({torch.float8_e4m3fn, torch.float32})),
+                "codebook": ParamConstraint(dtypes=frozenset({bool})),
+            },
+            default_devices=all_devices,
+        ),
+        "dequantize_w4a8_int8_weight": FunctionConstraints(
+            params={
+                "qdata": ParamConstraint(dtypes=frozenset({torch.int8}), shape_rules=(ExactDims(2),)),
+                "s_rel": ParamConstraint(dtypes=frozenset({torch.float8_e4m3fn, torch.float32}), shape_rules=(ExactDims(2),)),
+                "s_channel": ParamConstraint(dtypes=frozenset({torch.float32}), shape_rules=(ExactDims(1),)),
+                "codebook": ParamConstraint(dtypes=frozenset({torch.float32}), shape_rules=(ExactDims(1),)),
+                "correction": ParamConstraint(dtypes=standard_floats, shape_rules=(ExactDims(2),)),
+                "group_size": ParamConstraint(dtypes=frozenset({int})),
+                "convrot_groupsize": ParamConstraint(dtypes=frozenset({int})),
+                "output_dtype": ParamConstraint(dtypes=standard_floats),
+            },
+            default_devices=all_devices,
+        ),
         "w4a8_int8_linear": FunctionConstraints(
             params={
                 "x": ParamConstraint(dtypes=standard_floats),
                 "qdata": ParamConstraint(dtypes=frozenset({torch.int8}), shape_rules=(ExactDims(2),)),
                 "s_rel": ParamConstraint(dtypes=frozenset({torch.float8_e4m3fn, torch.float32}), shape_rules=(ExactDims(2),)),
                 "s_channel": ParamConstraint(dtypes=frozenset({torch.float32}), shape_rules=(ExactDims(1),)),
+                "codebook": ParamConstraint(dtypes=frozenset({torch.float32}), shape_rules=(ExactDims(1),)),
+                "correction": ParamConstraint(dtypes=standard_floats, shape_rules=(ExactDims(2),)),
                 "bias": ParamConstraint(dtypes=standard_floats),
                 "group_size": ParamConstraint(dtypes=frozenset({int})),
                 "convrot_groupsize": ParamConstraint(dtypes=frozenset({int})),
+                "out_dtype": ParamConstraint(dtypes=standard_floats),
             },
             default_devices=all_devices,
         ),
@@ -423,6 +458,13 @@ def _build_constraints() -> dict:
             "weight": ParamConstraint(dtypes=standard_floats, shape_rules=(ExactDims(2),)),
             "group_size": ParamConstraint(dtypes=frozenset({int})),
             "stochastic_rounding": ParamConstraint(dtypes=frozenset({int})),
+        },
+        default_devices=all_devices,
+    )
+    out["rotate_int8_convrot_weight"] = FunctionConstraints(
+        params={
+            "weight": ParamConstraint(dtypes=standard_floats, shape_rules=(ExactDims(2),)),
+            "group_size": ParamConstraint(dtypes=frozenset({int})),
         },
         default_devices=all_devices,
     )

--- a/comfy_kitchen/backends/eager/__init__.py
+++ b/comfy_kitchen/backends/eager/__init__.py
@@ -43,6 +43,7 @@ __all__ = [
     "scaled_mm_svdquant_w4a4",
     "stochastic_rounding_fp8",
     "int8_linear",
+    "w4a8_int8_linear",
 ]
 
 import torch
@@ -102,6 +103,7 @@ from .rope import (
     rms_rope_split_half_,
 )
 from .svdquant import quantize_svdquant_w4a4, scaled_mm_svdquant_w4a4
+from .w4a8_int8 import w4a8_int8_linear
 
 
 def _build_constraints() -> dict:
@@ -357,6 +359,18 @@ def _build_constraints() -> dict:
                 "convrot_groupsize": ParamConstraint(dtypes=frozenset({int})),
                 "quant_group_size": ParamConstraint(dtypes=frozenset({int})),
                 "linear_dtype": ParamConstraint(dtypes=frozenset({str})),
+            },
+            default_devices=all_devices,
+        ),
+        "w4a8_int8_linear": FunctionConstraints(
+            params={
+                "x": ParamConstraint(dtypes=standard_floats),
+                "qdata": ParamConstraint(dtypes=frozenset({torch.int8}), shape_rules=(ExactDims(2),)),
+                "s_rel": ParamConstraint(dtypes=frozenset({torch.float8_e4m3fn, torch.float32}), shape_rules=(ExactDims(2),)),
+                "s_channel": ParamConstraint(dtypes=frozenset({torch.float32}), shape_rules=(ExactDims(1),)),
+                "bias": ParamConstraint(dtypes=standard_floats),
+                "group_size": ParamConstraint(dtypes=frozenset({int})),
+                "convrot_groupsize": ParamConstraint(dtypes=frozenset({int})),
             },
             default_devices=all_devices,
         ),

--- a/comfy_kitchen/backends/eager/quantization.py
+++ b/comfy_kitchen/backends/eager/quantization.py
@@ -906,6 +906,12 @@ def quantize_int8_convrot_weight(
     return quantize_int8_rowwise(weight_rot, stochastic_rounding=stochastic_rounding)
 
 
+def rotate_int8_convrot_weight(weight: torch.Tensor, group_size: int) -> torch.Tensor:
+    """Portable ConvRot weight rotation used when no accelerated backend is available."""
+    h = _build_hadamard(group_size, device=weight.device, dtype=weight.dtype)
+    return _rotate_weight(weight, h, group_size)
+
+
 def dequantize_int8_convrot_weight(q: torch.Tensor, scale: torch.Tensor, group_size: int) -> torch.Tensor:
     """Dequantize INT8 ConvRot weights and rotate them back to the original basis."""
     h = _build_hadamard(group_size, device=q.device, dtype=torch.float32)

--- a/comfy_kitchen/backends/eager/w4a8_int8.py
+++ b/comfy_kitchen/backends/eager/w4a8_int8.py
@@ -20,16 +20,19 @@ def _dequant_int4_grouped_to_int8(
     folded in, per-channel scale left for the GEMM epilogue. Bit-exact with CUDA."""
     n, k_half = qdata.shape
     k = k_half * 2
+    groups = k // group_size
     b = qdata.to(torch.int32) & 0xFF
     q = torch.empty(n, k, dtype=torch.int32, device=qdata.device)
     q[:, 0::2] = b & 0xF
     q[:, 1::2] = (b >> 4) & 0xF
-    srel = s_rel.float().repeat_interleave(group_size, dim=1)  # [N, K]
     if codebook is not None:
         vals = codebook.to(device=qdata.device, dtype=torch.float32)[q]  # direct [0,15] index
     else:
         vals = q.float() - 8.0  # symmetric uniform levels -8..7
-    return (vals * srel).round().clamp_(-127, 127).to(torch.int8)
+    # Broadcast the per-group scale via a grouped view instead of repeat_interleave
+    # (avoids a full [N, K] fp32 scale copy).
+    vals = vals.view(n, groups, group_size) * s_rel.float().unsqueeze(-1)  # [N, groups, 1]
+    return vals.view(n, k).round().clamp_(-127, 127).to(torch.int8)
 
 
 def w4a8_int8_linear(

--- a/comfy_kitchen/backends/eager/w4a8_int8.py
+++ b/comfy_kitchen/backends/eager/w4a8_int8.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Eager (pure-torch) AsymW4A8Int8 path -- portable fallback for any torch device
+(CPU/CUDA/ROCm). Bit-exact int4->int8 dequant feeding the shared ``int8_linear``.
+"""
+from __future__ import annotations
+
+import torch
+
+from .quantization import int8_linear
+
+
+def _dequant_int4_grouped_to_int8(
+    qdata: torch.Tensor,      # [N, K/2] packed uint4 (even col=low nibble)
+    s_rel: torch.Tensor,      # [N, K/group] per-group scale (fp8 or fp32)
+    codebook: torch.Tensor | None,  # [16] levels, or None for uniform (q-8)
+    group_size: int,
+) -> torch.Tensor:
+    """int4 -> grouped int8: round(clamp(level(q) * s_rel, -127, 127)). Per-group scale
+    folded in, per-channel scale left for the GEMM epilogue. Bit-exact with CUDA."""
+    n, k_half = qdata.shape
+    k = k_half * 2
+    b = qdata.to(torch.int32) & 0xFF
+    q = torch.empty(n, k, dtype=torch.int32, device=qdata.device)
+    q[:, 0::2] = b & 0xF
+    q[:, 1::2] = (b >> 4) & 0xF
+    srel = s_rel.float().repeat_interleave(group_size, dim=1)  # [N, K]
+    if codebook is not None:
+        vals = codebook.to(device=qdata.device, dtype=torch.float32)[q]  # direct [0,15] index
+    else:
+        vals = q.float() - 8.0  # symmetric uniform levels -8..7
+    return (vals * srel).round().clamp_(-127, 127).to(torch.int8)
+
+
+def w4a8_int8_linear(
+    x: torch.Tensor,
+    qdata: torch.Tensor,
+    s_rel: torch.Tensor,
+    s_channel: torch.Tensor,
+    codebook: torch.Tensor | None = None,
+    bias: torch.Tensor | None = None,
+    group_size: int = 16,
+    convrot_groupsize: int = 256,
+    out_dtype: torch.dtype = torch.bfloat16,
+) -> torch.Tensor:
+    """``x @ W.T + bias`` for AsymW4A8Int8 (symmetric): dequant int4->int8, then the
+    shared INT8 linear (ConvRot activation rotation + per-channel weight scale)."""
+    int8_w = _dequant_int4_grouped_to_int8(qdata, s_rel, codebook, group_size)
+    return int8_linear(
+        x, int8_w, s_channel, bias=bias, out_dtype=out_dtype,
+        convrot=True, convrot_groupsize=convrot_groupsize,
+    )

--- a/comfy_kitchen/backends/eager/w4a8_int8.py
+++ b/comfy_kitchen/backends/eager/w4a8_int8.py
@@ -1,38 +1,318 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Eager (pure-torch) AsymW4A8Int8 path -- portable fallback for any torch device
-(CPU/CUDA/ROCm). Bit-exact int4->int8 dequant feeding the shared ``int8_linear``.
-"""
+"""Eager W4A8 weight preparation, dequantization, and linear operations."""
+
 from __future__ import annotations
 
 import torch
 
-from .quantization import int8_linear
+from .quantization import int8_linear, rotate_int8_convrot_weight
+
+
+def _assign_codes(normalized: torch.Tensor, codebook: torch.Tensor) -> torch.Tensor:
+    """Find nearest codebook indices without a trailing 16-wide temporary."""
+    best = (normalized - codebook[0]).abs()
+    indices = torch.zeros_like(normalized, dtype=torch.int32)
+    for index in range(1, codebook.numel()):
+        distance = (normalized - codebook[index]).abs()
+        closer = distance < best
+        best = torch.where(closer, distance, best)
+        indices = torch.where(closer, index, indices)
+    return indices
+
+
+def _assign_grid(
+    weight: torch.Tensor,
+    levels: torch.Tensor,
+    s_channel: torch.Tensor,
+) -> torch.Tensor:
+    """Find the nearest decoded INT8 level for each grouped weight."""
+    target = weight / s_channel.view(-1, 1, 1)
+    best = (target - levels[..., 0:1].expand_as(weight)).abs()
+    indices = torch.zeros_like(weight, dtype=torch.int32)
+    for index in range(1, 16):
+        distance = (target - levels[..., index : index + 1].expand_as(weight)).abs()
+        closer = distance < best
+        best = torch.where(closer, distance, best)
+        indices = torch.where(closer, index, indices)
+    return indices
+
+
+def _fit_codebook(
+    normalized: torch.Tensor,
+    levels: int = 16,
+    iterations: int = 25,
+    sample_size: int = 300000,
+) -> torch.Tensor:
+    """Fit a data-free Lloyd-Max codebook to normalized rotated weights."""
+    samples = normalized.flatten()
+    if samples.numel() > sample_size:
+        generator = torch.Generator(device=samples.device).manual_seed(0)
+        indices = torch.randint(
+            0,
+            samples.numel(),
+            (sample_size,),
+            device=samples.device,
+            generator=generator,
+        )
+        samples = samples[indices]
+    samples = samples.float()
+    codebook = torch.quantile(
+        samples,
+        torch.linspace(0, 1, levels, device=samples.device),
+    )
+    for _ in range(iterations):
+        assignments = (samples.unsqueeze(-1) - codebook).abs().argmin(-1)
+        updated = codebook.clone()
+        for index in range(levels):
+            selected = assignments == index
+            if selected.any():
+                updated[index] = samples[selected].mean()
+        codebook = updated
+    return codebook.contiguous()
+
+
+def validate_w4a8_weight_shape(
+    weight: torch.Tensor,
+    group_size: int,
+    convrot_groupsize: int,
+) -> None:
+    """Validate a floating weight before W4A8 preparation."""
+    if weight.dim() != 2:
+        raise ValueError(f"W4A8 weight must be 2D, got shape {tuple(weight.shape)}")
+    k = weight.shape[1]
+    if (
+        k % 16 != 0
+        or k % group_size != 0
+        or k % convrot_groupsize != 0
+        or group_size < 4
+        or (16 % group_size != 0 and group_size % 16 != 0)
+    ):
+        raise ValueError(
+            f"K={k} must be divisible by 16, group_size={group_size}, and "
+            f"convrot_groupsize={convrot_groupsize}; group_size must be >=4 "
+            f"and divide 16 or be a multiple of 16"
+        )
+
+
+def _quantize_rotated_w4a8_int8_weight(
+    weight: torch.Tensor,
+    group_size: int = 16,
+    symmetric: bool = True,
+    scale_dtype: torch.dtype = torch.float8_e4m3fn,
+    codebook: bool = True,
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor | None,
+    torch.Tensor | None,
+]:
+    """Quantize an already ConvRot-rotated weight into W4A8 storage."""
+    if scale_dtype not in (torch.float32, torch.float8_e4m3fn):
+        raise ValueError(f"scale_dtype must be float32 or float8_e4m3fn, got {scale_dtype}")
+
+    original_dtype = weight.dtype
+    n, k = weight.shape
+    groups = k // group_size
+    grouped_weight = weight.float().view(n, groups, group_size)
+
+    codebook_tensor = None
+    if symmetric and codebook:
+        group_scale = grouped_weight.abs().amax(dim=-1, keepdim=True).clamp(min=1e-8)
+        normalized = grouped_weight / group_scale
+        codebook_tensor = _fit_codebook(normalized)
+        quantized = _assign_codes(normalized, codebook_tensor)
+        for _ in range(3):
+            quantized_codebook = codebook_tensor[quantized]
+            group_scale = (
+                (grouped_weight * quantized_codebook).sum(-1, keepdim=True)
+                / (quantized_codebook * quantized_codebook).sum(-1, keepdim=True).clamp(min=1e-8)
+            ).clamp(min=1e-8)
+            quantized = _assign_codes(grouped_weight / group_scale, codebook_tensor)
+        unsigned = quantized.to(torch.int32).view(n, k)
+        shifted_weight = codebook_tensor[quantized] * group_scale
+        correction = None
+    elif symmetric:
+        group_scale = (grouped_weight.abs().amax(dim=-1, keepdim=True) / 7.0).clamp(min=1e-8)
+        signed = (grouped_weight / group_scale).round().clamp(-8, 7).to(torch.int32)
+        unsigned = (signed + 8).view(n, k)
+        shifted_weight = signed * group_scale
+        correction = None
+    else:
+        minimum = grouped_weight.amin(dim=-1, keepdim=True)
+        group_scale = ((grouped_weight.amax(dim=-1, keepdim=True) - minimum) / 15.0).clamp(min=1e-8)
+        unsigned = (
+            ((grouped_weight - minimum) / group_scale)
+            .round()
+            .clamp(0, 15)
+            .to(torch.int32)
+            .view(n, k)
+        )
+        shifted_weight = (unsigned.view(n, groups, group_size) - 8) * group_scale
+        correction = (8.0 * group_scale + minimum).squeeze(-1).t().contiguous().to(original_dtype)
+
+    s_channel = (shifted_weight.abs().amax(dim=(1, 2)) / 127.0).clamp(min=1e-8)
+    s_rel = (group_scale.squeeze(-1) / s_channel.unsqueeze(1)).float().contiguous()
+    if scale_dtype != torch.float32:
+        s_rel = s_rel.to(scale_dtype).contiguous()
+    if codebook_tensor is not None:
+        levels = (
+            (codebook_tensor.view(1, 1, 16) * s_rel.float().unsqueeze(-1))
+            .round_()
+            .clamp_(-127, 127)
+        )
+        unsigned = _assign_grid(grouped_weight, levels, s_channel).view(n, k)
+
+    packed = (
+        ((unsigned[:, 0::2] & 0xF) | ((unsigned[:, 1::2] & 0xF) << 4)).to(torch.int8).contiguous()
+    )
+    return (
+        packed,
+        s_rel,
+        s_channel.float().contiguous(),
+        correction,
+        codebook_tensor,
+    )
+
+
+def quantize_w4a8_int8_weight(
+    weight: torch.Tensor,
+    group_size: int = 16,
+    convrot_groupsize: int = 256,
+    symmetric: bool = True,
+    scale_dtype: torch.dtype = torch.float8_e4m3fn,
+    codebook: bool = True,
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor | None,
+    torch.Tensor | None,
+]:
+    """Rotate and prepare a floating weight for grouped W4A8 storage."""
+    validate_w4a8_weight_shape(weight, group_size, convrot_groupsize)
+    rotated = rotate_int8_convrot_weight(weight, convrot_groupsize)
+    return _quantize_rotated_w4a8_int8_weight(
+        rotated,
+        group_size=group_size,
+        symmetric=symmetric,
+        scale_dtype=scale_dtype,
+        codebook=codebook,
+    )
 
 
 def _dequant_int4_grouped_to_int8(
-    qdata: torch.Tensor,      # [N, K/2] packed uint4 (even col=low nibble)
-    s_rel: torch.Tensor,      # [N, K/group] per-group scale (fp8 or fp32)
-    codebook: torch.Tensor | None,  # [16] levels, or None for uniform (q-8)
+    qdata: torch.Tensor,
+    s_rel: torch.Tensor,
+    codebook: torch.Tensor | None,
     group_size: int,
 ) -> torch.Tensor:
-    """int4 -> grouped int8: round(clamp(level(q) * s_rel, -127, 127)). Per-group scale
-    folded in, per-channel scale left for the GEMM epilogue. Bit-exact with CUDA."""
+    """Decode grouped INT4 storage to the INT8 grid consumed by the GEMM."""
     n, k_half = qdata.shape
     k = k_half * 2
     groups = k // group_size
-    b = qdata.to(torch.int32) & 0xFF
-    q = torch.empty(n, k, dtype=torch.int32, device=qdata.device)
-    q[:, 0::2] = b & 0xF
-    q[:, 1::2] = (b >> 4) & 0xF
+    packed = qdata.to(torch.int32) & 0xFF
+    quantized = torch.empty(n, k, dtype=torch.int32, device=qdata.device)
+    quantized[:, 0::2] = packed & 0xF
+    quantized[:, 1::2] = (packed >> 4) & 0xF
     if codebook is not None:
-        vals = codebook.to(device=qdata.device, dtype=torch.float32)[q]  # direct [0,15] index
+        values = codebook.to(device=qdata.device, dtype=torch.float32)[quantized]
     else:
-        vals = q.float() - 8.0  # symmetric uniform levels -8..7
-    # Broadcast the per-group scale via a grouped view instead of repeat_interleave
-    # (avoids a full [N, K] fp32 scale copy).
-    vals = vals.view(n, groups, group_size) * s_rel.float().unsqueeze(-1)  # [N, groups, 1]
-    return vals.view(n, k).round().clamp_(-127, 127).to(torch.int8)
+        values = quantized.float() - 8.0
+    values = values.view(n, groups, group_size) * s_rel.float().unsqueeze(-1)
+    return values.view(n, k).round().clamp_(-127, 127).to(torch.int8)
+
+
+def validate_w4a8_operands(
+    qdata: torch.Tensor,
+    s_rel: torch.Tensor,
+    s_channel: torch.Tensor,
+    codebook: torch.Tensor | None,
+    correction: torch.Tensor | None,
+    group_size: int,
+    convrot_groupsize: int,
+) -> None:
+    """Validate packed W4A8 tensors shared by dequantize and linear."""
+    if qdata.dim() != 2 or qdata.dtype != torch.int8:
+        raise ValueError("packed weight must be a 2D int8 tensor")
+    n, k_half = qdata.shape
+    k = k_half * 2
+    if (
+        group_size < 4
+        or k % 16 != 0
+        or k % group_size != 0
+        or k % convrot_groupsize != 0
+        or (16 % group_size != 0 and group_size % 16 != 0)
+    ):
+        raise ValueError(
+            f"K={k} must be divisible by 16, group_size={group_size}, and "
+            f"convrot_groupsize={convrot_groupsize}; group_size must be >=4 "
+            f"and divide 16 or be a multiple of 16"
+        )
+    groups = k // group_size
+    expected_scale_shape = (n, groups)
+    if tuple(s_rel.shape) != expected_scale_shape:
+        raise ValueError(f"s_rel must have shape {expected_scale_shape}, got {tuple(s_rel.shape)}")
+    if tuple(s_channel.shape) != (n,):
+        raise ValueError(f"s_channel must have shape {(n,)}, got {tuple(s_channel.shape)}")
+    if correction is not None and tuple(correction.shape) != (groups, n):
+        raise ValueError(f"correction must have shape {(groups, n)}, got {tuple(correction.shape)}")
+    if codebook is not None and tuple(codebook.shape) != (16,):
+        raise ValueError(f"codebook must have shape (16,), got {tuple(codebook.shape)}")
+
+
+def _dequantize_w4a8_int8_weight_from_int8(
+    int8_weight: torch.Tensor,
+    s_channel: torch.Tensor,
+    correction: torch.Tensor | None,
+    group_size: int,
+    output_dtype: torch.dtype,
+) -> torch.Tensor:
+    """Apply channel scaling and correction to decoded grouped INT8 weights."""
+    n, k = int8_weight.shape
+    groups = k // group_size
+    weight_rotated = int8_weight.float().view(n, groups, group_size)
+    weight_rotated = weight_rotated * s_channel.float().view(n, 1, 1)
+    if correction is not None:
+        weight_rotated = weight_rotated + correction.t().unsqueeze(-1).float()
+    return weight_rotated.view(n, k).to(output_dtype)
+
+
+def dequantize_w4a8_int8_weight(
+    qdata: torch.Tensor,
+    s_rel: torch.Tensor,
+    s_channel: torch.Tensor,
+    codebook: torch.Tensor | None = None,
+    correction: torch.Tensor | None = None,
+    group_size: int = 16,
+    convrot_groupsize: int = 256,
+    output_dtype: torch.dtype = torch.bfloat16,
+) -> torch.Tensor:
+    """Decode W4A8 storage into its physical [N, K] floating weight."""
+    validate_w4a8_operands(
+        qdata,
+        s_rel,
+        s_channel,
+        codebook,
+        correction,
+        group_size,
+        convrot_groupsize,
+    )
+    int8_weight = _dequant_int4_grouped_to_int8(
+        qdata,
+        s_rel,
+        codebook,
+        group_size,
+    )
+    weight_rotated = _dequantize_w4a8_int8_weight_from_int8(
+        int8_weight,
+        s_channel,
+        correction,
+        group_size,
+        output_dtype,
+    )
+    return rotate_int8_convrot_weight(weight_rotated, convrot_groupsize).to(output_dtype)
 
 
 def w4a8_int8_linear(
@@ -41,15 +321,49 @@ def w4a8_int8_linear(
     s_rel: torch.Tensor,
     s_channel: torch.Tensor,
     codebook: torch.Tensor | None = None,
+    correction: torch.Tensor | None = None,
     bias: torch.Tensor | None = None,
     group_size: int = 16,
     convrot_groupsize: int = 256,
     out_dtype: torch.dtype = torch.bfloat16,
 ) -> torch.Tensor:
-    """``x @ W.T + bias`` for AsymW4A8Int8 (symmetric): dequant int4->int8, then the
-    shared INT8 linear (ConvRot activation rotation + per-channel weight scale)."""
-    int8_w = _dequant_int4_grouped_to_int8(qdata, s_rel, codebook, group_size)
+    """Compute x @ W.T + bias using portable W4A8 operations."""
+    validate_w4a8_operands(
+        qdata,
+        s_rel,
+        s_channel,
+        codebook,
+        correction,
+        group_size,
+        convrot_groupsize,
+    )
+    if x.shape[-1] != qdata.shape[-1] * 2:
+        raise ValueError(f"Input K={x.shape[-1]} does not match qdata K={qdata.shape[-1] * 2}")
+    if correction is not None:
+        weight = dequantize_w4a8_int8_weight(
+            qdata,
+            s_rel,
+            s_channel,
+            codebook=codebook,
+            correction=correction,
+            group_size=group_size,
+            convrot_groupsize=convrot_groupsize,
+            output_dtype=x.dtype,
+        )
+        return torch.nn.functional.linear(x, weight, bias).to(out_dtype)
+
+    int8_weight = _dequant_int4_grouped_to_int8(
+        qdata,
+        s_rel,
+        codebook,
+        group_size,
+    )
     return int8_linear(
-        x, int8_w, s_channel, bias=bias, out_dtype=out_dtype,
-        convrot=True, convrot_groupsize=convrot_groupsize,
+        x,
+        int8_weight,
+        s_channel,
+        bias=bias,
+        out_dtype=out_dtype,
+        convrot=True,
+        convrot_groupsize=convrot_groupsize,
     )

--- a/comfy_kitchen/backends/triton/__init__.py
+++ b/comfy_kitchen/backends/triton/__init__.py
@@ -242,9 +242,12 @@ def _build_constraints() -> dict:
                 "qdata": ParamConstraint(dtypes=frozenset({torch.int8}), shape_rules=(ExactDims(2),)),
                 "s_rel": ParamConstraint(dtypes=frozenset({torch.float8_e4m3fn, torch.float32}), shape_rules=(ExactDims(2),)),
                 "s_channel": ParamConstraint(dtypes=frozenset({torch.float32}), shape_rules=(ExactDims(1),)),
+                "codebook": ParamConstraint(dtypes=frozenset({torch.float32}), shape_rules=(ExactDims(1),)),
+                "correction": ParamConstraint(dtypes=standard_floats, shape_rules=(ExactDims(2),)),
                 "bias": ParamConstraint(dtypes=standard_floats),
                 "group_size": ParamConstraint(dtypes=frozenset({int})),
                 "convrot_groupsize": ParamConstraint(dtypes=frozenset({int})),
+                "out_dtype": ParamConstraint(dtypes=standard_floats),
             },
             default_devices=triton_devices,
             min_compute_capability=(8, 0),  # Required for Triton INT8 dot

--- a/comfy_kitchen/backends/triton/__init__.py
+++ b/comfy_kitchen/backends/triton/__init__.py
@@ -25,6 +25,7 @@ __all__ = [
     "int8_linear",
     "quantize_int8_rowwise",
     "quantize_and_rotate_rowwise",
+    "w4a8_int8_linear",
 ]
 
 # Try to import triton and register if available
@@ -84,6 +85,7 @@ try:
         apply_rope_split_half1_,
         apply_rope_split_half_,
     )
+    from .w4a8_int8 import w4a8_int8_linear
 except ImportError as e:
     _TRITON_AVAILABLE = False
     _TRITON_ERROR = f"ImportError: {e!s}"
@@ -230,6 +232,19 @@ def _build_constraints() -> dict:
                 "convrot": ParamConstraint(dtypes=frozenset({bool})),
                 "convrot_groupsize": ParamConstraint(dtypes=frozenset({int})),
                 "input_act": ParamConstraint(dtypes=frozenset({str, type(None)})),
+            },
+            default_devices=triton_devices,
+            min_compute_capability=(8, 0),  # Required for Triton INT8 dot
+        ),
+        "w4a8_int8_linear": FunctionConstraints(
+            params={
+                "x": ParamConstraint(dtypes=standard_floats),
+                "qdata": ParamConstraint(dtypes=frozenset({torch.int8}), shape_rules=(ExactDims(2),)),
+                "s_rel": ParamConstraint(dtypes=frozenset({torch.float8_e4m3fn, torch.float32}), shape_rules=(ExactDims(2),)),
+                "s_channel": ParamConstraint(dtypes=frozenset({torch.float32}), shape_rules=(ExactDims(1),)),
+                "bias": ParamConstraint(dtypes=standard_floats),
+                "group_size": ParamConstraint(dtypes=frozenset({int})),
+                "convrot_groupsize": ParamConstraint(dtypes=frozenset({int})),
             },
             default_devices=triton_devices,
             min_compute_capability=(8, 0),  # Required for Triton INT8 dot

--- a/comfy_kitchen/backends/triton/w4a8_int8.py
+++ b/comfy_kitchen/backends/triton/w4a8_int8.py
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Triton AsymW4A8Int8 linear (AMD/CUDA) -- the accelerated path where the compiled
+CUDA backend is unavailable. A fused kernel dequantizes int4->grouped int8 in one launch
+(matching CUDA), feeding the Triton INT8 GEMM.
+"""
+from __future__ import annotations
+
+import torch
+
+import triton
+import triton.language as tl
+from triton.language.extra import libdevice
+
+from .quantization import int8_linear
+
+
+@triton.jit
+def _dequant_int4_grouped_to_int8_kernel(
+    qdata_ptr,   # [n, k/2] packed uint4 (int8 storage): even col=low nibble, odd=high
+    srel_ptr,    # [n, groups] fp32 per-group scale (fp8 decoded to fp32 by the wrapper)
+    cb_ptr,      # [16] fp32 codebook (unused when has_cb is False)
+    out_ptr,     # [n, k] int8 output
+    n, k, group_size,
+    stride_qn, stride_qk,
+    stride_sn, stride_sg,
+    stride_on, stride_ok,
+    has_cb: tl.constexpr,
+    block_n: tl.constexpr,
+    block_kh: tl.constexpr,  # packed byte-columns per tile (each -> 2 output columns)
+):
+    pid_n = tl.program_id(0)
+    pid_k = tl.program_id(1)
+    k_half = k // 2
+
+    rows = pid_n * block_n + tl.arange(0, block_n)          # [block_n]
+    bcols = pid_k * block_kh + tl.arange(0, block_kh)       # [block_kh] packed byte cols
+    m = (rows[:, None] < n) & (bcols[None, :] < k_half)     # [block_n, block_kh]
+
+    byte = tl.load(qdata_ptr + rows[:, None] * stride_qn + bcols[None, :] * stride_qk,
+                   mask=m, other=0).to(tl.int32) & 0xFF
+    low = byte & 0xF
+    high = (byte >> 4) & 0xF
+
+    # even group_size => a byte's two nibbles share a group -> one scale load per byte
+    grp = (2 * bcols) // group_size                         # [block_kh]
+    s = tl.load(srel_ptr + rows[:, None] * stride_sn + grp[None, :] * stride_sg,
+                mask=m, other=0.0)                          # [block_n, block_kh] fp32
+
+    if has_cb:
+        v_low = tl.load(cb_ptr + low)                       # gather (indices always 0..15)
+        v_high = tl.load(cb_ptr + high)
+    else:
+        v_low = (low - 8).to(tl.float32)                    # symmetric uniform levels
+        v_high = (high - 8).to(tl.float32)
+
+    q_low = tl.clamp(libdevice.rint(v_low * s), -127.0, 127.0).to(tl.int8)
+    q_high = tl.clamp(libdevice.rint(v_high * s), -127.0, 127.0).to(tl.int8)
+
+    tl.store(out_ptr + rows[:, None] * stride_on + (2 * bcols)[None, :] * stride_ok, q_low, mask=m)
+    tl.store(out_ptr + rows[:, None] * stride_on + (2 * bcols + 1)[None, :] * stride_ok, q_high, mask=m)
+
+
+def _dequant_int4_grouped_to_int8(
+    qdata: torch.Tensor,
+    s_rel: torch.Tensor,
+    codebook: torch.Tensor | None,
+    group_size: int,
+) -> torch.Tensor:
+    """Fused Triton int4 -> grouped int8: round(clamp(level(q) * s_rel, -127, 127))."""
+    n, k_half = qdata.shape
+    k = k_half * 2
+    qi = qdata.contiguous()
+    srel_f = s_rel.float().contiguous()  # decode fp8 scale to fp32 (small tensor)
+    has_cb = codebook is not None
+    cb = (codebook.float().contiguous() if has_cb
+          else torch.empty(16, device=qdata.device, dtype=torch.float32))
+    out = torch.empty(n, k, dtype=torch.int8, device=qdata.device)
+
+    block_n, block_kh = 32, 128
+    grid = (triton.cdiv(n, block_n), triton.cdiv(k_half, block_kh))
+    _dequant_int4_grouped_to_int8_kernel[grid](
+        qi, srel_f, cb, out,
+        n, k, group_size,
+        qi.stride(0), qi.stride(1),
+        srel_f.stride(0), srel_f.stride(1),
+        out.stride(0), out.stride(1),
+        has_cb=has_cb, block_n=block_n, block_kh=block_kh,
+    )
+    return out
+
+
+def w4a8_int8_linear(
+    x: torch.Tensor,
+    qdata: torch.Tensor,
+    s_rel: torch.Tensor,
+    s_channel: torch.Tensor,
+    codebook: torch.Tensor | None = None,
+    bias: torch.Tensor | None = None,
+    group_size: int = 16,
+    convrot_groupsize: int = 256,
+    out_dtype: torch.dtype = torch.bfloat16,
+) -> torch.Tensor:
+    """``x @ W.T + bias`` for AsymW4A8Int8 via the fused Triton dequant + INT8 GEMM."""
+    int8_w = _dequant_int4_grouped_to_int8(qdata, s_rel, codebook, group_size)
+    return int8_linear(
+        x, int8_w, s_channel, bias=bias, out_dtype=out_dtype,
+        convrot=True, convrot_groupsize=convrot_groupsize,
+    )

--- a/comfy_kitchen/backends/triton/w4a8_int8.py
+++ b/comfy_kitchen/backends/triton/w4a8_int8.py
@@ -10,6 +10,12 @@ import torch
 
 import triton
 import triton.language as tl
+from comfy_kitchen.backends.eager.w4a8_int8 import (
+    validate_w4a8_operands,
+)
+from comfy_kitchen.backends.eager.w4a8_int8 import (
+    w4a8_int8_linear as eager_w4a8_int8_linear,
+)
 from triton.language.extra import libdevice
 
 from .quantization import int8_linear
@@ -96,12 +102,40 @@ def w4a8_int8_linear(
     s_rel: torch.Tensor,
     s_channel: torch.Tensor,
     codebook: torch.Tensor | None = None,
+    correction: torch.Tensor | None = None,
     bias: torch.Tensor | None = None,
     group_size: int = 16,
     convrot_groupsize: int = 256,
     out_dtype: torch.dtype = torch.bfloat16,
 ) -> torch.Tensor:
     """``x @ W.T + bias`` for AsymW4A8Int8 via the fused Triton dequant + INT8 GEMM."""
+    validate_w4a8_operands(
+        qdata,
+        s_rel,
+        s_channel,
+        codebook,
+        correction,
+        group_size,
+        convrot_groupsize,
+    )
+    if x.shape[-1] != qdata.shape[-1] * 2:
+        raise ValueError(
+            f"Input K={x.shape[-1]} does not match qdata K={qdata.shape[-1] * 2}"
+        )
+    if correction is not None:
+        return eager_w4a8_int8_linear(
+            x,
+            qdata,
+            s_rel,
+            s_channel,
+            codebook=codebook,
+            correction=correction,
+            bias=bias,
+            group_size=group_size,
+            convrot_groupsize=convrot_groupsize,
+            out_dtype=out_dtype,
+        )
+
     int8_w = _dequant_int4_grouped_to_int8(qdata, s_rel, codebook, group_size)
     return int8_linear(
         x, int8_w, s_channel, bias=bias, out_dtype=out_dtype,

--- a/comfy_kitchen/tensor/__init__.py
+++ b/comfy_kitchen/tensor/__init__.py
@@ -1,4 +1,5 @@
 """Quantized tensor types with typed layout parameters."""
+from .w4a8_int8 import AsymW4A8Int8Layout
 from .awq_w4a16 import TensorCoreAWQW4A16Layout
 from .base import (
     BaseLayoutParams,
@@ -29,6 +30,7 @@ from .svdquant_w4a4 import (
 )
 
 __all__ = [
+    "AsymW4A8Int8Layout",
     "BaseLayoutParams",
     "QuantizedLayout",
     "QuantizedTensor",
@@ -53,6 +55,7 @@ __all__ = [
     "svdquant_w4a4_grouped_linear",
 ]
 
+register_layout_class("AsymW4A8Int8Layout", AsymW4A8Int8Layout)
 register_layout_class("TensorCoreAWQW4A16Layout", TensorCoreAWQW4A16Layout)
 register_layout_class("TensorCoreConvRotW4A4Layout", TensorCoreConvRotW4A4Layout)
 register_layout_class("TensorCoreFP8Layout", TensorCoreFP8Layout)

--- a/comfy_kitchen/tensor/__init__.py
+++ b/comfy_kitchen/tensor/__init__.py
@@ -1,5 +1,4 @@
 """Quantized tensor types with typed layout parameters."""
-from .w4a8_int8 import AsymW4A8Int8Layout
 from .awq_w4a16 import TensorCoreAWQW4A16Layout
 from .base import (
     BaseLayoutParams,
@@ -28,6 +27,7 @@ from .svdquant_w4a4 import (
     svdquant_w4a4_fused_grouped_linear,
     svdquant_w4a4_grouped_linear,
 )
+from .w4a8_int8 import AsymW4A8Int8Layout
 
 __all__ = [
     "AsymW4A8Int8Layout",

--- a/comfy_kitchen/tensor/__init__.py
+++ b/comfy_kitchen/tensor/__init__.py
@@ -27,7 +27,12 @@ from .svdquant_w4a4 import (
     svdquant_w4a4_fused_grouped_linear,
     svdquant_w4a4_grouped_linear,
 )
-from .w4a8_int8 import AsymW4A8Int8Layout
+from .w4a8_int8 import (
+    AsymW4A8Int8Layout,
+    dequantize_w4a8_int8_weight,
+    quantize_w4a8_int8_weight,
+    w4a8_int8_linear,
+)
 
 __all__ = [
     "AsymW4A8Int8Layout",
@@ -44,15 +49,18 @@ __all__ = [
     "convrot_w4a4_linear",
     "dequantize_args",
     "dequantize_convrot_w4a4_weight",
+    "dequantize_w4a8_int8_weight",
     "get_cuda_capability",
     "get_layout_class",
     "register_layout_class",
     "register_layout_op",
     "quantize_convrot_w4a4_weight",
+    "quantize_w4a8_int8_weight",
     "svdquant_w4a4_can_share_quant",
     "svdquant_w4a4_fuse_linear_weights",
     "svdquant_w4a4_fused_grouped_linear",
     "svdquant_w4a4_grouped_linear",
+    "w4a8_int8_linear",
 ]
 
 register_layout_class("AsymW4A8Int8Layout", AsymW4A8Int8Layout)

--- a/comfy_kitchen/tensor/w4a8_int8.py
+++ b/comfy_kitchen/tensor/w4a8_int8.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import dataclasses
 import logging
+import os
 from dataclasses import dataclass
 
 import torch
@@ -45,6 +46,12 @@ from .base import (
 from .int8 import _dtype_code
 
 logger = logging.getLogger(__name__)
+
+# Chunked fused path: dequant int4->int8 in L2-sized column chunks feeding the strided
+# int8 GEMM, so the int8 weight chunk stays cache-resident instead of the full [N,K]
+# round-tripping global memory. Matches convrot_w4a4's speed at our codebook quality.
+# Set COMFY_KITCHEN_W4A8_CHUNKED=0 to force the 2-pass path (e.g. for A/B timing).
+_W4A8_CHUNKED = os.environ.get("COMFY_KITCHEN_W4A8_CHUNKED", "1") != "0"
 
 
 class AsymW4A8Int8Layout(QuantizedLayout):
@@ -287,9 +294,33 @@ def _w4a8_int8_matmul(x, weight, bias, out_dtype):
     m = x2.shape[0]
 
     sp = torch.cuda.current_stream(x.device).cuda_stream
-    # int4 -> grouped int8 (transient; weights stay int4 in storage, freed after use)
-    int8_w = torch.empty(n, k, dtype=torch.int8, device=x.device)
     cb = _wrap_for_dlpack(p.codebook) if p.codebook is not None else None
+    # fused rotate + int8 activation quant
+    xq, xs = quantize_int8_rowwise_convrot(x2, p.convrot_groupsize)
+    out = torch.empty(m, n, dtype=out_dtype, device=x.device)
+    # Fuse bias into the epilogue (D = acc*xs*s_channel + bias). fp32 compute type;
+    # the [N] cast is cheap -- don't cache it (inference tensors have no _version).
+    biasf = bias.float().contiguous() if bias is not None else None
+
+    # Chunked fused path (symmetric codebook, fp8 scale): dequant int4->int8 in
+    # L2-sized column chunks feeding the strided int8 GEMM -- no full [N,K] round-trip.
+    if (_W4A8_CHUNKED and p.correction is None and p.codebook is not None
+            and p.scale.dtype == torch.float8_e4m3fn):
+        from comfy_kitchen.backends.cuda import _int4_int8_weight_chunk_cols
+        chunk_cols = _int4_int8_weight_chunk_cols(m, n)
+        workspace = torch.empty(min(chunk_cols, n), k, dtype=torch.int8, device=x.device)
+        ok = _C.w4a8_codebook_gemm_chunked(
+            _wrap_for_dlpack(xq), _wrap_for_dlpack(weight._qdata),
+            _wrap_for_dlpack(p.scale.view(torch.uint8)), cb,
+            _wrap_for_dlpack(p.s_channel), _wrap_for_dlpack(xs.reshape(m).contiguous()),
+            _wrap_for_dlpack(biasf) if biasf is not None else None,
+            _wrap_for_dlpack(workspace), _wrap_for_dlpack(out),
+            g, chunk_cols, _dtype_code(out_dtype), sp)
+        if ok:
+            return out.reshape(*x.shape[:-1], n)
+
+    # 2-pass fallback: full int4 -> int8 dequant, then the int8 GEMM (+ asym correction).
+    int8_w = torch.empty(n, k, dtype=torch.int8, device=x.device)
     if p.scale.dtype == torch.float8_e4m3fn:
         _C.dequant_int4_grouped_to_int8_e4m3(
             _wrap_for_dlpack(weight._qdata), _wrap_for_dlpack(p.scale.view(torch.uint8)),
@@ -298,27 +329,12 @@ def _w4a8_int8_matmul(x, weight, bias, out_dtype):
         _C.dequant_int4_grouped_to_int8(
             _wrap_for_dlpack(weight._qdata), _wrap_for_dlpack(p.scale), cb,
             _wrap_for_dlpack(int8_w), g, sp)
-
-    # fused rotate + int8 activation quant
-    xq, xs = quantize_int8_rowwise_convrot(x2, p.convrot_groupsize)
-
-    out = torch.empty(m, n, dtype=out_dtype, device=x.device)
-    # Fuse bias into the CUTLASS epilogue (D = acc*xs*s_channel + bias) instead of
-    # a separate M*N add pass. fp32 for the epilogue compute type; the cast is
-    # cached on the bias tensor, keyed by _version to catch in-place patches.
-    if bias is None:
-        biasf = _empty_cuda_tensor(x.device, torch.float32)
-    else:
-        cached = getattr(bias, "_ck_bias_f32", None)
-        if cached is None or cached[1] != bias._version:
-            bias._ck_bias_f32 = cached = (bias.float().contiguous(), bias._version)
-        biasf = cached[0]
+    bf = biasf if biasf is not None else _empty_cuda_tensor(x.device, torch.float32)
     used = _C.cutlass_int8_dequant(
         _wrap_for_dlpack(xq), _wrap_for_dlpack(int8_w), _wrap_for_dlpack(xs),
-        _wrap_for_dlpack(p.s_channel), _wrap_for_dlpack(biasf),
+        _wrap_for_dlpack(p.s_channel), _wrap_for_dlpack(bf),
         _wrap_for_dlpack(out), _dtype_code(out_dtype), sp)
     if not used:
-        # tuned path unavailable -> dequant fallback
         return torch.nn.functional.linear(x, weight.dequantize(), bias)
 
     # asymmetric zero-point correction (rank-(K/group)); symmetric path has none.

--- a/comfy_kitchen/tensor/w4a8_int8.py
+++ b/comfy_kitchen/tensor/w4a8_int8.py
@@ -400,8 +400,8 @@ def _w4a8_int8_matmul(x, weight, bias, out_dtype):
         _wrap_for_dlpack(xq), _wrap_for_dlpack(int8_w), _wrap_for_dlpack(xs),
         _wrap_for_dlpack(p.s_channel), _wrap_for_dlpack(bf),
         _wrap_for_dlpack(out), _dtype_code(out_dtype), sp)
-    if not used:
-        return torch.nn.functional.linear(x, _storage_dequant(weight), bias)
+    if not used:  # match x.dtype -- orig_dtype may differ from the runtime dtype (autocast)
+        return torch.nn.functional.linear(x, _storage_dequant(weight).to(x.dtype), bias)
 
     # asymmetric zero-point correction (rank-(K/group)); symmetric path has none.
     if p.correction is not None:

--- a/comfy_kitchen/tensor/w4a8_int8.py
+++ b/comfy_kitchen/tensor/w4a8_int8.py
@@ -216,7 +216,10 @@ class AsymW4A8Int8Layout(QuantizedLayout):
         """MSE-optimal (Lloyd-Max) 16-level codebook on normalized weights, data-free."""
         x = wn.flatten()
         if x.numel() > sample:
-            idx = torch.randint(0, x.numel(), (sample,), device=x.device)
+            # Fixed-seed local generator so the codebook (and the packed codes, hence the
+            # exported checkpoint) is reproducible run-to-run, independent of global RNG.
+            gen = torch.Generator(device=x.device).manual_seed(0)
+            idx = torch.randint(0, x.numel(), (sample,), device=x.device, generator=gen)
             x = x[idx]
         x = x.float()
         cb = torch.quantile(x, torch.linspace(0, 1, levels, device=x.device))
@@ -241,19 +244,21 @@ class AsymW4A8Int8Layout(QuantizedLayout):
         q = torch.empty(n, k, dtype=torch.int32, device=qdata.device)
         q[:, 0::2] = b & 0xF
         q[:, 1::2] = (b >> 4) & 0xF
-        s_rel = params.scale.float()  # fp8/fp32 -> fp32
-        s_g = (s_rel * params.s_channel.unsqueeze(1)).unsqueeze(-1)  # [N,groups,1]
+        s_rel = params.scale.float().unsqueeze(-1)  # [N, groups, 1]
+        s_channel = params.s_channel.float().view(n, 1, 1)  # [N, 1, 1]
         if params.codebook is not None:
-            # w = codebook[q] * s_g (q is a direct [0,15] index)
-            lvl = params.codebook.to(q.device).float()[q.view(n, groups, g)]
-            w_rot = (lvl * s_g).view(n, k)
+            lvl = params.codebook.to(q.device).float()[q.view(n, groups, g)]  # [N,groups,g]
         else:
-            qc = (q.view(n, groups, g).float() - 8.0) * s_g
-            if params.correction is None:
-                w_rot = qc.view(n, k)  # symmetric: w = (q-8)*s_g
-            else:
-                corr = params.correction.t().unsqueeze(-1).float()  # [N,groups,1] = 8*s_g + min
-                w_rot = (qc + corr).view(n, k)  # w = q*s_g + min = (q-8)*s_g + corr
+            lvl = q.view(n, groups, g).float() - 8.0  # symmetric uniform levels -8..7
+        # Match the executed paths (CUDA/Triton/eager): the per-group scale is folded into a
+        # rounded int8 weight and the per-channel scale is applied afterward, so the reference
+        # dequant must fold the same round+clamp -- else it returns weights the kernels never
+        # use (the codes were even picked against this grid in quantize).
+        int8_w = (lvl * s_rel).round_().clamp_(-127, 127)  # [N, groups, g]
+        w_rot = int8_w * s_channel  # [N, groups, g]
+        if params.correction is not None:  # asymmetric zero-point (rank correction folded per-elem here)
+            w_rot = w_rot + params.correction.t().unsqueeze(-1).float()  # [N,groups,1] = 8*s_g + min
+        w_rot = w_rot.view(n, k)
         # undo rotation (involutory) -> storage-basis weight [N, K]. The base
         # QuantizedTensor.dequantize() applies the lazy-transpose flag (returns W.T for a
         # transposed tensor), so this must always return the [N, K] storage orientation.

--- a/comfy_kitchen/tensor/w4a8_int8.py
+++ b/comfy_kitchen/tensor/w4a8_int8.py
@@ -40,16 +40,16 @@ logger = logging.getLogger(__name__)
 # the layout dispatches dequant + INT8 GEMM through the registry (Triton, else eager) and
 # rotates in portable torch -- runnable on any torch device.
 try:
-    from comfy_kitchen.backends.cuda import _C as _CUDA_C  # noqa: F401
-    _CUDA_AVAILABLE = True
-except Exception as _e:  # pragma: no cover - non-CUDA builds
-    _CUDA_AVAILABLE = False
-    # Loud only when CUDA hardware is present but the extension failed to load; quiet on
-    # ROCm/CPU where the fallback is expected.
-    if torch.cuda.is_available():
-        logger.warning(
-            "W4A8: CUDA backend import failed though CUDA is available (%s); falling "
-            "back to the portable Triton/eager path (slower).", _e)
+    from comfy_kitchen.backends.cuda import _C as _CUDA_C
+except Exception:  # pragma: no cover - non-CUDA builds
+    _CUDA_C = None
+# The cuda module imports successfully but sets _C=None when the compiled extension fails
+# to load, so importing it is not proof of availability -- gate on the real extension.
+# (is_cuda is also True for ROCm tensors, and there _C is None, so this correctly routes
+# ROCm to the portable Triton/eager path rather than into CUDA-only kernels.)
+_CUDA_AVAILABLE = _CUDA_C is not None
+if not _CUDA_AVAILABLE and torch.version.cuda is not None:  # real CUDA build, ext missing
+    logger.warning("W4A8: CUDA extension unavailable; using the portable Triton/eager path (slower).")
 
 
 def _convrot_rotate(w: torch.Tensor, groupsize: int) -> torch.Tensor:
@@ -107,6 +107,10 @@ class AsymW4A8Int8Layout(QuantizedLayout):
         orig_dtype = tensor.dtype
         orig_shape = tuple(tensor.shape)
         n, k = tensor.shape
+        # The group-scale kernel is templated only for fp32 and fp8-e4m3; any other dtype
+        # (e.g. fp16) would produce a checkpoint no backend can execute.
+        if scale_dtype not in (torch.float32, torch.float8_e4m3fn):
+            raise ValueError(f"scale_dtype must be float32 or float8_e4m3fn, got {scale_dtype}")
         # K must be a multiple of 16: the CUDA dequant kernel is vectorized (uint2 load ->
         # uint4 store, 16 int8/thread, n_vec = N*K/16), so a non-16 K truncates the tail and
         # misaligns the row start. G must be >=4 and in {4,8,16} or a multiple of 16: the
@@ -293,7 +297,8 @@ class AsymW4A8Int8Layout(QuantizedLayout):
         # Preserve quant options across the dequantize->patch->requantize LoRA path.
         p = qtensor._params
         return {"group_size": p.group_size, "convrot_groupsize": p.convrot_groupsize,
-                "symmetric": p.correction is None, "codebook": p.codebook is not None}
+                "symmetric": p.correction is None, "codebook": p.codebook is not None,
+                "scale_dtype": p.scale.dtype}
 
 
 def _storage_dequant(weight):
@@ -352,7 +357,10 @@ def _w4a8_int8_matmul(x, weight, bias, out_dtype):
     m = x2.shape[0]
 
     sp = torch.cuda.current_stream(x.device).cuda_stream
-    cb = _wrap_for_dlpack(p.codebook) if p.codebook is not None else None
+    # DLPack capsules are single-use, so wrap the codebook fresh per native call -- the
+    # chunked path may consume it and return False, then the 2-pass fallback needs its own.
+    def wrap_cb():
+        return _wrap_for_dlpack(p.codebook) if p.codebook is not None else None
     # fused rotate + int8 activation quant
     xq, xs = quantize_int8_rowwise_convrot(x2, p.convrot_groupsize)
     out = torch.empty(m, n, dtype=out_dtype, device=x.device)
@@ -369,7 +377,7 @@ def _w4a8_int8_matmul(x, weight, bias, out_dtype):
         workspace = torch.empty(min(chunk_cols, n), k, dtype=torch.int8, device=x.device)
         ok = _C.w4a8_codebook_gemm_chunked(
             _wrap_for_dlpack(xq), _wrap_for_dlpack(weight._qdata),
-            _wrap_for_dlpack(p.scale.view(torch.uint8)), cb,
+            _wrap_for_dlpack(p.scale.view(torch.uint8)), wrap_cb(),
             _wrap_for_dlpack(p.s_channel), _wrap_for_dlpack(xs.reshape(m).contiguous()),
             _wrap_for_dlpack(biasf) if biasf is not None else None,
             _wrap_for_dlpack(workspace), _wrap_for_dlpack(out),
@@ -382,10 +390,10 @@ def _w4a8_int8_matmul(x, weight, bias, out_dtype):
     if p.scale.dtype == torch.float8_e4m3fn:
         _C.dequant_int4_grouped_to_int8_e4m3(
             _wrap_for_dlpack(weight._qdata), _wrap_for_dlpack(p.scale.view(torch.uint8)),
-            cb, _wrap_for_dlpack(int8_w), g, sp)
+            wrap_cb(), _wrap_for_dlpack(int8_w), g, sp)
     else:
         _C.dequant_int4_grouped_to_int8(
-            _wrap_for_dlpack(weight._qdata), _wrap_for_dlpack(p.scale), cb,
+            _wrap_for_dlpack(weight._qdata), _wrap_for_dlpack(p.scale), wrap_cb(),
             _wrap_for_dlpack(int8_w), g, sp)
     bf = biasf if biasf is not None else _empty_cuda_tensor(x.device, torch.float32)
     used = _C.cutlass_int8_dequant(
@@ -443,7 +451,13 @@ def _handle_w4a8int8_mm(qt, args, kwargs):
 @register_layout_op(torch.ops.aten.addmm.default, AsymW4A8Int8Layout)
 def _handle_w4a8int8_addmm(qt, args, kwargs):
     bias, x, weight = args[0], args[1], args[2]
-    if not _is_w4a8(weight) or not getattr(weight._params, "transposed", False):
+    # The fast path only models F.linear's addmm: bias + x @ W.T with a 1-D bias and
+    # beta=alpha=1. Anything else (scaled addmm, matrix-shaped addend) takes the dequant
+    # fallback, which honors alpha/beta and general addend shapes.
+    scaled = kwargs.get("beta", 1) != 1 or kwargs.get("alpha", 1) != 1
+    bias_nd = isinstance(bias, torch.Tensor) and bias.dim() != 1
+    if (not _is_w4a8(weight) or not getattr(weight._params, "transposed", False)
+            or scaled or bias_nd):
         return torch.addmm(*dequantize_args(args), **dequantize_args(kwargs))
     if isinstance(x, QuantizedTensor):
         x = x.dequantize()

--- a/comfy_kitchen/tensor/w4a8_int8.py
+++ b/comfy_kitchen/tensor/w4a8_int8.py
@@ -107,12 +107,15 @@ class AsymW4A8Int8Layout(QuantizedLayout):
         orig_dtype = tensor.dtype
         orig_shape = tuple(tensor.shape)
         n, k = tensor.shape
-        # G must be >=4 and in {4,8,16} or a multiple of 16: the dequant kernel loads
-        # at most 4 group scales per 16-col vec, so G>=4 (G=2 would mis-scale cols 8-15).
-        if (k % group_size != 0 or group_size < 4
+        # K must be a multiple of 16: the CUDA dequant kernel is vectorized (uint2 load ->
+        # uint4 store, 16 int8/thread, n_vec = N*K/16), so a non-16 K truncates the tail and
+        # misaligns the row start. G must be >=4 and in {4,8,16} or a multiple of 16: the
+        # kernel loads at most 4 group scales per 16-col vec (G=2 would mis-scale cols 8-15).
+        if (k % 16 != 0 or k % group_size != 0 or group_size < 4
                 or (16 % group_size != 0 and group_size % 16 != 0)):
             raise ValueError(
-                f"K={k}%G and G={group_size} must be >=4 & (divides 16 or mult of 16)")
+                f"K={k} must be a multiple of 16 and G={group_size} >=4 & "
+                f"(divides 16 or mult of 16)")
         groups = k // group_size
 
         # Data-free rotation (paired with the fused convrot activation quant).
@@ -261,6 +264,12 @@ class AsymW4A8Int8Layout(QuantizedLayout):
 
     @classmethod
     def state_dict_tensors(cls, qdata: torch.Tensor, params: Params) -> dict[str, torch.Tensor]:
+        # Export-only (checkpoint serialization). The ``_s_rel`` suffix intentionally does
+        # NOT match the ``scale`` field name: it names the per-group *relative* scale to
+        # distinguish it from ``_s_channel``, and matches the checkpoint format the loader
+        # reads. On load, ComfyUI's ``_load_quantized_module`` remaps weight_s_rel->scale,
+        # weight_s_channel->s_channel, etc. explicitly (not by field name). In-memory
+        # flatten/unflatten (__tensor_flatten__) uses field names, so it is unaffected.
         out = {
             "": qdata,
             "_s_rel": params.scale,

--- a/comfy_kitchen/tensor/w4a8_int8.py
+++ b/comfy_kitchen/tensor/w4a8_int8.py
@@ -1,0 +1,376 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Grouped W4A8 on the tuned INT8 CUTLASS GEMM (symmetric default).
+
+Calibration-free 4-bit weight storage that runs at near-int8-tensor-core speed
+by reusing comfy's tuned INT8 GEMM:
+
+- Weights are rotated (data-free Hadamard / ConvRot) then quantized per group of
+  ``group_size``. The default is **symmetric group-16 with a Lloyd-Max codebook
+  and fp8 (e4m3) group scales**: a per-tensor 16-level MSE-optimal codebook fit
+  to the rotated (~Gaussian) weights, plus an alternating least-squares refit of
+  the group scales and a final code assignment against the fp8-rounded scale the
+  kernel actually decodes with. ~0.073 weight relL2 on real DiT weights (NVFP4
+  0.094), ~0.56 B/elem (under NVFP4's footprint, ~56% of int8), no zero-point
+  correction -> ~1.09x int8 speed. ``symmetric=False`` gives asymmetric uniform
+  (uint4 [0,15], per-group min/scale) at the cost of a rank-(K/group) correction
+  pass (~1.4x int8); it is dominated by the symmetric+codebook default.
+- At matmul time the int4 weights are dequantized to the *grouped int8
+  representation* ``round((q-8)*s_rel)`` (group scale folded in, per-channel
+  scale ``s_channel`` left for the GEMM epilogue) and fed to the tuned INT8
+  CUTLASS GEMM. Symmetric packs ``q_signed+8`` so the same kernel computes
+  ``(q-8)*s_rel = q_signed*s_rel``.
+- Asymmetric only: the zero-point is added back as ``Sx @ Cᵀ`` (Sx = per-row
+  per-group int8-activation sums, ``C = 8*s_g + min``).
+
+Storage: int4 weights + per-group scale metadata. Persistent weights stay int4;
+the int8 dequant target is a transient per-call buffer (no int8-sized cache).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+from dataclasses import dataclass
+
+import torch
+
+from .base import (
+    BaseLayoutParams,
+    QuantizedLayout,
+    QuantizedTensor,
+    dequantize_args,
+    register_layout_op,
+)
+from .int8 import _dtype_code
+
+logger = logging.getLogger(__name__)
+
+
+class AsymW4A8Int8Layout(QuantizedLayout):
+    """Asymmetric grouped int4 weights, run on the tuned int8 GEMM."""
+
+    MIN_SM_VERSION = (8, 0)
+
+    @dataclass(frozen=True)
+    class Params(BaseLayoutParams):
+        # scale (inherited) holds s_rel: per-group relative scale [N, K//group] fp32.
+        s_channel: torch.Tensor = None   # [N] fp32 per-channel scale
+        correction: torch.Tensor = None  # [K//group, N] = 8*s_g+min (asym only; None=symmetric)
+        codebook: torch.Tensor = None    # [16] fp32 non-uniform levels (None=uniform q-8)
+        group_size: int = 16
+        convrot_groupsize: int = 256
+        transposed: bool = False
+
+        def _tensor_fields(self) -> list[str]:
+            f = ["scale", "s_channel"]
+            if self.correction is not None:
+                f.append("correction")
+            if self.codebook is not None:
+                f.append("codebook")
+            return f
+
+        def _validate_tensor_fields(self):
+            pass
+
+    @classmethod
+    def quantize(
+        cls,
+        tensor: torch.Tensor,
+        group_size: int = 16,
+        convrot_groupsize: int = 256,
+        symmetric: bool = True,
+        scale_dtype: torch.dtype = torch.float8_e4m3fn,
+        codebook: bool = True,
+        **kwargs,
+    ) -> tuple[torch.Tensor, Params]:
+        from comfy_kitchen.backends.cuda import rotate_int8_convrot_weight
+
+        orig_dtype = tensor.dtype
+        orig_shape = tuple(tensor.shape)
+        n, k = tensor.shape
+        # G must be even and pair-aligned to the 16-wide dequant vec: either
+        # divides 16 (fine: 4, 8, 16) or is a multiple of 16 (coarse: 32, 64...).
+        if k % group_size != 0 or group_size % 2 != 0 or (16 % group_size != 0 and group_size % 16 != 0):
+            raise ValueError(f"K={k}%G and G={group_size} must be even & (divides 16 or mult of 16)")
+        groups = k // group_size
+
+        # Data-free rotation (paired with the fused convrot activation quant).
+        w = rotate_int8_convrot_weight(tensor, convrot_groupsize).float().view(n, groups, group_size)
+
+        cb = None
+        if symmetric and codebook:
+            # Non-uniform 16-level codebook (Lloyd-Max on the rotated-Gaussian weight,
+            # calibration-free). ConvRot makes weights ~Gaussian; a codebook matched to
+            # it beats uniform int4 by ~14% at coarse groups, same storage/speed. The
+            # 4-bit code indexes cb directly; kernel computes cb[q]*s_rel.
+            s_g = w.abs().amax(dim=-1, keepdim=True).clamp(min=1e-8)  # group absmax
+            wn = (w / s_g)  # [n, groups, group] normalized to [-1, 1]
+            cb = cls._fit_codebook(wn)  # [16] fp32
+            q = cls._assign_codes(wn, cb)  # [n,groups,group] indices
+            # Alternating least-squares refit of the group scale given the codes:
+            # absmax is only optimal when the extreme code sits at +-1, which a
+            # Lloyd-Max codebook's extreme levels don't. 3 rounds, ~free at quant time.
+            for _ in range(3):
+                cbq = cb[q]
+                s_g = ((w * cbq).sum(-1, keepdim=True)
+                       / (cbq * cbq).sum(-1, keepdim=True).clamp(min=1e-8)).clamp(min=1e-8)
+                q = cls._assign_codes(w / s_g, cb)
+            q_u = q.to(torch.int32).view(n, k)  # [0,15]
+            wshift = (cb[q] * s_g)
+            correction = None
+        elif symmetric:
+            # Symmetric grouped int4 (levels -8..7); no zero-point => no correction pass.
+            # Quality beats NVFP4 at group 16 (~0.085 vs 0.093 relL2) calibration-free.
+            s_g = (w.abs().amax(dim=-1, keepdim=True) / 7.0).clamp(min=1e-8)
+            q_signed = (w / s_g).round().clamp(-8, 7).to(torch.int32)
+            # pack q_signed+8 as uint4; the dequant kernel computes (q-8)*s_rel = q_signed*s_rel
+            q_u = (q_signed + 8).view(n, k)
+            wshift = q_signed * s_g
+            correction = None
+        else:
+            mn = w.amin(dim=-1, keepdim=True)
+            s_g = ((w.amax(dim=-1, keepdim=True) - mn) / 15.0).clamp(min=1e-8)
+            q_u = ((w - mn) / s_g).round().clamp(0, 15).to(torch.int32).view(n, k)
+            wshift = (q_u.view(n, groups, group_size) - 8) * s_g
+            correction = (8.0 * s_g + mn).squeeze(-1).t().contiguous().to(orig_dtype)  # [groups, N]
+
+        s_channel = (wshift.abs().amax(dim=(1, 2)) / 127.0).clamp(min=1e-8)  # [N]
+        s_rel = (s_g.squeeze(-1) / s_channel.unsqueeze(1)).float().contiguous()  # [N, groups]
+        # fp8 e4m3 group scale halves the scale metadata (~half int8 storage),
+        # still beats NVFP4 (~0.089 vs 0.093); fp32 keeps max quality (~0.085).
+        if scale_dtype != torch.float32:
+            s_rel = s_rel.to(scale_dtype).contiguous()
+        if cb is not None:
+            # int8-grid-aware final assignment: pick codes against the values the
+            # kernel actually decodes -- round(clamp(cb_j * s_rel)) * s_channel,
+            # with s_rel in its stored dtype. Subsumes the fp8-scale-aware
+            # reassignment AND folds the int8 re-rounding into the choice
+            # (measured 0.0730 -> 0.0727 weight relL2 on Krea2 g16-fp8).
+            levels = (cb.view(1, 1, 16) * s_rel.float().unsqueeze(-1)).round_().clamp_(-127, 127)
+            q_u = cls._assign_grid(w, levels, s_channel).view(n, k)
+        # pack uint4: even col -> low nibble, odd col -> high nibble
+        qpacked = ((q_u[:, 0::2] & 0xF) | ((q_u[:, 1::2] & 0xF) << 4)).to(torch.int8).contiguous()
+
+        params = cls.Params(
+            scale=s_rel,
+            s_channel=s_channel.float().contiguous(),
+            correction=correction,
+            codebook=cb,
+            orig_dtype=orig_dtype,
+            orig_shape=orig_shape,
+            group_size=group_size,
+            convrot_groupsize=convrot_groupsize,
+        )
+        return qpacked, params
+
+    @staticmethod
+    def _assign_codes(xn: torch.Tensor, cb: torch.Tensor) -> torch.Tensor:
+        """Nearest-codebook index without materializing the [..., 16] distance tensor
+        (loop the 16 levels; keeps peak memory at a couple of [...] tensors).
+
+        int32 index: half the peak memory of long, still a valid indexing dtype
+        (uint8 is NOT -- byte index tensors are treated as boolean masks)."""
+        best = (xn - cb[0]).abs()
+        idx = torch.zeros_like(xn, dtype=torch.int32)
+        for j in range(1, cb.numel()):
+            d = (xn - cb[j]).abs()
+            m = d < best
+            best = torch.where(m, d, best)
+            idx = torch.where(m, j, idx)
+        return idx
+
+    @staticmethod
+    def _assign_grid(wv: torch.Tensor, levels: torch.Tensor, s_channel: torch.Tensor) -> torch.Tensor:
+        """Nearest decoded-int8 level: argmin_j |wv/s_channel - levels[n,g,j]| with
+        per-(channel, group) levels, looped over j like _assign_codes. `levels` is
+        [N, groups, 16] (= K floats/row at group 16; scales up at finer groups)."""
+        t = wv / s_channel.view(-1, 1, 1)
+        best = (t - levels[..., 0:1].expand_as(wv)).abs()
+        idx = torch.zeros_like(wv, dtype=torch.int32)
+        for j in range(1, 16):
+            d = (t - levels[..., j:j + 1].expand_as(wv)).abs()
+            m = d < best
+            best = torch.where(m, d, best)
+            idx = torch.where(m, j, idx)
+        return idx
+
+    @staticmethod
+    def _fit_codebook(wn: torch.Tensor, levels: int = 16, iters: int = 25,
+                      sample: int = 300000) -> torch.Tensor:
+        """MSE-optimal (Lloyd-Max) 16-level codebook on normalized weights, data-free."""
+        x = wn.flatten()
+        if x.numel() > sample:
+            idx = torch.randint(0, x.numel(), (sample,), device=x.device)
+            x = x[idx]
+        x = x.float()
+        cb = torch.quantile(x, torch.linspace(0, 1, levels, device=x.device))
+        for _ in range(iters):
+            a = (x.unsqueeze(-1) - cb).abs().argmin(-1)
+            new = cb.clone()
+            for j in range(levels):
+                m = a == j
+                if m.any():
+                    new[j] = x[m].mean()
+            cb = new
+        return cb.contiguous()
+
+    @classmethod
+    def dequantize(cls, qdata: torch.Tensor, params: Params) -> torch.Tensor:
+        # Reference dequant (rotated-basis weight); for fallbacks/inspection.
+        from comfy_kitchen.backends.cuda import rotate_int8_convrot_weight
+
+        n, k_half = qdata.shape
+        k = k_half * 2
+        g = params.group_size
+        groups = k // g
+        b = qdata.to(torch.int32) & 0xFF
+        q = torch.empty(n, k, dtype=torch.int32, device=qdata.device)
+        q[:, 0::2] = b & 0xF
+        q[:, 1::2] = (b >> 4) & 0xF
+        s_rel = params.scale.float()  # fp8/fp32 -> fp32
+        s_g = (s_rel * params.s_channel.unsqueeze(1)).unsqueeze(-1)  # [N,groups,1]
+        if params.codebook is not None:
+            # w = codebook[q] * s_g (q is a direct [0,15] index)
+            lvl = params.codebook.to(q.device).float()[q.view(n, groups, g)]
+            return rotate_int8_convrot_weight(
+                (lvl * s_g).view(n, k).to(params.orig_dtype), params.convrot_groupsize).to(params.orig_dtype)
+        qc = (q.view(n, groups, g).float() - 8.0) * s_g
+        if params.correction is None:
+            w_rot = qc.view(n, k)  # symmetric: w = (q-8)*s_g
+        else:
+            C = params.correction.t().unsqueeze(-1).float()  # [N,groups,1] = 8*s_g + min
+            w_rot = (qc + C).view(n, k)  # w = q*s_g + min = (q-8)*s_g + C
+        # undo rotation (involutory)
+        return rotate_int8_convrot_weight(w_rot.to(params.orig_dtype), params.convrot_groupsize).to(params.orig_dtype)
+
+    @classmethod
+    def get_plain_tensors(cls, qtensor: QuantizedTensor):
+        p = qtensor._params
+        return qtensor._qdata, p.scale, p.s_channel, p.correction
+
+    @classmethod
+    def state_dict_tensors(cls, qdata: torch.Tensor, params: Params) -> dict[str, torch.Tensor]:
+        out = {
+            "": qdata,
+            "_s_rel": params.scale,
+            "_s_channel": params.s_channel,
+        }
+        if params.correction is not None:
+            out["_correction"] = params.correction
+        if params.codebook is not None:
+            out["_codebook"] = params.codebook
+        return out
+
+    @classmethod
+    def requantize_kwargs(cls, qtensor: QuantizedTensor) -> dict[str, object]:
+        # Preserve quant options across the dequantize->patch->requantize LoRA path.
+        p = qtensor._params
+        return {"group_size": p.group_size, "convrot_groupsize": p.convrot_groupsize,
+                "symmetric": p.correction is None, "codebook": p.codebook is not None}
+
+
+def _w4a8_int8_matmul(x, weight, bias, out_dtype):
+    from comfy_kitchen.backends.cuda import (
+        _C,
+        _empty_cuda_tensor,
+        _wrap_for_dlpack,
+        quantize_int8_rowwise_convrot,
+    )
+
+    p = weight._params
+    n, k_half = weight._qdata.shape
+    k = k_half * 2
+    g = p.group_size
+    groups = k // g
+    x2 = x.reshape(-1, k).contiguous()
+    m = x2.shape[0]
+
+    sp = torch.cuda.current_stream(x.device).cuda_stream
+    # int4 -> grouped int8 (transient; weights stay int4 in storage, freed after use)
+    int8_w = torch.empty(n, k, dtype=torch.int8, device=x.device)
+    cb = _wrap_for_dlpack(p.codebook) if p.codebook is not None else None
+    if p.scale.dtype == torch.float8_e4m3fn:
+        _C.dequant_int4_grouped_to_int8_e4m3(
+            _wrap_for_dlpack(weight._qdata), _wrap_for_dlpack(p.scale.view(torch.uint8)),
+            cb, _wrap_for_dlpack(int8_w), g, sp)
+    else:
+        _C.dequant_int4_grouped_to_int8(
+            _wrap_for_dlpack(weight._qdata), _wrap_for_dlpack(p.scale), cb,
+            _wrap_for_dlpack(int8_w), g, sp)
+
+    # fused rotate + int8 activation quant
+    xq, xs = quantize_int8_rowwise_convrot(x2, p.convrot_groupsize)
+
+    out = torch.empty(m, n, dtype=out_dtype, device=x.device)
+    # Fuse bias into the CUTLASS epilogue (D = acc*xs*s_channel + bias) instead of
+    # a separate M*N add pass. fp32 for the epilogue compute type; the cast is
+    # cached on the bias tensor, keyed by _version to catch in-place patches.
+    if bias is None:
+        biasf = _empty_cuda_tensor(x.device, torch.float32)
+    else:
+        cached = getattr(bias, "_ck_bias_f32", None)
+        if cached is None or cached[1] != bias._version:
+            bias._ck_bias_f32 = cached = (bias.float().contiguous(), bias._version)
+        biasf = cached[0]
+    used = _C.cutlass_int8_dequant(
+        _wrap_for_dlpack(xq), _wrap_for_dlpack(int8_w), _wrap_for_dlpack(xs),
+        _wrap_for_dlpack(p.s_channel), _wrap_for_dlpack(biasf),
+        _wrap_for_dlpack(out), _dtype_code(out_dtype), sp)
+    if not used:
+        # tuned path unavailable -> dequant fallback
+        return torch.nn.functional.linear(x, weight.dequantize(), bias)
+
+    # asymmetric zero-point correction (rank-(K/group)); symmetric path has none.
+    if p.correction is not None:
+        sx = (xq.view(m, groups, g).sum(-1, dtype=torch.int32).to(out_dtype) * xs.to(out_dtype))
+        out.addmm_(sx, p.correction.to(out_dtype))
+    return out.reshape(*x.shape[:-1], n)
+
+
+def _is_w4a8(w):
+    return isinstance(w, QuantizedTensor) and w._layout_cls == "AsymW4A8Int8Layout"
+
+
+@register_layout_op(torch.ops.aten.t.default, AsymW4A8Int8Layout)
+def _handle_w4a8int8_t(qt, args, kwargs):
+    inp = args[0]
+    if not isinstance(inp, QuantizedTensor):
+        return torch.ops.aten.t.default(*args, **kwargs)
+    old = inp._params
+    new = dataclasses.replace(
+        old, orig_shape=(old.orig_shape[1], old.orig_shape[0]), transposed=not old.transposed)
+    return QuantizedTensor(inp._qdata, "AsymW4A8Int8Layout", new)
+
+
+@register_layout_op(torch.ops.aten.linear.default, AsymW4A8Int8Layout)
+def _handle_w4a8int8_linear(qt, args, kwargs):
+    x, weight = args[0], args[1]
+    bias = args[2] if len(args) > 2 else None
+    if not _is_w4a8(weight) or getattr(weight._params, "transposed", False):
+        return torch.nn.functional.linear(*dequantize_args(args), **dequantize_args(kwargs))
+    if isinstance(x, QuantizedTensor):
+        x = x.dequantize()
+    out_dtype = kwargs.get("out_dtype", weight._params.orig_dtype)
+    return _w4a8_int8_matmul(x, weight, bias, out_dtype)
+
+
+@register_layout_op(torch.ops.aten.mm.default, AsymW4A8Int8Layout)
+def _handle_w4a8int8_mm(qt, args, kwargs):
+    x, weight = args[0], args[1]
+    # F.linear -> x @ W.t(): weight arrives transposed, storage still [N,K].
+    if not _is_w4a8(weight) or not getattr(weight._params, "transposed", False):
+        return torch.mm(*dequantize_args(args), **dequantize_args(kwargs))
+    if isinstance(x, QuantizedTensor):
+        x = x.dequantize()
+    return _w4a8_int8_matmul(x, weight, None, weight._params.orig_dtype)
+
+
+@register_layout_op(torch.ops.aten.addmm.default, AsymW4A8Int8Layout)
+def _handle_w4a8int8_addmm(qt, args, kwargs):
+    bias, x, weight = args[0], args[1], args[2]
+    if not _is_w4a8(weight) or not getattr(weight._params, "transposed", False):
+        return torch.addmm(*dequantize_args(args), **dequantize_args(kwargs))
+    if isinstance(x, QuantizedTensor):
+        x = x.dequantize()
+    return _w4a8_int8_matmul(x, weight, bias, weight._params.orig_dtype)

--- a/comfy_kitchen/tensor/w4a8_int8.py
+++ b/comfy_kitchen/tensor/w4a8_int8.py
@@ -246,15 +246,17 @@ class AsymW4A8Int8Layout(QuantizedLayout):
         if params.codebook is not None:
             # w = codebook[q] * s_g (q is a direct [0,15] index)
             lvl = params.codebook.to(q.device).float()[q.view(n, groups, g)]
-            return _convrot_rotate(
-                (lvl * s_g).view(n, k).to(params.orig_dtype), params.convrot_groupsize).to(params.orig_dtype)
-        qc = (q.view(n, groups, g).float() - 8.0) * s_g
-        if params.correction is None:
-            w_rot = qc.view(n, k)  # symmetric: w = (q-8)*s_g
+            w_rot = (lvl * s_g).view(n, k)
         else:
-            corr = params.correction.t().unsqueeze(-1).float()  # [N,groups,1] = 8*s_g + min
-            w_rot = (qc + corr).view(n, k)  # w = q*s_g + min = (q-8)*s_g + corr
-        # undo rotation (involutory)
+            qc = (q.view(n, groups, g).float() - 8.0) * s_g
+            if params.correction is None:
+                w_rot = qc.view(n, k)  # symmetric: w = (q-8)*s_g
+            else:
+                corr = params.correction.t().unsqueeze(-1).float()  # [N,groups,1] = 8*s_g + min
+                w_rot = (qc + corr).view(n, k)  # w = q*s_g + min = (q-8)*s_g + corr
+        # undo rotation (involutory) -> storage-basis weight [N, K]. The base
+        # QuantizedTensor.dequantize() applies the lazy-transpose flag (returns W.T for a
+        # transposed tensor), so this must always return the [N, K] storage orientation.
         return _convrot_rotate(w_rot.to(params.orig_dtype), params.convrot_groupsize).to(params.orig_dtype)
 
     @classmethod
@@ -289,6 +291,14 @@ class AsymW4A8Int8Layout(QuantizedLayout):
                 "symmetric": p.correction is None, "codebook": p.codebook is not None}
 
 
+def _storage_dequant(weight):
+    """Dequantize to the [N, K] storage orientation, undoing the lazy-transpose flag.
+    The GEMM fallbacks compute x @ W.T from the [N, K] weight, so they must not see the
+    (K, N) orientation that ``weight.dequantize()`` returns for a transposed tensor."""
+    w = weight.dequantize()
+    return w.t() if weight._params.transposed else w
+
+
 def _w4a8_int8_matmul_portable(x, weight, bias, out_dtype):
     """Backend-agnostic W4A8 linear via the registry (Triton on AMD, else eager). Symmetric
     weights take the dequant + INT8 GEMM path; asymmetric has no INT8-GEMM form so it falls
@@ -297,7 +307,7 @@ def _w4a8_int8_matmul_portable(x, weight, bias, out_dtype):
 
     p = weight._params
     if p.correction is not None:
-        return torch.nn.functional.linear(x, weight.dequantize().to(x.dtype), bias)
+        return torch.nn.functional.linear(x, _storage_dequant(weight).to(x.dtype), bias)
     kwargs = {
         "x": x,
         "qdata": weight._qdata,
@@ -378,7 +388,7 @@ def _w4a8_int8_matmul(x, weight, bias, out_dtype):
         _wrap_for_dlpack(p.s_channel), _wrap_for_dlpack(bf),
         _wrap_for_dlpack(out), _dtype_code(out_dtype), sp)
     if not used:
-        return torch.nn.functional.linear(x, weight.dequantize(), bias)
+        return torch.nn.functional.linear(x, _storage_dequant(weight), bias)
 
     # asymmetric zero-point correction (rank-(K/group)); symmetric path has none.
     if p.correction is not None:

--- a/comfy_kitchen/tensor/w4a8_int8.py
+++ b/comfy_kitchen/tensor/w4a8_int8.py
@@ -1,28 +1,21 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Grouped W4A8 on the tuned INT8 CUTLASS GEMM (symmetric default).
+"""Grouped W4A8 weights executed through the shared INT8 linear operation.
 
-Calibration-free 4-bit weight storage at near-int8-tensor-core speed, reusing comfy's
-tuned INT8 GEMM. Weights are ConvRot-rotated (data-free Hadamard) then quantized per
-``group_size``. Default = symmetric group-16 with a per-tensor Lloyd-Max 16-level codebook
-+ fp8 (e4m3) group scales: ~0.073 weight relL2 on real DiT weights (NVFP4 0.094),
-~0.56 B/elem, no zero-point correction -> ~1.09x int8 speed. ``symmetric=False`` adds a
-rank-(K/group) zero-point correction (~1.4x int8) and is dominated by the default.
-
-At matmul the int4 weights dequant to "grouped int8" ``round((q-8)*s_rel)`` -- group scale
-folded in, per-channel ``s_channel`` left for the GEMM epilogue -- feeding the INT8 GEMM.
-Symmetric packs ``q_signed+8``; asymmetric adds the zero-point back as ``Sx @ Cᵀ``.
-Weights stay int4 in memory; the int8 dequant target is a transient per-call buffer.
+Weights are ConvRot-rotated and quantized per ``group_size``. The default uses
+a symmetric Lloyd-Max codebook and FP8 group scales. The tensor layout owns
+only metadata and operator routing; eager, CUDA, and Triton backends own the
+operation implementations.
 """
 
 from __future__ import annotations
 
 import dataclasses
-import logging
-import os
 from dataclasses import dataclass
 
 import torch
+
+from comfy_kitchen.registry import registry
 
 from .base import (
     BaseLayoutParams,
@@ -31,67 +24,150 @@ from .base import (
     dequantize_args,
     register_layout_op,
 )
-from .int8 import _dtype_code
-from .int8_utils import _build_hadamard, _rotate_weight
-
-logger = logging.getLogger(__name__)
-
-# The tuned W4A8 kernels live in the compiled CUDA backend. Without it (ROCm/AMD, CPU)
-# the layout dispatches dequant + INT8 GEMM through the registry (Triton, else eager) and
-# rotates in portable torch -- runnable on any torch device.
-try:
-    from comfy_kitchen.backends.cuda import _C as _CUDA_C
-except Exception:  # pragma: no cover - non-CUDA builds
-    _CUDA_C = None
-# The cuda module imports successfully but sets _C=None when the compiled extension fails
-# to load, so importing it is not proof of availability -- gate on the real extension.
-# (is_cuda is also True for ROCm tensors, and there _C is None, so this correctly routes
-# ROCm to the portable Triton/eager path rather than into CUDA-only kernels.)
-_CUDA_AVAILABLE = _CUDA_C is not None
-if not _CUDA_AVAILABLE and torch.version.cuda is not None:  # real CUDA build, ext missing
-    logger.warning("W4A8: CUDA extension unavailable; using the portable Triton/eager path (slower).")
 
 
-def _convrot_rotate(w: torch.Tensor, groupsize: int) -> torch.Tensor:
-    """Involutory ConvRot (Regular-Hadamard) rotation. Uses the CUDA kernel when
-    available, else the portable int8_utils implementation (bit-matches to ~bf16 eps)."""
-    if _CUDA_AVAILABLE and w.is_cuda:
-        from comfy_kitchen.backends.cuda import rotate_int8_convrot_weight
-        return rotate_int8_convrot_weight(w, groupsize)
-    h = _build_hadamard(groupsize, device=w.device, dtype=w.dtype)
-    return _rotate_weight(w, h, groupsize)
+def quantize_w4a8_int8_weight(
+    weight: torch.Tensor,
+    group_size: int = 16,
+    convrot_groupsize: int = 256,
+    symmetric: bool = True,
+    scale_dtype: torch.dtype = torch.float8_e4m3fn,
+    codebook: bool = True,
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor | None,
+    torch.Tensor | None,
+]:
+    """Rotate and prepare a floating weight for grouped W4A8 storage."""
+    if scale_dtype not in (torch.float32, torch.float8_e4m3fn):
+        raise ValueError(f"scale_dtype must be float32 or float8_e4m3fn, got {scale_dtype}")
+    kwargs = {
+        "weight": weight,
+        "group_size": group_size,
+        "convrot_groupsize": convrot_groupsize,
+        "symmetric": symmetric,
+        "scale_dtype": scale_dtype,
+        "codebook": codebook,
+    }
+    impl = registry.get_implementation("quantize_w4a8_int8_weight", kwargs=kwargs)
+    return impl(**kwargs)
 
-# Chunked fused path: dequant int4->int8 in L2-sized column chunks feeding the strided
-# int8 GEMM, so each int8 chunk stays cache-resident (no full [N,K] global round-trip).
-# COMFY_KITCHEN_W4A8_CHUNKED=0 forces the 2-pass path.
-_W4A8_CHUNKED = os.environ.get("COMFY_KITCHEN_W4A8_CHUNKED", "1") != "0"
+
+def dequantize_w4a8_int8_weight(
+    qdata: torch.Tensor,
+    s_rel: torch.Tensor,
+    s_channel: torch.Tensor,
+    codebook: torch.Tensor | None = None,
+    correction: torch.Tensor | None = None,
+    group_size: int = 16,
+    convrot_groupsize: int = 256,
+    output_dtype: torch.dtype = torch.bfloat16,
+) -> torch.Tensor:
+    """Dequantize a packed W4A8 weight into its original basis."""
+    kwargs = {
+        "qdata": qdata,
+        "s_rel": s_rel,
+        "s_channel": s_channel,
+        "codebook": codebook,
+        "correction": correction,
+        "group_size": group_size,
+        "convrot_groupsize": convrot_groupsize,
+        "output_dtype": output_dtype,
+    }
+    impl = registry.get_implementation("dequantize_w4a8_int8_weight", kwargs=kwargs)
+    return impl(**kwargs)
+
+
+def w4a8_int8_linear(
+    x: torch.Tensor,
+    qdata: torch.Tensor,
+    s_rel: torch.Tensor,
+    s_channel: torch.Tensor,
+    codebook: torch.Tensor | None = None,
+    correction: torch.Tensor | None = None,
+    bias: torch.Tensor | None = None,
+    group_size: int = 16,
+    convrot_groupsize: int = 256,
+    out_dtype: torch.dtype = torch.bfloat16,
+) -> torch.Tensor:
+    """Compute ``x @ W.T + bias`` with the selected W4A8 backend."""
+    kwargs = {
+        "x": x,
+        "qdata": qdata,
+        "s_rel": s_rel,
+        "s_channel": s_channel,
+        "codebook": codebook,
+        "correction": correction,
+        "bias": bias,
+        "group_size": group_size,
+        "convrot_groupsize": convrot_groupsize,
+        "out_dtype": out_dtype,
+    }
+    impl = registry.get_implementation("w4a8_int8_linear", kwargs=kwargs)
+    return impl(**kwargs)
 
 
 class AsymW4A8Int8Layout(QuantizedLayout):
-    """Asymmetric grouped int4 weights, run on the tuned int8 GEMM."""
+    """Grouped W4A8 weights run through the selected INT8 backend."""
 
     MIN_SM_VERSION = (8, 0)
+    QUANTIZES_INPUT = False
 
     @dataclass(frozen=True)
     class Params(BaseLayoutParams):
-        # scale (inherited) holds s_rel: per-group relative scale [N, K//group] fp32.
-        s_channel: torch.Tensor = None   # [N] fp32 per-channel scale
-        correction: torch.Tensor = None  # [K//group, N] = 8*s_g+min (asym only; None=symmetric)
-        codebook: torch.Tensor = None    # [16] fp32 non-uniform levels (None=uniform q-8)
+        # scale holds s_rel: per-group relative scale [N, K // group_size].
+        s_channel: torch.Tensor | None = None
+        correction: torch.Tensor | None = None
+        codebook: torch.Tensor | None = None
         group_size: int = 16
         convrot_groupsize: int = 256
         transposed: bool = False
 
         def _tensor_fields(self) -> list[str]:
-            f = ["scale", "s_channel"]
+            fields = ["scale", "s_channel"]
             if self.correction is not None:
-                f.append("correction")
+                fields.append("correction")
             if self.codebook is not None:
-                f.append("codebook")
-            return f
+                fields.append("codebook")
+            return fields
 
         def _validate_tensor_fields(self):
-            pass
+            if len(self.orig_shape) != 2:
+                raise ValueError(f"orig_shape must be 2D, got {self.orig_shape}")
+            n, k = self.orig_shape
+            if self.transposed:
+                n, k = k, n
+            if (
+                self.group_size < 4
+                or k % 16 != 0
+                or k % self.group_size != 0
+                or k % self.convrot_groupsize != 0
+                or (16 % self.group_size != 0 and self.group_size % 16 != 0)
+            ):
+                raise ValueError(
+                    f"K={k} must be divisible by 16, group_size={self.group_size}, and "
+                    f"convrot_groupsize={self.convrot_groupsize}; group_size must be >=4 "
+                    f"and divide 16 or be a multiple of 16"
+                )
+            groups = k // self.group_size
+            expected_scale_shape = (n, groups)
+            if tuple(self.scale.shape) != expected_scale_shape:
+                raise ValueError(
+                    f"scale must have shape {expected_scale_shape}, got {tuple(self.scale.shape)}"
+                )
+            if self.s_channel is None or tuple(self.s_channel.shape) != (n,):
+                actual_shape = None if self.s_channel is None else tuple(self.s_channel.shape)
+                raise ValueError(f"s_channel must have shape {(n,)}, got {actual_shape}")
+            if self.correction is not None and tuple(self.correction.shape) != (groups, n):
+                raise ValueError(
+                    f"correction must have shape {(groups, n)}, got {tuple(self.correction.shape)}"
+                )
+            if self.codebook is not None and tuple(self.codebook.shape) != (16,):
+                raise ValueError(
+                    f"codebook must have shape (16,), got {tuple(self.codebook.shape)}"
+                )
 
     @classmethod
     def quantize(
@@ -104,183 +180,61 @@ class AsymW4A8Int8Layout(QuantizedLayout):
         codebook: bool = True,
         **kwargs,
     ) -> tuple[torch.Tensor, Params]:
-        orig_dtype = tensor.dtype
-        orig_shape = tuple(tensor.shape)
-        n, k = tensor.shape
-        # The group-scale kernel is templated only for fp32 and fp8-e4m3; any other dtype
-        # (e.g. fp16) would produce a checkpoint no backend can execute.
-        if scale_dtype not in (torch.float32, torch.float8_e4m3fn):
-            raise ValueError(f"scale_dtype must be float32 or float8_e4m3fn, got {scale_dtype}")
-        # K must be a multiple of 16: the CUDA dequant kernel is vectorized (uint2 load ->
-        # uint4 store, 16 int8/thread, n_vec = N*K/16), so a non-16 K truncates the tail and
-        # misaligns the row start. G must be >=4 and in {4,8,16} or a multiple of 16: the
-        # kernel loads at most 4 group scales per 16-col vec (G=2 would mis-scale cols 8-15).
-        if (k % 16 != 0 or k % group_size != 0 or group_size < 4
-                or (16 % group_size != 0 and group_size % 16 != 0)):
-            raise ValueError(
-                f"K={k} must be a multiple of 16 and G={group_size} >=4 & "
-                f"(divides 16 or mult of 16)")
-        groups = k // group_size
-
-        # Data-free rotation (paired with the fused convrot activation quant).
-        w = _convrot_rotate(tensor, convrot_groupsize).float().view(n, groups, group_size)
-
-        cb = None
-        if symmetric and codebook:
-            # Non-uniform 16-level codebook (Lloyd-Max, calibration-free). ConvRot makes
-            # weights ~Gaussian; a matched codebook beats uniform int4 ~14% at coarse
-            # groups, same storage/speed. Code indexes cb directly; kernel does cb[q]*s_rel.
-            s_g = w.abs().amax(dim=-1, keepdim=True).clamp(min=1e-8)  # group absmax
-            wn = (w / s_g)  # [n, groups, group] normalized to [-1, 1]
-            cb = cls._fit_codebook(wn)  # [16] fp32
-            q = cls._assign_codes(wn, cb)  # [n,groups,group] indices
-            # Least-squares refit of the group scale given the codes (absmax is only
-            # optimal when the extreme code sits at +-1, which Lloyd-Max levels don't).
-            for _ in range(3):
-                cbq = cb[q]
-                s_g = ((w * cbq).sum(-1, keepdim=True)
-                       / (cbq * cbq).sum(-1, keepdim=True).clamp(min=1e-8)).clamp(min=1e-8)
-                q = cls._assign_codes(w / s_g, cb)
-            q_u = q.to(torch.int32).view(n, k)  # [0,15]
-            wshift = (cb[q] * s_g)
-            correction = None
-        elif symmetric:
-            # Symmetric grouped int4 (levels -8..7); no zero-point => no correction pass.
-            # Quality beats NVFP4 at group 16 (~0.085 vs 0.093 relL2) calibration-free.
-            s_g = (w.abs().amax(dim=-1, keepdim=True) / 7.0).clamp(min=1e-8)
-            q_signed = (w / s_g).round().clamp(-8, 7).to(torch.int32)
-            # pack q_signed+8 as uint4; the dequant kernel computes (q-8)*s_rel = q_signed*s_rel
-            q_u = (q_signed + 8).view(n, k)
-            wshift = q_signed * s_g
-            correction = None
-        else:
-            mn = w.amin(dim=-1, keepdim=True)
-            s_g = ((w.amax(dim=-1, keepdim=True) - mn) / 15.0).clamp(min=1e-8)
-            q_u = ((w - mn) / s_g).round().clamp(0, 15).to(torch.int32).view(n, k)
-            wshift = (q_u.view(n, groups, group_size) - 8) * s_g
-            correction = (8.0 * s_g + mn).squeeze(-1).t().contiguous().to(orig_dtype)  # [groups, N]
-
-        s_channel = (wshift.abs().amax(dim=(1, 2)) / 127.0).clamp(min=1e-8)  # [N]
-        s_rel = (s_g.squeeze(-1) / s_channel.unsqueeze(1)).float().contiguous()  # [N, groups]
-        # fp8 e4m3 group scale halves the scale metadata (~half int8 storage),
-        # still beats NVFP4 (~0.089 vs 0.093); fp32 keeps max quality (~0.085).
-        if scale_dtype != torch.float32:
-            s_rel = s_rel.to(scale_dtype).contiguous()
-        if cb is not None:
-            # Final code assignment against the values the kernel actually decodes
-            # (round(clamp(cb_j * s_rel)) * s_channel, s_rel in its stored dtype) -- folds
-            # the fp8-scale and int8 re-rounding into the choice (0.0730 -> 0.0727 g16-fp8).
-            levels = (cb.view(1, 1, 16) * s_rel.float().unsqueeze(-1)).round_().clamp_(-127, 127)
-            q_u = cls._assign_grid(w, levels, s_channel).view(n, k)
-        # pack uint4: even col -> low nibble, odd col -> high nibble
-        qpacked = ((q_u[:, 0::2] & 0xF) | ((q_u[:, 1::2] & 0xF) << 4)).to(torch.int8).contiguous()
-
+        qdata, s_rel, s_channel, correction, codebook_tensor = quantize_w4a8_int8_weight(
+            tensor,
+            group_size=group_size,
+            convrot_groupsize=convrot_groupsize,
+            symmetric=symmetric,
+            scale_dtype=scale_dtype,
+            codebook=codebook,
+        )
         params = cls.Params(
             scale=s_rel,
-            s_channel=s_channel.float().contiguous(),
+            s_channel=s_channel,
             correction=correction,
-            codebook=cb,
-            orig_dtype=orig_dtype,
-            orig_shape=orig_shape,
+            codebook=codebook_tensor,
+            orig_dtype=tensor.dtype,
+            orig_shape=tuple(tensor.shape),
             group_size=group_size,
             convrot_groupsize=convrot_groupsize,
         )
-        return qpacked, params
-
-    @staticmethod
-    def _assign_codes(xn: torch.Tensor, cb: torch.Tensor) -> torch.Tensor:
-        """Nearest-codebook index, looping the 16 levels to avoid a [..., 16] distance
-        tensor. int32 (not uint8 -- byte index tensors are treated as boolean masks)."""
-        best = (xn - cb[0]).abs()
-        idx = torch.zeros_like(xn, dtype=torch.int32)
-        for j in range(1, cb.numel()):
-            d = (xn - cb[j]).abs()
-            m = d < best
-            best = torch.where(m, d, best)
-            idx = torch.where(m, j, idx)
-        return idx
-
-    @staticmethod
-    def _assign_grid(wv: torch.Tensor, levels: torch.Tensor, s_channel: torch.Tensor) -> torch.Tensor:
-        """Nearest decoded-int8 level: argmin_j |wv/s_channel - levels[n,g,j]|, looped
-        over j. `levels` is [N, groups, 16] (the per-channel/group decoded values)."""
-        t = wv / s_channel.view(-1, 1, 1)
-        best = (t - levels[..., 0:1].expand_as(wv)).abs()
-        idx = torch.zeros_like(wv, dtype=torch.int32)
-        for j in range(1, 16):
-            d = (t - levels[..., j:j + 1].expand_as(wv)).abs()
-            m = d < best
-            best = torch.where(m, d, best)
-            idx = torch.where(m, j, idx)
-        return idx
-
-    @staticmethod
-    def _fit_codebook(wn: torch.Tensor, levels: int = 16, iters: int = 25,
-                      sample: int = 300000) -> torch.Tensor:
-        """MSE-optimal (Lloyd-Max) 16-level codebook on normalized weights, data-free."""
-        x = wn.flatten()
-        if x.numel() > sample:
-            # Fixed-seed local generator so the codebook (and the packed codes, hence the
-            # exported checkpoint) is reproducible run-to-run, independent of global RNG.
-            gen = torch.Generator(device=x.device).manual_seed(0)
-            idx = torch.randint(0, x.numel(), (sample,), device=x.device, generator=gen)
-            x = x[idx]
-        x = x.float()
-        cb = torch.quantile(x, torch.linspace(0, 1, levels, device=x.device))
-        for _ in range(iters):
-            a = (x.unsqueeze(-1) - cb).abs().argmin(-1)
-            new = cb.clone()
-            for j in range(levels):
-                m = a == j
-                if m.any():
-                    new[j] = x[m].mean()
-            cb = new
-        return cb.contiguous()
+        return qdata, params
 
     @classmethod
     def dequantize(cls, qdata: torch.Tensor, params: Params) -> torch.Tensor:
-        # Reference dequant (original-basis weight); for fallbacks/inspection.
-        n, k_half = qdata.shape
-        k = k_half * 2
-        g = params.group_size
-        groups = k // g
-        b = qdata.to(torch.int32) & 0xFF
-        q = torch.empty(n, k, dtype=torch.int32, device=qdata.device)
-        q[:, 0::2] = b & 0xF
-        q[:, 1::2] = (b >> 4) & 0xF
-        s_rel = params.scale.float().unsqueeze(-1)  # [N, groups, 1]
-        s_channel = params.s_channel.float().view(n, 1, 1)  # [N, 1, 1]
-        if params.codebook is not None:
-            lvl = params.codebook.to(q.device).float()[q.view(n, groups, g)]  # [N,groups,g]
-        else:
-            lvl = q.view(n, groups, g).float() - 8.0  # symmetric uniform levels -8..7
-        # Match the executed paths (CUDA/Triton/eager): the per-group scale is folded into a
-        # rounded int8 weight and the per-channel scale is applied afterward, so the reference
-        # dequant must fold the same round+clamp -- else it returns weights the kernels never
-        # use (the codes were even picked against this grid in quantize).
-        int8_w = (lvl * s_rel).round_().clamp_(-127, 127)  # [N, groups, g]
-        w_rot = int8_w * s_channel  # [N, groups, g]
-        if params.correction is not None:  # asymmetric zero-point (rank correction folded per-elem here)
-            w_rot = w_rot + params.correction.t().unsqueeze(-1).float()  # [N,groups,1] = 8*s_g + min
-        w_rot = w_rot.view(n, k)
-        # undo rotation (involutory) -> storage-basis weight [N, K]. The base
-        # QuantizedTensor.dequantize() applies the lazy-transpose flag (returns W.T for a
-        # transposed tensor), so this must always return the [N, K] storage orientation.
-        return _convrot_rotate(w_rot.to(params.orig_dtype), params.convrot_groupsize).to(params.orig_dtype)
+        return dequantize_w4a8_int8_weight(
+            qdata,
+            params.scale,
+            params.s_channel,
+            codebook=params.codebook,
+            correction=params.correction,
+            group_size=params.group_size,
+            convrot_groupsize=params.convrot_groupsize,
+            output_dtype=params.orig_dtype,
+        )
 
     @classmethod
-    def get_plain_tensors(cls, qtensor: QuantizedTensor):
-        p = qtensor._params
-        return qtensor._qdata, p.scale, p.s_channel, p.correction
+    def get_plain_tensors(
+        cls,
+        qtensor: QuantizedTensor,
+    ) -> tuple[
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor | None,
+        torch.Tensor | None,
+    ]:
+        params = qtensor._params
+        return (
+            qtensor._qdata,
+            params.scale,
+            params.s_channel,
+            params.correction,
+            params.codebook,
+        )
 
     @classmethod
     def state_dict_tensors(cls, qdata: torch.Tensor, params: Params) -> dict[str, torch.Tensor]:
-        # Export-only (checkpoint serialization). The ``_s_rel`` suffix intentionally does
-        # NOT match the ``scale`` field name: it names the per-group *relative* scale to
-        # distinguish it from ``_s_channel``, and matches the checkpoint format the loader
-        # reads. On load, ComfyUI's ``_load_quantized_module`` remaps weight_s_rel->scale,
-        # weight_s_channel->s_channel, etc. explicitly (not by field name). In-memory
-        # flatten/unflatten (__tensor_flatten__) uses field names, so it is unaffected.
         out = {
             "": qdata,
             "_s_rel": params.scale,
@@ -294,171 +248,105 @@ class AsymW4A8Int8Layout(QuantizedLayout):
 
     @classmethod
     def requantize_kwargs(cls, qtensor: QuantizedTensor) -> dict[str, object]:
-        # Preserve quant options across the dequantize->patch->requantize LoRA path.
-        p = qtensor._params
-        return {"group_size": p.group_size, "convrot_groupsize": p.convrot_groupsize,
-                "symmetric": p.correction is None, "codebook": p.codebook is not None,
-                "scale_dtype": p.scale.dtype}
+        params = qtensor._params
+        return {
+            "group_size": params.group_size,
+            "convrot_groupsize": params.convrot_groupsize,
+            "symmetric": params.correction is None,
+            "codebook": params.codebook is not None,
+            "scale_dtype": params.scale.dtype,
+        }
 
 
-def _storage_dequant(weight):
-    """Dequantize to the [N, K] storage orientation, undoing the lazy-transpose flag.
-    The GEMM fallbacks compute x @ W.T from the [N, K] weight, so they must not see the
-    (K, N) orientation that ``weight.dequantize()`` returns for a transposed tensor."""
-    w = weight.dequantize()
-    return w.t() if weight._params.transposed else w
+def _is_w4a8(weight: object) -> bool:
+    return isinstance(weight, QuantizedTensor) and weight._layout_cls == "AsymW4A8Int8Layout"
 
 
-def _w4a8_int8_matmul_portable(x, weight, bias, out_dtype):
-    """Backend-agnostic W4A8 linear via the registry (Triton on AMD, else eager). Symmetric
-    weights take the dequant + INT8 GEMM path; asymmetric has no INT8-GEMM form so it falls
-    back to dequantize + F.linear."""
-    from comfy_kitchen.registry import registry
+def _resolve_w4a8_rhs(rhs: QuantizedTensor) -> QuantizedTensor:
+    if not rhs._params.transposed:
+        raise RuntimeError("W4A8 GEMM expects RHS W.T. Use F.linear(x, W) or mm(x, W.t()).")
+    return rhs
 
-    p = weight._params
-    if p.correction is not None:
-        return torch.nn.functional.linear(x, _storage_dequant(weight).to(x.dtype), bias)
-    kwargs = {
-        "x": x,
-        "qdata": weight._qdata,
-        "s_rel": p.scale,
-        "s_channel": p.s_channel,
-        "bias": bias,
-        "group_size": p.group_size,
-        "convrot_groupsize": p.convrot_groupsize,
-    }
-    impl = registry.get_implementation("w4a8_int8_linear", kwargs=kwargs)
-    return impl(
-        x, weight._qdata, p.scale, p.s_channel,
-        codebook=p.codebook, bias=bias, group_size=p.group_size,
-        convrot_groupsize=p.convrot_groupsize, out_dtype=out_dtype,
+
+def _w4a8_int8_forward(
+    input_tensor: torch.Tensor,
+    weight: QuantizedTensor,
+    bias: torch.Tensor | None,
+    out_dtype: torch.dtype,
+) -> torch.Tensor:
+    qdata, s_rel, s_channel, correction, codebook = AsymW4A8Int8Layout.get_plain_tensors(weight)
+    params = weight._params
+    return w4a8_int8_linear(
+        input_tensor,
+        qdata,
+        s_rel,
+        s_channel,
+        codebook=codebook,
+        correction=correction,
+        bias=bias,
+        group_size=params.group_size,
+        convrot_groupsize=params.convrot_groupsize,
+        out_dtype=out_dtype,
     )
-
-
-def _w4a8_int8_matmul(x, weight, bias, out_dtype):
-    # Portable path (Triton on AMD, else pure-torch eager) when the tuned CUDA kernels
-    # are unavailable or the input is not on CUDA.
-    if not (_CUDA_AVAILABLE and x.is_cuda):
-        return _w4a8_int8_matmul_portable(x, weight, bias, out_dtype)
-
-    from comfy_kitchen.backends.cuda import (
-        _C,
-        _empty_cuda_tensor,
-        _wrap_for_dlpack,
-        quantize_int8_rowwise_convrot,
-    )
-
-    p = weight._params
-    n, k_half = weight._qdata.shape
-    k = k_half * 2
-    g = p.group_size
-    groups = k // g
-    x2 = x.reshape(-1, k).contiguous()
-    m = x2.shape[0]
-
-    sp = torch.cuda.current_stream(x.device).cuda_stream
-    # DLPack capsules are single-use, so wrap the codebook fresh per native call -- the
-    # chunked path may consume it and return False, then the 2-pass fallback needs its own.
-    def wrap_cb():
-        return _wrap_for_dlpack(p.codebook) if p.codebook is not None else None
-    # fused rotate + int8 activation quant
-    xq, xs = quantize_int8_rowwise_convrot(x2, p.convrot_groupsize)
-    out = torch.empty(m, n, dtype=out_dtype, device=x.device)
-    # Bias fuses into the GEMM epilogue (D = acc*xs*s_channel + bias). Cast fresh each
-    # call -- don't cache on the bias tensor (inference tensors have no _version).
-    biasf = bias.float().contiguous() if bias is not None else None
-
-    # Chunked fused path (symmetric codebook, fp8 scale): dequant int4->int8 in
-    # L2-sized column chunks feeding the strided int8 GEMM -- no full [N,K] round-trip.
-    if (_W4A8_CHUNKED and p.correction is None and p.codebook is not None
-            and p.scale.dtype == torch.float8_e4m3fn):
-        from comfy_kitchen.backends.cuda import _int4_int8_weight_chunk_cols
-        chunk_cols = _int4_int8_weight_chunk_cols(m, n)
-        workspace = torch.empty(min(chunk_cols, n), k, dtype=torch.int8, device=x.device)
-        ok = _C.w4a8_codebook_gemm_chunked(
-            _wrap_for_dlpack(xq), _wrap_for_dlpack(weight._qdata),
-            _wrap_for_dlpack(p.scale.view(torch.uint8)), wrap_cb(),
-            _wrap_for_dlpack(p.s_channel), _wrap_for_dlpack(xs.reshape(m).contiguous()),
-            _wrap_for_dlpack(biasf) if biasf is not None else None,
-            _wrap_for_dlpack(workspace), _wrap_for_dlpack(out),
-            g, chunk_cols, _dtype_code(out_dtype), sp)
-        if ok:
-            return out.reshape(*x.shape[:-1], n)
-
-    # 2-pass fallback: full int4 -> int8 dequant, then the int8 GEMM (+ asym correction).
-    int8_w = torch.empty(n, k, dtype=torch.int8, device=x.device)
-    if p.scale.dtype == torch.float8_e4m3fn:
-        _C.dequant_int4_grouped_to_int8_e4m3(
-            _wrap_for_dlpack(weight._qdata), _wrap_for_dlpack(p.scale.view(torch.uint8)),
-            wrap_cb(), _wrap_for_dlpack(int8_w), g, sp)
-    else:
-        _C.dequant_int4_grouped_to_int8(
-            _wrap_for_dlpack(weight._qdata), _wrap_for_dlpack(p.scale), wrap_cb(),
-            _wrap_for_dlpack(int8_w), g, sp)
-    bf = biasf if biasf is not None else _empty_cuda_tensor(x.device, torch.float32)
-    used = _C.cutlass_int8_dequant(
-        _wrap_for_dlpack(xq), _wrap_for_dlpack(int8_w), _wrap_for_dlpack(xs),
-        _wrap_for_dlpack(p.s_channel), _wrap_for_dlpack(bf),
-        _wrap_for_dlpack(out), _dtype_code(out_dtype), sp)
-    if not used:  # match x.dtype -- orig_dtype may differ from the runtime dtype (autocast)
-        return torch.nn.functional.linear(x, _storage_dequant(weight).to(x.dtype), bias)
-
-    # asymmetric zero-point correction (rank-(K/group)); symmetric path has none.
-    if p.correction is not None:
-        sx = (xq.view(m, groups, g).sum(-1, dtype=torch.int32).to(out_dtype) * xs.to(out_dtype))
-        out.addmm_(sx, p.correction.to(out_dtype))
-    return out.reshape(*x.shape[:-1], n)
-
-
-def _is_w4a8(w):
-    return isinstance(w, QuantizedTensor) and w._layout_cls == "AsymW4A8Int8Layout"
 
 
 @register_layout_op(torch.ops.aten.t.default, AsymW4A8Int8Layout)
 def _handle_w4a8int8_t(qt, args, kwargs):
-    inp = args[0]
-    if not isinstance(inp, QuantizedTensor):
+    input_tensor = args[0]
+    if not isinstance(input_tensor, QuantizedTensor):
         return torch.ops.aten.t.default(*args, **kwargs)
-    old = inp._params
-    new = dataclasses.replace(
-        old, orig_shape=(old.orig_shape[1], old.orig_shape[0]), transposed=not old.transposed)
-    return QuantizedTensor(inp._qdata, "AsymW4A8Int8Layout", new)
+    old = input_tensor._params
+    new_params = dataclasses.replace(
+        old,
+        orig_shape=(old.orig_shape[1], old.orig_shape[0]),
+        transposed=not old.transposed,
+    )
+    return QuantizedTensor(input_tensor._qdata, "AsymW4A8Int8Layout", new_params)
 
 
 @register_layout_op(torch.ops.aten.linear.default, AsymW4A8Int8Layout)
 def _handle_w4a8int8_linear(qt, args, kwargs):
-    x, weight = args[0], args[1]
+    input_tensor, weight = args[0], args[1]
     bias = args[2] if len(args) > 2 else None
-    if not _is_w4a8(weight) or getattr(weight._params, "transposed", False):
-        return torch.nn.functional.linear(*dequantize_args(args), **dequantize_args(kwargs))
-    if isinstance(x, QuantizedTensor):
-        x = x.dequantize()
+    if not _is_w4a8(weight):
+        return torch.nn.functional.linear(*dequantize_args((input_tensor, weight, bias)))
+    if isinstance(input_tensor, QuantizedTensor):
+        input_tensor = input_tensor.dequantize()
+    if weight._params.transposed:
+        return torch.nn.functional.linear(input_tensor, weight.dequantize(), bias)
     out_dtype = kwargs.get("out_dtype", weight._params.orig_dtype)
-    return _w4a8_int8_matmul(x, weight, bias, out_dtype)
+    return _w4a8_int8_forward(input_tensor, weight, bias, out_dtype)
 
 
 @register_layout_op(torch.ops.aten.mm.default, AsymW4A8Int8Layout)
 def _handle_w4a8int8_mm(qt, args, kwargs):
-    x, weight = args[0], args[1]
-    # F.linear -> x @ W.t(): weight arrives transposed, storage still [N,K].
-    if not _is_w4a8(weight) or not getattr(weight._params, "transposed", False):
-        return torch.mm(*dequantize_args(args), **dequantize_args(kwargs))
-    if isinstance(x, QuantizedTensor):
-        x = x.dequantize()
-    return _w4a8_int8_matmul(x, weight, None, weight._params.orig_dtype)
+    input_tensor, weight = args[0], args[1]
+    if not _is_w4a8(weight):
+        return torch.mm(*dequantize_args((input_tensor, weight)))
+    if isinstance(input_tensor, QuantizedTensor):
+        input_tensor = input_tensor.dequantize()
+    weight = _resolve_w4a8_rhs(weight)
+    return _w4a8_int8_forward(
+        input_tensor,
+        weight,
+        bias=None,
+        out_dtype=weight._params.orig_dtype,
+    )
 
 
 @register_layout_op(torch.ops.aten.addmm.default, AsymW4A8Int8Layout)
 def _handle_w4a8int8_addmm(qt, args, kwargs):
-    bias, x, weight = args[0], args[1], args[2]
-    # The fast path only models F.linear's addmm: bias + x @ W.T with a 1-D bias and
-    # beta=alpha=1. Anything else (scaled addmm, matrix-shaped addend) takes the dequant
-    # fallback, which honors alpha/beta and general addend shapes.
+    bias, input_tensor, weight = args[0], args[1], args[2]
     scaled = kwargs.get("beta", 1) != 1 or kwargs.get("alpha", 1) != 1
-    bias_nd = isinstance(bias, torch.Tensor) and bias.dim() != 1
-    if (not _is_w4a8(weight) or not getattr(weight._params, "transposed", False)
-            or scaled or bias_nd):
+    matrix_addend = isinstance(bias, torch.Tensor) and bias.dim() != 1
+    if not _is_w4a8(weight) or scaled or matrix_addend:
         return torch.addmm(*dequantize_args(args), **dequantize_args(kwargs))
-    if isinstance(x, QuantizedTensor):
-        x = x.dequantize()
-    return _w4a8_int8_matmul(x, weight, bias, weight._params.orig_dtype)
+    if isinstance(input_tensor, QuantizedTensor):
+        input_tensor = input_tensor.dequantize()
+    weight = _resolve_w4a8_rhs(weight)
+    return _w4a8_int8_forward(
+        input_tensor,
+        weight,
+        bias=bias,
+        out_dtype=weight._params.orig_dtype,
+    )

--- a/comfy_kitchen/tensor/w4a8_int8.py
+++ b/comfy_kitchen/tensor/w4a8_int8.py
@@ -2,29 +2,17 @@
 # SPDX-License-Identifier: Apache-2.0
 """Grouped W4A8 on the tuned INT8 CUTLASS GEMM (symmetric default).
 
-Calibration-free 4-bit weight storage that runs at near-int8-tensor-core speed
-by reusing comfy's tuned INT8 GEMM:
+Calibration-free 4-bit weight storage at near-int8-tensor-core speed, reusing comfy's
+tuned INT8 GEMM. Weights are ConvRot-rotated (data-free Hadamard) then quantized per
+``group_size``. Default = symmetric group-16 with a per-tensor Lloyd-Max 16-level codebook
++ fp8 (e4m3) group scales: ~0.073 weight relL2 on real DiT weights (NVFP4 0.094),
+~0.56 B/elem, no zero-point correction -> ~1.09x int8 speed. ``symmetric=False`` adds a
+rank-(K/group) zero-point correction (~1.4x int8) and is dominated by the default.
 
-- Weights are rotated (data-free Hadamard / ConvRot) then quantized per group of
-  ``group_size``. The default is **symmetric group-16 with a Lloyd-Max codebook
-  and fp8 (e4m3) group scales**: a per-tensor 16-level MSE-optimal codebook fit
-  to the rotated (~Gaussian) weights, plus an alternating least-squares refit of
-  the group scales and a final code assignment against the fp8-rounded scale the
-  kernel actually decodes with. ~0.073 weight relL2 on real DiT weights (NVFP4
-  0.094), ~0.56 B/elem (under NVFP4's footprint, ~56% of int8), no zero-point
-  correction -> ~1.09x int8 speed. ``symmetric=False`` gives asymmetric uniform
-  (uint4 [0,15], per-group min/scale) at the cost of a rank-(K/group) correction
-  pass (~1.4x int8); it is dominated by the symmetric+codebook default.
-- At matmul time the int4 weights are dequantized to the *grouped int8
-  representation* ``round((q-8)*s_rel)`` (group scale folded in, per-channel
-  scale ``s_channel`` left for the GEMM epilogue) and fed to the tuned INT8
-  CUTLASS GEMM. Symmetric packs ``q_signed+8`` so the same kernel computes
-  ``(q-8)*s_rel = q_signed*s_rel``.
-- Asymmetric only: the zero-point is added back as ``Sx @ Cᵀ`` (Sx = per-row
-  per-group int8-activation sums, ``C = 8*s_g + min``).
-
-Storage: int4 weights + per-group scale metadata. Persistent weights stay int4;
-the int8 dequant target is a transient per-call buffer (no int8-sized cache).
+At matmul the int4 weights dequant to "grouped int8" ``round((q-8)*s_rel)`` -- group scale
+folded in, per-channel ``s_channel`` left for the GEMM epilogue -- feeding the INT8 GEMM.
+Symmetric packs ``q_signed+8``; asymmetric adds the zero-point back as ``Sx @ Cᵀ``.
+Weights stay int4 in memory; the int8 dequant target is a transient per-call buffer.
 """
 
 from __future__ import annotations
@@ -44,13 +32,38 @@ from .base import (
     register_layout_op,
 )
 from .int8 import _dtype_code
+from .int8_utils import _build_hadamard, _rotate_weight
 
 logger = logging.getLogger(__name__)
 
+# The tuned W4A8 kernels live in the compiled CUDA backend. Without it (ROCm/AMD, CPU)
+# the layout dispatches dequant + INT8 GEMM through the registry (Triton, else eager) and
+# rotates in portable torch -- runnable on any torch device.
+try:
+    from comfy_kitchen.backends.cuda import _C as _CUDA_C  # noqa: F401
+    _CUDA_AVAILABLE = True
+except Exception as _e:  # pragma: no cover - non-CUDA builds
+    _CUDA_AVAILABLE = False
+    # Loud only when CUDA hardware is present but the extension failed to load; quiet on
+    # ROCm/CPU where the fallback is expected.
+    if torch.cuda.is_available():
+        logger.warning(
+            "W4A8: CUDA backend import failed though CUDA is available (%s); falling "
+            "back to the portable Triton/eager path (slower).", _e)
+
+
+def _convrot_rotate(w: torch.Tensor, groupsize: int) -> torch.Tensor:
+    """Involutory ConvRot (Regular-Hadamard) rotation. Uses the CUDA kernel when
+    available, else the portable int8_utils implementation (bit-matches to ~bf16 eps)."""
+    if _CUDA_AVAILABLE and w.is_cuda:
+        from comfy_kitchen.backends.cuda import rotate_int8_convrot_weight
+        return rotate_int8_convrot_weight(w, groupsize)
+    h = _build_hadamard(groupsize, device=w.device, dtype=w.dtype)
+    return _rotate_weight(w, h, groupsize)
+
 # Chunked fused path: dequant int4->int8 in L2-sized column chunks feeding the strided
-# int8 GEMM, so the int8 weight chunk stays cache-resident instead of the full [N,K]
-# round-tripping global memory. Matches convrot_w4a4's speed at our codebook quality.
-# Set COMFY_KITCHEN_W4A8_CHUNKED=0 to force the 2-pass path (e.g. for A/B timing).
+# int8 GEMM, so each int8 chunk stays cache-resident (no full [N,K] global round-trip).
+# COMFY_KITCHEN_W4A8_CHUNKED=0 forces the 2-pass path.
 _W4A8_CHUNKED = os.environ.get("COMFY_KITCHEN_W4A8_CHUNKED", "1") != "0"
 
 
@@ -91,33 +104,31 @@ class AsymW4A8Int8Layout(QuantizedLayout):
         codebook: bool = True,
         **kwargs,
     ) -> tuple[torch.Tensor, Params]:
-        from comfy_kitchen.backends.cuda import rotate_int8_convrot_weight
-
         orig_dtype = tensor.dtype
         orig_shape = tuple(tensor.shape)
         n, k = tensor.shape
-        # G must be even and pair-aligned to the 16-wide dequant vec: either
-        # divides 16 (fine: 4, 8, 16) or is a multiple of 16 (coarse: 32, 64...).
-        if k % group_size != 0 or group_size % 2 != 0 or (16 % group_size != 0 and group_size % 16 != 0):
-            raise ValueError(f"K={k}%G and G={group_size} must be even & (divides 16 or mult of 16)")
+        # G must be >=4 and in {4,8,16} or a multiple of 16: the dequant kernel loads
+        # at most 4 group scales per 16-col vec, so G>=4 (G=2 would mis-scale cols 8-15).
+        if (k % group_size != 0 or group_size < 4
+                or (16 % group_size != 0 and group_size % 16 != 0)):
+            raise ValueError(
+                f"K={k}%G and G={group_size} must be >=4 & (divides 16 or mult of 16)")
         groups = k // group_size
 
         # Data-free rotation (paired with the fused convrot activation quant).
-        w = rotate_int8_convrot_weight(tensor, convrot_groupsize).float().view(n, groups, group_size)
+        w = _convrot_rotate(tensor, convrot_groupsize).float().view(n, groups, group_size)
 
         cb = None
         if symmetric and codebook:
-            # Non-uniform 16-level codebook (Lloyd-Max on the rotated-Gaussian weight,
-            # calibration-free). ConvRot makes weights ~Gaussian; a codebook matched to
-            # it beats uniform int4 by ~14% at coarse groups, same storage/speed. The
-            # 4-bit code indexes cb directly; kernel computes cb[q]*s_rel.
+            # Non-uniform 16-level codebook (Lloyd-Max, calibration-free). ConvRot makes
+            # weights ~Gaussian; a matched codebook beats uniform int4 ~14% at coarse
+            # groups, same storage/speed. Code indexes cb directly; kernel does cb[q]*s_rel.
             s_g = w.abs().amax(dim=-1, keepdim=True).clamp(min=1e-8)  # group absmax
             wn = (w / s_g)  # [n, groups, group] normalized to [-1, 1]
             cb = cls._fit_codebook(wn)  # [16] fp32
             q = cls._assign_codes(wn, cb)  # [n,groups,group] indices
-            # Alternating least-squares refit of the group scale given the codes:
-            # absmax is only optimal when the extreme code sits at +-1, which a
-            # Lloyd-Max codebook's extreme levels don't. 3 rounds, ~free at quant time.
+            # Least-squares refit of the group scale given the codes (absmax is only
+            # optimal when the extreme code sits at +-1, which Lloyd-Max levels don't).
             for _ in range(3):
                 cbq = cb[q]
                 s_g = ((w * cbq).sum(-1, keepdim=True)
@@ -149,11 +160,9 @@ class AsymW4A8Int8Layout(QuantizedLayout):
         if scale_dtype != torch.float32:
             s_rel = s_rel.to(scale_dtype).contiguous()
         if cb is not None:
-            # int8-grid-aware final assignment: pick codes against the values the
-            # kernel actually decodes -- round(clamp(cb_j * s_rel)) * s_channel,
-            # with s_rel in its stored dtype. Subsumes the fp8-scale-aware
-            # reassignment AND folds the int8 re-rounding into the choice
-            # (measured 0.0730 -> 0.0727 weight relL2 on Krea2 g16-fp8).
+            # Final code assignment against the values the kernel actually decodes
+            # (round(clamp(cb_j * s_rel)) * s_channel, s_rel in its stored dtype) -- folds
+            # the fp8-scale and int8 re-rounding into the choice (0.0730 -> 0.0727 g16-fp8).
             levels = (cb.view(1, 1, 16) * s_rel.float().unsqueeze(-1)).round_().clamp_(-127, 127)
             q_u = cls._assign_grid(w, levels, s_channel).view(n, k)
         # pack uint4: even col -> low nibble, odd col -> high nibble
@@ -173,11 +182,8 @@ class AsymW4A8Int8Layout(QuantizedLayout):
 
     @staticmethod
     def _assign_codes(xn: torch.Tensor, cb: torch.Tensor) -> torch.Tensor:
-        """Nearest-codebook index without materializing the [..., 16] distance tensor
-        (loop the 16 levels; keeps peak memory at a couple of [...] tensors).
-
-        int32 index: half the peak memory of long, still a valid indexing dtype
-        (uint8 is NOT -- byte index tensors are treated as boolean masks)."""
+        """Nearest-codebook index, looping the 16 levels to avoid a [..., 16] distance
+        tensor. int32 (not uint8 -- byte index tensors are treated as boolean masks)."""
         best = (xn - cb[0]).abs()
         idx = torch.zeros_like(xn, dtype=torch.int32)
         for j in range(1, cb.numel()):
@@ -189,9 +195,8 @@ class AsymW4A8Int8Layout(QuantizedLayout):
 
     @staticmethod
     def _assign_grid(wv: torch.Tensor, levels: torch.Tensor, s_channel: torch.Tensor) -> torch.Tensor:
-        """Nearest decoded-int8 level: argmin_j |wv/s_channel - levels[n,g,j]| with
-        per-(channel, group) levels, looped over j like _assign_codes. `levels` is
-        [N, groups, 16] (= K floats/row at group 16; scales up at finer groups)."""
+        """Nearest decoded-int8 level: argmin_j |wv/s_channel - levels[n,g,j]|, looped
+        over j. `levels` is [N, groups, 16] (the per-channel/group decoded values)."""
         t = wv / s_channel.view(-1, 1, 1)
         best = (t - levels[..., 0:1].expand_as(wv)).abs()
         idx = torch.zeros_like(wv, dtype=torch.int32)
@@ -224,9 +229,7 @@ class AsymW4A8Int8Layout(QuantizedLayout):
 
     @classmethod
     def dequantize(cls, qdata: torch.Tensor, params: Params) -> torch.Tensor:
-        # Reference dequant (rotated-basis weight); for fallbacks/inspection.
-        from comfy_kitchen.backends.cuda import rotate_int8_convrot_weight
-
+        # Reference dequant (original-basis weight); for fallbacks/inspection.
         n, k_half = qdata.shape
         k = k_half * 2
         g = params.group_size
@@ -240,16 +243,16 @@ class AsymW4A8Int8Layout(QuantizedLayout):
         if params.codebook is not None:
             # w = codebook[q] * s_g (q is a direct [0,15] index)
             lvl = params.codebook.to(q.device).float()[q.view(n, groups, g)]
-            return rotate_int8_convrot_weight(
+            return _convrot_rotate(
                 (lvl * s_g).view(n, k).to(params.orig_dtype), params.convrot_groupsize).to(params.orig_dtype)
         qc = (q.view(n, groups, g).float() - 8.0) * s_g
         if params.correction is None:
             w_rot = qc.view(n, k)  # symmetric: w = (q-8)*s_g
         else:
-            C = params.correction.t().unsqueeze(-1).float()  # [N,groups,1] = 8*s_g + min
-            w_rot = (qc + C).view(n, k)  # w = q*s_g + min = (q-8)*s_g + C
+            corr = params.correction.t().unsqueeze(-1).float()  # [N,groups,1] = 8*s_g + min
+            w_rot = (qc + corr).view(n, k)  # w = q*s_g + min = (q-8)*s_g + corr
         # undo rotation (involutory)
-        return rotate_int8_convrot_weight(w_rot.to(params.orig_dtype), params.convrot_groupsize).to(params.orig_dtype)
+        return _convrot_rotate(w_rot.to(params.orig_dtype), params.convrot_groupsize).to(params.orig_dtype)
 
     @classmethod
     def get_plain_tensors(cls, qtensor: QuantizedTensor):
@@ -277,7 +280,38 @@ class AsymW4A8Int8Layout(QuantizedLayout):
                 "symmetric": p.correction is None, "codebook": p.codebook is not None}
 
 
+def _w4a8_int8_matmul_portable(x, weight, bias, out_dtype):
+    """Backend-agnostic W4A8 linear via the registry (Triton on AMD, else eager). Symmetric
+    weights take the dequant + INT8 GEMM path; asymmetric has no INT8-GEMM form so it falls
+    back to dequantize + F.linear."""
+    from comfy_kitchen.registry import registry
+
+    p = weight._params
+    if p.correction is not None:
+        return torch.nn.functional.linear(x, weight.dequantize().to(x.dtype), bias)
+    kwargs = {
+        "x": x,
+        "qdata": weight._qdata,
+        "s_rel": p.scale,
+        "s_channel": p.s_channel,
+        "bias": bias,
+        "group_size": p.group_size,
+        "convrot_groupsize": p.convrot_groupsize,
+    }
+    impl = registry.get_implementation("w4a8_int8_linear", kwargs=kwargs)
+    return impl(
+        x, weight._qdata, p.scale, p.s_channel,
+        codebook=p.codebook, bias=bias, group_size=p.group_size,
+        convrot_groupsize=p.convrot_groupsize, out_dtype=out_dtype,
+    )
+
+
 def _w4a8_int8_matmul(x, weight, bias, out_dtype):
+    # Portable path (Triton on AMD, else pure-torch eager) when the tuned CUDA kernels
+    # are unavailable or the input is not on CUDA.
+    if not (_CUDA_AVAILABLE and x.is_cuda):
+        return _w4a8_int8_matmul_portable(x, weight, bias, out_dtype)
+
     from comfy_kitchen.backends.cuda import (
         _C,
         _empty_cuda_tensor,
@@ -298,8 +332,8 @@ def _w4a8_int8_matmul(x, weight, bias, out_dtype):
     # fused rotate + int8 activation quant
     xq, xs = quantize_int8_rowwise_convrot(x2, p.convrot_groupsize)
     out = torch.empty(m, n, dtype=out_dtype, device=x.device)
-    # Fuse bias into the epilogue (D = acc*xs*s_channel + bias). fp32 compute type;
-    # the [N] cast is cheap -- don't cache it (inference tensors have no _version).
+    # Bias fuses into the GEMM epilogue (D = acc*xs*s_channel + bias). Cast fresh each
+    # call -- don't cache on the bias tensor (inference tensors have no _version).
     biasf = bias.float().contiguous() if bias is not None else None
 
     # Chunked fused path (symmetric codebook, fp8 scale): dequant int4->int8 in


### PR DESCRIPTION
Calibration-free 4-bit weight storage that runs on int8 gemm with convrot activations.

`AsymW4A8Int8Layout`: ConvRot-rotated int4 weights + a per-tensor Lloyd-Max
codebook + fp8 group scales, dequantized to grouped int8 and fed to the int8
CUTLASS GEMM. ~0.073 weight relL2 on real DiT weights (NVFP4 ~0.094), ~0.56
B/elem, ~1.09× int8 speed, no calibration.

Backends:
- CUDA: chunked fused int4→int8 dequant + strided INT8 GEMM.
- Triton + pure-torch eager (AMD/CPU): fused int4→int8 dequant, bit-exact with the CUDA kernel

Core PR: 

https://github.com/Comfy-Org/ComfyUI/pull/15308

Test model: 

https://huggingface.co/Kijai/MiniMax-H3-experimental/blob/main/minimax_h3_fl2va_pruned_w4a8_mixed.safetensors

Example result on a 5090 (nvfp4 is not accelerated here):

https://github.com/user-attachments/assets/3ab99015-300a-4ef2-9051-2701347afac5


