### PR TITLE
HIP port of #88: swiglu input_act and partial-rotary rot_dim

### DIFF
--- a/comfy_kitchen/backends/hip/__init__.py
+++ b/comfy_kitchen/backends/hip/__init__.py
@@ -28,6 +28,8 @@ from comfy_kitchen._rope_utils import check_rope_inplace, trim_rope_freqs
 from comfy_kitchen.backends import eager as _eager
 from comfy_kitchen.backends._activations import apply_input_act as _apply_input_act
 from comfy_kitchen.backends._activations import input_act_code as _input_act_code
+from comfy_kitchen.backends._activations import input_act_width as _input_act_width
+from comfy_kitchen.backends.eager import rope as _eager_rope
 from comfy_kitchen.backends.eager.quantization import DTYPE_CODE_TO_DTYPE, DTYPE_TO_CODE
 
 logger = logging.getLogger("comfy_kitchen.hip")
@@ -522,7 +524,9 @@ def _convrot_supported(
 def _rotate_quant_int8(
     x2d: torch.Tensor, group_size: int, input_act: str | None = None
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    m, k = x2d.shape
+    m, k_in = x2d.shape
+    # swiglu halves the row: the [gate | up] input is twice the quantized width.
+    k = k_in // _input_act_width(input_act)
     q = torch.empty((m, k), dtype=torch.int8, device=x2d.device)
     scales = torch.empty((m,), dtype=torch.float32, device=x2d.device)
     # check_convrot_k queries the current device's LDS budget, so pin it to the
@@ -593,14 +597,11 @@ def int8_linear(
     """INT8 linear with dynamic row-wise activation quantization, on WMMA."""
     # Rejected here so every route fails the same way, not just the fused one.
     _input_act_code(input_act)
-    if input_act == "swiglu":
-        # The WMMA quantizer does not fuse the gated pair; apply it eagerly so
-        # the row width and result match the fused backends.
-        x = _apply_input_act(x, input_act)
-        input_act = None
-    if x.shape[-1] != weight.shape[-1]:
+    # k_act is the activated (quantized) row width: swiglu halves the raw row.
+    k_act = x.shape[-1] // _input_act_width(input_act)
+    if k_act != weight.shape[-1]:
         raise ValueError(
-            f"Input and weight inner dimensions must match, got {x.shape[-1]} and {weight.shape[-1]}"
+            f"Input and weight inner dimensions must match, got {k_act} and {weight.shape[-1]}"
         )
 
     weight = _aligned(weight.to(device=x.device).contiguous())
@@ -612,7 +613,8 @@ def int8_linear(
 
     orig_shape = x.shape
     x2d = x.reshape(-1, orig_shape[-1]).contiguous()
-    m, k = x2d.shape
+    m = x2d.shape[0]
+    k = k_act
     n = weight.shape[0]
 
     # The WMMA K-step and the small-M GEMV both read a row 16 bytes at a time.
@@ -1100,7 +1102,7 @@ def _rms_rope_weight(scale: torch.Tensor, head_dim: int) -> torch.Tensor | None:
     return scale.contiguous()
 
 
-def _rms_rope(q, k, freqs_cis, q_scale, k_scale, epsilon, split_half, inplace=False):
+def _rms_rope(q, k, freqs_cis, q_scale, k_scale, epsilon, split_half, inplace=False, rot_dim=0):
     if k is not None and k_scale is None:
         k_scale = q_scale
     # One dtype code and one stream are passed for the whole launch, so every
@@ -1119,11 +1121,19 @@ def _rms_rope(q, k, freqs_cis, q_scale, k_scale, epsilon, split_half, inplace=Fa
         # No fused path; eager returns fresh tensors, so in place they are
         # written back through the views.
         if k is None:
-            impl = _eager.rms_rope_split_half1 if split_half else _eager.rms_rope1
-            out = impl(q, freqs_cis, q_scale, epsilon)
+            if rot_dim:
+                # Only the private eager helper takes rot_dim for a single tensor.
+                out = _eager_rope._rms_rope1(
+                    q, freqs_cis, q_scale, epsilon, split_half=split_half, rot_dim=rot_dim)
+            else:
+                impl = _eager.rms_rope_split_half1 if split_half else _eager.rms_rope1
+                out = impl(q, freqs_cis, q_scale, epsilon)
             return (q.copy_(out) if inplace else out), None
+        # Only the split-half pair takes rot_dim upstream; rot_dim never reaches
+        # the interleaved path, which has no public rot_dim argument.
         impl = _eager.rms_rope_split_half if split_half else _eager.rms_rope
-        q_out, k_out = impl(q, k, freqs_cis, q_scale, k_scale, epsilon)
+        kwargs = {"rot_dim": rot_dim} if rot_dim and split_half else {}
+        q_out, k_out = impl(q, k, freqs_cis, q_scale, k_scale, epsilon, **kwargs)
         if inplace:
             return q.copy_(q_out), k.copy_(k_out)
         return q_out, k_out
@@ -1142,12 +1152,13 @@ def _rms_rope(q, k, freqs_cis, q_scale, k_scale, epsilon, split_half, inplace=Fa
         _dl(q), None if k is None else _dl(k), _dl(freqs_cis),
         _dl(q_weight), None if k_weight is None else _dl(k_weight),
         _dl(q_out), None if k_out is None else _dl(k_out),
-        epsilon, split_half, _stream(q),
+        epsilon, split_half, _stream(q), rot_dim,
     )
     return q_out, k_out
 
 
-def _rms_rope_pair(q, k, freqs_cis, q_scale, k_scale, epsilon, split_half, inplace=False):
+def _rms_rope_pair(q, k, freqs_cis, q_scale, k_scale, epsilon, split_half, inplace=False,
+                   rot_dim=0):
     if k_scale is None:
         k_scale = q_scale
     # One dtype code covers both inputs and one more both weights, so a difference
@@ -1159,10 +1170,12 @@ def _rms_rope_pair(q, k, freqs_cis, q_scale, k_scale, epsilon, split_half, inpla
         or (inplace and _effective_strides(q) != _effective_strides(k))
     ):
         return (
-            _rms_rope(q, None, freqs_cis, q_scale, None, epsilon, split_half, inplace)[0],
-            _rms_rope(k, None, freqs_cis, k_scale, None, epsilon, split_half, inplace)[0],
+            _rms_rope(q, None, freqs_cis, q_scale, None, epsilon, split_half, inplace,
+                      rot_dim)[0],
+            _rms_rope(k, None, freqs_cis, k_scale, None, epsilon, split_half, inplace,
+                      rot_dim)[0],
         )
-    return _rms_rope(q, k, freqs_cis, q_scale, k_scale, epsilon, split_half, inplace)
+    return _rms_rope(q, k, freqs_cis, q_scale, k_scale, epsilon, split_half, inplace, rot_dim)
 
 
 def rms_rope1(
@@ -1237,11 +1250,7 @@ def rms_rope_split_half(
     epsilon: float = 1e-6,
     rot_dim: int = 0,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    if rot_dim and rot_dim != q.shape[-1]:
-        # partial rotary is not fused in the WMMA kernel
-        return _eager.rms_rope_split_half(
-            q, k, freqs_cis, q_scale, k_scale, epsilon, rot_dim=rot_dim)
-    return _rms_rope_pair(q, k, freqs_cis, q_scale, k_scale, epsilon, True)
+    return _rms_rope_pair(q, k, freqs_cis, q_scale, k_scale, epsilon, True, rot_dim=rot_dim)
 
 
 def rms_rope_split_half_(
@@ -1255,12 +1264,9 @@ def rms_rope_split_half_(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     if k_scale is None:
         k_scale = q_scale
-    if rot_dim and rot_dim != q.shape[-1]:
-        # partial rotary is not fused in the WMMA kernel
-        return _eager.rms_rope_split_half_(
-            q, k, freqs_cis, q_scale, k_scale, epsilon, rot_dim=rot_dim)
     check_rope_inplace(q, k, readonly=(freqs_cis, q_scale, k_scale))
-    return _rms_rope_pair(q, k, freqs_cis, q_scale, k_scale, epsilon, True, inplace=True)
+    return _rms_rope_pair(q, k, freqs_cis, q_scale, k_scale, epsilon, True, inplace=True,
+                          rot_dim=rot_dim)
 
 
 # ---------------------------------------------------------------------------

--- a/comfy_kitchen/backends/hip/dlpack_bindings.cpp
+++ b/comfy_kitchen/backends/hip/dlpack_bindings.cpp
@@ -78,8 +78,8 @@ void launch_apply_rope_kernel(const void*, const void*, const void*, void*, void
 void launch_rms_rope_kernel(const void*, const void*, const void*, const void*, const void*, void*,
                             void*, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t,
                             int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t,
-                            int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, int, int, int,
-                            float, bool, hipStream_t);
+                            int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, int, int,
+                            int, float, bool, hipStream_t);
 }
 
 static void check_hip_launch() {
@@ -391,7 +391,10 @@ void quantize_int8_convrot(nb::ndarray<> x, nb::ndarray<> q, nb::ndarray<> scale
     require_convrot_group(K, group_size, kFn);
     require_dtype(x, 0, 2, kFn, "x");
     require_dtype(q, 4, 4, kFn, "q");
-    require_len(x, static_cast<int64_t>(M) * K, kFn, "x");
+    // K is the activated (written) width; swiglu (code 2, see INPUT_ACT_TO_CODE)
+    // reads a [gate | up] row twice as wide. The launcher rejects unknown codes.
+    const int64_t in_width = act_code == 2 ? 2 : 1;
+    require_len(x, static_cast<int64_t>(M) * K * in_width, kFn, "x");
     require_len(q, static_cast<int64_t>(M) * K, kFn, "q");
     require_scale_len(scales, static_cast<size_t>(M), kFn, "scales");
 
@@ -571,27 +574,35 @@ void rms_adaln(nb::ndarray<> x, nb::ndarray<> scale, nb::ndarray<> shift, nb::nd
                /*subtract_mean=*/false, stream_ptr);
 }
 
-// x is (batch, dim1, dim2, head_dim); freqs is (fb, fd1, fd2, head_dim/2, 2, 2).
+// x is (batch, dim1, dim2, head_dim); freqs is (fb, fd1, fd2, rot_dim/2, 2, 2).
 // Shapes and strides are read off the arrays so the broadcast rules stay in one
 // place rather than being recomputed on the Python side. Shared by apply_rope and
-// rms_rope, which index both tensors the same way.
-static void require_rope_shapes(const nb::ndarray<>& x, const nb::ndarray<>& freqs,
-                                const char* fn) {
+// rms_rope, which index both tensors the same way. rot_dim is the rotated head-dim
+// prefix; 0 rotates everything.
+static int64_t require_rope_shapes(const nb::ndarray<>& x, const nb::ndarray<>& freqs,
+                                   const char* fn, int64_t rot_dim = 0) {
     // map_dtype_to_code returns -1 for anything else, which the device decoder
     // would misread; the other operands are checked against x's dtype separately.
     require_dtype(x, 0, 2, fn, "x");
     require_dtype(freqs, 0, 2, fn, "freqs_cis");
     if (x.ndim() != 4) throw std::runtime_error(std::string(fn) + " expects a 4D input");
     if (freqs.ndim() != 6) throw std::runtime_error(std::string(fn) + " expects a 6D freqs_cis");
-    if (x.shape(3) % 2 != 0) {
-        throw std::runtime_error(std::string(fn) + " expects an even head_dim");
+
+    // Only the rotated prefix is paired, so an odd head_dim is fine as long as the
+    // resolved rot is even: the leftover tail is norm-only. apply_rope stays
+    // covered because its rot resolves to head_dim.
+    const int64_t head_dim = static_cast<int64_t>(x.shape(3));
+    const int64_t rot = rot_dim > 0 ? rot_dim : head_dim;
+    if (rot % 2 != 0 || rot > head_dim) {
+        throw std::runtime_error(std::string(fn) + " expects an even rot_dim <= head_dim");
     }
 
-    // The kernel indexes freqs as (fb, fd1, fd2, head_dim/2, 2, 2), broadcasting a
+    // The kernel indexes freqs as (fb, fd1, fd2, rot_dim/2, 2, 2), broadcasting a
     // leading dim only when it is 1. Anything else walks off the end of the array.
-    if (freqs.shape(3) != x.shape(3) / 2 || freqs.shape(4) != 2 || freqs.shape(5) != 2) {
+    if (freqs.shape(3) != static_cast<size_t>(rot / 2) || freqs.shape(4) != 2 ||
+        freqs.shape(5) != 2) {
         throw std::runtime_error(std::string(fn) +
-                                 " expects freqs_cis trailing dims (head_dim/2, 2, 2)");
+                                 " expects freqs_cis trailing dims (rot_dim/2, 2, 2)");
     }
     for (size_t i = 0; i < 3; ++i) {
         if (freqs.shape(i) != 1 && freqs.shape(i) != x.shape(i)) {
@@ -600,6 +611,7 @@ static void require_rope_shapes(const nb::ndarray<>& x, const nb::ndarray<>& fre
                 " expects each leading freqs_cis dim to be 1 or match the input");
         }
     }
+    return rot;
 }
 
 // An output is walked with its own strides, so it only has to match the extents.
@@ -670,9 +682,9 @@ void apply_rope(nb::ndarray<> xq, OptArray xk, nb::ndarray<> freqs, nb::ndarray<
 // weight for each input.
 void rms_rope(nb::ndarray<> q, OptArray k, nb::ndarray<> freqs, nb::ndarray<> q_scale,
               OptArray k_scale, nb::ndarray<> q_out, OptArray k_out, float epsilon,
-              bool split_half, uintptr_t stream_ptr) {
+              bool split_half, uintptr_t stream_ptr, int64_t rot_dim) {
     constexpr const char* kFn = "rms_rope";
-    require_rope_shapes(q, freqs, kFn);
+    const int64_t rot = require_rope_shapes(q, freqs, kFn, rot_dim);
 
     // k, its scale and its output are one operand set.
     if (k.has_value() != k_out.has_value() || k.has_value() != k_scale.has_value()) {
@@ -701,7 +713,7 @@ void rms_rope(nb::ndarray<> q, OptArray k, nb::ndarray<> freqs, nb::ndarray<> q_
         k_scale.has_value() ? k_scale->data() : nullptr, q_out.data(),
         k_out.has_value() ? k_out->data() : nullptr,
         static_cast<int64_t>(q.shape(0)), static_cast<int64_t>(q.shape(1)),
-        static_cast<int64_t>(q.shape(2)), head_dim,
+        static_cast<int64_t>(q.shape(2)), head_dim, rot,
         static_cast<int64_t>(freqs.shape(0)), static_cast<int64_t>(freqs.shape(1)),
         static_cast<int64_t>(freqs.shape(2)),
         static_cast<int64_t>(q.stride(0)), static_cast<int64_t>(q.stride(1)),

--- a/comfy_kitchen/backends/hip/hadamard.h
+++ b/comfy_kitchen/backends/hip/hadamard.h
@@ -83,11 +83,13 @@ __forceinline__ __device__ float load_in(const void* x, int64_t idx, int code) {
     return static_cast<float>(static_cast<const __bf16*>(x)[idx]);
 }
 
-// Codes match comfy_kitchen.backends._activations.INPUT_ACT_TO_CODE.
-enum : int { kActNone = 0, kActGeluTanh = 1 };
+// Codes match comfy_kitchen.backends._activations.INPUT_ACT_TO_CODE. SwiGLU is
+// the gated pair: the raw row is [gate | up] (2*K wide) and the activated row
+// silu(gate) * up is K wide; the others are elementwise.
+enum : int { kActNone = 0, kActGeluTanh = 1, kActSwiGLU = 2 };
 
 inline void check_convrot_act(int act) {
-    if (act != kActNone && act != kActGeluTanh) {
+    if (act != kActNone && act != kActGeluTanh && act != kActSwiGLU) {
         throw std::runtime_error("convrot: unsupported input activation code");
     }
 }
@@ -101,6 +103,22 @@ __forceinline__ __device__ float apply_input_act(float v) {
         return 0.5f * v * (1.0f + tanhf(kBeta * (v + kKappa * v * v * v)));
     }
     return v;
+}
+
+// One activated value: column `col` of the K-wide activated row starting at
+// `in_row`. SwiGLU reads the gate at col and the up at K + col; every other
+// activation reads the same K-wide row it writes.
+template <int ACT>
+__forceinline__ __device__ float load_input_act(
+    const void* x, int64_t in_row, int col, int K, int code) {
+    if constexpr (ACT == kActSwiGLU) {
+        // Matches torch silu(gate) * up.
+        const float gate = load_in(x, in_row + col, code);
+        const float up = load_in(x, in_row + K + col, code);
+        return (gate / (1.0f + expf(-gate))) * up;
+    } else {
+        return apply_input_act<ACT>(load_in(x, in_row + col, code));
+    }
 }
 
 template <typename RowT>
@@ -147,15 +165,15 @@ __global__ __launch_bounds__(256) void convrot_quant_kernel(
     const int gbase_idx = glocal * G;
     const float norm = rsqrtf(static_cast<float>(G));
     const int ngrp = K / G;
+    // SwiGLU reads a [gate | up] raw row twice as wide as the K it writes.
+    constexpr int kInWidth = (ACT == kActSwiGLU) ? 2 : 1;
+    const int64_t in_row = static_cast<int64_t>(row) * K * kInWidth;
 
     float lmax = 0.0f;
     for (int gbase = 0; gbase < ngrp; gbase += gpw) {
         const int grp = gbase + glocal;
         const bool active = grp < ngrp;
-        g[t] = active ? apply_input_act<ACT>(load_in(
-                            x, static_cast<int64_t>(row) * K + static_cast<int64_t>(grp) * G + e,
-                            in_dtype))
-                      : 0.0f;
+        g[t] = active ? load_input_act<ACT>(x, in_row, grp * G + e, K, in_dtype) : 0.0f;
         __syncthreads();
 
         for (int stage = 0; stage < nstages; ++stage) {

--- a/comfy_kitchen/backends/hip/ops/quantize_int8.hip
+++ b/comfy_kitchen/backends/hip/ops/quantize_int8.hip
@@ -188,7 +188,8 @@ extern "C" void launch_quantize_int8_rowwise_kernel(
         x, in_code, static_cast<int8_t*>(q), static_cast<float*>(scales), M, K);
 }
 
-// Fused ConvRot rotation + rowwise int8 quantize. act_code: 0 none, 1 gelu tanh.
+// Fused ConvRot rotation + rowwise int8 quantize. act_code: 0 none, 1 gelu tanh,
+// 2 swiglu. K is the activated (written) width; swiglu reads a row twice as wide.
 extern "C" void launch_quantize_int8_convrot_kernel(
     const void* x, int in_code, void* q, void* scales,
     int M, int K, int group_size, int act_code, hipStream_t stream) {
@@ -202,6 +203,10 @@ extern "C" void launch_quantize_int8_convrot_kernel(
     }
     if (act_code == kActGeluTanh) {
         launch_convrot_quant<false, kActGeluTanh>(
+            x, in_code, static_cast<int8_t*>(q), static_cast<float*>(scales),
+            M, K, group_size, stream);
+    } else if (act_code == kActSwiGLU) {
+        launch_convrot_quant<false, kActSwiGLU>(
             x, in_code, static_cast<int8_t*>(q), static_cast<float*>(scales),
             M, K, group_size, stream);
     } else {

--- a/comfy_kitchen/backends/hip/ops/rms_rope.hip
+++ b/comfy_kitchen/backends/hip/ops/rms_rope.hip
@@ -28,7 +28,7 @@ __global__ __launch_bounds__(kRmsRopeThreads) void rms_rope_kernel(
     const void* __restrict__ q, const void* __restrict__ k,
     const void* __restrict__ freqs, const void* __restrict__ q_scale,
     const void* __restrict__ k_scale, T* __restrict__ q_out, T* __restrict__ k_out,
-    int64_t dim1, int64_t dim2, int head_dim,
+    int64_t dim1, int64_t dim2, int head_dim, int rot_dim,
     int64_t fb, int64_t fd1, int64_t fd2,
     int64_t sx_b, int64_t sx_d1, int64_t sx_d2, int64_t sx_d,
     int64_t so_b, int64_t so_d1, int64_t so_d2, int64_t so_d,
@@ -80,7 +80,9 @@ __global__ __launch_bounds__(kRmsRopeThreads) void rms_rope_kernel(
     const int64_t foff_row = (fb == 1 ? 0 : b) * sf_b + (fd1 == 1 ? 0 : d1) * sf_d1 +
                              (fd2 == 1 ? 0 : d2) * sf_d2;
 
-    const int n_pairs = head_dim / 2;
+    // Rotation covers the first rot_dim dims, in split-half pairs (p, p + rot_dim/2);
+    // the reduction above always spans the full head_dim.
+    const int n_pairs = rot_dim / 2;
     for (int p = t; p < n_pairs; p += kRmsRopeThreads) {
         const int64_t ia = split_half ? p : 2 * p;
         const int64_t ib = split_half ? p + n_pairs : 2 * p + 1;
@@ -111,6 +113,18 @@ __global__ __launch_bounds__(kRmsRopeThreads) void rms_rope_kernel(
             rope_store<T>(k_out, ib_out, rope_combine(f10, ka, f11, kb, f_code, split_half));
         }
     }
+
+    // Dims past rot_dim are normalized and scaled but never rotated. The store
+    // rounds to T, which is the single rounding eager's rms_norm applies. Empty
+    // when rot_dim == head_dim.
+    for (int d = rot_dim + t; d < head_dim; d += kRmsRopeThreads) {
+        const int64_t in = xoff + d * sx_d;
+        const int64_t out = ooff + d * so_d;
+        rope_store<T>(q_out, out, load_in(q, in, x_code) * rrms_q * load_in(q_scale, d, s_code));
+        if (has_k) {
+            rope_store<T>(k_out, out, load_in(k, in, x_code) * rrms_k * load_in(k_scale, d, s_code));
+        }
+    }
 }
 
 }  // namespace comfy::hip_backend
@@ -118,7 +132,7 @@ __global__ __launch_bounds__(kRmsRopeThreads) void rms_rope_kernel(
 extern "C" void launch_rms_rope_kernel(
     const void* q, const void* k, const void* freqs, const void* q_scale, const void* k_scale,
     void* q_out, void* k_out,
-    int64_t batch, int64_t dim1, int64_t dim2, int64_t head_dim,
+    int64_t batch, int64_t dim1, int64_t dim2, int64_t head_dim, int64_t rot_dim,
     int64_t fb, int64_t fd1, int64_t fd2,
     int64_t sx_b, int64_t sx_d1, int64_t sx_d2, int64_t sx_d,
     int64_t so_b, int64_t so_d1, int64_t so_d2, int64_t so_d,
@@ -135,11 +149,17 @@ extern "C" void launch_rms_rope_kernel(
     if (rows > 0xffffffffLL) {
         throw std::runtime_error("rms_rope: too many rows for a single grid");
     }
+    // 0 rotates everything; anything else is a partial-rotary prefix.
+    const int64_t rot = rot_dim > 0 ? rot_dim : head_dim;
+    if (rot % 2 != 0 || rot > head_dim) {
+        throw std::runtime_error("rms_rope: rot_dim must be even and <= head_dim");
+    }
 
 #define CK_RMS_ROPE_LAUNCH(T)                                                                  \
     rms_rope_kernel<T><<<static_cast<unsigned int>(rows), kRmsRopeThreads, 0, stream>>>(       \
         q, k, freqs, q_scale, k_scale, static_cast<T*>(q_out), static_cast<T*>(k_out), dim1,   \
-        dim2, static_cast<int>(head_dim), fb, fd1, fd2, sx_b, sx_d1, sx_d2, sx_d, so_b, so_d1, \
+        dim2, static_cast<int>(head_dim), static_cast<int>(rot), fb, fd1, fd2, sx_b, sx_d1,    \
+        sx_d2, sx_d, so_b, so_d1,                                                              \
         so_d2, so_d, sf_b, sf_d1, sf_d2, sf_d, sf_rot, sf_pair, x_code, f_code, s_code,        \
         epsilon, split_half)
 

--- a/tests/test_hip_wmma.py
+++ b/tests/test_hip_wmma.py
@@ -228,6 +228,70 @@ def test_int8_linear_input_act_matches_the_eager_chain(tag, shape, kwargs):
     assert (out.float() - ref.float()).abs().max().item() < 0.05 * scale, tag
 
 
+def _swiglu(x):
+    gate, up = x.chunk(2, dim=-1)
+    return torch.nn.functional.silu(gate) * up
+
+
+# swiglu is the gated pair: the input row is [gate | up] and the quantized row is
+# half as wide, so the shapes below give the raw (2 * K) width.
+@needs_wmma
+@pytest.mark.parametrize(
+    ("tag", "shape", "kwargs"),
+    [
+        ("fused convrot", (256, 2 * 1024), {"convrot": True, "convrot_groupsize": 256}),
+        ("no convrot", (256, 2 * 1024), {"convrot": False}),
+        ("m == 1", (1, 2 * 1024), {"convrot": True, "convrot_groupsize": 256}),
+    ],
+)
+def test_int8_linear_swiglu_matches_the_eager_chain(tag, shape, kwargs):
+    """int8_linear(x, input_act="swiglu") == int8_linear(swiglu(x)) on every route."""
+    torch.manual_seed(0)
+    m, k2 = shape
+    k = k2 // 2
+    n = 256
+    x = torch.randn(m, k2, device=DEV, dtype=torch.bfloat16)
+    w = torch.randn(n, k, device=DEV, dtype=torch.bfloat16)
+    wq, ws = ck.quantize_int8_rowwise(w)
+    ws = ws.reshape(-1)
+
+    with ck.use_backend("hip"):
+        ref = ck.int8_linear(_swiglu(x), wq, ws, None, torch.bfloat16, **kwargs)
+        out = ck.int8_linear(x, wq, ws, None, torch.bfloat16,
+                             input_act="swiglu", **kwargs)
+
+    assert out.shape == (m, n), tag
+    scale = ref.float().abs().max().item()
+    assert (out.float() - ref.float()).abs().max().item() < 0.05 * scale, tag
+
+
+@needs_wmma
+def test_swiglu_quantizer_is_at_least_as_accurate_as_the_chain(hip):
+    """Fusing the gate into the rotation's load must not lose accuracy against
+    materializing silu(gate) * up in bf16 first."""
+    torch.manual_seed(0)
+    m, k, group = 512, 1024, 256
+    x = torch.randn(m, 2 * k, device=DEV, dtype=torch.bfloat16) * 2.0
+
+    xd = x.double()
+    activated = torch.nn.functional.silu(xd[:, :k]) * xd[:, k:]
+    mat = _build_hadamard(group, device=x.device, dtype=torch.float64)
+    rotated = (activated.reshape(-1, k // group, group) @ mat).reshape(-1, k)
+    scale = (rotated.abs().amax(-1, keepdim=True) / 127.0).clamp(min=1e-30)
+    exact = (rotated / scale).round().clamp(-128, 127)
+
+    chain_q, _ = hip._rotate_quant_int8(_swiglu(x).contiguous(), group)
+    fused_q, fused_s = hip._rotate_quant_int8(x, group, "swiglu")
+
+    err_chain = (chain_q.double() - exact).abs().mean().item()
+    err_fused = (fused_q.double() - exact).abs().mean().item()
+    assert err_fused <= max(err_chain * 1.05, 1e-4), (
+        f"fused ({err_fused:.6f}) less accurate than chain ({err_chain:.6f})"
+    )
+    assert fused_q.shape == (m, k)
+    assert fused_s.shape == (m,)
+
+
 @needs_wmma
 def test_int8_linear_input_act_none_is_the_identity():
     """None and "none" must be bit-identical to omitting the argument."""
@@ -736,6 +800,144 @@ def test_rms_rope_matches_eager(split_half, freqs_dtype, shape, freqs_shape):
     assert torch.equal(out_one, out_q)
 
 
+def _partial_rotary_reference(x, freqs, scale, epsilon, rot_dim):
+    """Norm over the full head_dim, split-half rotation over the first rot_dim."""
+    x_float = x.float()
+    rrms = torch.rsqrt(x_float.square().mean(dim=-1, keepdim=True) + epsilon)
+    x_norm = (x_float * rrms * scale.float()).to(x.dtype).float()
+    half = rot_dim // 2
+    x1, x2 = x_norm[..., :half], x_norm[..., half:rot_dim]
+    f = freqs.float()
+    o1 = f[..., 0, 0] * x1 + f[..., 0, 1] * x2
+    o2 = f[..., 1, 0] * x1 + f[..., 1, 1] * x2
+    return torch.cat([o1, o2, x_norm[..., rot_dim:]], dim=-1).to(x.dtype)
+
+
+@pytest.mark.parametrize("rot_dim", [32, 64, 96])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16], ids=["bf16", "fp16"])
+def test_rms_rope_partial_rotary(hip, rot_dim, dtype):
+    """rot_dim rotates a head-dim prefix; the tail is normalized but not rotated."""
+    torch.manual_seed(0)
+    s, h, d = 333, 8, 128
+    q = torch.randn(1, s, h, d, device=DEV, dtype=dtype)
+    k = torch.randn(1, s, h, d, device=DEV, dtype=dtype)
+    freqs = torch.randn(1, s, 1, rot_dim // 2, 2, 2, device=DEV, dtype=torch.float32)
+    q_scale = torch.randn(d, device=DEV, dtype=torch.float32)
+    k_scale = torch.randn(d, device=DEV, dtype=torch.float32)
+
+    out_q, out_k = hip.rms_rope_split_half(q, k, freqs, q_scale, k_scale, rot_dim=rot_dim)
+
+    for out, x, scale in ((out_q, q, q_scale), (out_k, k, k_scale)):
+        ref = _partial_rotary_reference(x, freqs, scale, 1e-6, rot_dim)
+        torch.testing.assert_close(out.float(), ref.float(), rtol=2e-2, atol=2e-2)
+
+
+def test_rms_rope_partial_rotary_with_an_odd_tail(hip, monkeypatch):
+    """Only the rotated prefix has to be even. A 65-wide row with rot_dim=64 leaves
+    one norm-only element, which the kernel handles, so it must not go to eager."""
+    monkeypatch.setattr(
+        hip._eager, "rms_rope_split_half",
+        lambda *a, **kw: pytest.fail("an odd head_dim with an even rot_dim fell back"),
+    )
+    torch.manual_seed(0)
+    s, h, d, rot_dim = 64, 4, 65, 64
+    q = torch.randn(1, s, h, d, device=DEV, dtype=torch.bfloat16)
+    k = torch.randn(1, s, h, d, device=DEV, dtype=torch.bfloat16)
+    freqs = torch.randn(1, s, 1, rot_dim // 2, 2, 2, device=DEV, dtype=torch.float32)
+    scale = torch.randn(d, device=DEV, dtype=torch.float32)
+
+    out_q, out_k = hip.rms_rope_split_half(q, k, freqs, scale, scale, rot_dim=rot_dim)
+
+    for out, x in ((out_q, q), (out_k, k)):
+        ref = _partial_rotary_reference(x, freqs, scale, 1e-6, rot_dim)
+        torch.testing.assert_close(out.float(), ref.float(), rtol=2e-2, atol=2e-2)
+
+
+def test_rms_rope_full_rot_dim_matches_the_default(hip):
+    """rot_dim == head_dim must be bit-identical to omitting it."""
+    torch.manual_seed(0)
+    s, h, d = 128, 4, 64
+    q = torch.randn(1, s, h, d, device=DEV, dtype=torch.bfloat16)
+    k = torch.randn(1, s, h, d, device=DEV, dtype=torch.bfloat16)
+    freqs = torch.randn(1, s, 1, d // 2, 2, 2, device=DEV, dtype=torch.float32)
+    scale = torch.randn(d, device=DEV, dtype=torch.float32)
+
+    full = hip.rms_rope_split_half(q, k, freqs, scale, scale, rot_dim=d)
+    default = hip.rms_rope_split_half(q, k, freqs, scale, scale)
+
+    assert torch.equal(full[0], default[0])
+    assert torch.equal(full[1], default[1])
+
+
+def test_rms_rope_partial_rotary_in_place_on_a_qkv_slice(hip):
+    """The MiniMax layout: q and k are strided slices of one packed projection."""
+    torch.manual_seed(0)
+    s, h, d, rot_dim = 96, 6, 128, 96
+    qkv = torch.randn(s, 3 * h * d, device=DEV, dtype=torch.bfloat16)
+    qkv_ref = qkv.clone()
+    freqs = torch.randn(1, s, 1, rot_dim // 2, 2, 2, device=DEV, dtype=torch.float32)
+    scale = torch.randn(d, device=DEV, dtype=torch.float32)
+
+    q, k, v = (t.view(1, s, h, d) for t in qkv.split(h * d, dim=-1))
+    q_ref, k_ref, v_ref = (t.view(1, s, h, d) for t in qkv_ref.split(h * d, dim=-1))
+
+    hip.rms_rope_split_half_(q, k, freqs, scale, scale, rot_dim=rot_dim)
+    expect_q, expect_k = hip.rms_rope_split_half(
+        q_ref, k_ref, freqs, scale, scale, rot_dim=rot_dim)
+
+    assert torch.equal(q, expect_q)
+    assert torch.equal(k, expect_k)
+    assert torch.equal(v, v_ref), "v must not be touched by in-place q/k rope"
+
+
+@pytest.mark.parametrize("rot_dim", [33, 66], ids=["odd", "over head_dim"])
+def test_rms_rope_rejects_an_unusable_rot_dim(hip, rot_dim):
+    """The rotation pairs (i, i + rot_dim/2) inside head_dim, so an odd prefix or
+    one wider than the row has no kernel."""
+    q = torch.randn(1, 8, 2, 64, device=DEV, dtype=torch.bfloat16)
+    k = torch.randn(1, 8, 2, 64, device=DEV, dtype=torch.bfloat16)
+    freqs = torch.randn(1, 8, 1, rot_dim // 2, 2, 2, device=DEV, dtype=torch.float32)
+    scale = torch.randn(64, device=DEV, dtype=torch.float32)
+
+    with pytest.raises(RuntimeError, match="rot_dim"):
+        hip.rms_rope_split_half(q, k, freqs, scale, scale, rot_dim=rot_dim)
+
+
+def test_rms_rope_forwards_rot_dim_to_the_eager_fallback(hip, monkeypatch):
+    """A weight the kernel cannot index goes back to eager, which must still be
+    told the rotation is partial: dropping rot_dim there rotates the whole row."""
+    q = torch.randn(1, 8, 2, 64, device=DEV, dtype=torch.bfloat16)
+    k = torch.randn(1, 8, 2, 64, device=DEV, dtype=torch.bfloat16)
+    freqs = torch.randn(1, 8, 1, 24, 2, 2, device=DEV, dtype=torch.float32)
+    scale = torch.randn(1, 64, device=DEV, dtype=torch.float32)  # 2D: no kernel
+
+    seen = {}
+    monkeypatch.setattr(
+        hip._eager, "rms_rope_split_half",
+        lambda *a, **kw: seen.update(kw) or (torch.zeros_like(q), torch.zeros_like(k)),
+    )
+    hip.rms_rope_split_half(q, k, freqs, scale, scale, rot_dim=48)
+
+    assert seen.get("rot_dim") == 48, "eager fallback lost rot_dim"
+
+
+def test_rms_rope_partial_rotary_with_mismatched_q_k_heads(hip):
+    """GQA splits the pair into two single-tensor launches; both need rot_dim."""
+    torch.manual_seed(0)
+    s, d, rot_dim = 65, 128, 96
+    q = torch.randn(1, s, 8, d, device=DEV, dtype=torch.bfloat16)
+    k = torch.randn(1, s, 2, d, device=DEV, dtype=torch.bfloat16)
+    freqs = torch.randn(1, s, 1, rot_dim // 2, 2, 2, device=DEV, dtype=torch.float32)
+    q_scale = torch.randn(d, device=DEV, dtype=torch.float32)
+    k_scale = torch.randn(d, device=DEV, dtype=torch.float32)
+
+    out_q, out_k = hip.rms_rope_split_half(q, k, freqs, q_scale, k_scale, rot_dim=rot_dim)
+
+    for out, x, scale in ((out_q, q, q_scale), (out_k, k, k_scale)):
+        ref = _partial_rotary_reference(x, freqs, scale, 1e-6, rot_dim)
+        torch.testing.assert_close(out.float(), ref.float(), rtol=2e-2, atol=2e-2)
+
+
 @pytest.mark.parametrize("split_half", [False, True])
 def test_rms_rope_reads_a_qkv_slice_in_place(hip, split_half):
     """A q/k pair sliced out of a packed qkv must match the copy bit for bit."""
@@ -827,7 +1029,7 @@ def test_rms_rope_rejects_a_short_weight(hip):
             q.__dlpack__(stream=-1), None, freqs.__dlpack__(stream=-1),
             torch.randn(32, device=DEV).__dlpack__(stream=-1), None,
             q_out.__dlpack__(stream=-1), None,
-            1e-6, False, torch.cuda.current_stream(q.device).cuda_stream,
+            1e-6, False, torch.cuda.current_stream(q.device).cuda_stream, 0,
         )
 
 


### PR DESCRIPTION
Ports #88 to the HIP backend.

#88 added `swiglu` as an `input_act` and a `rot_dim` prefix for `rms_rope_split_half`, fusing both into the CUDA kernels. HIP took them as eager fallbacks, so results were already correct. This is a performance port, not a correctness fix.

### Partial rotary `rot_dim`

`rms_rope.hip` rotates the first `rot_dim` dims in split-half pairs `(p, p + rot_dim/2)` and adds a norm-only tail for the rest. The RMS reduction still spans the full `head_dim`. The tail's store performs the single rounding eager's `rms_norm` applies, so no extra rounding step is needed there.

`require_rope_shapes` now validates the freqs table against `rot_dim` instead of `head_dim`. It is shared with `apply_rope`, which passes `head_dim` and is unchanged. `rot_dim = 0` keeps rotating everything.

The eager bail-outs in `rms_rope_split_half` / `rms_rope_split_half_` are gone. The GQA path, where q and k have different head counts and route through single-tensor calls, carries `rot_dim` through as well.

### SwiGLU `input_act`

The ConvRot int8 quantizer gains act code 2, reading a `[gate | up]` row twice as wide as the K it stages and writes. Only the activated row is staged in LDS, so the per-device K budget is unchanged.

`int8_linear` now tracks the activated width `k_act` separately from the raw input width, so the `% 16` check, the group-divisibility check and the LDS budget all see the width actually being quantized rather than the doubled input. Routes
the fused quantizer cannot serve (no convrot, K over the LDS cap) still apply the activation eagerly, matching the CUDA backend.

### Architecture coverage

`rms_rope.hip` has no WMMA dependency, so partial rotary works on RDNA2 through RDNA4. `rms_rope_split_half` is not in `_WMMA_ONLY_OPS`, so it still dispatches to HIP on RDNA2.

The swiglu kernel also compiles everywhere, but on RDNA2 `int8_linear` is dropped from the constraints (no matrix cores), so the fused path is unreachable there and the op routes to triton/eager. Same situation as the existing `gelu_tanh` fusion.

Compile-verified on gfx1030 (RDNA2), gfx1100 (RDNA3), gfx1151 (RDNA3.5) and gfx1200 (RDNA4). Run-verified on RDNA4 only - the test machine has a single gfx1200, which cannot execute gfx11 or gfx10 code.

### Tests

14 new cases in `tests/test_hip_wmma.py`:

- partial rotary against a reference across `rot_dim` and dtype
- `rot_dim == head_dim` bit-identical to omitting it
- in-place on packed-QKV slices, with `v` proven untouched
- odd `rot_dim` rejected
- swiglu on all three routes (fused convrot, no convrot, m == 1)
- fused swiglu at least as accurate as materializing `silu(gate) * up` first

#88's tests parametrize over `["cuda", "triton", "eager"]` only, so HIP coverage has to live in the HIP suite.

One existing line changed: `test_rms_rope_rejects_a_short_weight` calls the raw `_C.rms_rope` binding positionally and needed the new argument.

### Results

`test_hip_wmma.py`, `test_hip_dispatch.py`, `test_int8_input_act.py` and `test_int8.py`: 335 passed, 64 skipped.

Full suite on gfx1200 (ROCm 7.15, torch 2.12): the failure set is identical with and without this change, verified by stashing and re-running. Those failures are pre-existing NVFP4/MXFP8 and triton-tolerance cases unrelated to the HIP backend.

Measured on gfx1200 at MiniMax shapes (56 x 128 heads, `rot_dim` 96, ffn 14336), against the eager fallback this replaces:

| | S=4096 | S=8192 |
|---|---|---|
| `rms_rope_split_half_` | 10.05 -> 2.06 ms (4.9x) | 20.19 -> 3.99 ms (5.1x) |
| `int8_linear` (fc2) | 12.84 -> 11.77 ms (1.09x) | 26.19 -> 24.36 ms (1.08x) |

Across 50 DiT blocks that is roughly 0.9 s per denoise step. MiniMax (`comfy/ldm/minimax/model.py`) is currently the only ComfyUI model requesting either feature, so this is a no-op elsewhere.
