### PR TITLE
HIP port of #90: grouped W4A8 over the INT8 GEMM

### DIFF
--- a/comfy_kitchen/backends/hip/CMakeLists.txt
+++ b/comfy_kitchen/backends/hip/CMakeLists.txt
@@ -163,6 +163,7 @@ set(HIP_SOURCES
     ops/rms_rope.hip
     ops/gemv_awq.hip
     ops/svdquant_w4a4.hip
+    ops/w4a8_dequant.hip
 )
 
 set(CPP_SOURCES

--- a/comfy_kitchen/backends/hip/__init__.py
+++ b/comfy_kitchen/backends/hip/__init__.py
@@ -31,6 +31,10 @@ from comfy_kitchen.backends._activations import input_act_code as _input_act_cod
 from comfy_kitchen.backends._activations import input_act_width as _input_act_width
 from comfy_kitchen.backends.eager import rope as _eager_rope
 from comfy_kitchen.backends.eager.quantization import DTYPE_CODE_TO_DTYPE, DTYPE_TO_CODE
+from comfy_kitchen.backends.eager.w4a8_int8 import (
+    _dequantize_w4a8_int8_weight_from_int8,
+    validate_w4a8_operands,
+)
 
 logger = logging.getLogger("comfy_kitchen.hip")
 
@@ -53,6 +57,7 @@ __all__ = [
     "dequantize_int8_convrot_weight_dtype",
     "dequantize_int8_simple_dtype",
     "dequantize_per_tensor_fp8",
+    "dequantize_w4a8_int8_weight",
     "has_wmma",
     "int8_linear",
     "is_available",
@@ -72,6 +77,7 @@ __all__ = [
     "rms_rope_split_half1_",
     "scaled_mm_fp8",
     "stochastic_rounding_fp8",
+    "w4a8_int8_linear",
 ]
 
 _C = None
@@ -152,6 +158,7 @@ _WMMA_ONLY_OPS = frozenset({
     "int8_linear",
     "convrot_w4a4_linear",
     "scaled_mm_svdquant_w4a4",
+    "w4a8_int8_linear",
 })
 
 
@@ -653,6 +660,239 @@ def int8_linear(
         m, n, k, DTYPE_TO_CODE[out_dtype], _stream(x),
     )
     return out.reshape(*orig_shape[:-1], n)
+
+
+# ---------------------------------------------------------------------------
+# Grouped W4A8 over the INT8 GEMM
+# ---------------------------------------------------------------------------
+
+def _dequant_int4_grouped_to_int8(
+    qdata: torch.Tensor,
+    s_rel: torch.Tensor,
+    codebook: torch.Tensor | None,
+    group_size: int,
+) -> torch.Tensor:
+    """Decode packed INT4 weights to the grouped INT8 grid the GEMM consumes."""
+    n, k_half = qdata.shape
+    k = k_half * 2
+    device = qdata.device
+    qdata_arg = _operand(qdata, device, "qdata")
+    scale_code = DTYPE_TO_CODE[s_rel.dtype]
+    # fp8 crosses the binding as raw bytes, as it does everywhere else here.
+    s_rel_arg = _operand(s_rel, device, "s_rel")
+    if s_rel.dtype == torch.float8_e4m3fn:
+        s_rel_arg = s_rel_arg.view(torch.uint8)
+    codebook_arg = (
+        None
+        if codebook is None
+        else codebook.to(device=device, dtype=torch.float32).reshape(-1).contiguous()
+    )
+
+    out = torch.empty((n, k), dtype=torch.int8, device=device)
+    _C.dequant_int4_grouped_to_int8(
+        _dl(qdata_arg),
+        _dl(s_rel_arg),
+        scale_code,
+        None if codebook_arg is None else _dl(codebook_arg),
+        _dl(out),
+        n,
+        k,
+        group_size,
+        _stream(qdata),
+    )
+    return out
+
+
+def _tuning_env_int(name: str, default: int) -> int:
+    """A non-negative tuning knob from the environment, or ``default``.
+
+    These are read at import, and the backend is imported unguarded, so letting a
+    typo raise would take out ``import comfy_kitchen`` itself rather than just the
+    knob. A tuning value is never worth that.
+    """
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        logger.warning("ignoring non-integer %s=%r, using %d", name, raw, default)
+        return default
+
+
+# A chunk is worth decoding separately only while it is still cached when the GEMM
+# reads it back, so the target is the device's own L2 rather than a tuned constant.
+# The cap matches the CUDA backend's chunk width, keeping a shallow K from making a
+# chunk pointlessly wide; the floor keeps a deep K from starving the GEMM's N grid,
+# which costs far more than the decode saves.
+_W4A8_MAX_CHUNK_COLS = _tuning_env_int("COMFY_KITCHEN_W4A8_CHUNK_COLS", 4096)
+_W4A8_MIN_CHUNK_COLS = 1024
+# Chunking pays while the decode, not the GEMM, sets the cost. Where that crossover
+# sits depends on the part, so the limit is the conservative end of what measured as
+# a win on every shape tried: above it the weight is decoded in one pass, which is
+# what this path did before chunking, so a part that crosses over later loses only
+# the extra win rather than regressing.
+_W4A8_CHUNK_MAX_ROWS = _tuning_env_int("COMFY_KITCHEN_W4A8_CHUNK_MAX_ROWS", 64)
+_W4A8_FALLBACK_L2_BYTES = 4 << 20
+_w4a8_l2_bytes: dict[int, int] = {}
+
+
+def _w4a8_chunk_cols(m: int, n: int, k: int, device: torch.device) -> int:
+    """How many weight columns to decode before running the GEMM on them.
+
+    ``n`` decodes the weight in one pass, which is what the chunked launcher does
+    with a single chunk.
+    """
+    if m > _W4A8_CHUNK_MAX_ROWS or not _W4A8_MAX_CHUNK_COLS:
+        return n
+
+    index = device.index if device.index is not None else torch.cuda.current_device()
+    budget = _w4a8_l2_bytes.get(index)
+    if budget is None:
+        props = torch.cuda.get_device_properties(index)
+        budget = getattr(props, "L2_cache_size", 0) or _W4A8_FALLBACK_L2_BYTES
+        _w4a8_l2_bytes[index] = budget
+
+    # Rounded to the widest N tile, so a chunk boundary never splits one.
+    cols = min(_W4A8_MAX_CHUNK_COLS, max(_W4A8_MIN_CHUNK_COLS, budget // max(k, 1) // 128 * 128))
+    return min(n, cols)
+
+
+def _w4a8_int8_linear_chunked(
+    x: torch.Tensor,
+    qdata: torch.Tensor,
+    s_rel: torch.Tensor,
+    s_channel: torch.Tensor,
+    codebook: torch.Tensor | None,
+    bias: torch.Tensor | None,
+    group_size: int,
+    convrot_groupsize: int,
+    out_dtype: torch.dtype,
+) -> torch.Tensor:
+    n, k_half = qdata.shape
+    k = k_half * 2
+    device = x.device
+    orig_shape = x.shape
+    x2d = x.reshape(-1, k).contiguous()
+    m = x2d.shape[0]
+
+    # Rotated and quantized once: the chunk loop only walks the weight.
+    xq, xs = _rotate_quant_int8(x2d, convrot_groupsize)
+
+    scale_code = DTYPE_TO_CODE[s_rel.dtype]
+    s_rel_arg = _operand(s_rel, device, "s_rel")
+    if s_rel.dtype == torch.float8_e4m3fn:
+        s_rel_arg = s_rel_arg.view(torch.uint8)
+    codebook_arg = (
+        None
+        if codebook is None
+        else codebook.to(device=device, dtype=torch.float32).reshape(-1).contiguous()
+    )
+    s_channel_arg = s_channel.to(device=device, dtype=torch.float32).reshape(-1).contiguous()
+    bias_arg = None if bias is None else _bias_operand(bias, n, device)
+
+    qdata_arg = _operand(qdata, device, "qdata")
+    xs_arg = xs.reshape(-1).contiguous()
+    # An empty weight has no chunk to size; the loop then has nothing to walk.
+    chunk_cols = max(1, _w4a8_chunk_cols(m, n, k, device))
+    workspace = torch.empty((chunk_cols, k), dtype=torch.int8, device=device)
+    out = torch.empty((m, n), dtype=out_dtype, device=device)
+    _C.w4a8_int8_gemm_chunked(
+        _dl(xq),
+        _dl(qdata_arg),
+        _dl(s_rel_arg),
+        scale_code,
+        None if codebook_arg is None else _dl(codebook_arg),
+        _dl(s_channel_arg),
+        _dl(xs_arg),
+        None if bias_arg is None else _dl(bias_arg),
+        _dl(workspace),
+        _dl(out),
+        m,
+        n,
+        k,
+        group_size,
+        chunk_cols,
+        DTYPE_TO_CODE[out_dtype],
+        _stream(x),
+    )
+    return out.reshape(*orig_shape[:-1], n)
+
+
+def dequantize_w4a8_int8_weight(
+    qdata: torch.Tensor,
+    s_rel: torch.Tensor,
+    s_channel: torch.Tensor,
+    codebook: torch.Tensor | None = None,
+    correction: torch.Tensor | None = None,
+    group_size: int = 16,
+    convrot_groupsize: int = 256,
+    output_dtype: torch.dtype = torch.bfloat16,
+) -> torch.Tensor:
+    """Decode W4A8 storage into its physical [N, K] floating weight."""
+    validate_w4a8_operands(
+        qdata, s_rel, s_channel, codebook, correction, group_size, convrot_groupsize
+    )
+    int8_weight = _dequant_int4_grouped_to_int8(qdata, s_rel, codebook, group_size)
+    weight_rotated = _dequantize_w4a8_int8_weight_from_int8(
+        int8_weight, s_channel, correction, group_size, output_dtype
+    )
+    # Rotating back has no HIP kernel. Eager applies the same orthonormal ConvRot
+    # transform the fused activation path uses, and it is its own inverse.
+    return _eager.rotate_int8_convrot_weight(weight_rotated, convrot_groupsize).to(output_dtype)
+
+
+def w4a8_int8_linear(
+    x: torch.Tensor,
+    qdata: torch.Tensor,
+    s_rel: torch.Tensor,
+    s_channel: torch.Tensor,
+    codebook: torch.Tensor | None = None,
+    correction: torch.Tensor | None = None,
+    bias: torch.Tensor | None = None,
+    group_size: int = 16,
+    convrot_groupsize: int = 256,
+    out_dtype: torch.dtype = torch.bfloat16,
+) -> torch.Tensor:
+    """``x @ W.T + bias`` via the HIP INT4 decode feeding the WMMA INT8 GEMM.
+
+    The weight is decoded a column chunk at a time so a chunk is still cached when
+    the GEMM reads it back, instead of the whole [N, K] INT8 weight round-tripping
+    through global memory.
+    """
+    validate_w4a8_operands(
+        qdata, s_rel, s_channel, codebook, correction, group_size, convrot_groupsize
+    )
+    if x.shape[-1] != qdata.shape[-1] * 2:
+        raise ValueError(f"Input K={x.shape[-1]} does not match qdata K={qdata.shape[-1] * 2}")
+
+    # The asymmetric zero-point correction is a rank-one term the INT8 epilogue
+    # cannot express, so that layout runs off the dequantized weight instead.
+    if correction is not None:
+        weight = dequantize_w4a8_int8_weight(
+            qdata,
+            s_rel,
+            s_channel,
+            codebook=codebook,
+            correction=correction,
+            group_size=group_size,
+            convrot_groupsize=convrot_groupsize,
+            output_dtype=x.dtype,
+        )
+        return torch.nn.functional.linear(x, weight, bias).to(out_dtype)
+
+    # The layout allows any ConvRot group that divides K; the fused activation
+    # quantizer takes only the three it has butterfly stages for, and its LDS
+    # budget bounds K. int8_linear applies the same test before its own fast path.
+    if not _convrot_supported(x.shape[-1], convrot_groupsize, x.device, x.dtype):
+        int8_weight = _dequant_int4_grouped_to_int8(qdata, s_rel, codebook, group_size)
+        return _eager.int8_linear(
+            x, int8_weight, s_channel, bias, out_dtype, True, convrot_groupsize
+        )
+
+    return _w4a8_int8_linear_chunked(
+        x, qdata, s_rel, s_channel, codebook, bias, group_size, convrot_groupsize, out_dtype
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -1352,6 +1592,54 @@ def _build_constraints(has_wmma: bool = True) -> dict:
             params={
                 "x": ParamConstraint(dtypes=floats, shape_rules=(DivisibleBy(-1, 16),)),
                 "weight": ParamConstraint(dtypes=frozenset({torch.int8})),
+                "out_dtype": ParamConstraint(dtypes=out_floats),
+            },
+            default_devices=dev,
+        ),
+        "dequantize_w4a8_int8_weight": FunctionConstraints(
+            params={
+                "qdata": ParamConstraint(
+                    dtypes=frozenset({torch.int8}), shape_rules=(ExactDims(2),)
+                ),
+                "s_rel": ParamConstraint(
+                    dtypes=frozenset({torch.float8_e4m3fn, torch.float32}),
+                    shape_rules=(ExactDims(2),),
+                ),
+                "s_channel": ParamConstraint(
+                    dtypes=frozenset({torch.float32}), shape_rules=(ExactDims(1),)
+                ),
+                "codebook": ParamConstraint(
+                    dtypes=frozenset({torch.float32}), shape_rules=(ExactDims(1),)
+                ),
+                "correction": ParamConstraint(dtypes=floats, shape_rules=(ExactDims(2),)),
+                "group_size": ParamConstraint(dtypes=frozenset({int})),
+                "convrot_groupsize": ParamConstraint(dtypes=frozenset({int})),
+                "output_dtype": ParamConstraint(dtypes=out_floats),
+            },
+            default_devices=dev,
+        ),
+        # K must be a multiple of 16 for the same reason as int8_linear, and so
+        # that the INT4 decode's 16-column store stays inside its own row.
+        "w4a8_int8_linear": FunctionConstraints(
+            params={
+                "x": ParamConstraint(dtypes=floats, shape_rules=(DivisibleBy(-1, 16),)),
+                "qdata": ParamConstraint(
+                    dtypes=frozenset({torch.int8}), shape_rules=(ExactDims(2),)
+                ),
+                "s_rel": ParamConstraint(
+                    dtypes=frozenset({torch.float8_e4m3fn, torch.float32}),
+                    shape_rules=(ExactDims(2),),
+                ),
+                "s_channel": ParamConstraint(
+                    dtypes=frozenset({torch.float32}), shape_rules=(ExactDims(1),)
+                ),
+                "codebook": ParamConstraint(
+                    dtypes=frozenset({torch.float32}), shape_rules=(ExactDims(1),)
+                ),
+                "correction": ParamConstraint(dtypes=floats, shape_rules=(ExactDims(2),)),
+                "bias": ParamConstraint(dtypes=floats),
+                "group_size": ParamConstraint(dtypes=frozenset({int})),
+                "convrot_groupsize": ParamConstraint(dtypes=frozenset({int})),
                 "out_dtype": ParamConstraint(dtypes=out_floats),
             },
             default_devices=dev,

--- a/comfy_kitchen/backends/hip/dlpack_bindings.cpp
+++ b/comfy_kitchen/backends/hip/dlpack_bindings.cpp
@@ -10,6 +10,8 @@
 #include <nanobind/ndarray.h>
 #include <nanobind/stl/optional.h>
 
+#include "launchers.h"
+
 namespace nb = nanobind;
 
 // Maps a DLPack dtype onto comfy_kitchen.backends.eager.quantization.DTYPE_TO_CODE:
@@ -42,8 +44,6 @@ void launch_stochastic_round_fp8_kernel(void*, const void*, int64_t, int, int, i
 
 void launch_scaled_mm_fp8_kernel(const void*, const void*, void*, const void*, const void*,
                                  const void*, int, int, int, int, int, hipStream_t);
-void launch_int8_gemm_kernel(const void*, const void*, void*, const void*, const void*, int,
-                             const void*, int, int, int, int, int, hipStream_t);
 void launch_convrot_w4a4_gemm_kernel(const void*, const void*, void*, const void*, const void*,
                                      const void*, int, int, int, int, int, hipStream_t);
 
@@ -315,8 +315,8 @@ void int8_gemm(nb::ndarray<> a, nb::ndarray<> b, nb::ndarray<> c, nb::ndarray<> 
     require_bias(bias, N, kFn);
 
     launch_int8_gemm_kernel(a.data(), b.data(), c.data(), scale_a.data(), scale_b.data(),
-                            scale_b_stride, opt_data(bias), opt_code(bias), M, N, K, out_code,
-                            reinterpret_cast<hipStream_t>(stream_ptr));
+                            scale_b_stride, opt_data(bias), opt_code(bias), M, N, K, N /*ldc*/,
+                            out_code, reinterpret_cast<hipStream_t>(stream_ptr));
     check_hip_launch();
 }
 
@@ -525,6 +525,84 @@ void unpack_int4(nb::ndarray<> q, nb::ndarray<> out, int64_t nbytes, uintptr_t s
 
     launch_unpack_int4_kernel(q.data(), out.data(), nbytes,
                               reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+// scale_code names the s_rel storage: 0 float32, 5 e4m3 (crossing as uint8, as
+// elsewhere). codebook is optional; without it the levels are uniform.
+void dequant_int4_grouped_to_int8(nb::ndarray<> qdata, nb::ndarray<> s_rel, int scale_code,
+                                  OptArray codebook, nb::ndarray<> out, int N, int K,
+                                  int group_size, uintptr_t stream_ptr) {
+    constexpr const char* kFn = "dequant_int4_grouped_to_int8";
+    require_nonneg(N, kFn, "N");
+    require_nonneg(K, kFn, "K");
+    require_positive(group_size, kFn, "group_size");
+    if (scale_code != 0 && scale_code != 5) {
+        throw std::runtime_error(std::string(kFn) + ": s_rel must be float32 or float8_e4m3fn");
+    }
+    if (K % group_size != 0) {
+        throw std::runtime_error(std::string(kFn) + ": group_size must divide K");
+    }
+    require_dtype(qdata, 4, 4, kFn, "qdata");
+    require_dtype(out, 4, 4, kFn, "out");
+    require_dtype(s_rel, scale_code == 0 ? 0 : 3, scale_code == 0 ? 0 : 3, kFn, "s_rel");
+    require_len(qdata, static_cast<int64_t>(N) * (K / 2), kFn, "qdata");
+    require_len(out, static_cast<int64_t>(N) * K, kFn, "out");
+    require_len(s_rel, static_cast<int64_t>(N) * (K / group_size), kFn, "s_rel");
+    if (codebook.has_value()) {
+        require_scale_len(*codebook, 16, kFn, "codebook");
+    }
+
+    launch_dequant_int4_grouped_to_int8_kernel(
+        qdata.data(), s_rel.data(), scale_code, opt_data(codebook), out.data(), N, K, group_size,
+        reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+// Chunked W4A8: decode chunk_cols weight columns at a time and run the INT8 GEMM
+// on each chunk, writing an N-wide slice of out. xq/xs are the already rotated and
+// quantized activation, so the loop only touches the weight.
+void w4a8_int8_gemm_chunked(nb::ndarray<> xq, nb::ndarray<> qdata, nb::ndarray<> s_rel,
+                            int scale_code, OptArray codebook, nb::ndarray<> s_channel,
+                            nb::ndarray<> xs, OptArray bias, nb::ndarray<> workspace,
+                            nb::ndarray<> out, int M, int N, int K, int group_size, int chunk_cols,
+                            int out_code, uintptr_t stream_ptr) {
+    constexpr const char* kFn = "w4a8_int8_gemm_chunked";
+    require_nonneg(M, kFn, "M");
+    require_nonneg(N, kFn, "N");
+    require_nonneg(K, kFn, "K");
+    require_positive(group_size, kFn, "group_size");
+    require_positive(chunk_cols, kFn, "chunk_cols");
+    if (scale_code != 0 && scale_code != 5) {
+        throw std::runtime_error(std::string(kFn) + ": s_rel must be float32 or float8_e4m3fn");
+    }
+    if (K % group_size != 0) {
+        throw std::runtime_error(std::string(kFn) + ": group_size must divide K");
+    }
+    require_dtype(xq, 4, 4, kFn, "xq");
+    require_dtype(qdata, 4, 4, kFn, "qdata");
+    require_dtype(workspace, 4, 4, kFn, "workspace");
+    require_dtype(out, 0, 2, kFn, "out");
+    require_out_matches(out, out_code, kFn);
+    require_dtype(s_rel, scale_code == 0 ? 0 : 3, scale_code == 0 ? 0 : 3, kFn, "s_rel");
+    require_len(xq, static_cast<int64_t>(M) * K, kFn, "xq");
+    require_len(qdata, static_cast<int64_t>(N) * (K / 2), kFn, "qdata");
+    require_len(s_rel, static_cast<int64_t>(N) * (K / group_size), kFn, "s_rel");
+    require_len(out, static_cast<int64_t>(M) * N, kFn, "out");
+    // Every chunk decodes into the same scratch, so it has to hold the widest one.
+    require_len(workspace, static_cast<int64_t>(chunk_cols < N ? chunk_cols : N) * K, kFn,
+                "workspace");
+    require_scale_len(s_channel, static_cast<size_t>(N), kFn, "s_channel");
+    require_scale_len(xs, static_cast<size_t>(M), kFn, "xs");
+    require_bias(bias, N, kFn);
+    if (codebook.has_value()) {
+        require_scale_len(*codebook, 16, kFn, "codebook");
+    }
+
+    launch_w4a8_int8_gemm_chunked_kernel(
+        xq.data(), qdata.data(), s_rel.data(), scale_code, opt_data(codebook), s_channel.data(),
+        xs.data(), opt_data(bias), opt_code(bias), workspace.data(), out.data(), M, N, K,
+        group_size, chunk_cols, out_code, reinterpret_cast<hipStream_t>(stream_ptr));
     check_hip_launch();
 }
 
@@ -879,6 +957,8 @@ NB_MODULE(_C, m) {
     m.def("convrot_quant_int4", &convrot_quant_int4);
     m.def("convrot_max_k", &convrot_max_k_host);
     m.def("unpack_int4", &unpack_int4);
+    m.def("dequant_int4_grouped_to_int8", &dequant_int4_grouped_to_int8);
+    m.def("w4a8_int8_gemm_chunked", &w4a8_int8_gemm_chunked);
     m.def("adaln", &adaln);
     m.def("rms_adaln", &rms_adaln);
     m.def("apply_rope", &apply_rope);

--- a/comfy_kitchen/backends/hip/gemm_wmma.h
+++ b/comfy_kitchen/backends/hip/gemm_wmma.h
@@ -5,7 +5,9 @@
 // gfx12.
 //
 // Computes C[M, N] = epilogue(A[M, K] @ B[N, K]^T). The B operand is the weight
-// in its natural (N, K) row-major form, matching torch linear.
+// in its natural (N, K) row-major form, matching torch linear. C is written with
+// row stride ldc, so a caller splitting N into column chunks can point at a slice
+// of a wider output; ldc == N for a whole GEMM.
 //
 // The tile loop is byte-addressed: LDS holds raw rows, and how many bytes of a
 // row one MMA consumes (Mma::kStepBytes) and how a lane reads its fragment out of
@@ -78,7 +80,7 @@ template <typename Mma, typename Epi, typename OutT,
           int BM, int BN, int BKB, int WARPS_M, int WARPS_N, int TM, int TN>
 __global__ __launch_bounds__(WARPS_M* WARPS_N* kWave) void gemm_wmma_kernel(
     const uint8_t* __restrict__ A, const uint8_t* __restrict__ B, OutT* __restrict__ C,
-    int M, int N, int kbytes, Epi epi) {
+    int M, int N, int kbytes, int ldc, Epi epi) {
 
     constexpr int kThreads = WARPS_M * WARPS_N * kWave;
     constexpr int kStride = BKB + kLdsPad;
@@ -205,7 +207,7 @@ __global__ __launch_bounds__(WARPS_M* WARPS_N* kWave) void gemm_wmma_kernel(
         for (int e = 0; e < 8; ++e) {
             const int r = m0 + wm * (TM * 16) + i * 16 + acc_row(lane, e);
             if (r >= M) continue;
-            OutT* crow = C + static_cast<int64_t>(r) * N;
+            OutT* crow = C + static_cast<int64_t>(r) * ldc;
             #pragma unroll
             for (int j = 0; j < TN; ++j) {
                 const int col = n0 + wn * (TN * 16) + j * 16 + col_lane;

--- a/comfy_kitchen/backends/hip/launchers.h
+++ b/comfy_kitchen/backends/hip/launchers.h
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Launchers called from more than one translation unit. They are extern "C", so a
+// declaration that drifts from its definition still links and then corrupts the
+// call frame; declaring them once where the definition can see it makes the
+// compiler check instead.
+#pragma once
+
+#include <hip/hip_runtime.h>
+
+#include <cstdint>
+
+extern "C" {
+
+// ldc is c's row stride, so a caller writing an N-column slice of a wider output
+// passes that output's width; a whole GEMM passes N.
+void launch_int8_gemm_kernel(const void* a, const void* b, void* c, const void* scale_a,
+                             const void* scale_b, int scale_b_stride, const void* bias,
+                             int bias_code, int M, int N, int K, int ldc, int out_code,
+                             hipStream_t stream);
+
+// scale_code is a DTYPE_TO_CODE value: 0 float32, 5 e4m3 (passed as raw bytes).
+// codebook is 16 floats, or null for the uniform levels.
+void launch_dequant_int4_grouped_to_int8_kernel(const void* qw, const void* s_rel, int scale_code,
+                                                const void* codebook, void* out, int64_t n,
+                                                int64_t k, int group_size, hipStream_t stream);
+
+void launch_w4a8_int8_gemm_chunked_kernel(const void* xq, const void* qw, const void* s_rel,
+                                          int scale_code, const void* codebook,
+                                          const void* s_channel, const void* xs, const void* bias,
+                                          int bias_code, void* workspace, void* out, int M, int N,
+                                          int K, int group_size, int chunk_cols, int out_code,
+                                          hipStream_t stream);
+
+}  // extern "C"

--- a/comfy_kitchen/backends/hip/ops/convrot_w4a4.hip
+++ b/comfy_kitchen/backends/hip/ops/convrot_w4a4.hip
@@ -37,17 +37,17 @@ static void launch_w4a4(const uint8_t* A, const uint8_t* B, OutT* C, int M, int 
         constexpr int BM = 256, BN = 128, BKB = 64;
         dim3 grid((N + BN - 1) / BN, (M + BM - 1) / BM);
         gemm_wmma_kernel<MmaInt4, EpiRowwise, OutT, BM, BN, BKB, 4, 2, 4, 4>
-            <<<grid, 256, 0, stream>>>(A, B, C, M, N, kbytes, epi);
+            <<<grid, 256, 0, stream>>>(A, B, C, M, N, kbytes, N, epi);
     } else if (M >= 96 && N >= 96) {
         constexpr int BM = 128, BN = 128, BKB = 64;
         dim3 grid((N + BN - 1) / BN, (M + BM - 1) / BM);
         gemm_wmma_kernel<MmaInt4, EpiRowwise, OutT, BM, BN, BKB, 4, 2, 2, 4>
-            <<<grid, 256, 0, stream>>>(A, B, C, M, N, kbytes, epi);
+            <<<grid, 256, 0, stream>>>(A, B, C, M, N, kbytes, N, epi);
     } else {
         constexpr int BM = 64, BN = 64, BKB = 64;
         dim3 grid((N + BN - 1) / BN, (M + BM - 1) / BM);
         gemm_wmma_kernel<MmaInt4, EpiRowwise, OutT, BM, BN, BKB, 2, 2, 2, 2>
-            <<<grid, 128, 0, stream>>>(A, B, C, M, N, kbytes, epi);
+            <<<grid, 128, 0, stream>>>(A, B, C, M, N, kbytes, N, epi);
     }
 }
 

--- a/comfy_kitchen/backends/hip/ops/gemm_fp8.hip
+++ b/comfy_kitchen/backends/hip/ops/gemm_fp8.hip
@@ -64,17 +64,17 @@ static void launch_fp8(const uint8_t* A, const uint8_t* B, OutT* C, int M, int N
         constexpr int BM = 256, BN = 128, BKB = 64;
         dim3 grid((N + BN - 1) / BN, (M + BM - 1) / BM);
         gemm_wmma_kernel<MmaFp8, EpiTensorwise, OutT, BM, BN, BKB, 4, 2, 4, 4>
-            <<<grid, 256, 0, stream>>>(A, B, C, M, N, K, epi);
+            <<<grid, 256, 0, stream>>>(A, B, C, M, N, K, N, epi);
     } else if (M >= 96 && N >= 96) {
         constexpr int BM = 128, BN = 128, BKB = 64;
         dim3 grid((N + BN - 1) / BN, (M + BM - 1) / BM);
         gemm_wmma_kernel<MmaFp8, EpiTensorwise, OutT, BM, BN, BKB, 4, 2, 2, 4>
-            <<<grid, 256, 0, stream>>>(A, B, C, M, N, K, epi);
+            <<<grid, 256, 0, stream>>>(A, B, C, M, N, K, N, epi);
     } else {
         constexpr int BM = 64, BN = 64, BKB = 64;
         dim3 grid((N + BN - 1) / BN, (M + BM - 1) / BM);
         gemm_wmma_kernel<MmaFp8, EpiTensorwise, OutT, BM, BN, BKB, 2, 2, 2, 2>
-            <<<grid, 128, 0, stream>>>(A, B, C, M, N, K, epi);
+            <<<grid, 128, 0, stream>>>(A, B, C, M, N, K, N, epi);
     }
 }
 

--- a/comfy_kitchen/backends/hip/ops/gemm_int8.hip
+++ b/comfy_kitchen/backends/hip/ops/gemm_int8.hip
@@ -8,6 +8,7 @@
 
 #include "../epilogue.h"
 #include "../gemm_wmma.h"
+#include "../launchers.h"
 
 namespace comfy::hip_backend {
 
@@ -15,7 +16,7 @@ namespace comfy::hip_backend {
 template <typename OutT>
 __global__ __launch_bounds__(256) void gemv_int8_kernel(
     const int8_t* __restrict__ A, const int8_t* __restrict__ B, OutT* __restrict__ C,
-    int M, int N, int K, EpiRowwise epi) {
+    int M, int N, int K, int ldc, EpiRowwise epi) {
 
     const int col = blockIdx.x * blockDim.y + threadIdx.y;
     const int row = blockIdx.y;
@@ -37,13 +38,13 @@ __global__ __launch_bounds__(256) void gemv_int8_kernel(
 
     if (threadIdx.x == 0) {
         epi.init();
-        C[static_cast<int64_t>(row) * N + col] =
+        C[static_cast<int64_t>(row) * ldc + col] =
             static_cast<OutT>(epi(row, col, static_cast<float>(sum)));
     }
 }
 
 template <typename OutT>
-static void launch_int8(const int8_t* A, const int8_t* B, OutT* C, int M, int N, int K,
+static void launch_int8(const int8_t* A, const int8_t* B, OutT* C, int M, int N, int K, int ldc,
                         EpiRowwise epi, hipStream_t stream) {
     const uint8_t* Au = reinterpret_cast<const uint8_t*>(A);
     const uint8_t* Bu = reinterpret_cast<const uint8_t*>(B);
@@ -51,24 +52,24 @@ static void launch_int8(const int8_t* A, const int8_t* B, OutT* C, int M, int N,
     if (M <= 8) {
         dim3 block(kWave, 8);
         dim3 grid((N + 7) / 8, M);
-        gemv_int8_kernel<OutT><<<grid, block, 0, stream>>>(A, B, C, M, N, K, epi);
+        gemv_int8_kernel<OutT><<<grid, block, 0, stream>>>(A, B, C, M, N, K, ldc, epi);
         return;
     }
     if (M >= 512 && N >= 128 && K > N) {
         constexpr int BM = 256, BN = 128, BKB = 64;
         dim3 grid((N + BN - 1) / BN, (M + BM - 1) / BM);
         gemm_wmma_kernel<MmaInt8, EpiRowwise, OutT, BM, BN, BKB, 4, 2, 4, 4>
-            <<<grid, 256, 0, stream>>>(Au, Bu, C, M, N, K, epi);
+            <<<grid, 256, 0, stream>>>(Au, Bu, C, M, N, K, ldc, epi);
     } else if (M >= 96 && N >= 96) {
         constexpr int BM = 128, BN = 128, BKB = 64;
         dim3 grid((N + BN - 1) / BN, (M + BM - 1) / BM);
         gemm_wmma_kernel<MmaInt8, EpiRowwise, OutT, BM, BN, BKB, 4, 2, 2, 4>
-            <<<grid, 256, 0, stream>>>(Au, Bu, C, M, N, K, epi);
+            <<<grid, 256, 0, stream>>>(Au, Bu, C, M, N, K, ldc, epi);
     } else {
         constexpr int BM = 64, BN = 64, BKB = 64;
         dim3 grid((N + BN - 1) / BN, (M + BM - 1) / BM);
         gemm_wmma_kernel<MmaInt8, EpiRowwise, OutT, BM, BN, BKB, 2, 2, 2, 2>
-            <<<grid, 128, 0, stream>>>(Au, Bu, C, M, N, K, epi);
+            <<<grid, 128, 0, stream>>>(Au, Bu, C, M, N, K, ldc, epi);
     }
 }
 
@@ -79,12 +80,16 @@ extern "C" void launch_int8_gemm_kernel(
     const void* a, const void* b, void* c,
     const void* scale_a, const void* scale_b, int scale_b_stride,
     const void* bias, int bias_code,
-    int M, int N, int K, int out_code, hipStream_t stream) {
+    int M, int N, int K, int ldc, int out_code, hipStream_t stream) {
 
     using namespace comfy::hip_backend;
 
     if (M == 0 || N == 0) {
         return;  // a zero-dimension grid is hipErrorInvalidConfiguration
+    }
+    if (ldc < N) {
+        throw std::runtime_error("int8_gemm: ldc=" + std::to_string(ldc) +
+                                 " is narrower than N=" + std::to_string(N));
     }
     // Both the tile loader and the small-M GEMV read a row 16 bytes at a time; an
     // unaligned K would take the last chunk past the end of the row. An empty GEMM
@@ -101,11 +106,11 @@ extern "C" void launch_int8_gemm_kernel(
     const int8_t* B = static_cast<const int8_t*>(b);
 
     if (out_code == kBF16) {
-        launch_int8<__bf16>(A, B, static_cast<__bf16*>(c), M, N, K, epi, stream);
+        launch_int8<__bf16>(A, B, static_cast<__bf16*>(c), M, N, K, ldc, epi, stream);
     } else if (out_code == kF16) {
-        launch_int8<__half>(A, B, static_cast<__half*>(c), M, N, K, epi, stream);
+        launch_int8<__half>(A, B, static_cast<__half*>(c), M, N, K, ldc, epi, stream);
     } else if (out_code == kF32) {
-        launch_int8<float>(A, B, static_cast<float*>(c), M, N, K, epi, stream);
+        launch_int8<float>(A, B, static_cast<float*>(c), M, N, K, ldc, epi, stream);
     } else {
         throw std::runtime_error("int8_gemm: unsupported output dtype");
     }

--- a/comfy_kitchen/backends/hip/ops/w4a8_dequant.hip
+++ b/comfy_kitchen/backends/hip/ops/w4a8_dequant.hip
@@ -1,0 +1,182 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Grouped INT4 -> INT8 weight decode for the W4A8 path. The per-group scale is
+// folded in here so the result feeds the WMMA int8 GEMM directly; the
+// per-channel scale stays for that GEMM's epilogue. Memory-bound.
+#include <stdexcept>
+
+#include "../fp8_utils.h"
+#include "../launchers.h"
+
+namespace comfy::hip_backend {
+
+// Bytes per element of a DTYPE_TO_CODE value. The chunk loop strides three
+// different operands, so one table keeps them from drifting apart.
+inline int64_t dtype_size(int code) {
+    switch (code) {
+        case 0: return 4;          // float32
+        case 1:
+        case 2: return 2;          // float16, bfloat16
+        default: return 1;         // uint8 storage, which is how fp8 crosses
+    }
+}
+
+// The group scale is stored as fp32 or as raw e4m3 bytes.
+template <typename ScaleT>
+__forceinline__ __device__ float load_group_scale(ScaleT v);
+
+template <>
+__forceinline__ __device__ float load_group_scale<float>(float v) {
+    return v;
+}
+
+template <>
+__forceinline__ __device__ float load_group_scale<uint8_t>(uint8_t v) {
+    return fp8_to_float(v);
+}
+
+__forceinline__ __device__ int8_t dequant_round(float v) {
+    // rintf is round-half-to-even, matching torch.round.
+    int q = static_cast<int>(rintf(v));
+    q = q < -127 ? -127 : (q > 127 ? 127 : q);
+    return static_cast<int8_t>(q);
+}
+
+// One thread reads 8 packed bytes and writes 16 int8. group_size is 4, 8, 16 or
+// a multiple of 16, so those 16 columns span at most four groups: load each of
+// those scales once instead of re-reading one per output pair.
+template <typename ScaleT>
+__global__ void dequant_int4_grouped_to_int8_kernel(
+    const int8_t* __restrict__ qw, const ScaleT* __restrict__ s_rel,
+    const float* __restrict__ codebook, int8_t* __restrict__ out,
+    int64_t vec_count, int k_half, int k, int group_size) {
+
+    __shared__ float cb[16];
+    if (codebook && threadIdx.x < 16) {
+        cb[threadIdx.x] = codebook[threadIdx.x];
+    }
+    if (codebook) {
+        __syncthreads();
+    }
+
+    const int64_t vec = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (vec >= vec_count) {
+        return;
+    }
+
+    const int vec_per_row = k_half / 8;
+    const int64_t row = vec / vec_per_row;
+    const int byte_base = static_cast<int>(vec % vec_per_row) * 8;
+    const int col_base = byte_base * 2;
+
+    const uint2 packed = *reinterpret_cast<const uint2*>(&qw[row * k_half + byte_base]);
+    const unsigned words[2] = {packed.x, packed.y};
+
+    const int64_t scale_row = row * (k / group_size);
+    const int group_base = col_base / group_size;
+    const float sc0 = load_group_scale<ScaleT>(s_rel[scale_row + group_base]);
+    float sc1 = sc0, sc2 = sc0, sc3 = sc0;
+    if (group_size < 16) {
+        sc1 = load_group_scale<ScaleT>(s_rel[scale_row + group_base + 1]);
+        if (group_size < 8) {
+            sc2 = load_group_scale<ScaleT>(s_rel[scale_row + group_base + 2]);
+            sc3 = load_group_scale<ScaleT>(s_rel[scale_row + group_base + 3]);
+        }
+    }
+
+    alignas(16) int8_t decoded[16];
+#pragma unroll
+    for (int w = 0; w < 2; ++w) {
+#pragma unroll
+        for (int b = 0; b < 4; ++b) {
+            const int pair = w * 4 + b;
+            const int local = (group_size >= 16) ? 0 : ((pair * 2) / group_size);
+            const float s = (local == 0) ? sc0 : (local == 1 ? sc1 : (local == 2 ? sc2 : sc3));
+            const unsigned byte = (words[w] >> (b * 8)) & 0xFFu;
+            const unsigned lo = byte & 0xFu;
+            const unsigned hi = (byte >> 4) & 0xFu;
+            const float v0 = codebook ? cb[lo] : (static_cast<float>(lo) - 8.0f);
+            const float v1 = codebook ? cb[hi] : (static_cast<float>(hi) - 8.0f);
+            decoded[pair * 2] = dequant_round(v0 * s);
+            decoded[pair * 2 + 1] = dequant_round(v1 * s);
+        }
+    }
+    *reinterpret_cast<uint4*>(&out[row * k + col_base]) =
+        *reinterpret_cast<const uint4*>(decoded);
+}
+
+}  // namespace comfy::hip_backend
+
+// Decode the weight in column chunks, running the INT8 GEMM on each chunk before
+// the next is decoded, so a chunk is still cached when the GEMM reads it back
+// instead of the whole [N, K] INT8 weight round-tripping through global memory.
+extern "C" void launch_w4a8_int8_gemm_chunked_kernel(
+    const void* xq, const void* qw, const void* s_rel, int scale_code, const void* codebook,
+    const void* s_channel, const void* xs, const void* bias, int bias_code, void* workspace,
+    void* out, int M, int N, int K, int group_size, int chunk_cols, int out_code,
+    hipStream_t stream) {
+
+    using namespace comfy::hip_backend;
+    if (chunk_cols <= 0) {
+        throw std::runtime_error("w4a8_int8_gemm_chunked: chunk_cols must be positive");
+    }
+    const int64_t k_half = K / 2;
+    const int64_t scale_row = (group_size > 0) ? K / group_size : 0;
+
+    for (int n0 = 0; n0 < N; n0 += chunk_cols) {
+        const int cols = (chunk_cols < N - n0) ? chunk_cols : (N - n0);
+        launch_dequant_int4_grouped_to_int8_kernel(
+            static_cast<const int8_t*>(qw) + n0 * k_half,
+            static_cast<const char*>(s_rel) + n0 * scale_row * dtype_size(scale_code), scale_code,
+            codebook, workspace, cols, K, group_size, stream);
+        launch_int8_gemm_kernel(
+            xq, workspace, static_cast<char*>(out) + n0 * dtype_size(out_code), xs,
+            static_cast<const float*>(s_channel) + n0, 1,
+            bias ? static_cast<const char*>(bias) + n0 * dtype_size(bias_code) : nullptr,
+            bias_code, M, cols, K, N /*ldc*/, out_code, stream);
+    }
+}
+
+// scale_code is a DTYPE_TO_CODE value: 0 float32, 5 e4m3 (passed as raw bytes).
+// codebook is 16 floats, or null for the uniform levels (code - 8).
+extern "C" void launch_dequant_int4_grouped_to_int8_kernel(
+    const void* qw, const void* s_rel, int scale_code, const void* codebook, void* out,
+    int64_t n, int64_t k, int group_size, hipStream_t stream) {
+
+    using namespace comfy::hip_backend;
+    // The vector load reads 8 packed bytes and the store writes 16 columns, so a
+    // row that is not a whole number of vectors would run into the next one.
+    if (k % 16 != 0) {
+        throw std::runtime_error("dequant_int4_grouped_to_int8: K must be divisible by 16");
+    }
+    // Four scales are loaded per vector, so a narrower group would span more.
+    if (group_size < 4 || k % group_size != 0 ||
+        (16 % group_size != 0 && group_size % 16 != 0)) {
+        throw std::runtime_error(
+            "dequant_int4_grouped_to_int8: group_size must be >=4 and divide 16 or be a "
+            "multiple of 16");
+    }
+    if (n == 0 || k == 0) {
+        return;  // a zero-block launch is hipErrorInvalidConfiguration
+    }
+
+    const int k_half = static_cast<int>(k / 2);
+    const int64_t vec_count = n * (k_half / 8);
+    constexpr int threads = 256;
+    const int64_t blocks = (vec_count + threads - 1) / threads;
+
+    if (scale_code == kFp8E4M3Code) {
+        dequant_int4_grouped_to_int8_kernel<uint8_t>
+            <<<static_cast<unsigned int>(blocks), threads, 0, stream>>>(
+                static_cast<const int8_t*>(qw), static_cast<const uint8_t*>(s_rel),
+                static_cast<const float*>(codebook), static_cast<int8_t*>(out), vec_count,
+                k_half, static_cast<int>(k), group_size);
+    } else {
+        dequant_int4_grouped_to_int8_kernel<float>
+            <<<static_cast<unsigned int>(blocks), threads, 0, stream>>>(
+                static_cast<const int8_t*>(qw), static_cast<const float*>(s_rel),
+                static_cast<const float*>(codebook), static_cast<int8_t*>(out), vec_count,
+                k_half, static_cast<int>(k), group_size);
+    }
+}

--- a/tests/test_hip_wmma.py
+++ b/tests/test_hip_wmma.py
@@ -8,11 +8,13 @@ import pytest
 import torch
 
 import comfy_kitchen as ck
+from comfy_kitchen.backends.eager import w4a8_int8 as eager_w4a8
 from comfy_kitchen.backends.eager.convrot_w4a4 import _unpack_int4_row_major
 from comfy_kitchen.backends.eager.quantization import (
     quantize_and_rotate_rowwise as eager_quantize_and_rotate_rowwise,
 )
 from comfy_kitchen.registry import registry
+from comfy_kitchen.tensor import AsymW4A8Int8Layout, QuantizedTensor
 from comfy_kitchen.tensor.int8_utils import _build_hadamard
 
 
@@ -447,6 +449,225 @@ def test_convrot_w4a4_roundtrip(hip):
     assert deq.shape == w.shape
     rel = (deq - w.float()).norm() / w.float().norm()
     assert rel < 0.2  # int4 weight fidelity
+
+
+# ---------------------------------------------------------------------------
+# Grouped W4A8 over the INT8 GEMM
+# ---------------------------------------------------------------------------
+
+def _quantize_w4a8(n, k, **kwargs):
+    w = torch.randn(n, k, device=DEV, dtype=torch.bfloat16) * 0.02
+    return w, eager_w4a8.quantize_w4a8_int8_weight(w, **kwargs)
+
+
+@pytest.mark.parametrize("group_size", [4, 8, 16, 32, 64])
+@pytest.mark.parametrize("scale_dtype", [torch.float8_e4m3fn, torch.float32])
+@pytest.mark.parametrize("codebook", [False, True])
+def test_w4a8_int4_decode_is_bit_exact(hip, group_size, scale_dtype, codebook):
+    """The decode rounds one value at a time, so it must agree with eager exactly."""
+    torch.manual_seed(0)
+    _, (qdata, s_rel, _, _, cb) = _quantize_w4a8(
+        128, 512, group_size=group_size, scale_dtype=scale_dtype, codebook=codebook
+    )
+
+    out = hip._dequant_int4_grouped_to_int8(qdata, s_rel, cb, group_size)
+    ref = eager_w4a8._dequant_int4_grouped_to_int8(qdata, s_rel, cb, group_size)
+
+    assert out.shape == ref.shape and out.dtype == torch.int8
+    assert torch.equal(out, ref)
+
+
+@pytest.mark.parametrize("symmetric", [True, False])
+def test_w4a8_dequantize_weight_matches_eager(hip, symmetric):
+    torch.manual_seed(0)
+    w, (qdata, s_rel, s_channel, correction, cb) = _quantize_w4a8(
+        128, 512, symmetric=symmetric, codebook=symmetric
+    )
+    kwargs = {"codebook": cb, "correction": correction, "output_dtype": torch.bfloat16}
+
+    out = hip.dequantize_w4a8_int8_weight(qdata, s_rel, s_channel, **kwargs)
+    ref = eager_w4a8.dequantize_w4a8_int8_weight(qdata, s_rel, s_channel, **kwargs)
+
+    torch.testing.assert_close(out.float(), ref.float(), rtol=0, atol=0)
+    rel = (out.float() - w.float()).norm() / w.float().norm()
+    assert rel < 0.2  # int4 weight fidelity
+
+
+@pytest.mark.parametrize(("m", "n", "k"), [(1, 256, 512), (17, 512, 256), (256, 1024, 512)])
+@pytest.mark.parametrize("bias", [False, True])
+@needs_wmma
+def test_w4a8_linear_matches_eager(hip, m, n, k, bias):
+    torch.manual_seed(0)
+    _, (qdata, s_rel, s_channel, correction, cb) = _quantize_w4a8(n, k)
+    x = torch.randn(m, k, device=DEV, dtype=torch.bfloat16)
+    bias_t = torch.randn(n, device=DEV, dtype=torch.bfloat16) if bias else None
+    kwargs = {
+        "codebook": cb,
+        "correction": correction,
+        "bias": bias_t,
+        "out_dtype": torch.bfloat16,
+    }
+
+    out = hip.w4a8_int8_linear(x, qdata, s_rel, s_channel, **kwargs)
+    ref = eager_w4a8.w4a8_int8_linear(x, qdata, s_rel, s_channel, **kwargs)
+
+    assert out.shape == (m, n)
+    # Both decode the weight identically and differ only in how the activation
+    # quantizer rounds, so compare with an int8-sized tolerance.
+    scale = ref.float().abs().max().item()
+    assert (out.float() - ref.float()).abs().max().item() < 0.05 * scale
+
+
+@pytest.mark.parametrize(("n", "chunk_cols"), [(1024, 256), (1280, 512), (1152, 384)])
+@pytest.mark.parametrize("m", [4, 192], ids=["gemv", "wmma"])
+@needs_wmma
+def test_w4a8_linear_chunking_does_not_change_the_result(hip, monkeypatch, n, chunk_cols, m):
+    """Each chunk writes an N-column slice of the output through ldc, so a chunk
+    boundary (including a short trailing one) must not disturb its neighbours."""
+    torch.manual_seed(0)
+    k = 512
+    _, (qdata, s_rel, s_channel, _, cb) = _quantize_w4a8(n, k)
+    x = torch.randn(m, k, device=DEV, dtype=torch.bfloat16)
+    bias = torch.randn(n, device=DEV, dtype=torch.bfloat16)
+
+    monkeypatch.setattr(hip, "_w4a8_chunk_cols", lambda *_: n)
+    one_pass = hip.w4a8_int8_linear(x, qdata, s_rel, s_channel, codebook=cb, bias=bias)
+    monkeypatch.setattr(hip, "_w4a8_chunk_cols", lambda *_: chunk_cols)
+    chunked = hip.w4a8_int8_linear(x, qdata, s_rel, s_channel, codebook=cb, bias=bias)
+
+    assert chunked.shape == (m, n)
+    assert torch.equal(chunked, one_pass)
+
+
+def test_w4a8_chunk_cols_stays_within_its_bounds(hip):
+    n, k, dev = 12288, 3072, torch.device(DEV, torch.cuda.current_device())
+    cols = hip._w4a8_chunk_cols(1, n, k, dev)
+    assert cols < n
+    assert cols % 128 == 0
+    assert hip._W4A8_MIN_CHUNK_COLS <= cols <= hip._W4A8_MAX_CHUNK_COLS
+    # Enough rows that the GEMM, not the decode, sets the cost.
+    assert hip._w4a8_chunk_cols(hip._W4A8_CHUNK_MAX_ROWS + 1, n, k, dev) == n
+    # A weight no wider than one chunk is decoded in one pass either way.
+    assert hip._w4a8_chunk_cols(1, cols // 2, k, dev) == cols // 2
+    # A deep K keeps the floor rather than shrinking the GEMM's N grid, and a
+    # shallow one keeps the cap rather than widening a chunk pointlessly.
+    assert hip._w4a8_chunk_cols(1, n, 1 << 20, dev) == hip._W4A8_MIN_CHUNK_COLS
+    assert hip._w4a8_chunk_cols(1, 1 << 20, 16, dev) == hip._W4A8_MAX_CHUNK_COLS
+
+
+@pytest.mark.parametrize("m", [4, 192], ids=["gemv", "wmma"])
+@needs_wmma
+def test_w4a8_realigns_an_offset_qdata(hip, m):
+    """The decode reads packed weights as uint2, so qdata has to start aligned;
+    contiguous() is a no-op on a slice that does not."""
+    torch.manual_seed(0)
+    n, k = 256, 512
+    _, (qdata, s_rel, s_channel, _, cb) = _quantize_w4a8(n, k)
+    offset = _offset_copy(qdata)
+    x = torch.randn(m, k, device=DEV, dtype=torch.bfloat16)
+
+    assert torch.equal(
+        hip._dequant_int4_grouped_to_int8(offset, s_rel, cb, 16),
+        hip._dequant_int4_grouped_to_int8(qdata, s_rel, cb, 16),
+    )
+    assert torch.equal(
+        hip.w4a8_int8_linear(x, offset, s_rel, s_channel, codebook=cb),
+        hip.w4a8_int8_linear(x, qdata, s_rel, s_channel, codebook=cb),
+    )
+
+
+@needs_wmma
+def test_w4a8_consumes_a_row_chunked_quantize(hip):
+    """The shared packer rotates and packs in row chunks and pins one codebook across
+    them. HIP owns no part of that, so what it must keep proving is that it decodes
+    whatever comes out, including a table reused across a requantize."""
+    torch.manual_seed(0)
+    k = 2048
+    n = eager_w4a8._QUANT_ROW_ELEM_BUDGET // k + 512  # over the packer's row budget
+    w = torch.randn(n, k, device=DEV, dtype=torch.bfloat16) * 0.02
+    qdata, s_rel, _, _, cb = eager_w4a8.quantize_w4a8_int8_weight(w)
+    assert cb is not None
+
+    assert torch.equal(
+        hip._dequant_int4_grouped_to_int8(qdata, s_rel, cb, 16),
+        eager_w4a8._dequant_int4_grouped_to_int8(qdata, s_rel, cb, 16),
+    )
+
+    # A LoRA-style reload pins the earlier table instead of choosing a new one.
+    updated = w + torch.randn_like(w) * 0.002
+    packed = eager_w4a8.quantize_w4a8_int8_weight(updated, codebook_tensor=cb)
+    x = torch.randn(64, k, device=DEV, dtype=torch.bfloat16)
+    out = hip.w4a8_int8_linear(x, packed[0], packed[1], packed[2], codebook=packed[4])
+    ref = eager_w4a8.w4a8_int8_linear(x, packed[0], packed[1], packed[2], codebook=packed[4])
+
+    scale = ref.float().abs().max().item()
+    assert (out.float() - ref.float()).abs().max().item() < 0.05 * scale
+
+
+@needs_wmma
+def test_w4a8_linear_asymmetric_matches_eager(hip):
+    """The zero-point correction has no INT8 epilogue; that layout runs off the
+    dequantized weight, which the eager path does too."""
+    torch.manual_seed(0)
+    _, (qdata, s_rel, s_channel, correction, cb) = _quantize_w4a8(
+        128, 512, symmetric=False, codebook=False
+    )
+    assert correction is not None
+    x = torch.randn(64, 512, device=DEV, dtype=torch.bfloat16)
+    kwargs = {"codebook": cb, "correction": correction, "out_dtype": torch.bfloat16}
+
+    out = hip.w4a8_int8_linear(x, qdata, s_rel, s_channel, **kwargs)
+    ref = eager_w4a8.w4a8_int8_linear(x, qdata, s_rel, s_channel, **kwargs)
+
+    torch.testing.assert_close(out.float(), ref.float(), rtol=0, atol=0)
+
+
+@needs_wmma
+def test_w4a8_linear_dispatches_to_hip():
+    torch.manual_seed(0)
+    w = torch.randn(256, 512, device=DEV, dtype=torch.bfloat16) * 0.02
+    qdata, params = AsymW4A8Int8Layout.quantize(w)
+    x = torch.randn(32, 512, device=DEV, dtype=torch.bfloat16)
+
+    impl = registry.get_implementation(
+        "w4a8_int8_linear",
+        kwargs={
+            "x": x,
+            "qdata": qdata,
+            "s_rel": params.scale,
+            "s_channel": params.s_channel,
+            "codebook": params.codebook,
+            "correction": params.correction,
+            "bias": None,
+            "group_size": params.group_size,
+            "convrot_groupsize": params.convrot_groupsize,
+            "out_dtype": torch.bfloat16,
+        },
+    )
+    assert impl.__module__ == "comfy_kitchen.backends.hip"
+
+    out = torch.nn.functional.linear(x, QuantizedTensor(qdata, "AsymW4A8Int8Layout", params))
+    rel = (out.float() - (x @ w.t()).float()).norm() / (x @ w.t()).float().norm()
+    assert out.shape == (32, 256)
+    assert rel < 0.2
+
+
+# 0 and 3 are caught by the positivity and divisibility checks. 2 and 12 divide
+# their K and only the vector layout rejects them: 2 is under the four scales a
+# vector loads, 12 neither divides 16 nor is a multiple of it.
+@pytest.mark.parametrize(("group_size", "k"), [(0, 256), (3, 256), (2, 256), (12, 48)])
+def test_w4a8_decode_launcher_rejects_an_unsupported_group_size(hip, group_size, k):
+    """Each vector loads four group scales, so the wrappers only reach the kernel
+    with a group of 4, 8, 16 or a multiple of 16; guard the C++ callers too."""
+    qdata = torch.zeros(8, k // 2, dtype=torch.int8, device=DEV)
+    s_rel = torch.ones(8, k // max(group_size, 1), dtype=torch.float32, device=DEV)
+    out = torch.zeros(8, k, dtype=torch.int8, device=DEV)
+
+    with pytest.raises(RuntimeError, match="group_size"):
+        hip._C.dequant_int4_grouped_to_int8(
+            hip._dl(qdata), hip._dl(s_rel), 0, None, hip._dl(out), 8, k, group_size,
+            hip._stream(qdata),
+        )
 
 
 def test_quantize_int8_rowwise_matches_eager():


### PR DESCRIPTION
Ports the AsymW4A8Int8 path from #90 to the HIP backend, which registered none of it and so fell through to eager on ROCm. Rebased on #96; that follow-up needed no HIP work (see below).

### What this adds

- `ops/w4a8_dequant.hip`: grouped int4 -> int8 weight decode. One thread reads 8 packed bytes and writes 16 int8 through a uint4 store, fp32 and e4m3 group scales via one templated kernel, optional codebook staged in LDS. Reuses `fp8_utils.h` for the e4m3 decode.
- `dequantize_w4a8_int8_weight` and `w4a8_int8_linear` plus constraints. The linear feeds the decoded weight into the existing WMMA `int8_linear` with `convrot=True`, so the activation rotation stays in the fused quantizer. `w4a8_int8_linear` is in `_WMMA_ONLY_OPS`, so RDNA2 routes it to triton/eager; the decode is elementwise and stays registered there.
- A chunked path, matching what #90 does on CUDA. The GEMM writeback gained an `ldc` row stride so a chunk can write an N-column slice of the output; the fp8 and int4 GEMMs pass N and are unchanged. The weight is decoded a chunk at a time so it is still cached when the GEMM reads it back, instead of the whole `[N, K]` int8 weight round-tripping through global memory.

`quantize_w4a8_int8_weight` is deliberately not registered. CUDA's version exists to use its native ConvRot rotate kernel, which HIP does not have, and that rotate measures at 0.1-0.2% of quantize time, so eager's packing math is what runs either way.

### Chunk sizing

The chunk width targets the device's own L2, capped at the CUDA backend's 4096 columns so a shallow K does not widen a chunk pointlessly and floored at 1024 so a deep K does not starve the GEMM's N grid. Chunking is limited to M <= 64, the conservative end of where it won on every shape tried: above that the weight is decoded in one pass, which is what this path did before chunking, so a part whose crossover sits higher loses the extra win rather than regressing. Both knobs are overridable via `COMFY_KITCHEN_W4A8_CHUNK_COLS` and `COMFY_KITCHEN_W4A8_CHUNK_MAX_ROWS`.

### Measurements (gfx1200, chunked vs single pass, min of 5x100 iters)

| shape          | M=1   | M=8   | M=16  | M=64  | M>64 |
| -------------- | ----- | ----- | ----- | ----- | ---- |
| N=12288 K=3072 | 1.77x | 3.08x | 1.43x | 1.40x | off  |
| N=3072 K=12288 | 1.49x | 1.65x | 1.27x | 1.30x | off  |
| N=5120 K=5120  | 1.80x | 1.21x | 1.32x | 1.26x | off  |
| N=3072 K=3072  | 1.13x | 1.40x | 1.02x | 1.00x | off  |

Against the eager fallback this replaces, the whole path is 4.6x to 23x faster.

### On #96

The frozen codebook LUT, the row-chunked quantize and the `codebook_tensor` kwarg all live in the shared eager layer, which the HIP backend inherits because it does not register `quantize_w4a8_int8_weight`. #96 does change what the packer emits, so there is a test that the HIP decode is bit exact against eager on a row-chunked quantize and on a requantize with a pinned codebook.

### Testing

- The int4 -> int8 decode is bit exact against eager across group sizes 4/8/16/32/64, both scale dtypes, and codebook on/off. The dequantized weight is bit identical. Linear matches eager to ~4e-3 relative, the activation quantizer rounding difference; eager's own error against fp is 0.02-0.055 on the same tensors.
- Chunk boundaries including a short trailing chunk (N=1152 with 384-column chunks) produce output identical to the single pass, on both the GEMV and WMMA paths.
- 303 passed, 2 skipped on `test_hip_wmma.py` and `test_hip_dispatch.py`.

Only ran on gfx1200. The 17-target fat binary builds clean, and the decode kernel compiles to identical ISA on gfx1030, gfx1100, gfx1151 and gfx1201 (31 VGPRs, no scratch spills, same vectorized load/store), but RDNA2/3/3.5 are compile and disassemble only here. The `ldc` change touches `gemm_wmma.h`, shared by the fp8, int8 and int4 GEMMs on every family, so a check on a 7900 or 6800 would be welcome.

### Required

Core PR:
https://github.com/Comfy-Org/ComfyUI/pull/15308

Test model:
https://huggingface.co/Kijai/MiniMax-H3-experimental/blob/main/minimax_h3_fl2va_pruned_w4a8_mixed.safetensors