### PR TITLE
Add na3d / na2d neighborhood attention

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Fast kernel library for Diffusion inference with multiple compute backends.
 | `scaled_mm_mxfp8`           | ✓     |      |        |     |
 | `adaln`                     | ✓     | ✓    | ✓      | ✓   |
 | `rms_adaln`                 | ✓     | ✓    | ✓      | ✓   |
+| `na3d`                      | ✓     | ✓    | ✓      |     |
+| `na2d`                      | ✓     | ✓    | ✓      |     |
 | `apply_rope`                | ✓     | ✓    | ✓      | ✓   |
 | `apply_rope1`               | ✓     | ✓    | ✓      | ✓   |
 | `apply_rope_split_half`     | ✓     | ✓    | ✓      | ✓   |

--- a/comfy_kitchen/__init__.py
+++ b/comfy_kitchen/__init__.py
@@ -37,10 +37,10 @@ else:
 __all__ = [
     # Normalization
     "adaln",
-    # Attention
-    "na3d",
-    "na2d",
     "rms_adaln",
+    # Attention
+    "na2d",
+    "na3d",
     # Quantization / dequantization
     "quantize_per_tensor_fp8",
     "dequantize_per_tensor_fp8",
@@ -145,6 +145,11 @@ def na2d(
     tensors; equivalent to ``na3d`` with a singleton, non-causal T axis."""
     if is_causal is None:
         is_causal = [False, False]
+    # Checked here: both lists gain a T entry below, hiding a wrong length.
+    if len(kernel_size) != 2:
+        raise ValueError(f"na2d kernel_size must have 2 elements, got {len(kernel_size)}")
+    if len(is_causal) != 2:
+        raise ValueError(f"na2d is_causal must have 2 elements, got {len(is_causal)}")
     out = torch.ops.comfy_kitchen.na3d(
         q.unsqueeze(1), k.unsqueeze(1), v.unsqueeze(1),
         [1, *kernel_size], [False, *is_causal], scale,

--- a/comfy_kitchen/__init__.py
+++ b/comfy_kitchen/__init__.py
@@ -37,6 +37,9 @@ else:
 __all__ = [
     # Normalization
     "adaln",
+    # Attention
+    "na3d",
+    "na2d",
     "rms_adaln",
     # Quantization / dequantization
     "quantize_per_tensor_fp8",
@@ -97,6 +100,56 @@ __all__ = [
 # =============================================================================
 # Public API Functions
 # =============================================================================
+
+
+def na3d(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    kernel_size: list[int],
+    is_causal: list[bool] | None = None,
+    scale: float | None = None,
+) -> torch.Tensor:
+    """3D neighborhood attention (NATTEN ``na3d`` semantics, dilation 1).
+
+    Per non-causal axis each query attends a window of exactly
+    ``kernel_size`` positions centered on it, shifted inward at grid
+    boundaries (kernels larger than an axis clamp to that axis); per causal
+    axis it attends the ``min(i + 1, kernel_size)`` nearest previous
+    positions. RoPE/normalization are the caller's responsibility.
+
+    Args:
+        q, k, v: ``(B, T, H, W, num_heads, head_dim)`` tensors, same shape/dtype.
+        kernel_size: Per-axis window sizes ``[k_t, k_h, k_w]``.
+        is_causal: Per-axis causal flags; None means non-causal everywhere.
+        scale: Score scale; None means ``head_dim ** -0.5``. Pass 1.0 for
+            pre-scaled queries.
+
+    Returns:
+        ``(B, T, H, W, num_heads, head_dim)`` attention output.
+    """
+    if is_causal is None:
+        is_causal = [False, False, False]
+    return torch.ops.comfy_kitchen.na3d(q, k, v, kernel_size, is_causal, scale)
+
+
+def na2d(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    kernel_size: list[int],
+    is_causal: list[bool] | None = None,
+    scale: float | None = None,
+) -> torch.Tensor:
+    """2D neighborhood attention over ``(B, H, W, num_heads, head_dim)``
+    tensors; equivalent to ``na3d`` with a singleton, non-causal T axis."""
+    if is_causal is None:
+        is_causal = [False, False]
+    out = torch.ops.comfy_kitchen.na3d(
+        q.unsqueeze(1), k.unsqueeze(1), v.unsqueeze(1),
+        [1, *kernel_size], [False, *is_causal], scale,
+    )
+    return out.squeeze(1)
 
 
 def adaln(

--- a/comfy_kitchen/__init__.py
+++ b/comfy_kitchen/__init__.py
@@ -114,8 +114,8 @@ def na3d(
     q: torch.Tensor,
     k: torch.Tensor,
     v: torch.Tensor,
-    kernel_size: list[int],
-    is_causal: list[bool] | None = None,
+    kernel_size: int | list[int],
+    is_causal: bool | list[bool] | None = None,
     scale: float | None = None,
 ) -> torch.Tensor:
     """3D neighborhood attention (NATTEN ``na3d`` semantics, dilation 1).
@@ -128,16 +128,22 @@ def na3d(
 
     Args:
         q, k, v: ``(B, T, H, W, num_heads, head_dim)`` tensors, same shape/dtype.
-        kernel_size: Per-axis window sizes ``[k_t, k_h, k_w]``.
-        is_causal: Per-axis causal flags; None means non-causal everywhere.
+        kernel_size: Per-axis window sizes ``[k_t, k_h, k_w]``; a bare int
+            repeats across the axes (NATTEN convention).
+        is_causal: Per-axis causal flags; a bare bool repeats across the axes;
+            None means non-causal everywhere.
         scale: Score scale; None means ``head_dim ** -0.5``. Pass 1.0 for
             pre-scaled queries.
 
     Returns:
         ``(B, T, H, W, num_heads, head_dim)`` attention output.
     """
+    if isinstance(kernel_size, int):
+        kernel_size = [kernel_size] * 3
     if is_causal is None:
         is_causal = [False, False, False]
+    elif isinstance(is_causal, bool):
+        is_causal = [is_causal] * 3
     return torch.ops.comfy_kitchen.na3d(q, k, v, kernel_size, is_causal, scale)
 
 
@@ -145,14 +151,19 @@ def na2d(
     q: torch.Tensor,
     k: torch.Tensor,
     v: torch.Tensor,
-    kernel_size: list[int],
-    is_causal: list[bool] | None = None,
+    kernel_size: int | list[int],
+    is_causal: bool | list[bool] | None = None,
     scale: float | None = None,
 ) -> torch.Tensor:
     """2D neighborhood attention over ``(B, H, W, num_heads, head_dim)``
-    tensors; equivalent to ``na3d`` with a singleton, non-causal T axis."""
+    tensors; equivalent to ``na3d`` with a singleton, non-causal T axis.
+    Bare-scalar ``kernel_size``/``is_causal`` repeat across both axes."""
+    if isinstance(kernel_size, int):
+        kernel_size = [kernel_size] * 2
     if is_causal is None:
         is_causal = [False, False]
+    elif isinstance(is_causal, bool):
+        is_causal = [is_causal] * 2
     # Checked here: both lists gain a T entry below, hiding a wrong length.
     if len(kernel_size) != 2:
         raise ValueError(f"na2d kernel_size must have 2 elements, got {len(kernel_size)}")

--- a/comfy_kitchen/backends/cuda/CMakeLists.txt
+++ b/comfy_kitchen/backends/cuda/CMakeLists.txt
@@ -131,6 +131,7 @@ set(CUDA_SOURCES
     ops/convrot_w4a4.cu
     ops/turing_int4.cu
     ops/rms_rope.cu
+    ops/na3d.cu
     ops/quantize_svdquant_w4a4.cu
     ops/scaled_mm_svdquant_w4a4.cu
     ops/awq_w4a16.cu

--- a/comfy_kitchen/backends/cuda/__init__.py
+++ b/comfy_kitchen/backends/cuda/__init__.py
@@ -27,6 +27,7 @@ from comfy_kitchen._rope_utils import (
 )
 
 __all__ = [
+    "na3d",
     "adaln",
     "rms_adaln",
     "apply_rope",
@@ -1943,6 +1944,40 @@ def int8_linear(
     return out if is_2d_output else out.reshape(*orig_shape[:-1], n)
 
 
+def na3d(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    kernel_size: list[int],
+    is_causal: list[bool] | None = None,
+    scale: float | None = None,
+) -> torch.Tensor:
+    """Fused 3D neighborhood attention (NATTEN ``na3d`` semantics) over
+    ``(B, T, H, W, NH, HD)`` tensors. See ops/na3d.cu."""
+    causal = [False, False, False] if is_causal is None else list(is_causal)
+    batch, t, h, w, nh, hd = q.shape
+    if scale is None:
+        scale = hd ** -0.5
+    q = q.contiguous()
+    k = k.contiguous()
+    v = v.contiguous()
+    out = torch.empty_like(q)
+    stream_ptr = torch.cuda.current_stream(q.device).cuda_stream
+    _C.na3d(
+        _wrap_for_dlpack(q),
+        _wrap_for_dlpack(k),
+        _wrap_for_dlpack(v),
+        _wrap_for_dlpack(out),
+        batch, t, h, w, nh, hd,
+        int(kernel_size[0]), int(kernel_size[1]), int(kernel_size[2]),
+        int(causal[0]), int(causal[1]), int(causal[2]),
+        float(scale),
+        DTYPE_TO_CODE[q.dtype],
+        stream_ptr,
+    )
+    return out
+
+
 def _adaln_impl(kernel, x: torch.Tensor, scale: torch.Tensor, shift: torch.Tensor, eps: float):
     orig_shape = x.shape
     d = x.shape[-1]
@@ -2626,9 +2661,41 @@ def gemv_awq_w4a16(
 
 
 def _build_constraints() -> dict:
+    def _na3d_call_rule(kwargs):
+        q = kwargs.get("q")
+        if q is not None:
+            hd = q.shape[-1]
+            if hd % 16 != 0 or hd > 64:
+                return ValidationResult.fail("q", "head_dim must be a multiple of 16 and <= 64")
+            if q.shape[1] * q.shape[2] > 65535 or q.shape[0] * q.shape[4] > 65535:
+                return ValidationResult.fail("q", "grid dims exceed CUDA limits")
+        kernel_size = kwargs.get("kernel_size")
+        if kernel_size is not None and len(kernel_size) != 3:
+            return ValidationResult.fail("kernel_size", "must have 3 elements")
+        return ValidationResult.ok()
+
     cuda_devices = frozenset({"cuda"})
 
     constraints = {
+        "na3d": FunctionConstraints(
+            params={
+                "q": ParamConstraint(
+                    dtypes=frozenset({torch.float16, torch.bfloat16}),
+                    shape_rules=(ExactDims(6),),
+                ),
+                "k": ParamConstraint(
+                    dtypes=frozenset({torch.float16, torch.bfloat16}),
+                    shape_rules=(ExactDims(6),),
+                ),
+                "v": ParamConstraint(
+                    dtypes=frozenset({torch.float16, torch.bfloat16}),
+                    shape_rules=(ExactDims(6),),
+                ),
+            },
+            default_devices=cuda_devices,
+            min_compute_capability=(8, 0),
+            call_rules=(_na3d_call_rule,),
+        ),
         "adaln": FunctionConstraints(
             params={
                 "x": ParamConstraint(

--- a/comfy_kitchen/backends/cuda/__init__.py
+++ b/comfy_kitchen/backends/cuda/__init__.py
@@ -155,6 +155,7 @@ from comfy_kitchen.backends._activations import (  # noqa: E402
 )
 from comfy_kitchen.backends._modulation import adaln_prep_modulation  # noqa: E402
 from comfy_kitchen.backends.eager import rope as _eager_rope  # noqa: E402
+from comfy_kitchen.backends.eager.na import na3d_common_call_rule  # noqa: E402
 from comfy_kitchen.backends.eager.quantization import (  # noqa: E402
     DTYPE_CODE_TO_DTYPE,
     DTYPE_TO_CODE,
@@ -2662,6 +2663,9 @@ def gemv_awq_w4a16(
 
 def _build_constraints() -> dict:
     def _na3d_call_rule(kwargs):
+        common = na3d_common_call_rule(kwargs)
+        if not common.success:
+            return common
         q = kwargs.get("q")
         if q is not None:
             hd = q.shape[-1]
@@ -2669,9 +2673,6 @@ def _build_constraints() -> dict:
                 return ValidationResult.fail("q", "head_dim must be a multiple of 16 and <= 64")
             if q.shape[1] * q.shape[2] > 65535 or q.shape[0] * q.shape[4] > 65535:
                 return ValidationResult.fail("q", "grid dims exceed CUDA limits")
-        kernel_size = kwargs.get("kernel_size")
-        if kernel_size is not None and len(kernel_size) != 3:
-            return ValidationResult.fail("kernel_size", "must have 3 elements")
         return ValidationResult.ok()
 
     cuda_devices = frozenset({"cuda"})

--- a/comfy_kitchen/backends/cuda/__init__.py
+++ b/comfy_kitchen/backends/cuda/__init__.py
@@ -159,7 +159,6 @@ from comfy_kitchen.backends._activations import (  # noqa: E402
 )
 from comfy_kitchen.backends._modulation import adaln_prep_modulation  # noqa: E402
 from comfy_kitchen.backends.eager import rope as _eager_rope  # noqa: E402
-from comfy_kitchen.backends.eager.na import na3d_common_call_rule  # noqa: E402
 from comfy_kitchen.backends.eager.quantization import (  # noqa: E402
     DTYPE_CODE_TO_DTYPE,
     DTYPE_TO_CODE,
@@ -190,6 +189,7 @@ from comfy_kitchen.constraints import (  # noqa: E402
     MinDims,
     ParamConstraint,
     ValidationResult,
+    na3d_common_call_rule,
 )
 from comfy_kitchen.float_utils import roundup  # noqa: E402
 from comfy_kitchen.registry import registry  # noqa: E402

--- a/comfy_kitchen/backends/cuda/dlpack_bindings.cpp
+++ b/comfy_kitchen/backends/cuda/dlpack_bindings.cpp
@@ -221,6 +221,14 @@ extern "C" {
         int dtype_code,
         cudaStream_t stream);
 
+    // Fused 3D neighborhood attention — see ops/na3d.cu.
+    void launch_na3d_kernel(
+        const void* q, const void* k, const void* v, void* out,
+        int batch, int t_size, int h_size, int w_size, int num_heads, int head_dim,
+        int kt, int kh, int kw,
+        int causal_t, int causal_h, int causal_w,
+        float scale, int dtype_code, cudaStream_t stream);
+
     // Fused AdaLN — see ops/adaln.cu. subtract_mean selects LayerNorm (true)
     // or RMSNorm (false) statistics.
     void launch_adaln_kernel(
@@ -909,6 +917,28 @@ void awq_w4a16(
     launch_awq_w4a16_kernel(
         x.data(), qweight.data(), wscales.data(), wzeros.data(), out.data(),
         M, N, K, group_size, dtype_code, stream);
+}
+
+// Nanobind wrapper for fused 3D neighborhood attention
+void na3d(
+    nb::ndarray<nb::device::cuda> q,
+    nb::ndarray<nb::device::cuda> k,
+    nb::ndarray<nb::device::cuda> v,
+    nb::ndarray<nb::device::cuda> out,
+    int64_t batch, int64_t t_size, int64_t h_size, int64_t w_size,
+    int64_t num_heads, int64_t head_dim,
+    int64_t kt, int64_t kh, int64_t kw,
+    int causal_t, int causal_h, int causal_w,
+    float scale,
+    int dtype_code,
+    uintptr_t stream_ptr)
+{
+    cudaStream_t stream = reinterpret_cast<cudaStream_t>(stream_ptr);
+    launch_na3d_kernel(
+        q.data(), k.data(), v.data(), out.data(),
+        (int)batch, (int)t_size, (int)h_size, (int)w_size, (int)num_heads, (int)head_dim,
+        (int)kt, (int)kh, (int)kw, causal_t, causal_h, causal_w,
+        scale, dtype_code, stream);
 }
 
 // Nanobind wrapper for fused AdaLN (LayerNorm statistics)
@@ -2694,6 +2724,15 @@ NB_MODULE(_C, m) {
           nb::arg("out"),
           nb::arg("group_size"),
           nb::arg("stream_ptr"));
+
+    m.def("na3d", &na3d,
+          "Fused 3D neighborhood attention (NATTEN na3d semantics)",
+          nb::arg("q"), nb::arg("k"), nb::arg("v"), nb::arg("out"),
+          nb::arg("batch"), nb::arg("t_size"), nb::arg("h_size"), nb::arg("w_size"),
+          nb::arg("num_heads"), nb::arg("head_dim"),
+          nb::arg("kt"), nb::arg("kh"), nb::arg("kw"),
+          nb::arg("causal_t"), nb::arg("causal_h"), nb::arg("causal_w"),
+          nb::arg("scale"), nb::arg("dtype_code"), nb::arg("stream_ptr"));
 
     m.def("adaln", &adaln,
           "Fused AdaLN: layernorm(x) * (1 + scale) + shift",

--- a/comfy_kitchen/backends/cuda/ops/na3d.cu
+++ b/comfy_kitchen/backends/cuda/ops/na3d.cu
@@ -1,0 +1,382 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Fused 3D neighborhood attention (NATTEN na3d semantics, dilation 1).
+//
+// Per non-causal axis each query attends a window of exactly kernel_size
+// positions centered on it, shifted inward at grid boundaries; per causal
+// axis it attends the min(i+1, kernel_size) nearest previous positions.
+//
+// Flash-attention-2 style: one block covers a run of BQ=64 queries along W
+// at a fixed (t, h), four warps each owning 16 query rows. Because the
+// mma.sync.m16n8k16 thread<->element mapping is documented, the score tile,
+// softmax statistics (m, l), the P operand, and the output accumulator all
+// live in registers for the whole kernel -- shared memory only stages the
+// K tile and a transposed V tile, and the only barriers guard that staging.
+// The T/H windows are scalar per block (key loops visit only valid planes);
+// per-element masking is needed on the W axis alone.
+//
+// Requires sm80+ (bf16 mma / f32 accumulators). head_dim in {16,32,48,64}.
+// Layout: q/k/v/out are contiguous (B, T, H, W, NH, HD).
+
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <cuda_bf16.h>
+
+#include <cstdint>
+
+namespace {
+
+constexpr int BQ = 64;         // queries per block (W run); 16 per warp
+constexpr int BK = 32;         // keys per inner tile (4 n8 mma tiles)
+constexpr int NTHREADS = 128;  // 4 warps
+constexpr float NEG_INF = -3.0e38f;
+
+__host__ __device__ inline int imin(int a, int b) { return a < b ? a : b; }
+__host__ __device__ inline int imax(int a, int b) { return a > b ? a : b; }
+
+__device__ inline void axis_window(int i, int k, int len, bool causal, int& lo, int& hi) {
+    if (causal) {
+        lo = imax(i - k + 1, 0);
+        hi = i + 1;
+    } else {
+        lo = imin(imax(i - k / 2, 0), len - k);
+        hi = lo + k;
+    }
+}
+
+template <typename T> struct MmaTraits;
+
+template <> struct MmaTraits<__half> {
+    static __device__ inline void mma(float* d, const uint32_t* a, const uint32_t* b) {
+        asm volatile(
+            "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 "
+            "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%0,%1,%2,%3};"
+            : "+f"(d[0]), "+f"(d[1]), "+f"(d[2]), "+f"(d[3])
+            : "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]), "r"(b[0]), "r"(b[1]));
+    }
+    static __device__ inline uint32_t pack(float lo, float hi) {
+        __half2 p = __floats2half2_rn(lo, hi);
+        return *reinterpret_cast<uint32_t*>(&p);
+    }
+};
+
+template <> struct MmaTraits<__nv_bfloat16> {
+    static __device__ inline void mma(float* d, const uint32_t* a, const uint32_t* b) {
+        asm volatile(
+            "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 "
+            "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%0,%1,%2,%3};"
+            : "+f"(d[0]), "+f"(d[1]), "+f"(d[2]), "+f"(d[3])
+            : "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]), "r"(b[0]), "r"(b[1]));
+    }
+    static __device__ inline uint32_t pack(float lo, float hi) {
+        __nv_bfloat162 p = __floats2bfloat162_rn(lo, hi);
+        return *reinterpret_cast<uint32_t*>(&p);
+    }
+};
+
+// mma.m16n8k16 fragment maps (PTX ISA), lane = g*4 + q (g = lane>>2, q = lane&3):
+//   A (16x16):  a0=(g, 2q..2q+1) a1=(g+8, 2q..2q+1) a2=(g, 2q+8..2q+9) a3=(g+8, 2q+8..2q+9)
+//   B (16x8):   b0=(k=2q..2q+1, n=g) b1=(k=2q+8..2q+9, n=g)   (packed along k)
+//   C (16x8):   c0=(g, 2q) c1=(g, 2q+1) c2=(g+8, 2q) c3=(g+8, 2q+1)   (f32)
+
+template <typename T, int HD>
+__global__ void __launch_bounds__(NTHREADS) na3d_kernel(
+    const T* __restrict__ q,
+    const T* __restrict__ k,
+    const T* __restrict__ v,
+    T* __restrict__ out,
+    int t_size, int h_size, int w_size, int num_heads,
+    int64_t s_b, int64_t s_t, int64_t s_h, int64_t s_w, int64_t s_n,
+    int kt, int kh, int kw,
+    bool causal_t, bool causal_h, bool causal_w,
+    float scale)
+{
+#if !defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 800
+    constexpr int KC = HD / 16;   // k-chunks for S = Q.K^T
+    constexpr int NT = HD / 8;    // n8 output tiles for O += P.V
+    constexpr int LDK = HD + 8;   // sK row stride (elements)
+    constexpr int LDV = BK + 8;   // sVt row stride (elements)
+
+    __shared__ T sK[BK * LDK];
+    __shared__ T sVt[HD * LDV];  // transposed V: sVt[col][key]
+
+    const int tid = threadIdx.x;
+    const int warp = tid >> 5;
+    const int lane = tid & 31;
+    const int g = lane >> 2;    // fragment row within m16 tiles
+    const int qd = lane & 3;    // quad thread: column pairs
+
+    const int t_q = blockIdx.y / h_size;
+    const int h_q = blockIdx.y % h_size;
+    const int64_t base = (int64_t)(blockIdx.z / num_heads) * s_b + (int64_t)(blockIdx.z % num_heads) * s_n;
+
+    const int w0 = blockIdx.x * BQ;
+    const int n_valid_q = imin(BQ, w_size - w0);
+
+    int t_lo, t_hi, h_lo, h_hi;
+    axis_window(t_q, kt, t_size, causal_t, t_lo, t_hi);
+    axis_window(h_q, kh, h_size, causal_h, h_lo, h_hi);
+
+    // This thread's two query rows (block-local r_blk, r_blk + 8).
+    const int r_blk = warp * 16 + g;
+    int wq_r[2], ws_r[2], we_r[2];
+    {
+        wq_r[0] = imin(w0 + r_blk, w_size - 1);
+        wq_r[1] = imin(w0 + r_blk + 8, w_size - 1);
+        int lo, hi;
+        axis_window(wq_r[0], kw, w_size, causal_w, lo, hi); ws_r[0] = lo; we_r[0] = hi;
+        axis_window(wq_r[1], kw, w_size, causal_w, lo, hi); ws_r[1] = lo; we_r[1] = hi;
+    }
+    // Block sweep range: window start of the first query, end of the last valid.
+    int w_lo, w_hi;
+    {
+        int lo0, hi0, lo1, hi1;
+        axis_window(imin(w0, w_size - 1), kw, w_size, causal_w, lo0, hi0);
+        axis_window(imin(w0 + BQ - 1, w_size - 1), kw, w_size, causal_w, lo1, hi1);
+        w_lo = lo0;
+        w_hi = hi1;
+    }
+
+    // Q operand fragments: loaded once, register-resident for the whole
+    // kernel. Out-of-range rows clamp to a real row (never stored back).
+    uint32_t qa[KC][4];
+    {
+        const int64_t qrow = base + (int64_t)t_q * s_t + (int64_t)h_q * s_h;
+        const int64_t row0 = qrow + (int64_t)wq_r[0] * s_w;
+        const int64_t row1 = qrow + (int64_t)wq_r[1] * s_w;
+        #pragma unroll
+        for (int kc = 0; kc < KC; ++kc) {
+            const int c0 = kc * 16 + qd * 2;
+            qa[kc][0] = *reinterpret_cast<const uint32_t*>(q + row0 + c0);
+            qa[kc][1] = *reinterpret_cast<const uint32_t*>(q + row1 + c0);
+            qa[kc][2] = *reinterpret_cast<const uint32_t*>(q + row0 + c0 + 8);
+            qa[kc][3] = *reinterpret_cast<const uint32_t*>(q + row1 + c0 + 8);
+        }
+    }
+
+    float o_acc[NT][4];
+    #pragma unroll
+    for (int nt = 0; nt < NT; ++nt) {
+        o_acc[nt][0] = 0.f; o_acc[nt][1] = 0.f; o_acc[nt][2] = 0.f; o_acc[nt][3] = 0.f;
+    }
+    float m_r[2] = {NEG_INF, NEG_INF};
+    float l_r[2] = {0.f, 0.f};
+
+    for (int tk = t_lo; tk < t_hi; ++tk) {
+        for (int hk = h_lo; hk < h_hi; ++hk) {
+            const int64_t plane = base + (int64_t)tk * s_t + (int64_t)hk * s_h;
+            for (int wk0 = w_lo; wk0 < w_hi; wk0 += BK) {
+                const int n_valid_k = imin(BK, w_hi - wk0);
+
+                // Stage K (row-major) and V (transposed) tiles cooperatively.
+                {
+                    constexpr int VECS = HD / 8;
+                    for (int idx = tid; idx < BK * VECS; idx += NTHREADS) {
+                        const int r = idx / VECS, c8 = idx % VECS;
+                        uint4 kv = make_uint4(0u, 0u, 0u, 0u);
+                        uint4 vv = make_uint4(0u, 0u, 0u, 0u);
+                        if (r < n_valid_k) {
+                            const int64_t off = plane + (int64_t)(wk0 + r) * s_w + c8 * 8;
+                            kv = *reinterpret_cast<const uint4*>(k + off);
+                            vv = *reinterpret_cast<const uint4*>(v + off);
+                        }
+                        *reinterpret_cast<uint4*>(sK + r * LDK + c8 * 8) = kv;
+                        const T* ve = reinterpret_cast<const T*>(&vv);
+                        #pragma unroll
+                        for (int e = 0; e < 8; ++e)
+                            sVt[(c8 * 8 + e) * LDV + r] = ve[e];
+                    }
+                }
+                __syncthreads();
+
+                // S = Q.K^T: 4 n8 tiles of 16x8, accumulated in registers.
+                float s_acc[4][4];
+                #pragma unroll
+                for (int nt = 0; nt < 4; ++nt) {
+                    s_acc[nt][0] = 0.f; s_acc[nt][1] = 0.f; s_acc[nt][2] = 0.f; s_acc[nt][3] = 0.f;
+                    const T* krow = sK + (nt * 8 + g) * LDK;
+                    #pragma unroll
+                    for (int kc = 0; kc < KC; ++kc) {
+                        uint32_t kb[2];
+                        kb[0] = *reinterpret_cast<const uint32_t*>(krow + kc * 16 + qd * 2);
+                        kb[1] = *reinterpret_cast<const uint32_t*>(krow + kc * 16 + qd * 2 + 8);
+                        MmaTraits<T>::mma(s_acc[nt], qa[kc], kb);
+                    }
+                }
+
+                // Masked online softmax, entirely in registers. This thread's
+                // score columns are wk0 + nt*8 + 2*qd (+1) for rows g / g+8.
+                float p_val[4][4];
+                float m_new[2] = {m_r[0], m_r[1]};
+                #pragma unroll
+                for (int nt = 0; nt < 4; ++nt) {
+                    const int c0 = wk0 + nt * 8 + qd * 2;
+                    #pragma unroll
+                    for (int e = 0; e < 4; ++e) {
+                        const int row = e >> 1;          // c0,c1 -> row g; c2,c3 -> row g+8
+                        const int wk = c0 + (e & 1);
+                        const bool vis = wk >= ws_r[row] && wk < we_r[row] && (wk - wk0) < n_valid_k;
+                        const float s = vis ? s_acc[nt][e] * scale : NEG_INF;
+                        p_val[nt][e] = s;
+                        m_new[row] = fmaxf(m_new[row], s);
+                    }
+                }
+                // Row max across the quad (a row's columns live in 4 lanes).
+                #pragma unroll
+                for (int off = 1; off <= 2; off <<= 1) {
+                    m_new[0] = fmaxf(m_new[0], __shfl_xor_sync(0xffffffffu, m_new[0], off));
+                    m_new[1] = fmaxf(m_new[1], __shfl_xor_sync(0xffffffffu, m_new[1], off));
+                }
+                const float alpha0 = __expf(m_r[0] - m_new[0]);
+                const float alpha1 = __expf(m_r[1] - m_new[1]);
+                m_r[0] = m_new[0];
+                m_r[1] = m_new[1];
+                float l_add[2] = {0.f, 0.f};
+                #pragma unroll
+                for (int nt = 0; nt < 4; ++nt) {
+                    #pragma unroll
+                    for (int e = 0; e < 4; ++e) {
+                        const int row = e >> 1;
+                        const float p = (p_val[nt][e] <= NEG_INF) ? 0.f : __expf(p_val[nt][e] - m_new[row]);
+                        p_val[nt][e] = p;
+                        l_add[row] += p;
+                    }
+                }
+                #pragma unroll
+                for (int off = 1; off <= 2; off <<= 1) {
+                    l_add[0] += __shfl_xor_sync(0xffffffffu, l_add[0], off);
+                    l_add[1] += __shfl_xor_sync(0xffffffffu, l_add[1], off);
+                }
+                l_r[0] = l_r[0] * alpha0 + l_add[0];
+                l_r[1] = l_r[1] * alpha1 + l_add[1];
+
+                // Rescale output accumulators (c0,c1 -> row g; c2,c3 -> g+8).
+                #pragma unroll
+                for (int nt = 0; nt < NT; ++nt) {
+                    o_acc[nt][0] *= alpha0; o_acc[nt][1] *= alpha0;
+                    o_acc[nt][2] *= alpha1; o_acc[nt][3] *= alpha1;
+                }
+
+                // P operand fragments: pure register repack of the score tile.
+                // k-step kk covers keys kk*16..+15 = score tiles 2kk, 2kk+1.
+                uint32_t pa[2][4];
+                #pragma unroll
+                for (int kk = 0; kk < 2; ++kk) {
+                    pa[kk][0] = MmaTraits<T>::pack(p_val[2 * kk][0], p_val[2 * kk][1]);
+                    pa[kk][1] = MmaTraits<T>::pack(p_val[2 * kk][2], p_val[2 * kk][3]);
+                    pa[kk][2] = MmaTraits<T>::pack(p_val[2 * kk + 1][0], p_val[2 * kk + 1][1]);
+                    pa[kk][3] = MmaTraits<T>::pack(p_val[2 * kk + 1][2], p_val[2 * kk + 1][3]);
+                }
+
+                // O += P.V via transposed-V fragments (32-bit loads along keys).
+                #pragma unroll
+                for (int nt = 0; nt < NT; ++nt) {
+                    const T* vcol = sVt + (nt * 8 + g) * LDV;
+                    #pragma unroll
+                    for (int kk = 0; kk < 2; ++kk) {
+                        uint32_t vb[2];
+                        vb[0] = *reinterpret_cast<const uint32_t*>(vcol + kk * 16 + qd * 2);
+                        vb[1] = *reinterpret_cast<const uint32_t*>(vcol + kk * 16 + qd * 2 + 8);
+                        MmaTraits<T>::mma(o_acc[nt], pa[kk], vb);
+                    }
+                }
+                __syncthreads();
+            }
+        }
+    }
+
+    // Epilogue: divide by l and store this thread's (row, col) elements.
+    const float inv_l0 = 1.f / fmaxf(l_r[0], 1e-30f);
+    const float inv_l1 = 1.f / fmaxf(l_r[1], 1e-30f);
+    const int64_t orow = base + (int64_t)t_q * s_t + (int64_t)h_q * s_h;
+    #pragma unroll
+    for (int rr = 0; rr < 2; ++rr) {
+        const int r = r_blk + rr * 8;
+        if (r >= n_valid_q)
+            continue;
+        const float inv_l = rr ? inv_l1 : inv_l0;
+        T* orow_p = out + orow + (int64_t)(w0 + r) * s_w;
+        #pragma unroll
+        for (int nt = 0; nt < NT; ++nt) {
+            const int c = nt * 8 + qd * 2;
+            *reinterpret_cast<uint32_t*>(orow_p + c) =
+                MmaTraits<T>::pack(o_acc[nt][rr * 2] * inv_l, o_acc[nt][rr * 2 + 1] * inv_l);
+        }
+    }
+#endif  // __CUDA_ARCH__ >= 800 (bf16 mma; dispatch constraints require sm80+)
+}
+
+template <typename T>
+void launch_na3d_typed(
+    const void* q, const void* k, const void* v, void* out,
+    int t_size, int h_size, int w_size, int num_heads, int head_dim,
+    int64_t s_b, int64_t s_t, int64_t s_h, int64_t s_w, int64_t s_n,
+    int kt, int kh, int kw,
+    bool causal_t, bool causal_h, bool causal_w,
+    float scale, int batch, cudaStream_t stream)
+{
+    const dim3 grid((w_size + BQ - 1) / BQ, t_size * h_size, batch * num_heads);
+
+#define NA3D_LAUNCH(HD_)                                                                    \
+    na3d_kernel<T, HD_><<<grid, NTHREADS, 0, stream>>>(                                     \
+        reinterpret_cast<const T*>(q), reinterpret_cast<const T*>(k),                       \
+        reinterpret_cast<const T*>(v), reinterpret_cast<T*>(out),                           \
+        t_size, h_size, w_size, num_heads, s_b, s_t, s_h, s_w, s_n,                         \
+        kt, kh, kw, causal_t, causal_h, causal_w, scale)
+
+    switch (head_dim) {
+        case 16: NA3D_LAUNCH(16); break;
+        case 32: NA3D_LAUNCH(32); break;
+        case 48: NA3D_LAUNCH(48); break;
+        case 64: NA3D_LAUNCH(64); break;
+        default: break;  // constrained out by the dispatcher
+    }
+#undef NA3D_LAUNCH
+}
+
+}  // namespace
+
+extern "C" void launch_na3d_kernel(
+    const void* q, const void* k, const void* v, void* out,
+    int batch, int t_size, int h_size, int w_size, int num_heads, int head_dim,
+    int kt, int kh, int kw,
+    int causal_t, int causal_h, int causal_w,
+    float scale, int dtype_code, cudaStream_t stream)
+{
+    // Contiguous (B, T, H, W, NH, HD) strides.
+    const int64_t s_n = head_dim;
+    const int64_t s_w = (int64_t)num_heads * head_dim;
+    const int64_t s_h = (int64_t)w_size * s_w;
+    const int64_t s_t = (int64_t)h_size * s_h;
+    const int64_t s_b = (int64_t)t_size * s_t;
+
+    // Non-causal kernels clamp to the axis length (NATTEN would reject this).
+    const int ckt = causal_t ? kt : imin(kt, t_size);
+    const int ckh = causal_h ? kh : imin(kh, h_size);
+    const int ckw = causal_w ? kw : imin(kw, w_size);
+
+    if (dtype_code == 1) {
+        launch_na3d_typed<__half>(q, k, v, out, t_size, h_size, w_size, num_heads, head_dim,
+                                  s_b, s_t, s_h, s_w, s_n, ckt, ckh, ckw,
+                                  causal_t != 0, causal_h != 0, causal_w != 0, scale, batch, stream);
+    } else if (dtype_code == 2) {
+        launch_na3d_typed<__nv_bfloat16>(q, k, v, out, t_size, h_size, w_size, num_heads, head_dim,
+                                         s_b, s_t, s_h, s_w, s_n, ckt, ckh, ckw,
+                                         causal_t != 0, causal_h != 0, causal_w != 0, scale, batch, stream);
+    }
+}

--- a/comfy_kitchen/backends/cuda/ops/na3d.cu
+++ b/comfy_kitchen/backends/cuda/ops/na3d.cu
@@ -21,14 +21,10 @@
 // positions centered on it, shifted inward at grid boundaries; per causal
 // axis it attends the min(i+1, kernel_size) nearest previous positions.
 //
-// Flash-attention-2 style: one block covers a run of BQ=64 queries along W
-// at a fixed (t, h), four warps each owning 16 query rows. Because the
-// mma.sync.m16n8k16 thread<->element mapping is documented, the score tile,
-// softmax statistics (m, l), the P operand, and the output accumulator all
-// live in registers for the whole kernel -- shared memory only stages the
-// K tile and a transposed V tile, and the only barriers guard that staging.
-// The T/H windows are scalar per block (key loops visit only valid planes);
-// per-element masking is needed on the W axis alone.
+// Flash-attention-2 style: one block covers BQ queries along W at a fixed
+// (t, h), 16 rows per warp. Scores, softmax stats, P and the accumulator stay
+// in registers; shared memory only stages K and V^T. T/H windows are scalar
+// per block, so only W needs per-element masking.
 //
 // Requires sm80+ (bf16 mma / f32 accumulators). head_dim in {16,32,48,64}.
 // Layout: q/k/v/out are contiguous (B, T, H, W, NH, HD).
@@ -38,13 +34,17 @@
 #include <cuda_bf16.h>
 
 #include <cstdint>
+#include <stdexcept>
+#include <string>
 
 namespace {
 
-constexpr int BQ = 64;         // queries per block (W run); 16 per warp
 constexpr int BK = 32;         // keys per inner tile (4 n8 mma tiles)
-constexpr int NTHREADS = 128;  // 4 warps
 constexpr float NEG_INF = -3.0e38f;
+
+// BQ (queries per block along W) is a template parameter, 16 rows per warp.
+__host__ __device__ constexpr int warps_for(int bq) { return bq / 16; }
+__host__ __device__ constexpr int threads_for(int bq) { return warps_for(bq) * 32; }
 
 __host__ __device__ inline int imin(int a, int b) { return a < b ? a : b; }
 __host__ __device__ inline int imax(int a, int b) { return a > b ? a : b; }
@@ -94,8 +94,8 @@ template <> struct MmaTraits<__nv_bfloat16> {
 //   B (16x8):   b0=(k=2q..2q+1, n=g) b1=(k=2q+8..2q+9, n=g)   (packed along k)
 //   C (16x8):   c0=(g, 2q) c1=(g, 2q+1) c2=(g+8, 2q) c3=(g+8, 2q+1)   (f32)
 
-template <typename T, int HD>
-__global__ void __launch_bounds__(NTHREADS) na3d_kernel(
+template <typename T, int HD, int BQ>
+__global__ void __launch_bounds__(threads_for(BQ)) na3d_kernel(
     const T* __restrict__ q,
     const T* __restrict__ k,
     const T* __restrict__ v,
@@ -111,6 +111,7 @@ __global__ void __launch_bounds__(NTHREADS) na3d_kernel(
     constexpr int NT = HD / 8;    // n8 output tiles for O += P.V
     constexpr int LDK = HD + 8;   // sK row stride (elements)
     constexpr int LDV = BK + 8;   // sVt row stride (elements)
+    constexpr int NTHREADS = threads_for(BQ);
 
     __shared__ T sK[BK * LDK];
     __shared__ T sVt[HD * LDV];  // transposed V: sVt[col][key]
@@ -150,6 +151,15 @@ __global__ void __launch_bounds__(NTHREADS) na3d_kernel(
         axis_window(imin(w0 + BQ - 1, w_size - 1), kw, w_size, causal_w, lo1, hi1);
         w_lo = lo0;
         w_hi = hi1;
+    }
+    // Key span of this warp's 16 queries: ~16 + kw against the block's BQ + kw.
+    int warp_lo, warp_hi;
+    {
+        int lo0, hi0, lo1, hi1;
+        axis_window(imin(w0 + warp * 16, w_size - 1), kw, w_size, causal_w, lo0, hi0);
+        axis_window(imin(w0 + warp * 16 + 15, w_size - 1), kw, w_size, causal_w, lo1, hi1);
+        warp_lo = lo0;
+        warp_hi = hi1;
     }
 
     // Q operand fragments: loaded once, register-resident for the whole
@@ -204,97 +214,103 @@ __global__ void __launch_bounds__(NTHREADS) na3d_kernel(
                 }
                 __syncthreads();
 
-                // S = Q.K^T: 4 n8 tiles of 16x8, accumulated in registers.
-                float s_acc[4][4];
-                #pragma unroll
-                for (int nt = 0; nt < 4; ++nt) {
-                    s_acc[nt][0] = 0.f; s_acc[nt][1] = 0.f; s_acc[nt][2] = 0.f; s_acc[nt][3] = 0.f;
-                    const T* krow = sK + (nt * 8 + g) * LDK;
+                // Skip fully masked tiles. No barrier inside the guard -- the
+                // one closing the loop is outside, so warps still rendezvous.
+                if (wk0 + BK > warp_lo && wk0 < warp_hi) {
+
+                    // S = Q.K^T: 4 n8 tiles of 16x8, accumulated in registers.
+                    float s_acc[4][4];
                     #pragma unroll
-                    for (int kc = 0; kc < KC; ++kc) {
-                        uint32_t kb[2];
-                        kb[0] = *reinterpret_cast<const uint32_t*>(krow + kc * 16 + qd * 2);
-                        kb[1] = *reinterpret_cast<const uint32_t*>(krow + kc * 16 + qd * 2 + 8);
-                        MmaTraits<T>::mma(s_acc[nt], qa[kc], kb);
+                    for (int nt = 0; nt < 4; ++nt) {
+                        s_acc[nt][0] = 0.f; s_acc[nt][1] = 0.f; s_acc[nt][2] = 0.f; s_acc[nt][3] = 0.f;
+                        const T* krow = sK + (nt * 8 + g) * LDK;
+                        #pragma unroll
+                        for (int kc = 0; kc < KC; ++kc) {
+                            uint32_t kb[2];
+                            kb[0] = *reinterpret_cast<const uint32_t*>(krow + kc * 16 + qd * 2);
+                            kb[1] = *reinterpret_cast<const uint32_t*>(krow + kc * 16 + qd * 2 + 8);
+                            MmaTraits<T>::mma(s_acc[nt], qa[kc], kb);
+                        }
                     }
-                }
 
-                // Masked online softmax, entirely in registers. This thread's
-                // score columns are wk0 + nt*8 + 2*qd (+1) for rows g / g+8.
-                float p_val[4][4];
-                float m_new[2] = {m_r[0], m_r[1]};
-                #pragma unroll
-                for (int nt = 0; nt < 4; ++nt) {
-                    const int c0 = wk0 + nt * 8 + qd * 2;
+                    // Masked online softmax, entirely in registers. This thread's
+                    // score columns are wk0 + nt*8 + 2*qd (+1) for rows g / g+8.
+                    float p_val[4][4];
+                    float m_new[2] = {m_r[0], m_r[1]};
                     #pragma unroll
-                    for (int e = 0; e < 4; ++e) {
-                        const int row = e >> 1;          // c0,c1 -> row g; c2,c3 -> row g+8
-                        const int wk = c0 + (e & 1);
-                        const bool vis = wk >= ws_r[row] && wk < we_r[row] && (wk - wk0) < n_valid_k;
-                        const float s = vis ? s_acc[nt][e] * scale : NEG_INF;
-                        p_val[nt][e] = s;
-                        m_new[row] = fmaxf(m_new[row], s);
+                    for (int nt = 0; nt < 4; ++nt) {
+                        const int c0 = wk0 + nt * 8 + qd * 2;
+                        #pragma unroll
+                        for (int e = 0; e < 4; ++e) {
+                            const int row = e >> 1;          // c0,c1 -> row g; c2,c3 -> row g+8
+                            const int wk = c0 + (e & 1);
+                            const bool vis = wk >= ws_r[row] && wk < we_r[row] && (wk - wk0) < n_valid_k;
+                            const float s = vis ? s_acc[nt][e] * scale : NEG_INF;
+                            p_val[nt][e] = s;
+                            m_new[row] = fmaxf(m_new[row], s);
+                        }
                     }
-                }
-                // Row max across the quad (a row's columns live in 4 lanes).
-                #pragma unroll
-                for (int off = 1; off <= 2; off <<= 1) {
-                    m_new[0] = fmaxf(m_new[0], __shfl_xor_sync(0xffffffffu, m_new[0], off));
-                    m_new[1] = fmaxf(m_new[1], __shfl_xor_sync(0xffffffffu, m_new[1], off));
-                }
-                const float alpha0 = __expf(m_r[0] - m_new[0]);
-                const float alpha1 = __expf(m_r[1] - m_new[1]);
-                m_r[0] = m_new[0];
-                m_r[1] = m_new[1];
-                float l_add[2] = {0.f, 0.f};
-                #pragma unroll
-                for (int nt = 0; nt < 4; ++nt) {
+                    // Row max across the quad (a row's columns live in 4 lanes).
                     #pragma unroll
-                    for (int e = 0; e < 4; ++e) {
-                        const int row = e >> 1;
-                        const float p = (p_val[nt][e] <= NEG_INF) ? 0.f : __expf(p_val[nt][e] - m_new[row]);
-                        p_val[nt][e] = p;
-                        l_add[row] += p;
+                    for (int off = 1; off <= 2; off <<= 1) {
+                        m_new[0] = fmaxf(m_new[0], __shfl_xor_sync(0xffffffffu, m_new[0], off));
+                        m_new[1] = fmaxf(m_new[1], __shfl_xor_sync(0xffffffffu, m_new[1], off));
                     }
-                }
-                #pragma unroll
-                for (int off = 1; off <= 2; off <<= 1) {
-                    l_add[0] += __shfl_xor_sync(0xffffffffu, l_add[0], off);
-                    l_add[1] += __shfl_xor_sync(0xffffffffu, l_add[1], off);
-                }
-                l_r[0] = l_r[0] * alpha0 + l_add[0];
-                l_r[1] = l_r[1] * alpha1 + l_add[1];
+                    const float alpha0 = __expf(m_r[0] - m_new[0]);
+                    const float alpha1 = __expf(m_r[1] - m_new[1]);
+                    m_r[0] = m_new[0];
+                    m_r[1] = m_new[1];
+                    float l_add[2] = {0.f, 0.f};
+                    #pragma unroll
+                    for (int nt = 0; nt < 4; ++nt) {
+                        #pragma unroll
+                        for (int e = 0; e < 4; ++e) {
+                            const int row = e >> 1;
+                            const float p = (p_val[nt][e] <= NEG_INF) ? 0.f : __expf(p_val[nt][e] - m_new[row]);
+                            p_val[nt][e] = p;
+                            l_add[row] += p;
+                        }
+                    }
+                    #pragma unroll
+                    for (int off = 1; off <= 2; off <<= 1) {
+                        l_add[0] += __shfl_xor_sync(0xffffffffu, l_add[0], off);
+                        l_add[1] += __shfl_xor_sync(0xffffffffu, l_add[1], off);
+                    }
+                    l_r[0] = l_r[0] * alpha0 + l_add[0];
+                    l_r[1] = l_r[1] * alpha1 + l_add[1];
 
-                // Rescale output accumulators (c0,c1 -> row g; c2,c3 -> g+8).
-                #pragma unroll
-                for (int nt = 0; nt < NT; ++nt) {
-                    o_acc[nt][0] *= alpha0; o_acc[nt][1] *= alpha0;
-                    o_acc[nt][2] *= alpha1; o_acc[nt][3] *= alpha1;
-                }
+                    // Rescale output accumulators (c0,c1 -> row g; c2,c3 -> g+8).
+                    #pragma unroll
+                    for (int nt = 0; nt < NT; ++nt) {
+                        o_acc[nt][0] *= alpha0; o_acc[nt][1] *= alpha0;
+                        o_acc[nt][2] *= alpha1; o_acc[nt][3] *= alpha1;
+                    }
 
-                // P operand fragments: pure register repack of the score tile.
-                // k-step kk covers keys kk*16..+15 = score tiles 2kk, 2kk+1.
-                uint32_t pa[2][4];
-                #pragma unroll
-                for (int kk = 0; kk < 2; ++kk) {
-                    pa[kk][0] = MmaTraits<T>::pack(p_val[2 * kk][0], p_val[2 * kk][1]);
-                    pa[kk][1] = MmaTraits<T>::pack(p_val[2 * kk][2], p_val[2 * kk][3]);
-                    pa[kk][2] = MmaTraits<T>::pack(p_val[2 * kk + 1][0], p_val[2 * kk + 1][1]);
-                    pa[kk][3] = MmaTraits<T>::pack(p_val[2 * kk + 1][2], p_val[2 * kk + 1][3]);
-                }
-
-                // O += P.V via transposed-V fragments (32-bit loads along keys).
-                #pragma unroll
-                for (int nt = 0; nt < NT; ++nt) {
-                    const T* vcol = sVt + (nt * 8 + g) * LDV;
+                    // P operand fragments: pure register repack of the score tile.
+                    // k-step kk covers keys kk*16..+15 = score tiles 2kk, 2kk+1.
+                    uint32_t pa[2][4];
                     #pragma unroll
                     for (int kk = 0; kk < 2; ++kk) {
-                        uint32_t vb[2];
-                        vb[0] = *reinterpret_cast<const uint32_t*>(vcol + kk * 16 + qd * 2);
-                        vb[1] = *reinterpret_cast<const uint32_t*>(vcol + kk * 16 + qd * 2 + 8);
-                        MmaTraits<T>::mma(o_acc[nt], pa[kk], vb);
+                        pa[kk][0] = MmaTraits<T>::pack(p_val[2 * kk][0], p_val[2 * kk][1]);
+                        pa[kk][1] = MmaTraits<T>::pack(p_val[2 * kk][2], p_val[2 * kk][3]);
+                        pa[kk][2] = MmaTraits<T>::pack(p_val[2 * kk + 1][0], p_val[2 * kk + 1][1]);
+                        pa[kk][3] = MmaTraits<T>::pack(p_val[2 * kk + 1][2], p_val[2 * kk + 1][3]);
                     }
-                }
+
+                    // O += P.V via transposed-V fragments (32-bit loads along keys).
+                    #pragma unroll
+                    for (int nt = 0; nt < NT; ++nt) {
+                        const T* vcol = sVt + (nt * 8 + g) * LDV;
+                        #pragma unroll
+                        for (int kk = 0; kk < 2; ++kk) {
+                            uint32_t vb[2];
+                            vb[0] = *reinterpret_cast<const uint32_t*>(vcol + kk * 16 + qd * 2);
+                            vb[1] = *reinterpret_cast<const uint32_t*>(vcol + kk * 16 + qd * 2 + 8);
+                            MmaTraits<T>::mma(o_acc[nt], pa[kk], vb);
+                        }
+                    }
+
+                }  // warp-active tile
                 __syncthreads();
             }
         }
@@ -321,8 +337,16 @@ __global__ void __launch_bounds__(NTHREADS) na3d_kernel(
 #endif  // __CUDA_ARCH__ >= 800 (bf16 mma; dispatch constraints require sm80+)
 }
 
-template <typename T>
-void launch_na3d_typed(
+// Widest tile covering a short axis, narrowest past that -- extra width only
+// adds tiles most warps skip. Measured on sm89, W 16..256, kw 5..17.
+__host__ __device__ inline int choose_bq(int w_size) {
+    if (w_size <= 16) return 16;
+    if (w_size <= 32) return 32;
+    return 16;
+}
+
+template <typename T, int BQ>
+void launch_na3d_bq(
     const void* q, const void* k, const void* v, void* out,
     int t_size, int h_size, int w_size, int num_heads, int head_dim,
     int64_t s_b, int64_t s_t, int64_t s_h, int64_t s_w, int64_t s_n,
@@ -333,7 +357,7 @@ void launch_na3d_typed(
     const dim3 grid((w_size + BQ - 1) / BQ, t_size * h_size, batch * num_heads);
 
 #define NA3D_LAUNCH(HD_)                                                                    \
-    na3d_kernel<T, HD_><<<grid, NTHREADS, 0, stream>>>(                                     \
+    na3d_kernel<T, HD_, BQ><<<grid, threads_for(BQ), 0, stream>>>(                          \
         reinterpret_cast<const T*>(q), reinterpret_cast<const T*>(k),                       \
         reinterpret_cast<const T*>(v), reinterpret_cast<T*>(out),                           \
         t_size, h_size, w_size, num_heads, s_b, s_t, s_h, s_w, s_n,                         \
@@ -344,9 +368,33 @@ void launch_na3d_typed(
         case 32: NA3D_LAUNCH(32); break;
         case 48: NA3D_LAUNCH(48); break;
         case 64: NA3D_LAUNCH(64); break;
-        default: break;  // constrained out by the dispatcher
+        default:
+            throw std::runtime_error(
+                "na3d supports head_dim 16/32/48/64, got " + std::to_string(head_dim));
     }
 #undef NA3D_LAUNCH
+}
+
+template <typename T>
+void launch_na3d_typed(
+    const void* q, const void* k, const void* v, void* out,
+    int t_size, int h_size, int w_size, int num_heads, int head_dim,
+    int64_t s_b, int64_t s_t, int64_t s_h, int64_t s_w, int64_t s_n,
+    int kt, int kh, int kw,
+    bool causal_t, bool causal_h, bool causal_w,
+    float scale, int batch, cudaStream_t stream)
+{
+#define NA3D_DISPATCH_BQ(BQ_)                                                               \
+    launch_na3d_bq<T, BQ_>(q, k, v, out, t_size, h_size, w_size, num_heads, head_dim,       \
+                           s_b, s_t, s_h, s_w, s_n, kt, kh, kw,                             \
+                           causal_t, causal_h, causal_w, scale, batch, stream)
+
+    // Only the widths choose_bq can return are instantiated.
+    switch (choose_bq(w_size)) {
+        case 32: NA3D_DISPATCH_BQ(32); break;
+        default: NA3D_DISPATCH_BQ(16); break;
+    }
+#undef NA3D_DISPATCH_BQ
 }
 
 }  // namespace
@@ -378,5 +426,8 @@ extern "C" void launch_na3d_kernel(
         launch_na3d_typed<__nv_bfloat16>(q, k, v, out, t_size, h_size, w_size, num_heads, head_dim,
                                          s_b, s_t, s_h, s_w, s_n, ckt, ckh, ckw,
                                          causal_t != 0, causal_h != 0, causal_w != 0, scale, batch, stream);
+    } else {
+        throw std::runtime_error(
+            "na3d supports FP16/BF16 only, got dtype code " + std::to_string(dtype_code));
     }
 }

--- a/comfy_kitchen/backends/eager/__init__.py
+++ b/comfy_kitchen/backends/eager/__init__.py
@@ -56,6 +56,7 @@ from comfy_kitchen.constraints import (
     ExactDims,
     FunctionConstraints,
     ParamConstraint,
+    na3d_common_call_rule,
 )
 from comfy_kitchen.registry import registry
 
@@ -67,7 +68,7 @@ from .convrot_w4a4 import (
     prepare_int4_weight_for_int8_linear,
     quantize_convrot_w4a4_weight,
 )
-from .na import na3d, na3d_common_call_rule
+from .na import na3d
 from .quantization import (
     dequantize_int8_convrot_weight,
     dequantize_int8_convrot_weight_dtype,

--- a/comfy_kitchen/backends/eager/__init__.py
+++ b/comfy_kitchen/backends/eager/__init__.py
@@ -63,7 +63,7 @@ from .convrot_w4a4 import (
     prepare_int4_weight_for_int8_linear,
     quantize_convrot_w4a4_weight,
 )
-from .na import na3d
+from .na import na3d, na3d_common_call_rule
 from .quantization import (
     dequantize_int8_convrot_weight,
     dequantize_int8_convrot_weight_dtype,
@@ -529,6 +529,7 @@ def _build_constraints() -> dict:
             "v": ParamConstraint(dtypes=standard_floats, shape_rules=(ExactDims(6),)),
         },
         default_devices=all_devices,
+        call_rules=(na3d_common_call_rule,),
     )
     return out
 

--- a/comfy_kitchen/backends/eager/__init__.py
+++ b/comfy_kitchen/backends/eager/__init__.py
@@ -1,5 +1,6 @@
 __all__ = [
     "adaln",
+    "na3d",
     "rms_adaln",
     "apply_rope",
     "apply_rope_",
@@ -62,6 +63,7 @@ from .convrot_w4a4 import (
     prepare_int4_weight_for_int8_linear,
     quantize_convrot_w4a4_weight,
 )
+from .na import na3d
 from .quantization import (
     dequantize_int8_convrot_weight,
     dequantize_int8_convrot_weight_dtype,
@@ -520,6 +522,14 @@ def _build_constraints() -> dict:
         "rms_rope_split_half1_": "rms_rope_split_half1",
     }.items():
         out[inplace_name] = out[functional_name]
+    out["na3d"] = FunctionConstraints(
+        params={
+            "q": ParamConstraint(dtypes=standard_floats, shape_rules=(ExactDims(6),)),
+            "k": ParamConstraint(dtypes=standard_floats, shape_rules=(ExactDims(6),)),
+            "v": ParamConstraint(dtypes=standard_floats, shape_rules=(ExactDims(6),)),
+        },
+        default_devices=all_devices,
+    )
     return out
 
 

--- a/comfy_kitchen/backends/eager/na.py
+++ b/comfy_kitchen/backends/eager/na.py
@@ -1,0 +1,179 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""3D neighborhood attention (NATTEN ``na3d`` semantics) in pure torch.
+
+Per non-causal axis each query attends a window of exactly ``kernel_size``
+positions centered on it, shifted inward at grid boundaries; per causal axis
+it attends the ``min(i + 1, kernel_size)`` nearest previous positions.
+Dilation is not supported.
+
+Strategy: queries are tiled; tiles sharing the same relative window geometry
+(all interior tiles, plus a handful of boundary cases per axis) are stacked
+into batched ``scaled_dot_product_attention`` calls with one additive mask per
+geometry group. SDPA's efficient backend does online softmax, so scores are
+never materialized on CUDA.
+"""
+
+import math
+
+import torch
+import torch.nn.functional as functional
+
+from comfy_kitchen.registry import registry
+
+# Element budget for one tile's [Nq, Nk] attention mask (bounds the mask
+# allocation and, on CPU, the math-backend score materialization).
+NA_SCORE_BUDGET = 2 ** 25
+# Element budget for the stacked K/V copies of one batched SDPA call on CUDA.
+NA_KV_STACK_BUDGET = 2 ** 28
+
+
+def _window_bounds(length, kernel, causal):
+    """Per-index (start, end) of the attended window along one axis."""
+    starts = []
+    ends = []
+    if causal:
+        for i in range(length):
+            starts.append(max(0, i - kernel + 1))
+            ends.append(i + 1)
+    else:
+        kernel = min(kernel, length)
+        lo = length - kernel
+        half = kernel // 2
+        for i in range(length):
+            s = min(max(i - half, 0), lo)
+            starts.append(s)
+            ends.append(s + kernel)
+    return starts, ends
+
+
+def _pick_tiles(dims, kernels):
+    """Per-axis query-tile lengths keeping one tile's [Nq, Nk] under budget."""
+    tiles = list(dims)
+
+    def cost(ts):
+        nq = math.prod(ts)
+        nk = math.prod(min(d, t + k - 1) for t, k, d in zip(ts, kernels, dims, strict=True))
+        return nq * nk
+
+    while cost(tiles) > NA_SCORE_BUDGET and max(tiles) > 1:
+        i = max(range(3), key=lambda a: tiles[a] / kernels[a])
+        if tiles[i] <= 1:
+            break
+        tiles[i] = max(1, (tiles[i] + 1) // 2)
+    return tiles
+
+
+def _group_mask(rel_bounds, dtype, device):
+    """Additive ``[1, 1, Nq, Nk]`` mask for one tile-geometry group.
+
+    ``rel_bounds``: per-axis (starts, ends) relative to the key region origin.
+    """
+    bools = []
+    for starts, ends in rel_bounds:
+        st = torch.tensor(starts, device=device)
+        en = torch.tensor(ends, device=device)
+        kj = torch.arange(int(en.max()), device=device)
+        bools.append((kj[None, :] >= st[:, None]) & (kj[None, :] < en[:, None]))
+    visible = (bools[0][:, None, None, :, None, None]
+               & bools[1][None, :, None, None, :, None]
+               & bools[2][None, None, :, None, None, :])
+    nq = visible.shape[0] * visible.shape[1] * visible.shape[2]
+    nk = visible.shape[3] * visible.shape[4] * visible.shape[5]
+    mask = torch.zeros((nq, nk), dtype=dtype, device=device)
+    mask.masked_fill_(~visible.reshape(nq, nk), torch.finfo(dtype).min)
+    return mask.reshape(1, 1, nq, nk)
+
+
+def na3d(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    kernel_size: list[int],
+    is_causal: list[bool] | None = None,
+    scale: float | None = None,
+) -> torch.Tensor:
+    """3D neighborhood attention over ``(B, T, H, W, NH, HD)`` tensors."""
+    batch, t, h, w, nh, hd = q.shape
+    dims = (t, h, w)
+    causal = [False, False, False] if is_causal is None else list(is_causal)
+    kernels = [k_ if c else min(k_, d) for k_, c, d in zip(kernel_size, causal, dims, strict=True)]
+    if scale is None:
+        scale = hd ** -0.5
+    device = q.device
+    if scale != 1.0:
+        q = q * scale
+
+    bounds = [_window_bounds(d, k_, c) for d, k_, c in zip(dims, kernels, causal, strict=True)]
+    tile_t, tile_h, tile_w = _pick_tiles(dims, [min(k_, d) for k_, d in zip(kernels, dims, strict=True)])
+
+    # Group tiles by relative window geometry so each group shares one mask
+    # and stacks into batched SDPA calls.
+    groups = {}
+    for t0 in range(0, t, tile_t):
+        t1 = min(t0 + tile_t, t)
+        rt0, rt1 = bounds[0][0][t0], bounds[0][1][t1 - 1]
+        rel_t = (tuple(s - rt0 for s in bounds[0][0][t0:t1]), tuple(e - rt0 for e in bounds[0][1][t0:t1]))
+        for h0 in range(0, h, tile_h):
+            h1 = min(h0 + tile_h, h)
+            rh0, rh1 = bounds[1][0][h0], bounds[1][1][h1 - 1]
+            rel_h = (tuple(s - rh0 for s in bounds[1][0][h0:h1]), tuple(e - rh0 for e in bounds[1][1][h0:h1]))
+            for w0 in range(0, w, tile_w):
+                w1 = min(w0 + tile_w, w)
+                rw0, rw1 = bounds[2][0][w0], bounds[2][1][w1 - 1]
+                rel_w = (tuple(s - rw0 for s in bounds[2][0][w0:w1]), tuple(e - rw0 for e in bounds[2][1][w0:w1]))
+                groups.setdefault((rel_t, rel_h, rel_w), []).append((
+                    (slice(t0, t1), slice(h0, h1), slice(w0, w1)),
+                    (slice(rt0, rt1), slice(rh0, rh1), slice(rw0, rw1)),
+                ))
+
+    out = torch.empty((batch, t, h, w, nh, hd), device=device, dtype=v.dtype)
+    for rel, tiles in groups.items():
+        mask = _group_mask(rel, q.dtype, device)
+        nq, nk = mask.shape[2], mask.shape[3]
+        if device.type == "cuda":
+            g_max = max(1, NA_KV_STACK_BUDGET // max(1, batch * nh * nk * hd * 2))
+        else:
+            g_max = 1  # CPU math backend materializes [G*B, NH, Nq, Nk]
+        qs0, _ = tiles[0]
+        tq, th, tw = (qs0[0].stop - qs0[0].start, qs0[1].stop - qs0[1].start, qs0[2].stop - qs0[2].start)
+        for c0 in range(0, len(tiles), g_max):
+            chunk = tiles[c0:c0 + g_max]
+            g = len(chunk)
+            q_s = torch.stack([q[:, qs[0], qs[1], qs[2]] for qs, _ in chunk])
+            k_s = torch.stack([k[:, rs[0], rs[1], rs[2]] for _, rs in chunk])
+            v_s = torch.stack([v[:, rs[0], rs[1], rs[2]] for _, rs in chunk])
+            # [G, B, t, h, w, NH, HD] -> [G*B, NH, N, HD]
+            q_s = q_s.permute(0, 1, 5, 2, 3, 4, 6).reshape(g * batch, nh, nq, hd)
+            k_s = k_s.permute(0, 1, 5, 2, 3, 4, 6).reshape(g * batch, nh, nk, hd)
+            v_s = v_s.permute(0, 1, 5, 2, 3, 4, 6).reshape(g * batch, nh, nk, hd)
+            o = functional.scaled_dot_product_attention(q_s, k_s, v_s, attn_mask=mask, scale=1.0)
+            o = o.view(g, batch, nh, tq, th, tw, hd).permute(0, 1, 3, 4, 5, 2, 6)
+            for i, (qs, _) in enumerate(chunk):
+                out[:, qs[0], qs[1], qs[2]] = o[i]
+
+    return out
+
+
+# =============================================================================
+# torch.library Custom Op Definitions
+# =============================================================================
+
+
+@torch.library.custom_op("comfy_kitchen::na3d", mutates_args=())
+def _op_na3d(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    kernel_size: list[int],
+    is_causal: list[bool],
+    scale: float | None,
+) -> torch.Tensor:
+    kwargs = {"q": q, "k": k, "v": v, "kernel_size": kernel_size, "is_causal": is_causal, "scale": scale}
+    impl = registry.get_implementation("na3d", kwargs=kwargs)
+    return impl(**kwargs)
+
+
+@_op_na3d.register_fake
+def _op_na3d_fake(q, k, v, kernel_size, is_causal, scale):
+    return torch.empty_like(q)

--- a/comfy_kitchen/backends/eager/na.py
+++ b/comfy_kitchen/backends/eager/na.py
@@ -19,6 +19,7 @@ import math
 import torch
 import torch.nn.functional as functional
 
+from comfy_kitchen.constraints import ValidationResult
 from comfy_kitchen.registry import registry
 
 # Element budget for one tile's [Nq, Nk] attention mask (bounds the mask
@@ -26,6 +27,33 @@ from comfy_kitchen.registry import registry
 NA_SCORE_BUDGET = 2 ** 25
 # Element budget for the stacked K/V copies of one batched SDPA call on CUDA.
 NA_KV_STACK_BUDGET = 2 ** 28
+
+
+def na3d_common_call_rule(kwargs):
+    """Shared ``na3d`` validation.
+
+    The fused backends size everything from ``q`` and pass ``k``/``v`` as bare
+    pointers, so a mismatch becomes an out-of-bounds read.
+    """
+    q = kwargs.get("q")
+    if q is not None:
+        for name in ("k", "v"):
+            other = kwargs.get(name)
+            if other is None:
+                continue
+            if tuple(other.shape) != tuple(q.shape):
+                return ValidationResult.fail(
+                    name, f"must have the same shape as q {tuple(q.shape)}, got {tuple(other.shape)}"
+                )
+            if other.dtype != q.dtype:
+                return ValidationResult.fail(
+                    name, f"must have the same dtype as q ({q.dtype}), got {other.dtype}"
+                )
+    for name in ("kernel_size", "is_causal"):
+        value = kwargs.get(name)
+        if value is not None and len(value) != 3:
+            return ValidationResult.fail(name, f"must have 3 elements, got {len(value)}")
+    return ValidationResult.ok()
 
 
 def _window_bounds(length, kernel, causal):
@@ -176,4 +204,4 @@ def _op_na3d(
 
 @_op_na3d.register_fake
 def _op_na3d_fake(q, k, v, kernel_size, is_causal, scale):
-    return torch.empty_like(q)
+    return torch.empty_like(v)  # v's dtype, as the eager implementation returns

--- a/comfy_kitchen/backends/eager/na.py
+++ b/comfy_kitchen/backends/eager/na.py
@@ -19,7 +19,6 @@ import math
 import torch
 import torch.nn.functional as functional
 
-from comfy_kitchen.constraints import ValidationResult
 from comfy_kitchen.registry import registry
 
 # Element budget for one tile's [Nq, Nk] attention mask (bounds the mask
@@ -27,33 +26,6 @@ from comfy_kitchen.registry import registry
 NA_SCORE_BUDGET = 2 ** 25
 # Element budget for the stacked K/V copies of one batched SDPA call on CUDA.
 NA_KV_STACK_BUDGET = 2 ** 28
-
-
-def na3d_common_call_rule(kwargs):
-    """Shared ``na3d`` validation.
-
-    The fused backends size everything from ``q`` and pass ``k``/``v`` as bare
-    pointers, so a mismatch becomes an out-of-bounds read.
-    """
-    q = kwargs.get("q")
-    if q is not None:
-        for name in ("k", "v"):
-            other = kwargs.get(name)
-            if other is None:
-                continue
-            if tuple(other.shape) != tuple(q.shape):
-                return ValidationResult.fail(
-                    name, f"must have the same shape as q {tuple(q.shape)}, got {tuple(other.shape)}"
-                )
-            if other.dtype != q.dtype:
-                return ValidationResult.fail(
-                    name, f"must have the same dtype as q ({q.dtype}), got {other.dtype}"
-                )
-    for name in ("kernel_size", "is_causal"):
-        value = kwargs.get(name)
-        if value is not None and len(value) != 3:
-            return ValidationResult.fail(name, f"must have 3 elements, got {len(value)}")
-    return ValidationResult.ok()
 
 
 def _window_bounds(length, kernel, causal):

--- a/comfy_kitchen/backends/triton/__init__.py
+++ b/comfy_kitchen/backends/triton/__init__.py
@@ -31,6 +31,7 @@ __all__ = [
 # Try to import triton and register if available
 import torch
 
+from comfy_kitchen.backends.eager.na import na3d_common_call_rule
 from comfy_kitchen.constraints import (
     ExactDims,
     FunctionConstraints,
@@ -116,12 +117,12 @@ if _TRITON_AVAILABLE:
 
 def _build_constraints() -> dict:
     def _na3d_call_rule(kwargs):
+        common = na3d_common_call_rule(kwargs)
+        if not common.success:
+            return common
         q = kwargs.get("q")
         if q is not None and q.shape[-1] > 128:
             return ValidationResult.fail("q", "head_dim > 128 not supported by triton na3d")
-        kernel_size = kwargs.get("kernel_size")
-        if kernel_size is not None and len(kernel_size) != 3:
-            return ValidationResult.fail("kernel_size", "must have 3 elements")
         return ValidationResult.ok()
 
     cuda_devices = frozenset({"cuda"})

--- a/comfy_kitchen/backends/triton/__init__.py
+++ b/comfy_kitchen/backends/triton/__init__.py
@@ -32,12 +32,12 @@ __all__ = [
 # Try to import triton and register if available
 import torch
 
-from comfy_kitchen.backends.eager.na import na3d_common_call_rule
 from comfy_kitchen.constraints import (
     ExactDims,
     FunctionConstraints,
     ParamConstraint,
     ValidationResult,
+    na3d_common_call_rule,
 )
 from comfy_kitchen.registry import registry
 
@@ -333,6 +333,8 @@ def _build_constraints() -> dict:
             "v": ParamConstraint(dtypes=standard_floats, shape_rules=(ExactDims(6),)),
         },
         default_devices=cuda_devices,
+        # tl.dot needs Ampere matrix capability for the non-IEEE float paths
+        min_compute_capability=(8, 0),
         call_rules=(_na3d_call_rule,),
     )
     return out

--- a/comfy_kitchen/backends/triton/__init__.py
+++ b/comfy_kitchen/backends/triton/__init__.py
@@ -1,5 +1,6 @@
 __all__ = [
     "adaln",
+    "na3d",
     "rms_adaln",
     "apply_rope",
     "apply_rope_",
@@ -34,6 +35,7 @@ from comfy_kitchen.constraints import (
     ExactDims,
     FunctionConstraints,
     ParamConstraint,
+    ValidationResult,
 )
 from comfy_kitchen.registry import registry
 
@@ -50,6 +52,7 @@ try:
     )
 
     from .adaln import adaln, rms_adaln
+    from .na import na3d
     from .quantization import (
         dequantize_nvfp4,
         dequantize_per_tensor_fp8,
@@ -112,6 +115,15 @@ if _TRITON_AVAILABLE:
 
 
 def _build_constraints() -> dict:
+    def _na3d_call_rule(kwargs):
+        q = kwargs.get("q")
+        if q is not None and q.shape[-1] > 128:
+            return ValidationResult.fail("q", "head_dim > 128 not supported by triton na3d")
+        kernel_size = kwargs.get("kernel_size")
+        if kernel_size is not None and len(kernel_size) != 3:
+            return ValidationResult.fail("kernel_size", "must have 3 elements")
+        return ValidationResult.ok()
+
     cuda_devices = frozenset({"cuda"})
     triton_devices = frozenset({"cuda", "xpu"})
     standard_floats = frozenset({torch.float32, torch.float16, torch.bfloat16})
@@ -295,6 +307,15 @@ def _build_constraints() -> dict:
         "rms_rope_split_half1_": "rms_rope_split_half1",
     }.items():
         out[inplace_name] = out[functional_name]
+    out["na3d"] = FunctionConstraints(
+        params={
+            "q": ParamConstraint(dtypes=standard_floats, shape_rules=(ExactDims(6),)),
+            "k": ParamConstraint(dtypes=standard_floats, shape_rules=(ExactDims(6),)),
+            "v": ParamConstraint(dtypes=standard_floats, shape_rules=(ExactDims(6),)),
+        },
+        default_devices=cuda_devices,
+        call_rules=(_na3d_call_rule,),
+    )
     return out
 
 

--- a/comfy_kitchen/backends/triton/na.py
+++ b/comfy_kitchen/backends/triton/na.py
@@ -95,6 +95,8 @@ def _na3d_kernel(
                     s = tl.dot(q_blk, tl.trans(k_blk)) * scale
                 vis = (wk[None, :] >= w_start[:, None]) & (wk[None, :] < w_end[:, None]) & kmask[None, :]
                 s = tl.where(vis, s, _NEG_INF)
+                # No fully-masked-row guard: such a row would hold m_i at _NEG_INF
+                # and give p = exp(0) = 1. Safe only because block_k >= block_q.
                 m_new = tl.maximum(m_i, tl.max(s, 1))
                 alpha = tl.exp(m_i - m_new)
                 p = tl.exp(s - m_new[:, None])
@@ -132,8 +134,10 @@ def na3d(
     out = torch.empty_like(q)
 
     hd_p = max(16, triton.next_power_of_2(hd))
-    block_q = 64 if w >= 64 else max(16, triton.next_power_of_2(w))
-    block_k = 64 if w >= 64 else max(16, triton.next_power_of_2(min(w + kw, 64)))
+    # Each query sees only kw of the ~block_q + kw keys swept, so wide blocks
+    # mostly compute masked scores. 16 (the tl.dot floor) measured fastest.
+    block_q = 16
+    block_k = max(16, min(32, triton.next_power_of_2(min(w, block_q + kw))))
 
     grid = (triton.cdiv(w, block_q), t * h, batch * nh)
     _na3d_kernel[grid](

--- a/comfy_kitchen/backends/triton/na.py
+++ b/comfy_kitchen/backends/triton/na.py
@@ -1,0 +1,151 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Fused 3D neighborhood attention (NATTEN ``na3d`` semantics) in Triton.
+
+One program handles a run of ``BLOCK_Q`` queries along W at a fixed (t, h),
+so the T/H windows are scalars for the whole block: the key loops iterate
+only valid (tk, hk) planes, and per-element masking is needed on the W axis
+alone. Online softmax (flash-style), fp32 accumulation, no materialized
+scores or gathered key windows.
+"""
+
+import torch
+
+import triton
+import triton.language as tl
+
+_NEG_INF = tl.constexpr(-3.0e38)
+
+
+@triton.jit
+def _na3d_kernel(
+    q_ptr, k_ptr, v_ptr, out_ptr,
+    t_size, h_size, w_size, num_heads,
+    s_b, s_t, s_h, s_w, s_n,
+    scale,
+    kt: tl.constexpr, kh: tl.constexpr, kw: tl.constexpr,
+    causal_t: tl.constexpr, causal_h: tl.constexpr, causal_w: tl.constexpr,
+    hd: tl.constexpr, hd_pad: tl.constexpr,
+    block_q: tl.constexpr, block_k: tl.constexpr,
+    is_fp32: tl.constexpr,
+):
+    pid_w = tl.program_id(0)
+    pid_th = tl.program_id(1)
+    pid_bn = tl.program_id(2)
+
+    t_q = pid_th // h_size
+    h_q = pid_th % h_size
+    base = (pid_bn // num_heads) * s_b + (pid_bn % num_heads) * s_n
+
+    w_off = pid_w * block_q + tl.arange(0, block_q)
+    w_valid = w_off < w_size
+    d_off = tl.arange(0, hd_pad)
+    d_mask = d_off < hd
+
+    q_ptrs = q_ptr + base + t_q * s_t + h_q * s_h + w_off[:, None] * s_w + d_off[None, :]
+    q_blk = tl.load(q_ptrs, mask=w_valid[:, None] & d_mask[None, :], other=0.0)
+
+    # Scalar T/H windows for the whole block.
+    if causal_t:
+        t_lo = tl.maximum(t_q - kt + 1, 0)
+        t_hi = t_q + 1
+    else:
+        t_lo = tl.minimum(tl.maximum(t_q - kt // 2, 0), t_size - kt)
+        t_hi = t_lo + kt
+    if causal_h:
+        h_lo = tl.maximum(h_q - kh + 1, 0)
+        h_hi = h_q + 1
+    else:
+        h_lo = tl.minimum(tl.maximum(h_q - kh // 2, 0), h_size - kh)
+        h_hi = h_lo + kh
+
+    # Per-query W windows (vector), and the block's key sweep range (scalar).
+    w_q = tl.where(w_valid, w_off, w_size - 1)  # clamp invalid lanes to a real index
+    if causal_w:
+        w_start = tl.maximum(w_q - kw + 1, 0)
+        w_end = w_q + 1
+        blk_first = tl.minimum(pid_w * block_q, w_size - 1)
+        blk_last = tl.minimum(pid_w * block_q + block_q - 1, w_size - 1)
+        w_lo = tl.maximum(blk_first - kw + 1, 0)
+        w_hi = blk_last + 1
+    else:
+        w_start = tl.minimum(tl.maximum(w_q - kw // 2, 0), w_size - kw)
+        w_end = w_start + kw
+        blk_first = tl.minimum(pid_w * block_q, w_size - 1)
+        blk_last = tl.minimum(pid_w * block_q + block_q - 1, w_size - 1)
+        w_lo = tl.minimum(tl.maximum(blk_first - kw // 2, 0), w_size - kw)
+        w_hi = tl.minimum(tl.maximum(blk_last - kw // 2, 0), w_size - kw) + kw
+
+    m_i = tl.full((block_q,), _NEG_INF, dtype=tl.float32)
+    l_i = tl.zeros((block_q,), dtype=tl.float32)
+    acc = tl.zeros((block_q, hd_pad), dtype=tl.float32)
+
+    for tk in range(t_lo, t_hi):
+        for hk in range(h_lo, h_hi):
+            plane = base + tk * s_t + hk * s_h
+            for wk0 in range(w_lo, w_hi, block_k):
+                wk = wk0 + tl.arange(0, block_k)
+                kmask = wk < w_hi
+                kv_ptrs = plane + wk[:, None] * s_w + d_off[None, :]
+                kv_mask = kmask[:, None] & d_mask[None, :]
+                k_blk = tl.load(k_ptr + kv_ptrs, mask=kv_mask, other=0.0)
+                if is_fp32:
+                    s = tl.dot(q_blk, tl.trans(k_blk), input_precision="ieee") * scale
+                else:
+                    s = tl.dot(q_blk, tl.trans(k_blk)) * scale
+                vis = (wk[None, :] >= w_start[:, None]) & (wk[None, :] < w_end[:, None]) & kmask[None, :]
+                s = tl.where(vis, s, _NEG_INF)
+                m_new = tl.maximum(m_i, tl.max(s, 1))
+                alpha = tl.exp(m_i - m_new)
+                p = tl.exp(s - m_new[:, None])
+                l_i = l_i * alpha + tl.sum(p, 1)
+                v_blk = tl.load(v_ptr + kv_ptrs, mask=kv_mask, other=0.0)
+                if is_fp32:
+                    acc = acc * alpha[:, None] + tl.dot(p, v_blk, input_precision="ieee")
+                else:
+                    acc = acc * alpha[:, None] + tl.dot(p.to(v_blk.dtype), v_blk)
+                m_i = m_new
+
+    out = acc / tl.maximum(l_i, 1e-30)[:, None]
+    out_ptrs = out_ptr + base + t_q * s_t + h_q * s_h + w_off[:, None] * s_w + d_off[None, :]
+    tl.store(out_ptrs, out.to(out_ptr.dtype.element_ty), mask=w_valid[:, None] & d_mask[None, :])
+
+
+def na3d(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    kernel_size: list[int],
+    is_causal: list[bool] | None = None,
+    scale: float | None = None,
+) -> torch.Tensor:
+    """3D neighborhood attention over ``(B, t_size, h_size, w_size, num_heads, HD)`` tensors."""
+    batch, t, h, w, nh, hd = q.shape
+    causal = [False, False, False] if is_causal is None else list(is_causal)
+    kt, kh, kw = (k_ if c else min(k_, d) for k_, c, d in zip(kernel_size, causal, (t, h, w), strict=True))
+    if scale is None:
+        scale = hd ** -0.5
+
+    q = q.contiguous()
+    k = k.contiguous()
+    v = v.contiguous()
+    out = torch.empty_like(q)
+
+    hd_p = max(16, triton.next_power_of_2(hd))
+    block_q = 64 if w >= 64 else max(16, triton.next_power_of_2(w))
+    block_k = 64 if w >= 64 else max(16, triton.next_power_of_2(min(w + kw, 64)))
+
+    grid = (triton.cdiv(w, block_q), t * h, batch * nh)
+    _na3d_kernel[grid](
+        q, k, v, out,
+        t, h, w, nh,
+        q.stride(0), q.stride(1), q.stride(2), q.stride(3), q.stride(4),
+        scale,
+        kt=kt, kh=kh, kw=kw,
+        causal_t=causal[0], causal_h=causal[1], causal_w=causal[2],
+        hd=hd, hd_pad=hd_p,
+        block_q=block_q, block_k=block_k,
+        is_fp32=q.dtype == torch.float32,
+        num_warps=4,
+    )
+    return out

--- a/comfy_kitchen/constraints.py
+++ b/comfy_kitchen/constraints.py
@@ -253,3 +253,34 @@ def validate_function_call(
 
     return ValidationResult.ok()
 
+
+def na3d_common_call_rule(kwargs):
+    """Shared ``na3d`` validation (used by every backend's entry).
+
+    The fused backends size everything from ``q`` and pass ``k``/``v`` as bare
+    pointers, so a mismatch becomes an out-of-bounds read.
+    """
+    q = kwargs.get("q")
+    if q is not None:
+        for name in ("k", "v"):
+            other = kwargs.get(name)
+            if other is None:
+                continue
+            if tuple(other.shape) != tuple(q.shape):
+                return ValidationResult.fail(
+                    name, f"must have the same shape as q {tuple(q.shape)}, got {tuple(other.shape)}"
+                )
+            if other.dtype != q.dtype:
+                return ValidationResult.fail(
+                    name, f"must have the same dtype as q ({q.dtype}), got {other.dtype}"
+                )
+    for name in ("kernel_size", "is_causal"):
+        value = kwargs.get(name)
+        if value is not None and len(value) != 3:
+            return ValidationResult.fail(name, f"must have 3 elements, got {len(value)}")
+    kernel_size = kwargs.get("kernel_size")
+    if kernel_size is not None and any(k < 1 for k in kernel_size):
+        return ValidationResult.fail(
+            "kernel_size", f"entries must be positive, got {list(kernel_size)}"
+        )
+    return ValidationResult.ok()

--- a/comfy_kitchen/constraints.py
+++ b/comfy_kitchen/constraints.py
@@ -274,6 +274,10 @@ def na3d_common_call_rule(kwargs):
                 return ValidationResult.fail(
                     name, f"must have the same dtype as q ({q.dtype}), got {other.dtype}"
                 )
+            if other.device != q.device:
+                return ValidationResult.fail(
+                    name, f"must be on the same device as q ({q.device}), got {other.device}"
+                )
     for name in ("kernel_size", "is_causal"):
         value = kwargs.get(name)
         if value is not None and len(value) != 3:

--- a/tests/test_na.py
+++ b/tests/test_na.py
@@ -5,6 +5,7 @@ import pytest
 import torch
 
 import comfy_kitchen as ck
+from comfy_kitchen.exceptions import NoCapableBackendError
 from tests.conftest import assert_values_close, get_capable_backends
 
 # ---------------------------------------------------------------------------
@@ -155,7 +156,7 @@ def test_na3d_rejects_mismatched_qkv(bad):
         k = k.float()
     else:
         v = v.float()
-    with pytest.raises(Exception, match=r"(?i)same (shape|dtype)|no backend"):
+    with pytest.raises(NoCapableBackendError, match=r"(?i)same (shape|dtype) as q"):
         ck.na3d(q, k, v, [3, 3, 3], [False, False, False], None)
 
 
@@ -167,7 +168,7 @@ def test_na3d_rejects_mismatched_qkv(bad):
 def test_na3d_rejects_bad_axis_lists(kernel, causal):
     device = "cuda" if torch.cuda.is_available() else "cpu"
     q, k, v = _qkv(device)
-    with pytest.raises(Exception, match=r"(?i)3 elements|no backend"):
+    with pytest.raises(NoCapableBackendError, match=r"(?i)must have 3 elements"):
         ck.na3d(q, k, v, kernel, causal, None)
 
 
@@ -184,7 +185,7 @@ def test_na2d_rejects_bad_axis_lists(kernel, causal):
 def test_na3d_rejects_non_positive_kernel(kernel):
     device = "cuda" if torch.cuda.is_available() else "cpu"
     q, k, v = _qkv(device)
-    with pytest.raises(Exception, match=r"(?i)positive|no backend"):
+    with pytest.raises(NoCapableBackendError, match=r"(?i)entries must be positive"):
         ck.na3d(q, k, v, kernel, [False, False, False], None)
 
 
@@ -196,7 +197,7 @@ def test_na3d_rejects_cross_device_qkv(bad):
         k = k.cpu()
     else:
         v = v.cpu()
-    with pytest.raises(Exception, match=r"(?i)same device|no backend"):
+    with pytest.raises(NoCapableBackendError, match=r"(?i)same device as q"):
         ck.na3d(q, k, v, [3, 3, 3], [False, False, False], None)
 
 

--- a/tests/test_na.py
+++ b/tests/test_na.py
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+
+import comfy_kitchen as ck
+from tests.conftest import assert_values_close, get_capable_backends
+
+# ---------------------------------------------------------------------------
+# Reference implementation: direct per-query loop over NATTEN window semantics
+# ---------------------------------------------------------------------------
+
+
+def _window(i, kernel, length, causal):
+    if causal:
+        return max(0, i - kernel + 1), i + 1
+    kernel = min(kernel, length)
+    s = min(max(i - kernel // 2, 0), length - kernel)
+    return s, s + kernel
+
+
+def _ref_na3d(q, k, v, kernel_size, is_causal, scale):
+    b, t, h, w, nh, hd = q.shape
+    if scale is None:
+        scale = hd ** -0.5
+    out = torch.empty_like(v)
+    for ti in range(t):
+        t0, t1 = _window(ti, kernel_size[0], t, is_causal[0])
+        for hi in range(h):
+            h0, h1 = _window(hi, kernel_size[1], h, is_causal[1])
+            for wi in range(w):
+                w0, w1 = _window(wi, kernel_size[2], w, is_causal[2])
+                kk = k[:, t0:t1, h0:h1, w0:w1].reshape(b, -1, nh, hd)
+                vv = v[:, t0:t1, h0:h1, w0:w1].reshape(b, -1, nh, hd)
+                qq = q[:, ti, hi, wi]  # [b, nh, hd]
+                s = torch.einsum("bnd,bknd->bnk", qq.float(), kk.float()) * scale
+                a = torch.softmax(s, dim=-1)
+                out[:, ti, hi, wi] = torch.einsum("bnk,bknd->bnd", a, vv.float()).to(v.dtype)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Cases
+# ---------------------------------------------------------------------------
+
+CASES = [
+    # (shape (B,T,H,W,NH,HD), kernel, is_causal)
+    ((1, 5, 9, 12, 2, 64), (3, 7, 7), (False, False, False)),
+    ((1, 12, 13, 15, 2, 64), (11, 11, 11), (False, False, False)),
+    ((2, 6, 8, 8, 4, 64), (5, 5, 5), (True, False, False)),   # causal T
+    ((1, 3, 6, 6, 2, 64), (5, 5, 5), (True, False, False)),   # kernel > dims, causal T
+    ((1, 2, 5, 5, 2, 64), (3, 7, 7), (False, False, False)),  # kernel > dims -> clamp
+    ((1, 1, 16, 16, 2, 64), (1, 5, 5), (False, False, False)),  # single frame (na2d shape)
+    ((1, 4, 7, 40, 2, 32), (3, 5, 5), (False, False, False)),  # hd 32, elongated W
+]
+
+
+def _tolerances(dtype):
+    if dtype == torch.float32:
+        return 2e-4, 2e-5
+    return 2e-2, 2e-2
+
+
+@pytest.mark.parametrize("shape,kernel,causal", CASES)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+@pytest.mark.parametrize("scale", [None, 1.0])
+def test_na3d_backends(shape, kernel, causal, dtype, scale):
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    backends = get_capable_backends("na3d", device)
+    assert backends, "no backend for na3d"
+
+    torch.manual_seed(0)
+    q = torch.randn(shape, device=device, dtype=dtype)
+    k = torch.randn(shape, device=device, dtype=dtype)
+    v = torch.randn(shape, device=device, dtype=dtype)
+    ref = _ref_na3d(q, k, v, kernel, causal, scale)
+
+    rtol, atol = _tolerances(dtype)
+    for backend in backends:
+        with ck.use_backend(backend):
+            out = ck.na3d(q, k, v, list(kernel), list(causal), scale)
+        assert_values_close(out.float(), ref.float(), rtol, atol, name=f"na3d[{backend}]")
+
+
+def test_na2d_matches_na3d_single_frame():
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    torch.manual_seed(1)
+    q = torch.randn(1, 16, 16, 2, 64, device=device)
+    k = torch.randn(1, 16, 16, 2, 64, device=device)
+    v = torch.randn(1, 16, 16, 2, 64, device=device)
+    out2d = ck.na2d(q, k, v, [5, 5])
+    ref = _ref_na3d(q.unsqueeze(1), k.unsqueeze(1), v.unsqueeze(1),
+                    (1, 5, 5), (False, False, False), None).squeeze(1)
+    assert_values_close(out2d.float(), ref.float(), 2e-4, 2e-5, name="na2d")
+
+
+def test_na3d_backend_agreement():
+    """Triton and eager must agree closely on identical inputs."""
+    if not torch.cuda.is_available():
+        pytest.skip("cuda only")
+    backends = get_capable_backends("na3d", "cuda")
+    if len(backends) < 2:
+        pytest.skip("single backend")
+    torch.manual_seed(2)
+    shape = (1, 8, 24, 24, 4, 64)
+    q = torch.randn(shape, device="cuda", dtype=torch.bfloat16)
+    k = torch.randn(shape, device="cuda", dtype=torch.bfloat16)
+    v = torch.randn(shape, device="cuda", dtype=torch.bfloat16)
+    outs = {}
+    for backend in backends:
+        with ck.use_backend(backend):
+            outs[backend] = ck.na3d(q, k, v, [3, 7, 7], [False, False, False], 1.0)
+    names = list(outs)
+    assert_values_close(outs[names[0]].float(), outs[names[1]].float(), 2e-2, 2e-2,
+                        name=f"{names[0]}-vs-{names[1]}")

--- a/tests/test_na.py
+++ b/tests/test_na.py
@@ -178,3 +178,45 @@ def test_na2d_rejects_bad_axis_lists(kernel, causal):
     q, k, v = (torch.randn(shape, device=device, dtype=torch.bfloat16) for _ in range(3))
     with pytest.raises(ValueError, match="2 elements"):
         ck.na2d(q, k, v, kernel, causal, None)
+
+
+@pytest.mark.parametrize("kernel", [[0, 3, 3], [3, -1, 3], [3, 3, 0]])
+def test_na3d_rejects_non_positive_kernel(kernel):
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    q, k, v = _qkv(device)
+    with pytest.raises(Exception, match=r"(?i)positive|no backend"):
+        ck.na3d(q, k, v, kernel, [False, False, False], None)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs two device types")
+@pytest.mark.parametrize("bad", ["k", "v"])
+def test_na3d_rejects_cross_device_qkv(bad):
+    q, k, v = _qkv("cuda", dtype=torch.float32)
+    if bad == "k":
+        k = k.cpu()
+    else:
+        v = v.cpu()
+    with pytest.raises(Exception, match=r"(?i)same device|no backend"):
+        ck.na3d(q, k, v, [3, 3, 3], [False, False, False], None)
+
+
+def test_na3d_scalar_kernel_and_causal():
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    q, k, v = _qkv(device)
+    ref = ck.na3d(q, k, v, [3, 3, 3], [True, True, True], None)
+    out = ck.na3d(q, k, v, 3, True, None)
+    torch.testing.assert_close(out, ref, rtol=0, atol=0)
+    torch.testing.assert_close(
+        ck.na3d(q, k, v, 3, None, None),
+        ck.na3d(q, k, v, [3, 3, 3], [False, False, False], None),
+        rtol=0, atol=0,
+    )
+
+
+def test_na2d_scalar_kernel_and_causal():
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    shape = (1, 8, 8, 2, 64)
+    q, k, v = (torch.randn(shape, device=device, dtype=torch.bfloat16) for _ in range(3))
+    ref = ck.na2d(q, k, v, [3, 3], [True, True], None)
+    out = ck.na2d(q, k, v, 3, True, None)
+    torch.testing.assert_close(out, ref, rtol=0, atol=0)

--- a/tests/test_na.py
+++ b/tests/test_na.py
@@ -53,6 +53,15 @@ CASES = [
     ((1, 2, 5, 5, 2, 64), (3, 7, 7), (False, False, False)),  # kernel > dims -> clamp
     ((1, 1, 16, 16, 2, 64), (1, 5, 5), (False, False, False)),  # single frame (na2d shape)
     ((1, 4, 7, 40, 2, 32), (3, 5, 5), (False, False, False)),  # hd 32, elongated W
+    # W past one CUDA query block and not a multiple of it: ragged tail block
+    ((1, 2, 3, 65, 2, 64), (3, 3, 5), (False, False, False)),
+    ((1, 2, 3, 96, 1, 64), (1, 3, 33), (False, False, False)),  # kw > CUDA BK=32
+    ((1, 3, 4, 34, 2, 16), (3, 3, 5), (False, False, False)),   # hd 16
+    ((1, 3, 4, 34, 2, 48), (3, 3, 5), (False, False, False)),   # hd 48 (not a power of 2)
+    ((1, 4, 6, 20, 2, 64), (3, 5, 7), (False, False, True)),    # causal W
+    ((1, 4, 6, 20, 2, 64), (3, 5, 7), (False, True, False)),    # causal H
+    ((1, 4, 6, 20, 2, 64), (3, 5, 7), (True, True, True)),      # causal on every axis
+    ((2, 3, 4, 18, 3, 32), (3, 3, 5), (False, False, False)),   # batch and heads > 1
 ]
 
 
@@ -63,10 +72,12 @@ def _tolerances(dtype):
 
 
 @pytest.mark.parametrize("shape,kernel,causal", CASES)
-@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
 @pytest.mark.parametrize("scale", [None, 1.0])
 def test_na3d_backends(shape, kernel, causal, dtype, scale):
     device = "cuda" if torch.cuda.is_available() else "cpu"
+    if device == "cpu" and dtype == torch.float16:
+        pytest.skip("fp16 SDPA is not supported on the CPU backend")
     backends = get_capable_backends("na3d", device)
     assert backends, "no backend for na3d"
 
@@ -95,22 +106,75 @@ def test_na2d_matches_na3d_single_frame():
     assert_values_close(out2d.float(), ref.float(), 2e-4, 2e-5, name="na2d")
 
 
-def test_na3d_backend_agreement():
-    """Triton and eager must agree closely on identical inputs."""
+@pytest.mark.parametrize("shape,kernel", [
+    ((1, 8, 24, 24, 4, 64), (3, 7, 7)),
+    ((1, 2, 3, 70, 2, 64), (3, 3, 7)),   # W spanning several CUDA query blocks
+])
+def test_na3d_backend_agreement(shape, kernel):
+    """Every capable backend must agree, not just the first two."""
     if not torch.cuda.is_available():
         pytest.skip("cuda only")
     backends = get_capable_backends("na3d", "cuda")
     if len(backends) < 2:
         pytest.skip("single backend")
     torch.manual_seed(2)
-    shape = (1, 8, 24, 24, 4, 64)
     q = torch.randn(shape, device="cuda", dtype=torch.bfloat16)
     k = torch.randn(shape, device="cuda", dtype=torch.bfloat16)
     v = torch.randn(shape, device="cuda", dtype=torch.bfloat16)
     outs = {}
     for backend in backends:
         with ck.use_backend(backend):
-            outs[backend] = ck.na3d(q, k, v, [3, 7, 7], [False, False, False], 1.0)
-    names = list(outs)
-    assert_values_close(outs[names[0]].float(), outs[names[1]].float(), 2e-2, 2e-2,
-                        name=f"{names[0]}-vs-{names[1]}")
+            outs[backend] = ck.na3d(q, k, v, list(kernel), [False, False, False], 1.0)
+    ref_name = next(iter(outs))
+    for name, out in outs.items():
+        if name == ref_name:
+            continue
+        assert_values_close(out.float(), outs[ref_name].float(), 2e-2, 2e-2,
+                            name=f"{ref_name}-vs-{name}")
+
+
+# ---------------------------------------------------------------------------
+# Input validation -- a mismatched k/v is an out-of-bounds read, so these raise
+# ---------------------------------------------------------------------------
+
+
+def _qkv(device, shape=(1, 2, 3, 8, 2, 64), dtype=torch.bfloat16):
+    return tuple(torch.randn(shape, device=device, dtype=dtype) for _ in range(3))
+
+
+@pytest.mark.parametrize("bad", ["k_shape", "v_shape", "k_dtype", "v_dtype"])
+def test_na3d_rejects_mismatched_qkv(bad):
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    dtype = torch.bfloat16
+    q, k, v = _qkv(device, dtype=dtype)
+    if bad == "k_shape":
+        k = torch.randn(1, 2, 3, 4, 2, 64, device=device, dtype=dtype)
+    elif bad == "v_shape":
+        v = torch.randn(1, 2, 3, 4, 2, 64, device=device, dtype=dtype)
+    elif bad == "k_dtype":
+        k = k.float()
+    else:
+        v = v.float()
+    with pytest.raises(Exception, match=r"(?i)same (shape|dtype)|no backend"):
+        ck.na3d(q, k, v, [3, 3, 3], [False, False, False], None)
+
+
+@pytest.mark.parametrize("kernel,causal", [
+    ([3, 3], [False, False, False]),
+    ([3, 3, 3, 3], [False, False, False]),
+    ([3, 3, 3], [False, False]),
+])
+def test_na3d_rejects_bad_axis_lists(kernel, causal):
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    q, k, v = _qkv(device)
+    with pytest.raises(Exception, match=r"(?i)3 elements|no backend"):
+        ck.na3d(q, k, v, kernel, causal, None)
+
+
+@pytest.mark.parametrize("kernel,causal", [([5, 5, 5], [False, False]), ([5], [False, False])])
+def test_na2d_rejects_bad_axis_lists(kernel, causal):
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    shape = (1, 8, 8, 2, 64)
+    q, k, v = (torch.randn(shape, device=device, dtype=torch.bfloat16) for _ in range(3))
+    with pytest.raises(ValueError, match="2 elements"):
+        ck.na2d(q, k, v, kernel, causal, None)


### PR DESCRIPTION
Adds fused neighborhood attention (NATTEN `na3d` semantics, dilation 1) over
`(B, T, H, W, num_heads, head_dim)` tensors, plus an `na2d` wrapper for the singleton-T case.

| backend | dtypes | head_dim | notes |
|---------|--------|----------|-------|
| cuda    | fp16, bf16 | 16/32/48/64 | fused mma kernel, sm80+ |
| triton  | fp32, fp16, bf16 | ≤ 128 | |
| eager   | fp32, fp16, bf16 | any | SDPA fallback, all devices |
