### PR TITLE
w4a8: stochastic rounding for LoRA merge + fused requant kernel

### DIFF
--- a/comfy_kitchen/backends/cuda/__init__.py
+++ b/comfy_kitchen/backends/cuda/__init__.py
@@ -173,6 +173,7 @@ from comfy_kitchen.backends.eager.svdquant import (  # noqa: E402
     _unpack_int4_row_major,
 )
 from comfy_kitchen.backends.eager.w4a8_int8 import (  # noqa: E402
+    _QUANT_ROW_ELEM_BUDGET,
     _decide_codebook,
     _dequantize_w4a8_int8_weight_from_int8,
     _quantize_w4a8_chunked,
@@ -1358,23 +1359,19 @@ _W4A8_FUSED_QUANT = hasattr(_C, "quantize_w4a8_convrot")
 _W4A8_FUSED_MAX_K = 16 * (47 * 1024 // 4)
 
 
-def _fused_quantize_w4a8(
+def _fused_quantize_w4a8_kernel(
     rotated: torch.Tensor,
-    codebook: torch.Tensor,
+    codebook_f32: torch.Tensor,
+    packed: torch.Tensor,
+    s_rel: torch.Tensor,
+    s_channel: torch.Tensor,
     stochastic_rounding: int,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, None, torch.Tensor]:
-    """One-launch requant of an already-rotated weight (group_size 16, fp8 s_rel)."""
-    n, k = rotated.shape
-    groups = k // 16
-    rotated = rotated.contiguous()
-    cb = codebook.to(device=rotated.device, dtype=torch.float32).contiguous()
-    packed = torch.empty(n, k // 2, dtype=torch.int8, device=rotated.device)
-    s_rel = torch.empty(n, groups, dtype=torch.float8_e4m3fn, device=rotated.device)
-    s_channel = torch.empty(n, dtype=torch.float32, device=rotated.device)
+) -> None:
+    """Run the fused kernel on ``rotated``, writing into the given (possibly row-sliced) outputs."""
     stream_ptr = torch.cuda.current_stream(rotated.device).cuda_stream
     _C.quantize_w4a8_convrot(
-        _wrap_for_dlpack(rotated),
-        _wrap_for_dlpack(cb),
+        _wrap_for_dlpack(rotated.contiguous()),
+        _wrap_for_dlpack(codebook_f32),
         _wrap_for_dlpack(packed),
         _wrap_for_dlpack(s_rel.view(torch.uint8)),
         _wrap_for_dlpack(s_channel),
@@ -1382,6 +1379,31 @@ def _fused_quantize_w4a8(
         int(stochastic_rounding),
         stream_ptr,
     )
+
+
+def _fused_quantize_w4a8(
+    weight: torch.Tensor,
+    codebook: torch.Tensor,
+    convrot_groupsize: int,
+    stochastic_rounding: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, None, torch.Tensor]:
+    """Rotate + fused requant (group_size 16, fp8 s_rel), row-chunked so peak memory stays
+    capped -- no full rotated copy. The kernel is per-row and s_rel/s_channel/packed are all
+    per-row, so row blocks write straight into their output slices (no cross-row reduction)."""
+    n, k = weight.shape
+    groups = k // 16
+    cb = codebook.to(device=weight.device, dtype=torch.float32).contiguous()
+    packed = torch.empty(n, k // 2, dtype=torch.int8, device=weight.device)
+    s_rel = torch.empty(n, groups, dtype=torch.float8_e4m3fn, device=weight.device)
+    s_channel = torch.empty(n, dtype=torch.float32, device=weight.device)
+    block = max(1, _QUANT_ROW_ELEM_BUDGET // max(k, 1))
+    for r0 in range(0, n, block):
+        r1 = min(r0 + block, n)
+        rot = rotate_int8_convrot_weight(weight[r0:r1].contiguous(), convrot_groupsize)
+        # offset the SR seed per block so chunks decorrelate yet stay deterministic
+        seed = stochastic_rounding + r0 if stochastic_rounding > 0 else 0
+        _fused_quantize_w4a8_kernel(rot, cb, packed[r0:r1], s_rel[r0:r1], s_channel[r0:r1], seed)
+        del rot
     return packed, s_rel, s_channel, None, cb
 
 
@@ -1418,8 +1440,7 @@ def quantize_w4a8_int8_weight(
             if codebook_tensor is not None
             else _decide_codebook(weight, rotate_int8_convrot_weight, group_size, convrot_groupsize)
         )
-        rotated = rotate_int8_convrot_weight(weight.contiguous(), convrot_groupsize)
-        return _fused_quantize_w4a8(rotated, cb, stochastic_rounding)
+        return _fused_quantize_w4a8(weight, cb, convrot_groupsize, stochastic_rounding)
     return _quantize_w4a8_chunked(
         weight,
         rotate_int8_convrot_weight,

--- a/comfy_kitchen/backends/cuda/__init__.py
+++ b/comfy_kitchen/backends/cuda/__init__.py
@@ -173,6 +173,7 @@ from comfy_kitchen.backends.eager.svdquant import (  # noqa: E402
     _unpack_int4_row_major,
 )
 from comfy_kitchen.backends.eager.w4a8_int8 import (  # noqa: E402
+    _decide_codebook,
     _dequantize_w4a8_int8_weight_from_int8,
     _quantize_w4a8_chunked,
     validate_w4a8_operands,
@@ -1351,6 +1352,39 @@ def rotate_int8_convrot_weight(weight: torch.Tensor, group_size: int) -> torch.T
     return output
 
 
+_W4A8_FUSED_QUANT = hasattr(_C, "quantize_w4a8_convrot")
+# Fused kernel holds K/16 fp32 group scales in shared memory; cap at ~48 KB so the launch
+# fits (K over ~190k -- far above any real layer -- falls back to eager).
+_W4A8_FUSED_MAX_K = 16 * (47 * 1024 // 4)
+
+
+def _fused_quantize_w4a8(
+    rotated: torch.Tensor,
+    codebook: torch.Tensor,
+    stochastic_rounding: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, None, torch.Tensor]:
+    """One-launch requant of an already-rotated weight (group_size 16, fp8 s_rel)."""
+    n, k = rotated.shape
+    groups = k // 16
+    rotated = rotated.contiguous()
+    cb = codebook.to(device=rotated.device, dtype=torch.float32).contiguous()
+    packed = torch.empty(n, k // 2, dtype=torch.int8, device=rotated.device)
+    s_rel = torch.empty(n, groups, dtype=torch.float8_e4m3fn, device=rotated.device)
+    s_channel = torch.empty(n, dtype=torch.float32, device=rotated.device)
+    stream_ptr = torch.cuda.current_stream(rotated.device).cuda_stream
+    _C.quantize_w4a8_convrot(
+        _wrap_for_dlpack(rotated),
+        _wrap_for_dlpack(cb),
+        _wrap_for_dlpack(packed),
+        _wrap_for_dlpack(s_rel.view(torch.uint8)),
+        _wrap_for_dlpack(s_channel),
+        stochastic_rounding > 0,
+        int(stochastic_rounding),
+        stream_ptr,
+    )
+    return packed, s_rel, s_channel, None, cb
+
+
 def quantize_w4a8_int8_weight(
     weight: torch.Tensor,
     group_size: int = 16,
@@ -1359,6 +1393,7 @@ def quantize_w4a8_int8_weight(
     scale_dtype: torch.dtype = torch.float8_e4m3fn,
     codebook: bool = True,
     codebook_tensor: torch.Tensor | None = None,
+    stochastic_rounding: int = 0,
 ) -> tuple[
     torch.Tensor,
     torch.Tensor,
@@ -1368,6 +1403,23 @@ def quantize_w4a8_int8_weight(
 ]:
     """Prepare W4A8 weights using native CUDA ConvRot and eager packing math."""
     validate_w4a8_weight_shape(weight, group_size, convrot_groupsize)
+    # Fused CUDA requant for the default codebook layout (group_size 16, fp8 scales);
+    # asym / uniform / fp32-scale / other group sizes use the chunked eager path.
+    if (
+        _W4A8_FUSED_QUANT
+        and symmetric
+        and codebook
+        and group_size == 16
+        and scale_dtype == torch.float8_e4m3fn
+        and weight.shape[1] <= _W4A8_FUSED_MAX_K
+    ):
+        cb = (
+            codebook_tensor
+            if codebook_tensor is not None
+            else _decide_codebook(weight, rotate_int8_convrot_weight, group_size, convrot_groupsize)
+        )
+        rotated = rotate_int8_convrot_weight(weight.contiguous(), convrot_groupsize)
+        return _fused_quantize_w4a8(rotated, cb, stochastic_rounding)
     return _quantize_w4a8_chunked(
         weight,
         rotate_int8_convrot_weight,
@@ -1377,6 +1429,7 @@ def quantize_w4a8_int8_weight(
         scale_dtype=scale_dtype,
         codebook=codebook,
         codebook_override=codebook_tensor,
+        stochastic_rounding=stochastic_rounding,
     )
 
 

--- a/comfy_kitchen/backends/cuda/dlpack_bindings.cpp
+++ b/comfy_kitchen/backends/cuda/dlpack_bindings.cpp
@@ -1169,6 +1169,19 @@ extern "C" {
         int64_t G,
         cudaStream_t stream);
 
+    void launch_quantize_w4a8_convrot(
+        const void* rotated,
+        const void* codebook,
+        void* packed,
+        void* s_rel,
+        void* s_channel,
+        int64_t N,
+        int64_t K,
+        int in_dtype_code,
+        bool stochastic,
+        uint64_t seed,
+        cudaStream_t stream);
+
     bool launch_w4a8_codebook_gemm_chunked(
         const void* xq,
         const void* weight,
@@ -1966,6 +1979,35 @@ void dequant_int4_grouped_to_int8_e4m3(
     launch_dequant_int4_grouped_to_int8_e4m3(qw.data(), s_rel.data(), cb, out.data(), N, K, G, stream);
 }
 
+// Fused W4A8 requantize (group_size=16): rotated weight [N,K] -> packed int4
+// [N,K/2] + fp8-e4m3 s_rel [N,K/16] + f32 s_channel [N] in one launch.
+void quantize_w4a8_convrot(
+    nb::ndarray<nb::ndim<2>, nb::device::cuda> rotated,          // [N, K] fp32/fp16/bf16
+    nb::ndarray<float, nb::ndim<1>, nb::device::cuda> codebook,  // [16]
+    nb::ndarray<int8_t, nb::ndim<2>, nb::device::cuda> packed,   // [N, K/2]
+    nb::ndarray<uint8_t, nb::ndim<2>, nb::device::cuda> s_rel,   // [N, K/16] e4m3 bits
+    nb::ndarray<float, nb::ndim<1>, nb::device::cuda> s_channel, // [N]
+    bool stochastic, uint64_t seed, uintptr_t stream_ptr) {
+    const int64_t N = rotated.shape(0);
+    const int64_t K = rotated.shape(1);
+    const int in_code = map_dtype_to_code(rotated.dtype());
+    if (in_code < 0 || in_code > 2)
+        throw std::runtime_error("quantize_w4a8_convrot: rotated must be fp32/fp16/bf16");
+    if (K % 16 != 0) throw std::runtime_error("quantize_w4a8_convrot: K must be a multiple of 16");
+    if (static_cast<int64_t>(packed.shape(0)) != N || static_cast<int64_t>(packed.shape(1)) != K / 2)
+        throw std::runtime_error("quantize_w4a8_convrot: packed must be [N, K/2]");
+    if (static_cast<int64_t>(s_rel.shape(0)) != N || static_cast<int64_t>(s_rel.shape(1)) != K / 16)
+        throw std::runtime_error("quantize_w4a8_convrot: s_rel must be [N, K/16]");
+    if (static_cast<int64_t>(s_channel.shape(0)) != N)
+        throw std::runtime_error("quantize_w4a8_convrot: s_channel must be [N]");
+    if (static_cast<int64_t>(codebook.shape(0)) != 16)
+        throw std::runtime_error("quantize_w4a8_convrot: codebook must be [16]");
+    cudaStream_t stream = reinterpret_cast<cudaStream_t>(stream_ptr);
+    launch_quantize_w4a8_convrot(
+        rotated.data(), codebook.data(), packed.data(), s_rel.data(), s_channel.data(),
+        N, K, in_code, stochastic, seed, stream);
+}
+
 static void validate_w4a8_codebook_gemm_contract(
     int64_t M, int64_t N, int64_t K,
     int64_t weight_khalf,
@@ -2753,6 +2795,11 @@ NB_MODULE(_C, m) {
           "Grouped int4 -> int8 dequant with fp8 e4m3 per-group scale; optional 16-entry codebook",
           nb::arg("qw"), nb::arg("s_rel"), nb::arg("codebook").none(), nb::arg("out"),
           nb::arg("g"), nb::arg("stream_ptr"));
+
+    m.def("quantize_w4a8_convrot", &quantize_w4a8_convrot,
+          "Fused W4A8 requant (group_size=16): rotated weight -> packed int4 + fp8 s_rel + f32 s_channel",
+          nb::arg("rotated"), nb::arg("codebook"), nb::arg("packed"), nb::arg("s_rel"),
+          nb::arg("s_channel"), nb::arg("stochastic"), nb::arg("seed"), nb::arg("stream_ptr"));
 
     m.def("w4a8_codebook_gemm_chunked", &w4a8_codebook_gemm_chunked,
           "Chunked fused W4A8: per-chunk codebook+s_rel dequant -> L2-hot int8 -> strided int8 GEMM",

--- a/comfy_kitchen/backends/cuda/dlpack_bindings.cpp
+++ b/comfy_kitchen/backends/cuda/dlpack_bindings.cpp
@@ -1169,7 +1169,7 @@ extern "C" {
         int64_t G,
         cudaStream_t stream);
 
-    void launch_quantize_w4a8_convrot(
+    bool launch_quantize_w4a8_convrot(
         const void* rotated,
         const void* codebook,
         void* packed,
@@ -1993,6 +1993,7 @@ void quantize_w4a8_convrot(
     const int in_code = map_dtype_to_code(rotated.dtype());
     if (in_code < 0 || in_code > 2)
         throw std::runtime_error("quantize_w4a8_convrot: rotated must be fp32/fp16/bf16");
+    if (N <= 0) throw std::runtime_error("quantize_w4a8_convrot: N must be positive");
     if (K % 16 != 0) throw std::runtime_error("quantize_w4a8_convrot: K must be a multiple of 16");
     if (static_cast<int64_t>(packed.shape(0)) != N || static_cast<int64_t>(packed.shape(1)) != K / 2)
         throw std::runtime_error("quantize_w4a8_convrot: packed must be [N, K/2]");
@@ -2003,9 +2004,12 @@ void quantize_w4a8_convrot(
     if (static_cast<int64_t>(codebook.shape(0)) != 16)
         throw std::runtime_error("quantize_w4a8_convrot: codebook must be [16]");
     cudaStream_t stream = reinterpret_cast<cudaStream_t>(stream_ptr);
-    launch_quantize_w4a8_convrot(
-        rotated.data(), codebook.data(), packed.data(), s_rel.data(), s_channel.data(),
-        N, K, in_code, stochastic, seed, stream);
+    if (!launch_quantize_w4a8_convrot(
+            rotated.data(), codebook.data(), packed.data(), s_rel.data(), s_channel.data(),
+            N, K, in_code, stochastic, seed, stream))
+        throw std::runtime_error(
+            "quantize_w4a8_convrot: launch failed (group scales exceed shared memory, or "
+            "invalid launch config)");
 }
 
 static void validate_w4a8_codebook_gemm_contract(

--- a/comfy_kitchen/backends/cuda/ops/w4a8_gemm.cu
+++ b/comfy_kitchen/backends/cuda/ops/w4a8_gemm.cu
@@ -10,6 +10,8 @@
 
 #include <cuda_runtime.h>
 #include <cuda_fp8.h>
+#include <cuda_fp16.h>
+#include <cuda_bf16.h>
 #include <cstdint>
 
 // Grouped int4 -> int8 dequant for the int8-GEMM W4A8 path: out[n,k] =
@@ -163,3 +165,168 @@ extern "C" bool launch_w4a8_codebook_gemm_chunked(
     return true;
 }
 
+
+
+// W4A8 requantize in one launch: rotated weight -> packed int4 + fp8 s_rel + f32
+// s_channel (codebook assign + 2 ALS scale iters + per-channel scale + optional
+// stochastic rounding + pack). Reads the already-rotated weight in its native
+// dtype -- same values the eager path sees. group_size fixed at 16.
+// One block per row; each thread owns whole 16-wide groups.
+namespace {
+
+__device__ __forceinline__ float rq_to_float(float v) { return v; }
+__device__ __forceinline__ float rq_to_float(__half v) { return __half2float(v); }
+__device__ __forceinline__ float rq_to_float(__nv_bfloat16 v) { return __bfloat162float(v); }
+
+__device__ __forceinline__ uint32_t rq_pcg(uint32_t x) {
+    x = x * 747796405u + 2891336453u;
+    uint32_t w = ((x >> ((x >> 28u) + 4u)) ^ x) * 277803737u;
+    return (w >> 22u) ^ w;
+}
+// uniform in [0,1) keyed by a global element index + seed
+__device__ __forceinline__ float rq_uniform(int64_t idx, uint64_t seed) {
+    uint32_t h = rq_pcg(static_cast<uint32_t>(idx) ^ static_cast<uint32_t>(seed)
+                        ^ static_cast<uint32_t>(seed >> 32));
+    return static_cast<float>(h >> 8) * (1.0f / 16777216.0f);
+}
+__device__ __forceinline__ float rq_warp_max(float v) {
+    #pragma unroll
+    for (int o = 16; o > 0; o >>= 1) v = fmaxf(v, __shfl_down_sync(0xffffffffu, v, o));
+    return v;
+}
+// nearest index in cb[16] (lowest index on tie); cb sorted ascending
+__device__ __forceinline__ int rq_nearest(float x, const float* cb) {
+    int best = 0; float bd = fabsf(x - cb[0]);
+    #pragma unroll
+    for (int j = 1; j < 16; ++j) { float d = fabsf(x - cb[j]); if (d < bd) { bd = d; best = j; } }
+    return best;
+}
+
+template <typename InputType, bool STOCHASTIC>
+__global__ void quantize_w4a8_convrot_kernel(
+    const InputType* __restrict__ rotated,  // [N, K]
+    const float* __restrict__ codebook,     // [16]
+    int8_t* __restrict__ packed,            // [N, K/2]
+    uint8_t* __restrict__ s_rel,            // [N, K/16] e4m3 bits
+    float* __restrict__ s_channel,          // [N]
+    int K, uint64_t seed)
+{
+    constexpr int G = 16;
+    const int row = blockIdx.x;
+    const int tid = threadIdx.x;
+    const int nthreads = blockDim.x;
+    const int groups = K / G;
+    const int64_t row_off = static_cast<int64_t>(row) * K;
+
+    __shared__ float cb[16];
+    __shared__ float warp_max[32];
+    extern __shared__ float gscale[];  // [groups]
+    if (tid < 16) cb[tid] = codebook[tid];
+    __syncthreads();
+
+    // --- Phase 1: per-group ALS group scale; accumulate row shifted-amax ---
+    float thr_amax = 0.0f;
+    for (int g = tid; g < groups; g += nthreads) {
+        const int64_t base = row_off + static_cast<int64_t>(g) * G;
+        float w[G];
+        float amax = 0.0f;
+        #pragma unroll
+        for (int i = 0; i < G; ++i) { w[i] = rq_to_float(rotated[base + i]); amax = fmaxf(amax, fabsf(w[i])); }
+        float gs = fmaxf(amax, 1e-8f);
+        int idx[G];
+        #pragma unroll
+        for (int i = 0; i < G; ++i) idx[i] = rq_nearest(w[i] / gs, cb);
+        #pragma unroll
+        for (int it = 0; it < 2; ++it) {       // matches eager _ALS_ITERS
+            float num = 0.0f, den = 0.0f;
+            #pragma unroll
+            for (int i = 0; i < G; ++i) { float c = cb[idx[i]]; num += w[i] * c; den += c * c; }
+            gs = fmaxf(num / fmaxf(den, 1e-8f), 1e-8f);
+            #pragma unroll
+            for (int i = 0; i < G; ++i) idx[i] = rq_nearest(w[i] / gs, cb);
+        }
+        gscale[g] = gs;
+        #pragma unroll
+        for (int i = 0; i < G; ++i) thr_amax = fmaxf(thr_amax, fabsf(cb[idx[i]] * gs));
+    }
+
+    // --- block reduce thr_amax -> s_channel = row_amax / 127 ---
+    float wm = rq_warp_max(thr_amax);
+    const int lane = tid & 31, wid = tid >> 5;
+    if (lane == 0) warp_max[wid] = wm;
+    __syncthreads();
+    if (wid == 0) {
+        const int nwarps = (nthreads + 31) >> 5;
+        float t = (lane < nwarps) ? warp_max[lane] : 0.0f;
+        t = rq_warp_max(t);
+        if (lane == 0) warp_max[0] = t;
+    }
+    __syncthreads();
+    const float sc = fmaxf(warp_max[0] / 127.0f, 1e-8f);
+    if (tid == 0) s_channel[row] = sc;
+
+    // --- Phase 2: s_rel (fp8) -> int8 levels -> assign (+SR) -> pack ---
+    const int64_t prow_off = static_cast<int64_t>(row) * (K / 2);
+    const int64_t srow_off = static_cast<int64_t>(row) * groups;
+    for (int g = tid; g < groups; g += nthreads) {
+        const float gs = gscale[g];
+        const float srel_f = gs / sc;
+        const uint8_t srel_bits = __nv_cvt_float_to_fp8(srel_f, __NV_SATFINITE, __NV_E4M3);
+        s_rel[srow_off + g] = srel_bits;
+        const float srel_r = __half2float(__nv_cvt_fp8_to_halfraw(srel_bits, __NV_E4M3));
+        float lv[16];
+        #pragma unroll
+        for (int j = 0; j < 16; ++j) lv[j] = fminf(127.0f, fmaxf(-127.0f, nearbyintf(cb[j] * srel_r)));
+        const int64_t base = row_off + static_cast<int64_t>(g) * G;
+        int u[G];
+        #pragma unroll
+        for (int i = 0; i < G; ++i) {
+            const float t = rq_to_float(rotated[base + i]) / sc;
+            int a;
+            if constexpr (STOCHASTIC) {
+                int lo = 0;
+                #pragma unroll
+                for (int j = 0; j < 16; ++j) lo += (lv[j] <= t);
+                lo = min(max(lo - 1, 0), 14);
+                const float thr = lv[lo] + rq_uniform(base + i, seed) * (lv[lo + 1] - lv[lo]);
+                a = min(lo + (t > thr ? 1 : 0), 15);
+            } else {
+                a = rq_nearest(t, lv);
+            }
+            u[i] = a;
+        }
+        const int64_t base_p = prow_off + static_cast<int64_t>(g) * (G / 2);
+        #pragma unroll
+        for (int p = 0; p < G / 2; ++p)
+            packed[base_p + p] = static_cast<int8_t>((u[2 * p] & 0xF) | ((u[2 * p + 1] & 0xF) << 4));
+    }
+}
+
+}  // namespace
+
+// rotated: [N,K] in in_dtype (0=fp32,1=fp16,2=bf16); s_rel: [N,K/16] e4m3 bits (uint8).
+extern "C" void launch_quantize_w4a8_convrot(
+    const void* rotated, const void* codebook, void* packed, void* s_rel, void* s_channel,
+    int64_t N, int64_t K, int in_dtype_code, bool stochastic, uint64_t seed, cudaStream_t stream)
+{
+    const int threads = 256;
+    const size_t shmem = static_cast<size_t>(K / 16) * sizeof(float);
+    dim3 grid(static_cast<unsigned>(N));
+#define RQ_LAUNCH(IT)                                                                              \
+    do {                                                                                           \
+        if (stochastic)                                                                            \
+            quantize_w4a8_convrot_kernel<IT, true><<<grid, threads, shmem, stream>>>(              \
+                static_cast<const IT*>(rotated), static_cast<const float*>(codebook),              \
+                static_cast<int8_t*>(packed), static_cast<uint8_t*>(s_rel),                        \
+                static_cast<float*>(s_channel), static_cast<int>(K), seed);                        \
+        else                                                                                       \
+            quantize_w4a8_convrot_kernel<IT, false><<<grid, threads, shmem, stream>>>(             \
+                static_cast<const IT*>(rotated), static_cast<const float*>(codebook),              \
+                static_cast<int8_t*>(packed), static_cast<uint8_t*>(s_rel),                        \
+                static_cast<float*>(s_channel), static_cast<int>(K), 0);                           \
+    } while (0)
+    if (in_dtype_code == 0) RQ_LAUNCH(float);
+    else if (in_dtype_code == 1) RQ_LAUNCH(__half);
+    else RQ_LAUNCH(__nv_bfloat16);
+#undef RQ_LAUNCH
+}

--- a/comfy_kitchen/backends/cuda/ops/w4a8_gemm.cu
+++ b/comfy_kitchen/backends/cuda/ops/w4a8_gemm.cu
@@ -305,12 +305,20 @@ __global__ void quantize_w4a8_convrot_kernel(
 }  // namespace
 
 // rotated: [N,K] in in_dtype (0=fp32,1=fp16,2=bf16); s_rel: [N,K/16] e4m3 bits (uint8).
-extern "C" void launch_quantize_w4a8_convrot(
+// Returns false (caller must fall back / raise) if the group-scale shared memory won't fit
+// or the launch is rejected, so uninitialized outputs are never mistaken for a result.
+extern "C" bool launch_quantize_w4a8_convrot(
     const void* rotated, const void* codebook, void* packed, void* s_rel, void* s_channel,
     int64_t N, int64_t K, int in_dtype_code, bool stochastic, uint64_t seed, cudaStream_t stream)
 {
     const int threads = 256;
     const size_t shmem = static_cast<size_t>(K / 16) * sizeof(float);
+    // Static shared is cb[16] + warp_max[32] = 192 bytes; bail if static+dynamic won't fit.
+    int dev = 0, max_shmem = 0;
+    if (cudaGetDevice(&dev) != cudaSuccess) return false;
+    if (cudaDeviceGetAttribute(&max_shmem, cudaDevAttrMaxSharedMemoryPerBlock, dev) != cudaSuccess)
+        return false;
+    if (shmem + 192 > static_cast<size_t>(max_shmem)) return false;
     dim3 grid(static_cast<unsigned>(N));
 #define RQ_LAUNCH(IT)                                                                              \
     do {                                                                                           \
@@ -329,4 +337,5 @@ extern "C" void launch_quantize_w4a8_convrot(
     else if (in_dtype_code == 1) RQ_LAUNCH(__half);
     else RQ_LAUNCH(__nv_bfloat16);
 #undef RQ_LAUNCH
+    return cudaGetLastError() == cudaSuccess;
 }

--- a/comfy_kitchen/backends/eager/w4a8_int8.py
+++ b/comfy_kitchen/backends/eager/w4a8_int8.py
@@ -18,6 +18,10 @@ _FIXED_LUT = (
 # -0.5; the threshold only trips on genuinely non-Gaussian ones (real models never do).
 _W4A8_GATE_KURTOSIS = -0.1
 _KURTOSIS_SAMPLE = 1 << 19
+# ALS group-scale refinement passes. Iteration 1 captures nearly all the gain (relL2 ~0.0706);
+# further passes add < 0.001, so 2 is the quality/speed knee (each pass is a gather + reduction
+# + reassign over the whole tensor, and requantize reruns this per layer under VRAM offload).
+_ALS_ITERS = 2
 
 
 def _codebook_for(normalized: torch.Tensor) -> torch.Tensor:
@@ -34,32 +38,69 @@ def _codebook_for(normalized: torch.Tensor) -> torch.Tensor:
 
 
 def _assign_codes(normalized: torch.Tensor, codebook: torch.Tensor) -> torch.Tensor:
-    """Find nearest codebook indices without a trailing 16-wide temporary."""
-    best = (normalized - codebook[0]).abs()
-    indices = torch.zeros_like(normalized, dtype=torch.int32)
-    for index in range(1, codebook.numel()):
-        distance = (normalized - codebook[index]).abs()
-        closer = distance < best
-        best = torch.where(closer, distance, best)
-        indices = torch.where(closer, index, indices)
-    return indices
+    """Nearest codebook index via binary search on the sorted codebook.
+
+    The codebook is monotonic, so the nearest level is one of the two neighbors of the
+    insertion point -- one searchsorted + a neighbor compare, vs a 16-pass linear scan.
+    Bit-identical to the scan (ties resolve to the lower index in both) and ~4x faster,
+    which matters because the ALS refinement calls this several times per requantize.
+    """
+    last = codebook.numel() - 1
+    pos = torch.searchsorted(codebook, normalized.contiguous())
+    lo = (pos - 1).clamp(0, last)
+    hi = pos.clamp(0, last)
+    dlo = (normalized - codebook[lo]).abs_()
+    dhi = (normalized - codebook[hi]).abs_()
+    return torch.where(dhi < dlo, hi, lo).to(torch.int32)
+
+
+def _stochastic_round(x: torch.Tensor, seed: int) -> torch.Tensor:
+    """Round to nearest integer with probability 1-frac, up with probability frac.
+
+    floor(x + U[0,1)) is stochastic rounding: unbiased in expectation, so sub-quantum deltas
+    (e.g. a small LoRA merged into a low-bit weight) survive instead of being rounded away.
+    """
+    gen = torch.Generator(device=x.device).manual_seed(int(seed))
+    noise = torch.rand(x.shape, generator=gen, device=x.device, dtype=x.dtype)
+    return torch.floor(x + noise)
+
+
+def _round(x: torch.Tensor, stochastic_rounding: int) -> torch.Tensor:
+    return _stochastic_round(x, stochastic_rounding) if stochastic_rounding > 0 else x.round()
 
 
 def _assign_grid(
     weight: torch.Tensor,
     levels: torch.Tensor,
     s_channel: torch.Tensor,
+    stochastic_rounding: int = 0,
 ) -> torch.Tensor:
-    """Find the nearest decoded INT8 level for each grouped weight."""
-    target = weight / s_channel.view(-1, 1, 1)
-    best = (target - levels[..., 0:1].expand_as(weight)).abs()
-    indices = torch.zeros_like(weight, dtype=torch.int32)
-    for index in range(1, 16):
-        distance = (target - levels[..., index : index + 1].expand_as(weight)).abs()
-        closer = distance < best
-        best = torch.where(closer, distance, best)
-        indices = torch.where(closer, index, indices)
-    return indices
+    """Pick a decoded INT8 codebook level for each grouped weight.
+
+    Nearest by default; with ``stochastic_rounding`` > 0, round stochastically between the two
+    bracketing (sorted) codebook levels so a merged LoRA delta below the int4 step is preserved.
+    """
+    n, groups, gsize = weight.shape
+    last = levels.shape[-1] - 1
+    lv = levels.reshape(n * groups, last + 1).contiguous()  # per-group sorted levels
+    tg = (weight / s_channel.view(-1, 1, 1)).reshape(n * groups, gsize).contiguous()
+    pos = torch.searchsorted(lv, tg)  # insertion point in the sorted levels
+    if stochastic_rounding > 0:
+        # SR = pick the upper level when the weight exceeds a uniform-random point in its
+        # bracket. Reruns per layer during inference under VRAM offload, so keep it lean.
+        lo = (pos - 1).clamp_(0, last - 1)  # lower bracket so hi = lo+1 stays in range
+        level_lo = torch.gather(lv, 1, lo)
+        width = torch.gather(lv, 1, lo + 1).sub_(level_lo)
+        gen = torch.Generator(device=tg.device).manual_seed(int(stochastic_rounding))
+        thr = torch.rand(tg.shape, generator=gen, device=tg.device, dtype=tg.dtype)
+        thr.mul_(width).add_(level_lo)  # uniform point in [level[lo], level[lo+1])
+        idx = (lo + (tg > thr)).clamp_(0, last)
+        return idx.to(torch.int32).reshape(n, groups, gsize)
+    lo = (pos - 1).clamp(0, last)
+    hi = pos.clamp(0, last)
+    dlo = tg.sub(torch.gather(lv, 1, lo)).abs_()
+    dhi = tg.sub(torch.gather(lv, 1, hi)).abs_()
+    return torch.where(dhi < dlo, hi, lo).to(torch.int32).reshape(n, groups, gsize)
 
 
 def _fit_codebook(
@@ -126,6 +167,7 @@ def _quantize_rotated_w4a8_int8_weight(
     scale_dtype: torch.dtype = torch.float8_e4m3fn,
     codebook: bool = True,
     codebook_override: torch.Tensor | None = None,
+    stochastic_rounding: int = 0,
 ) -> tuple[
     torch.Tensor,
     torch.Tensor,
@@ -136,7 +178,8 @@ def _quantize_rotated_w4a8_int8_weight(
     """Quantize an already ConvRot-rotated weight into W4A8 storage.
 
     ``codebook_override`` lets a chunked caller pin the same table across chunks; when None
-    it is chosen from this (sub)tensor via _codebook_for.
+    it is chosen from this (sub)tensor via _codebook_for. ``stochastic_rounding`` > 0 seeds
+    stochastic rounding of the final level assignment (the LoRA-merge path).
     """
     if scale_dtype not in (torch.float32, torch.float8_e4m3fn):
         raise ValueError(f"scale_dtype must be float32 or float8_e4m3fn, got {scale_dtype}")
@@ -156,7 +199,7 @@ def _quantize_rotated_w4a8_int8_weight(
             else _codebook_for(normalized)
         )
         quantized = _assign_codes(normalized, codebook_tensor)
-        for _ in range(3):
+        for _ in range(_ALS_ITERS):
             quantized_codebook = codebook_tensor[quantized]
             group_scale = (
                 (grouped_weight * quantized_codebook).sum(-1, keepdim=True)
@@ -168,7 +211,7 @@ def _quantize_rotated_w4a8_int8_weight(
         correction = None
     elif symmetric:
         group_scale = (grouped_weight.abs().amax(dim=-1, keepdim=True) / 7.0).clamp(min=1e-8)
-        signed = (grouped_weight / group_scale).round().clamp(-8, 7).to(torch.int32)
+        signed = _round(grouped_weight / group_scale, stochastic_rounding).clamp(-8, 7).to(torch.int32)
         unsigned = (signed + 8).view(n, k)
         shifted_weight = signed * group_scale
         correction = None
@@ -176,8 +219,7 @@ def _quantize_rotated_w4a8_int8_weight(
         minimum = grouped_weight.amin(dim=-1, keepdim=True)
         group_scale = ((grouped_weight.amax(dim=-1, keepdim=True) - minimum) / 15.0).clamp(min=1e-8)
         unsigned = (
-            ((grouped_weight - minimum) / group_scale)
-            .round()
+            _round((grouped_weight - minimum) / group_scale, stochastic_rounding)
             .clamp(0, 15)
             .to(torch.int32)
             .view(n, k)
@@ -195,7 +237,9 @@ def _quantize_rotated_w4a8_int8_weight(
             .round_()
             .clamp_(-127, 127)
         )
-        unsigned = _assign_grid(grouped_weight, levels, s_channel).view(n, k)
+        unsigned = _assign_grid(
+            grouped_weight, levels, s_channel, stochastic_rounding
+        ).view(n, k)
 
     packed = (
         ((unsigned[:, 0::2] & 0xF) | ((unsigned[:, 1::2] & 0xF) << 4)).to(torch.int8).contiguous()
@@ -248,6 +292,7 @@ def _quantize_w4a8_chunked(
     scale_dtype: torch.dtype,
     codebook: bool,
     codebook_override: torch.Tensor | None = None,
+    stochastic_rounding: int = 0,
 ) -> tuple[
     torch.Tensor,
     torch.Tensor,
@@ -260,7 +305,9 @@ def _quantize_w4a8_chunked(
     One codebook is chosen for the whole tensor -- from a caller ``codebook_override`` (e.g. a
     LoRA requantize reusing the prior table), else from a whole-tensor-spanning sample -- and
     shared across every chunk, so the packed result does not depend on the chunk size. Row math
-    is otherwise independent.
+    is otherwise independent. ``stochastic_rounding`` > 0 seeds SR of the final assignment
+    (the LoRA-merge path); the seed is offset by the row start so chunks decorrelate yet stay
+    deterministic for a fixed chunk size.
     """
     n, k = weight.shape
     block = max(1, _QUANT_ROW_ELEM_BUDGET // max(k, 1))
@@ -280,12 +327,14 @@ def _quantize_w4a8_chunked(
             scale_dtype=scale_dtype,
             codebook=codebook,
             codebook_override=override,
+            stochastic_rounding=stochastic_rounding,
         )
 
     packed_parts, srel_parts, sch_parts, corr_parts = [], [], [], []
     codebook_tensor = None
     for r0 in range(0, n, block):
         rot = rotate_fn(weight[r0 : r0 + block].contiguous(), convrot_groupsize)
+        chunk_sr = stochastic_rounding + r0 if stochastic_rounding > 0 else 0
         packed, s_rel, s_channel, correction, codebook_tensor = (
             _quantize_rotated_w4a8_int8_weight(
                 rot,
@@ -294,6 +343,7 @@ def _quantize_w4a8_chunked(
                 scale_dtype=scale_dtype,
                 codebook=codebook,
                 codebook_override=override,
+                stochastic_rounding=chunk_sr,
             )
         )
         packed_parts.append(packed)
@@ -320,6 +370,7 @@ def quantize_w4a8_int8_weight(
     scale_dtype: torch.dtype = torch.float8_e4m3fn,
     codebook: bool = True,
     codebook_tensor: torch.Tensor | None = None,
+    stochastic_rounding: int = 0,
 ) -> tuple[
     torch.Tensor,
     torch.Tensor,
@@ -338,6 +389,7 @@ def quantize_w4a8_int8_weight(
         scale_dtype=scale_dtype,
         codebook=codebook,
         codebook_override=codebook_tensor,
+        stochastic_rounding=stochastic_rounding,
     )
 
 

--- a/comfy_kitchen/tensor/w4a8_int8.py
+++ b/comfy_kitchen/tensor/w4a8_int8.py
@@ -34,6 +34,7 @@ def quantize_w4a8_int8_weight(
     scale_dtype: torch.dtype = torch.float8_e4m3fn,
     codebook: bool = True,
     codebook_tensor: torch.Tensor | None = None,
+    stochastic_rounding: int = 0,
 ) -> tuple[
     torch.Tensor,
     torch.Tensor,
@@ -44,7 +45,9 @@ def quantize_w4a8_int8_weight(
     """Rotate and prepare a floating weight for grouped W4A8 storage.
 
     ``codebook_tensor`` reuses a previously decided table (e.g. on LoRA requantize) so the
-    codebook decision -- kurtosis probe and any k-means -- is skipped.
+    codebook decision -- kurtosis probe and any k-means -- is skipped. ``stochastic_rounding``
+    > 0 seeds stochastic rounding of the level assignment so a merged LoRA below the int4 step
+    is preserved instead of rounded away.
     """
     if scale_dtype not in (torch.float32, torch.float8_e4m3fn):
         raise ValueError(f"scale_dtype must be float32 or float8_e4m3fn, got {scale_dtype}")
@@ -56,6 +59,7 @@ def quantize_w4a8_int8_weight(
         "scale_dtype": scale_dtype,
         "codebook": codebook,
         "codebook_tensor": codebook_tensor,
+        "stochastic_rounding": stochastic_rounding,
     }
     impl = registry.get_implementation("quantize_w4a8_int8_weight", kwargs=kwargs)
     return impl(**kwargs)
@@ -185,6 +189,7 @@ class AsymW4A8Int8Layout(QuantizedLayout):
         scale_dtype: torch.dtype = torch.float8_e4m3fn,
         codebook: bool = True,
         codebook_tensor: torch.Tensor | None = None,
+        stochastic_rounding: int = 0,
         **kwargs,
     ) -> tuple[torch.Tensor, Params]:
         qdata, s_rel, s_channel, correction, codebook_tensor = quantize_w4a8_int8_weight(
@@ -195,6 +200,7 @@ class AsymW4A8Int8Layout(QuantizedLayout):
             scale_dtype=scale_dtype,
             codebook=codebook,
             codebook_tensor=codebook_tensor,
+            stochastic_rounding=stochastic_rounding,
         )
         params = cls.Params(
             scale=s_rel,


### PR DESCRIPTION
w4a8: stochastic rounding for LoRA merge + fused requant kernel

- Stochastic rounding on requantize
- Fused CUDA requant kernel (rotate-fed): per-group codebook assign +
  ALS + per-channel scale + SR + int4 pack in one launch. Requant
  166ms -> 0.6ms/layer; falls back to eager for non-default configs.
- Eager path also sped up (searchsorted codebook assign, ALS 3->2)
  and made memory-frugal for the lowvram per-fault path.
