### PR TITLE
HIP ports of #99 (fused W4A8 requantize) and #95 (na3d / na2d)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Fast kernel library for Diffusion inference with multiple compute backends.
 | `scaled_mm_mxfp8`           | ✓     |      |        |     |
 | `adaln`                     | ✓     | ✓    | ✓      | ✓   |
 | `rms_adaln`                 | ✓     | ✓    | ✓      | ✓   |
-| `na3d`                      | ✓     | ✓    | ✓      |     |
-| `na2d`                      | ✓     | ✓    | ✓      |     |
+| `na3d`                      | ✓     | ✓    | ✓      | ✓   |
+| `na2d`                      | ✓     | ✓    | ✓      | ✓   |
 | `apply_rope`                | ✓     | ✓    | ✓      | ✓   |
 | `apply_rope1`               | ✓     | ✓    | ✓      | ✓   |
 | `apply_rope_split_half`     | ✓     | ✓    | ✓      | ✓   |

--- a/comfy_kitchen/backends/hip/CMakeLists.txt
+++ b/comfy_kitchen/backends/hip/CMakeLists.txt
@@ -164,6 +164,7 @@ set(HIP_SOURCES
     ops/gemv_awq.hip
     ops/svdquant_w4a4.hip
     ops/w4a8_dequant.hip
+    ops/w4a8_requant.hip
 )
 
 set(CPP_SOURCES

--- a/comfy_kitchen/backends/hip/CMakeLists.txt
+++ b/comfy_kitchen/backends/hip/CMakeLists.txt
@@ -159,6 +159,7 @@ set(HIP_SOURCES
     ops/gemm_int8.hip
     ops/convrot_w4a4.hip
     ops/adaln.hip
+    ops/na3d.hip
     ops/apply_rope.hip
     ops/rms_rope.hip
     ops/gemv_awq.hip

--- a/comfy_kitchen/backends/hip/__init__.py
+++ b/comfy_kitchen/backends/hip/__init__.py
@@ -44,6 +44,7 @@ logger = logging.getLogger("comfy_kitchen.hip")
 
 __all__ = [
     "adaln",
+    "na3d",
     "rms_adaln",
     "gemv_awq_w4a16",
     "quantize_svdquant_w4a4",
@@ -161,6 +162,7 @@ _ARCH_SUPPORTED = _ARCH_ELEMENTWISE_ONLY | _ARCH_WMMA
 # which gates on has_wmma() itself rather than through the registry.
 _WMMA_ONLY_OPS = frozenset({
     "int8_linear",
+    "na3d",
     "convrot_w4a4_linear",
     "scaled_mm_svdquant_w4a4",
     "w4a8_int8_linear",
@@ -1299,6 +1301,54 @@ def scaled_mm_svdquant_w4a4(
 # Normalization and positional encoding
 # ---------------------------------------------------------------------------
 
+# ---------------------------------------------------------------------------
+# Neighborhood attention
+# ---------------------------------------------------------------------------
+
+
+def na3d(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    kernel_size: Sequence[int],
+    is_causal: Sequence[bool] | None = None,
+    scale: float | None = None,
+) -> torch.Tensor:
+    """Fused 3D neighborhood attention (NATTEN ``na3d`` semantics) over
+    ``(B, T, H, W, NH, HD)`` tensors, on WMMA. See ops/na3d.hip."""
+    causal = (False, False, False) if is_causal is None else tuple(is_causal)
+    batch, t, h, w, num_heads, head_dim = q.shape
+    if scale is None:
+        scale = head_dim ** -0.5
+
+    q = q.contiguous()
+    k = k.contiguous()
+    v = v.contiguous()
+    out = torch.empty_like(q)
+    _C.na3d(
+        _dl(q),
+        _dl(k),
+        _dl(v),
+        _dl(out),
+        batch,
+        t,
+        h,
+        w,
+        num_heads,
+        head_dim,
+        int(kernel_size[0]),
+        int(kernel_size[1]),
+        int(kernel_size[2]),
+        int(causal[0]),
+        int(causal[1]),
+        int(causal[2]),
+        float(scale),
+        DTYPE_TO_CODE[q.dtype],
+        _stream(q),
+    )
+    return out
+
+
 def _adaln_impl(kernel, x, scale, shift, eps) -> torch.Tensor:
     """``kernel`` is _C.adaln (LayerNorm) or _C.rms_adaln (RMSNorm)."""
     from comfy_kitchen.backends._modulation import adaln_prep_modulation
@@ -1636,15 +1686,43 @@ def _build_constraints(has_wmma: bool = True) -> dict:
         ExactDims,
         FunctionConstraints,
         ParamConstraint,
+        ValidationResult,
+        na3d_common_call_rule,
     )
 
     # PyTorch exposes ROCm tensors with device type "cuda".
     dev = frozenset({"cuda", "hip"})
     floats = frozenset({torch.float32, torch.float16, torch.bfloat16})
+    half_floats = frozenset({torch.float16, torch.bfloat16})
     fp8s = frozenset({torch.float8_e4m3fn, torch.float8_e5m2})
     out_floats = frozenset({torch.float32, torch.float16, torch.bfloat16})
 
+    def _na3d_call_rule(kwargs):
+        common = na3d_common_call_rule(kwargs)
+        if not common.success:
+            return common
+        q = kwargs.get("q")
+        if q is not None:
+            head_dim = q.shape[-1]
+            # The WMMA K-step is 16 wide and the output accumulators are held in
+            # registers, one 16-column tile each.
+            if head_dim % 16 != 0 or head_dim > 64:
+                return ValidationResult.fail("q", "head_dim must be a multiple of 16 and <= 64")
+            if q.shape[1] * q.shape[2] > 65535 or q.shape[0] * q.shape[4] > 65535:
+                return ValidationResult.fail("q", "grid dims exceed HIP limits")
+        return ValidationResult.ok()
+
     constraints = {
+        # fp32 has no 16-bit matrix path, so it goes to triton/eager.
+        "na3d": FunctionConstraints(
+            params={
+                "q": ParamConstraint(dtypes=half_floats, shape_rules=(ExactDims(6),)),
+                "k": ParamConstraint(dtypes=half_floats, shape_rules=(ExactDims(6),)),
+                "v": ParamConstraint(dtypes=half_floats, shape_rules=(ExactDims(6),)),
+            },
+            default_devices=dev,
+            call_rules=(_na3d_call_rule,),
+        ),
         "quantize_per_tensor_fp8": FunctionConstraints(
             params={
                 "x": ParamConstraint(dtypes=floats),

--- a/comfy_kitchen/backends/hip/__init__.py
+++ b/comfy_kitchen/backends/hip/__init__.py
@@ -32,8 +32,12 @@ from comfy_kitchen.backends._activations import input_act_width as _input_act_wi
 from comfy_kitchen.backends.eager import rope as _eager_rope
 from comfy_kitchen.backends.eager.quantization import DTYPE_CODE_TO_DTYPE, DTYPE_TO_CODE
 from comfy_kitchen.backends.eager.w4a8_int8 import (
+    _QUANT_ROW_ELEM_BUDGET,
+    _decide_codebook,
     _dequantize_w4a8_int8_weight_from_int8,
+    _quantize_w4a8_chunked,
     validate_w4a8_operands,
+    validate_w4a8_weight_shape,
 )
 
 logger = logging.getLogger("comfy_kitchen.hip")
@@ -67,6 +71,7 @@ __all__ = [
     "quantize_int8_rowwise",
     "quantize_int8_tensorwise",
     "quantize_per_tensor_fp8",
+    "quantize_w4a8_int8_weight",
     "rms_rope",
     "rms_rope_",
     "rms_rope1",
@@ -817,6 +822,118 @@ def _w4a8_int8_linear_chunked(
         _stream(x),
     )
     return out.reshape(*orig_shape[:-1], n)
+
+
+# Keyed by device: the fused requantize holds one float per 16-wide group in LDS,
+# so the widest K it can take is a property of whichever card the weight lives on.
+_w4a8_requant_max_k: dict[int, int] = {}
+
+
+def _requant_supported(k: int, device: torch.device, dtype: torch.dtype) -> bool:
+    """Whether the fused requantize can take a row of this width on ``device``.
+
+    The budget is read for the weight's own device rather than the process-current
+    one, so a multi-GPU process asks the card the kernel will actually launch on.
+    """
+    if not _EXT_AVAILABLE or k % 16 != 0:
+        return False
+    if dtype not in (torch.float32, torch.float16, torch.bfloat16):
+        return False
+
+    index = device.index if device.index is not None else torch.cuda.current_device()
+    max_k = _w4a8_requant_max_k.get(index)
+    if max_k is None:
+        with torch.cuda.device(index):
+            max_k = _C.w4a8_requant_max_k()
+        _w4a8_requant_max_k[index] = max_k
+    return max_k > 0 and k <= max_k
+
+
+def _fused_quantize_w4a8(
+    weight: torch.Tensor,
+    codebook: torch.Tensor,
+    convrot_groupsize: int,
+    stochastic_rounding: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, None, torch.Tensor]:
+    """Rotate and requantize a row block at a time, so no whole rotated copy is held.
+
+    Every output is per-row and the kernel reduces only within a row, so a block
+    writes straight into its own output slices.
+    """
+    n, k = weight.shape
+    cb = codebook.to(device=weight.device, dtype=torch.float32).contiguous()
+    packed = torch.empty(n, k // 2, dtype=torch.int8, device=weight.device)
+    s_rel = torch.empty(n, k // 16, dtype=torch.float8_e4m3fn, device=weight.device)
+    s_channel = torch.empty(n, dtype=torch.float32, device=weight.device)
+    block = max(1, _QUANT_ROW_ELEM_BUDGET // max(k, 1))
+    for r0 in range(0, n, block):
+        r1 = min(r0 + block, n)
+        rot = _eager.rotate_int8_convrot_weight(weight[r0:r1].contiguous(), convrot_groupsize)
+        # Offset the seed by the row start so blocks decorrelate but a fixed block
+        # size still reproduces.
+        seed = stochastic_rounding + r0 if stochastic_rounding > 0 else 0
+        _C.quantize_w4a8_convrot(
+            _dl(rot.contiguous()),
+            _dl(cb),
+            _dl(packed[r0:r1]),
+            _dl(s_rel[r0:r1].view(torch.uint8)),
+            _dl(s_channel[r0:r1]),
+            r1 - r0,
+            k,
+            stochastic_rounding > 0,
+            seed,
+            _stream(weight),
+        )
+        del rot
+    return packed, s_rel, s_channel, None, cb
+
+
+def quantize_w4a8_int8_weight(
+    weight: torch.Tensor,
+    group_size: int = 16,
+    convrot_groupsize: int = 256,
+    symmetric: bool = True,
+    scale_dtype: torch.dtype = torch.float8_e4m3fn,
+    codebook: bool = True,
+    codebook_tensor: torch.Tensor | None = None,
+    stochastic_rounding: int = 0,
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor | None,
+    torch.Tensor | None,
+]:
+    """Prepare W4A8 weights with the fused HIP requantize and eager ConvRot."""
+    validate_w4a8_weight_shape(weight, group_size, convrot_groupsize)
+    # The fused kernel covers the default codebook layout only. Asymmetric, uniform,
+    # fp32-scale and other group sizes stay on the chunked eager path.
+    if (
+        symmetric
+        and codebook
+        and group_size == 16
+        and scale_dtype == torch.float8_e4m3fn
+        and _requant_supported(weight.shape[1], weight.device, weight.dtype)
+    ):
+        cb = (
+            codebook_tensor
+            if codebook_tensor is not None
+            else _decide_codebook(
+                weight, _eager.rotate_int8_convrot_weight, group_size, convrot_groupsize
+            )
+        )
+        return _fused_quantize_w4a8(weight, cb, convrot_groupsize, stochastic_rounding)
+    return _quantize_w4a8_chunked(
+        weight,
+        _eager.rotate_int8_convrot_weight,
+        group_size,
+        convrot_groupsize,
+        symmetric=symmetric,
+        scale_dtype=scale_dtype,
+        codebook=codebook,
+        codebook_override=codebook_tensor,
+        stochastic_rounding=stochastic_rounding,
+    )
 
 
 def dequantize_w4a8_int8_weight(
@@ -1593,6 +1710,17 @@ def _build_constraints(has_wmma: bool = True) -> dict:
                 "x": ParamConstraint(dtypes=floats, shape_rules=(DivisibleBy(-1, 16),)),
                 "weight": ParamConstraint(dtypes=frozenset({torch.int8})),
                 "out_dtype": ParamConstraint(dtypes=out_floats),
+            },
+            default_devices=dev,
+        ),
+        "quantize_w4a8_int8_weight": FunctionConstraints(
+            params={
+                "weight": ParamConstraint(dtypes=floats, shape_rules=(ExactDims(2),)),
+                "group_size": ParamConstraint(dtypes=frozenset({int})),
+                "convrot_groupsize": ParamConstraint(dtypes=frozenset({int})),
+                "scale_dtype": ParamConstraint(
+                    dtypes=frozenset({torch.float32, torch.float8_e4m3fn})
+                ),
             },
             default_devices=dev,
         ),

--- a/comfy_kitchen/backends/hip/dlpack_bindings.cpp
+++ b/comfy_kitchen/backends/hip/dlpack_bindings.cpp
@@ -60,6 +60,10 @@ void launch_convrot_quant_int4_kernel(const void*, int, void*, void*, int, int, 
 void launch_unpack_int4_kernel(const void*, void*, int64_t, hipStream_t);
 int convrot_max_k_host(int);
 
+void launch_quantize_w4a8_convrot_kernel(const void*, const void*, void*, void*, void*, int64_t,
+                                         int64_t, int, bool, uint64_t, hipStream_t);
+int w4a8_requant_max_k_kernel();
+
 void launch_adaln_kernel(const void*, const void*, const void*, void*, int, int, int, int, float,
                          int, int, int, bool, hipStream_t);
 void launch_gemv_awq_kernel(const void*, const void*, const void*, const void*, const void*, void*,
@@ -530,6 +534,33 @@ void unpack_int4(nb::ndarray<> q, nb::ndarray<> out, int64_t nbytes, uintptr_t s
 
 // scale_code names the s_rel storage: 0 float32, 5 e4m3 (crossing as uint8, as
 // elsewhere). codebook is optional; without it the levels are uniform.
+// Fused W4A8 requantize (group_size 16): a rotated weight [N, K] becomes packed
+// int4 [N, K/2], raw e4m3 s_rel [N, K/16] and f32 s_channel [N] in one launch.
+void quantize_w4a8_convrot(nb::ndarray<> rotated, nb::ndarray<> codebook, nb::ndarray<> packed,
+                           nb::ndarray<> s_rel, nb::ndarray<> s_channel, int N, int K,
+                           bool stochastic, uint64_t seed, uintptr_t stream_ptr) {
+    constexpr const char* kFn = "quantize_w4a8_convrot";
+    require_nonneg(N, kFn, "N");
+    require_nonneg(K, kFn, "K");
+    if (K % 16 != 0) {
+        throw std::runtime_error(std::string(kFn) + ": K must be a multiple of 16");
+    }
+    require_dtype(rotated, 0, 2, kFn, "rotated");
+    require_dtype(packed, 4, 4, kFn, "packed");
+    require_dtype(s_rel, 3, 3, kFn, "s_rel");
+    require_scale_len(s_channel, static_cast<size_t>(N), kFn, "s_channel");
+    require_scale_len(codebook, 16, kFn, "codebook");
+    require_len(rotated, static_cast<int64_t>(N) * K, kFn, "rotated");
+    require_len(packed, static_cast<int64_t>(N) * (K / 2), kFn, "packed");
+    require_len(s_rel, static_cast<int64_t>(N) * (K / 16), kFn, "s_rel");
+
+    launch_quantize_w4a8_convrot_kernel(rotated.data(), codebook.data(), packed.data(),
+                                        s_rel.data(), s_channel.data(), N, K,
+                                        map_dtype_to_code(rotated.dtype()), stochastic, seed,
+                                        reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
 void dequant_int4_grouped_to_int8(nb::ndarray<> qdata, nb::ndarray<> s_rel, int scale_code,
                                   OptArray codebook, nb::ndarray<> out, int N, int K,
                                   int group_size, uintptr_t stream_ptr) {
@@ -958,6 +989,8 @@ NB_MODULE(_C, m) {
     m.def("convrot_max_k", &convrot_max_k_host);
     m.def("unpack_int4", &unpack_int4);
     m.def("dequant_int4_grouped_to_int8", &dequant_int4_grouped_to_int8);
+    m.def("quantize_w4a8_convrot", &quantize_w4a8_convrot);
+    m.def("w4a8_requant_max_k", &w4a8_requant_max_k_kernel);
     m.def("w4a8_int8_gemm_chunked", &w4a8_int8_gemm_chunked);
     m.def("adaln", &adaln);
     m.def("rms_adaln", &rms_adaln);

--- a/comfy_kitchen/backends/hip/dlpack_bindings.cpp
+++ b/comfy_kitchen/backends/hip/dlpack_bindings.cpp
@@ -63,6 +63,8 @@ int convrot_max_k_host(int);
 void launch_quantize_w4a8_convrot_kernel(const void*, const void*, void*, void*, void*, int64_t,
                                          int64_t, int, bool, uint64_t, hipStream_t);
 int w4a8_requant_max_k_kernel();
+void launch_na3d_kernel(const void*, const void*, const void*, void*, int, int, int, int, int, int,
+                        int, int, int, int, int, int, float, int, hipStream_t);
 
 void launch_adaln_kernel(const void*, const void*, const void*, void*, int, int, int, int, float,
                          int, int, int, bool, hipStream_t);
@@ -671,6 +673,44 @@ static void adaln_impl(const char* kFn, nb::ndarray<>& x, nb::ndarray<>& scale,
     check_hip_launch();
 }
 
+// Fused 3D neighborhood attention. Every extent is caller-supplied and the kernel
+// indexes up to it, so the operands are sized here rather than trusted.
+void na3d(nb::ndarray<> q, nb::ndarray<> k, nb::ndarray<> v, nb::ndarray<> out, int batch,
+          int t_size, int h_size, int w_size, int num_heads, int head_dim, int kt, int kh, int kw,
+          int causal_t, int causal_h, int causal_w, float scale, int dtype_code,
+          uintptr_t stream_ptr) {
+    constexpr const char* kFn = "na3d";
+    require_positive(batch, kFn, "batch");
+    require_positive(t_size, kFn, "t_size");
+    require_positive(h_size, kFn, "h_size");
+    require_positive(w_size, kFn, "w_size");
+    require_positive(num_heads, kFn, "num_heads");
+    require_positive(head_dim, kFn, "head_dim");
+    require_positive(kt, kFn, "kt");
+    require_positive(kh, kFn, "kh");
+    require_positive(kw, kFn, "kw");
+    if (dtype_code != 1 && dtype_code != 2) {
+        throw std::runtime_error(std::string(kFn) + ": q must be float16 or bfloat16");
+    }
+    // The kernel reads k and v off bare pointers with q's extents, so a differing
+    // dtype or a shorter operand is an out-of-bounds device read.
+    const int64_t need = static_cast<int64_t>(batch) * t_size * h_size * w_size * num_heads *
+                         head_dim;
+    require_dtype(q, dtype_code, dtype_code, kFn, "q");
+    require_dtype(k, dtype_code, dtype_code, kFn, "k");
+    require_dtype(v, dtype_code, dtype_code, kFn, "v");
+    require_dtype(out, dtype_code, dtype_code, kFn, "out");
+    require_len(q, need, kFn, "q");
+    require_len(k, need, kFn, "k");
+    require_len(v, need, kFn, "v");
+    require_len(out, need, kFn, "out");
+
+    launch_na3d_kernel(q.data(), k.data(), v.data(), out.data(), batch, t_size, h_size, w_size,
+                       num_heads, head_dim, kt, kh, kw, causal_t, causal_h, causal_w, scale,
+                       dtype_code, reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
 void adaln(nb::ndarray<> x, nb::ndarray<> scale, nb::ndarray<> shift, nb::ndarray<> out, int N,
            int D, int scale_group, int shift_group, float eps, uintptr_t stream_ptr) {
     adaln_impl("adaln", x, scale, shift, out, N, D, scale_group, shift_group, eps,
@@ -992,6 +1032,7 @@ NB_MODULE(_C, m) {
     m.def("quantize_w4a8_convrot", &quantize_w4a8_convrot);
     m.def("w4a8_requant_max_k", &w4a8_requant_max_k_kernel);
     m.def("w4a8_int8_gemm_chunked", &w4a8_int8_gemm_chunked);
+    m.def("na3d", &na3d);
     m.def("adaln", &adaln);
     m.def("rms_adaln", &rms_adaln);
     m.def("apply_rope", &apply_rope);

--- a/comfy_kitchen/backends/hip/launchers.h
+++ b/comfy_kitchen/backends/hip/launchers.h
@@ -13,6 +13,13 @@
 
 extern "C" {
 
+// Fused 3D neighborhood attention over contiguous (B, T, H, W, NH, HD) tensors.
+// dtype_code is a DTYPE_TO_CODE value: 1 float16, 2 bfloat16. See ops/na3d.hip.
+void launch_na3d_kernel(const void* q, const void* k, const void* v, void* out, int batch,
+                        int t_size, int h_size, int w_size, int num_heads, int head_dim, int kt,
+                        int kh, int kw, int causal_t, int causal_h, int causal_w, float scale,
+                        int dtype_code, hipStream_t stream);
+
 // ldc is c's row stride, so a caller writing an N-column slice of a wider output
 // passes that output's width; a whole GEMM passes N.
 void launch_int8_gemm_kernel(const void* a, const void* b, void* c, const void* scale_a,

--- a/comfy_kitchen/backends/hip/launchers.h
+++ b/comfy_kitchen/backends/hip/launchers.h
@@ -26,6 +26,16 @@ void launch_dequant_int4_grouped_to_int8_kernel(const void* qw, const void* s_re
                                                 const void* codebook, void* out, int64_t n,
                                                 int64_t k, int group_size, hipStream_t stream);
 
+// in_dtype_code is a DTYPE_TO_CODE value: 0 float32, 1 float16, 2 bfloat16.
+// s_rel is written as raw e4m3 bytes; seed is ignored unless stochastic is set.
+void launch_quantize_w4a8_convrot_kernel(const void* rotated, const void* codebook, void* packed,
+                                         void* s_rel, void* s_channel, int64_t n, int64_t k,
+                                         int in_dtype_code, bool stochastic, uint64_t seed,
+                                         hipStream_t stream);
+
+// Widest K the fused requantize can take on the current device, 0 if unknown.
+int w4a8_requant_max_k_kernel();
+
 void launch_w4a8_int8_gemm_chunked_kernel(const void* xq, const void* qw, const void* s_rel,
                                           int scale_code, const void* codebook,
                                           const void* s_channel, const void* xs, const void* bias,

--- a/comfy_kitchen/backends/hip/mma.h
+++ b/comfy_kitchen/backends/hip/mma.h
@@ -44,6 +44,8 @@ typedef int v8i __attribute__((ext_vector_type(8)));
 typedef float v8f __attribute__((ext_vector_type(8)));
 typedef __bf16 v8bf __attribute__((ext_vector_type(8)));
 typedef __bf16 v16bf __attribute__((ext_vector_type(16)));
+typedef _Float16 v8h __attribute__((ext_vector_type(8)));
+typedef _Float16 v16h __attribute__((ext_vector_type(16)));
 
 constexpr int kWave = 32;
 
@@ -109,6 +111,22 @@ __forceinline__ __device__ v16bf load_frag_fp8_as_bf16(const void* lds, int row,
         r[i] = static_cast<__bf16>(E5M2 ? bf8_to_float(p[i]) : fp8_to_float(p[i]));
     }
     return r;
+}
+
+// A K-step of a 16-bit row, straight out of whatever address space `row` points
+// at. The half-wave slice is the policy's, since gfx11 hands every lane the whole
+// K-step and gfx12 splits it. The elements are contiguous, so this folds into
+// vector loads.
+template <typename Mma>
+__forceinline__ __device__ typename Mma::Frag load_frag_16bit(const typename Mma::Elem* row,
+                                                              int lane) {
+    typename Mma::Frag f;
+    const typename Mma::Elem* p = row + Mma::frag_base(lane);
+    #pragma unroll
+    for (int i = 0; i < Mma::kFragElems; ++i) {
+        f[i] = p[i];
+    }
+    return f;
 }
 
 // ---------------------------------------------------------------------------
@@ -185,6 +203,35 @@ struct MmaInt4 {
     static __forceinline__ __device__ float get(Acc c, int e) { return static_cast<float>(c[e]); }
 };
 
+// 16-bit float MMA, used by the attention kernels rather than the GEMM core: they
+// build fragments from global memory and from LDS scratch, so the policy exposes
+// the element type and the half-wave's K slice instead of a byte-addressed load.
+struct MmaBf16 {
+    using Acc = v8f;
+    using Frag = v8bf;
+    using Elem = __bf16;
+    static constexpr int kFragElems = 8;
+    static __forceinline__ __device__ int frag_base(int lane) { return 8 * (lane / 16); }
+    static __forceinline__ __device__ Acc zero() { return Acc{0, 0, 0, 0, 0, 0, 0, 0}; }
+    static __forceinline__ __device__ Acc mma(Frag a, Frag b, Acc c) {
+        return __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(a, b, c);
+    }
+    static __forceinline__ __device__ float get(Acc c, int e) { return c[e]; }
+};
+
+struct MmaF16 {
+    using Acc = v8f;
+    using Frag = v8h;
+    using Elem = _Float16;
+    static constexpr int kFragElems = 8;
+    static __forceinline__ __device__ int frag_base(int lane) { return 8 * (lane / 16); }
+    static __forceinline__ __device__ Acc zero() { return Acc{0, 0, 0, 0, 0, 0, 0, 0}; }
+    static __forceinline__ __device__ Acc mma(Frag a, Frag b, Acc c) {
+        return __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a, b, c);
+    }
+    static __forceinline__ __device__ float get(Acc c, int e) { return c[e]; }
+};
+
 #elif defined(COMFY_MMA_GFX11)
 
 struct MmaFp8 {
@@ -253,6 +300,34 @@ struct MmaInt4 {
     static __forceinline__ __device__ float get(Acc c, int e) { return static_cast<float>(c[e]); }
 };
 
+
+// gfx11 hands every lane the whole 16-wide K-step, duplicated across half-waves.
+struct MmaBf16 {
+    using Acc = v8f;
+    using Frag = v16bf;
+    using Elem = __bf16;
+    static constexpr int kFragElems = 16;
+    static __forceinline__ __device__ int frag_base(int) { return 0; }
+    static __forceinline__ __device__ Acc zero() { return Acc{0, 0, 0, 0, 0, 0, 0, 0}; }
+    static __forceinline__ __device__ Acc mma(Frag a, Frag b, Acc c) {
+        return __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a, b, c);
+    }
+    static __forceinline__ __device__ float get(Acc c, int e) { return c[e]; }
+};
+
+struct MmaF16 {
+    using Acc = v8f;
+    using Frag = v16h;
+    using Elem = _Float16;
+    static constexpr int kFragElems = 16;
+    static __forceinline__ __device__ int frag_base(int) { return 0; }
+    static __forceinline__ __device__ Acc zero() { return Acc{0, 0, 0, 0, 0, 0, 0, 0}; }
+    static __forceinline__ __device__ Acc mma(Frag a, Frag b, Acc c) {
+        return __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a, b, c);
+    }
+    static __forceinline__ __device__ float get(Acc c, int e) { return c[e]; }
+};
+
 #else
 
 // No matrix cores (RDNA2 and older) and the host pass. The GEMM kernels are
@@ -287,6 +362,28 @@ struct MmaInt8 {
 };
 
 struct MmaInt4 : MmaInt8 {};
+
+struct MmaBf16 {
+    using Acc = v8f;
+    using Frag = v8bf;
+    using Elem = __bf16;
+    static constexpr int kFragElems = 8;
+    static __forceinline__ __device__ int frag_base(int) { return 0; }
+    static __forceinline__ __device__ Acc zero() { return Acc{0, 0, 0, 0, 0, 0, 0, 0}; }
+    static __forceinline__ __device__ Acc mma(Frag, Frag, Acc c) { COMFY_MMA_STUB_BODY }
+    static __forceinline__ __device__ float get(Acc c, int e) { return c[e]; }
+};
+
+struct MmaF16 {
+    using Acc = v8f;
+    using Frag = v8h;
+    using Elem = _Float16;
+    static constexpr int kFragElems = 8;
+    static __forceinline__ __device__ int frag_base(int) { return 0; }
+    static __forceinline__ __device__ Acc zero() { return Acc{0, 0, 0, 0, 0, 0, 0, 0}; }
+    static __forceinline__ __device__ Acc mma(Frag, Frag, Acc c) { COMFY_MMA_STUB_BODY }
+    static __forceinline__ __device__ float get(Acc c, int e) { return c[e]; }
+};
 
 #undef COMFY_MMA_STUB_BODY
 

--- a/comfy_kitchen/backends/hip/ops/na3d.hip
+++ b/comfy_kitchen/backends/hip/ops/na3d.hip
@@ -1,0 +1,324 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Fused 3D neighborhood attention (NATTEN na3d semantics, dilation 1).
+//
+// Per non-causal axis each query attends a window of exactly kernel_size
+// positions centered on it, shifted inward at grid boundaries; per causal axis it
+// attends the min(i+1, kernel_size) nearest previous positions.
+//
+// Flash-attention-2 style on the 16x16x16 WMMA: one wave covers 16 queries along
+// W at a fixed (t, h) and sweeps that block's key span 16 keys at a time. Scores,
+// softmax state and the output accumulator stay in registers; LDS holds only the
+// transposed V tile and the probability tile.
+//
+// The T and H windows are constant across a block, so only W is masked per
+// element. head_dim in {16, 32, 48, 64}; q/k/v/out are contiguous
+// (B, T, H, W, NH, HD).
+#include <stdexcept>
+#include <string>
+
+#include "../mma.h"
+
+namespace comfy::hip_backend {
+
+// One wave, 16 queries. A wider block would only add key tiles that most of it
+// then skips, since the window a query sees is narrow by construction.
+constexpr int kNaQueries = 16;
+constexpr int kNaKeys = 16;
+constexpr int kNaThreads = 32;
+// LDS rows are padded to 9 dwords. LDS has 32 four-byte banks and gcd(9, 32) = 1,
+// so the 16 row-strided lanes of a fragment read reach 16 distinct banks; an
+// 8-dword or 12-dword row collapses them onto 4 or 8.
+constexpr int kNaRowStride = 18;
+constexpr float kNaNegInf = -3.0e38f;
+
+namespace {
+
+__forceinline__ __device__ int na_min(int a, int b) { return a < b ? a : b; }
+__forceinline__ __device__ int na_max(int a, int b) { return a > b ? a : b; }
+
+__forceinline__ __device__ void axis_window(int i, int k, int len, bool causal, int& lo, int& hi) {
+    if (causal) {
+        lo = na_max(i - k + 1, 0);
+        hi = i + 1;
+    } else {
+        lo = na_min(na_max(i - k / 2, 0), len - k);
+        hi = lo + k;
+    }
+}
+
+// Reduce across the 16 lanes holding one accumulator row. They are a half-wave, so
+// the offsets stop at 8 and never cross into the other half's rows.
+__forceinline__ __device__ float row_reduce_max(float v) {
+    #pragma unroll
+    for (int off = 1; off <= 8; off <<= 1) {
+        v = fmaxf(v, __shfl_xor(v, off, kWave));
+    }
+    return v;
+}
+
+__forceinline__ __device__ float row_reduce_sum(float v) {
+    #pragma unroll
+    for (int off = 1; off <= 8; off <<= 1) {
+        v += __shfl_xor(v, off, kWave);
+    }
+    return v;
+}
+
+template <typename Mma, int HD>
+__global__ __launch_bounds__(kNaThreads) void na3d_kernel(
+    const typename Mma::Elem* __restrict__ q,
+    const typename Mma::Elem* __restrict__ k,
+    const typename Mma::Elem* __restrict__ v,
+    typename Mma::Elem* __restrict__ out,
+    int t_size, int h_size, int w_size, int num_heads,
+    int64_t s_b, int64_t s_t, int64_t s_h, int64_t s_w, int64_t s_n,
+    int kt, int kh, int kw,
+    bool causal_t, bool causal_h, bool causal_w,
+    float scale) {
+
+    using Elem = typename Mma::Elem;
+    constexpr int KC = HD / 16;   // k-chunks of S = Q.K^T
+    constexpr int NT = HD / 16;   // output column tiles of O += P.V
+    constexpr int LD = kNaRowStride;
+
+    __shared__ Elem sVt[HD * LD];         // transposed V: sVt[column][key]
+    __shared__ Elem sP[kNaQueries * LD];  // probabilities: sP[query][key]
+
+    const int lane = threadIdx.x;
+    const int r = frag_row(lane);  // fragment row, and this lane's score column
+    const int t_q = blockIdx.y / h_size;
+    const int h_q = blockIdx.y % h_size;
+    const int64_t base = static_cast<int64_t>(blockIdx.z / num_heads) * s_b +
+                         static_cast<int64_t>(blockIdx.z % num_heads) * s_n;
+
+    const int w0 = blockIdx.x * kNaQueries;
+    const int n_valid_q = na_min(kNaQueries, w_size - w0);
+
+    int t_lo, t_hi, h_lo, h_hi;
+    axis_window(t_q, kt, t_size, causal_t, t_lo, t_hi);
+    axis_window(h_q, kh, h_size, causal_h, h_lo, h_hi);
+
+    // The eight accumulator rows this lane owns, and each one's W window.
+    int ws[8], we[8];
+    #pragma unroll
+    for (int e = 0; e < 8; ++e) {
+        const int wq = na_min(w0 + acc_row(lane, e), w_size - 1);
+        axis_window(wq, kw, w_size, causal_w, ws[e], we[e]);
+    }
+
+    // Key span of the block: the first query's window start through the last
+    // valid query's window end.
+    int w_lo, w_hi;
+    {
+        int lo0, hi0, lo1, hi1;
+        axis_window(na_min(w0, w_size - 1), kw, w_size, causal_w, lo0, hi0);
+        axis_window(na_min(w0 + n_valid_q - 1, w_size - 1), kw, w_size, causal_w, lo1, hi1);
+        w_lo = lo0;
+        w_hi = hi1;
+    }
+
+    // Loaded once, register-resident for the whole kernel. A row past the grid
+    // clamps to a real one; it is never stored back.
+    typename Mma::Frag qa[KC];
+    {
+        const int64_t qrow = base + static_cast<int64_t>(t_q) * s_t +
+                             static_cast<int64_t>(h_q) * s_h +
+                             static_cast<int64_t>(na_min(w0 + r, w_size - 1)) * s_w;
+        #pragma unroll
+        for (int kc = 0; kc < KC; ++kc) {
+            qa[kc] = load_frag_16bit<Mma>(q + qrow + kc * 16, lane);
+        }
+    }
+
+    typename Mma::Acc o_acc[NT];
+    #pragma unroll
+    for (int nt = 0; nt < NT; ++nt) {
+        o_acc[nt] = Mma::zero();
+    }
+    float m_r[8], l_r[8];
+    #pragma unroll
+    for (int e = 0; e < 8; ++e) {
+        m_r[e] = kNaNegInf;
+        l_r[e] = 0.0f;
+    }
+
+    for (int tk = t_lo; tk < t_hi; ++tk) {
+        for (int hk = h_lo; hk < h_hi; ++hk) {
+            const int64_t plane = base + static_cast<int64_t>(tk) * s_t +
+                                  static_cast<int64_t>(hk) * s_h;
+            for (int wk0 = w_lo; wk0 < w_hi; wk0 += kNaKeys) {
+                const int n_valid_k = na_min(kNaKeys, w_hi - wk0);
+
+                // Stage V transposed; only the LDS write is scattered.
+                {
+                    constexpr int kVecs = HD / 8;
+                    for (int idx = lane; idx < kNaKeys * kVecs; idx += kNaThreads) {
+                        const int kk = idx / kVecs;
+                        const int c8 = idx % kVecs;
+                        Elem vals[8];
+                        if (kk < n_valid_k) {
+                            const Elem* src = v + plane +
+                                              static_cast<int64_t>(wk0 + kk) * s_w + c8 * 8;
+                            #pragma unroll
+                            for (int e = 0; e < 8; ++e) {
+                                vals[e] = src[e];
+                            }
+                        } else {
+                            #pragma unroll
+                            for (int e = 0; e < 8; ++e) {
+                                vals[e] = static_cast<Elem>(0.0f);
+                            }
+                        }
+                        #pragma unroll
+                        for (int e = 0; e < 8; ++e) {
+                            sVt[(c8 * 8 + e) * LD + kk] = vals[e];
+                        }
+                    }
+                }
+
+                // The key row clamps into range; a column past n_valid_k is masked
+                // below, so whatever it read never survives.
+                typename Mma::Acc s_acc = Mma::zero();
+                {
+                    const int64_t krow =
+                        plane + static_cast<int64_t>(na_min(wk0 + r, w_size - 1)) * s_w;
+                    #pragma unroll
+                    for (int kc = 0; kc < KC; ++kc) {
+                        s_acc = Mma::mma(qa[kc], load_frag_16bit<Mma>(k + krow + kc * 16, lane),
+                                         s_acc);
+                    }
+                }
+
+                // Masked online softmax. This lane holds score column wk0 + r for
+                // each of its accumulator rows.
+                const int wk = wk0 + r;
+                const bool in_tile = (wk - wk0) < n_valid_k;
+                float p_val[8], m_new[8];
+                #pragma unroll
+                for (int e = 0; e < 8; ++e) {
+                    const bool vis = in_tile && wk >= ws[e] && wk < we[e];
+                    p_val[e] = vis ? Mma::get(s_acc, e) * scale : kNaNegInf;
+                    m_new[e] = row_reduce_max(fmaxf(m_r[e], p_val[e]));
+                }
+                #pragma unroll
+                for (int e = 0; e < 8; ++e) {
+                    const float alpha = __expf(m_r[e] - m_new[e]);
+                    m_r[e] = m_new[e];
+                    p_val[e] = (p_val[e] <= kNaNegInf) ? 0.0f : __expf(p_val[e] - m_new[e]);
+                    l_r[e] = l_r[e] * alpha + row_reduce_sum(p_val[e]);
+                    #pragma unroll
+                    for (int nt = 0; nt < NT; ++nt) {
+                        o_acc[nt][e] *= alpha;
+                    }
+                }
+
+                // Through LDS because the next A operand wants a whole row per lane
+                // and the accumulator gave this lane a column. The barrier below
+                // publishes the V transpose staged above as well.
+                #pragma unroll
+                for (int e = 0; e < 8; ++e) {
+                    sP[acc_row(lane, e) * LD + acc_col(lane)] = static_cast<Elem>(p_val[e]);
+                }
+                __syncthreads();
+
+                const typename Mma::Frag pa = load_frag_16bit<Mma>(sP + r * LD, lane);
+                #pragma unroll
+                for (int nt = 0; nt < NT; ++nt) {
+                    o_acc[nt] = Mma::mma(
+                        pa, load_frag_16bit<Mma>(sVt + (nt * 16 + r) * LD, lane), o_acc[nt]);
+                }
+                __syncthreads();
+            }
+        }
+    }
+
+    const int64_t orow = base + static_cast<int64_t>(t_q) * s_t + static_cast<int64_t>(h_q) * s_h;
+    #pragma unroll
+    for (int e = 0; e < 8; ++e) {
+        const int row = acc_row(lane, e);
+        if (row >= n_valid_q) {
+            continue;
+        }
+        const float inv_l = 1.0f / fmaxf(l_r[e], 1e-30f);
+        Elem* dst = out + orow + static_cast<int64_t>(w0 + row) * s_w + acc_col(lane);
+        #pragma unroll
+        for (int nt = 0; nt < NT; ++nt) {
+            dst[nt * 16] = static_cast<Elem>(Mma::get(o_acc[nt], e) * inv_l);
+        }
+    }
+}
+
+template <typename Mma>
+void launch_na3d_typed(
+    const void* q, const void* k, const void* v, void* out,
+    int batch, int t_size, int h_size, int w_size, int num_heads, int head_dim,
+    int64_t s_b, int64_t s_t, int64_t s_h, int64_t s_w, int64_t s_n,
+    int kt, int kh, int kw,
+    bool causal_t, bool causal_h, bool causal_w,
+    float scale, hipStream_t stream) {
+
+    using Elem = typename Mma::Elem;
+    const dim3 grid((w_size + kNaQueries - 1) / kNaQueries, t_size * h_size, batch * num_heads);
+
+#define COMFY_NA3D_LAUNCH(HD_)                                                                 \
+    na3d_kernel<Mma, HD_><<<grid, kNaThreads, 0, stream>>>(                                    \
+        reinterpret_cast<const Elem*>(q), reinterpret_cast<const Elem*>(k),                    \
+        reinterpret_cast<const Elem*>(v), reinterpret_cast<Elem*>(out),                        \
+        t_size, h_size, w_size, num_heads, s_b, s_t, s_h, s_w, s_n,                            \
+        kt, kh, kw, causal_t, causal_h, causal_w, scale)
+
+    switch (head_dim) {
+        case 16: COMFY_NA3D_LAUNCH(16); break;
+        case 32: COMFY_NA3D_LAUNCH(32); break;
+        case 48: COMFY_NA3D_LAUNCH(48); break;
+        case 64: COMFY_NA3D_LAUNCH(64); break;
+        default:
+            throw std::runtime_error("na3d supports head_dim 16/32/48/64, got " +
+                                     std::to_string(head_dim));
+    }
+#undef COMFY_NA3D_LAUNCH
+}
+
+}  // namespace
+}  // namespace comfy::hip_backend
+
+// dtype_code is a DTYPE_TO_CODE value: 1 float16, 2 bfloat16.
+extern "C" void launch_na3d_kernel(
+    const void* q, const void* k, const void* v, void* out,
+    int batch, int t_size, int h_size, int w_size, int num_heads, int head_dim,
+    int kt, int kh, int kw,
+    int causal_t, int causal_h, int causal_w,
+    float scale, int dtype_code, hipStream_t stream) {
+
+    using namespace comfy::hip_backend;
+    if (batch <= 0 || t_size <= 0 || h_size <= 0 || w_size <= 0 || num_heads <= 0) {
+        throw std::runtime_error("na3d: every extent must be positive");
+    }
+
+    // Contiguous (B, T, H, W, NH, HD) strides.
+    const int64_t s_n = head_dim;
+    const int64_t s_w = static_cast<int64_t>(num_heads) * head_dim;
+    const int64_t s_h = static_cast<int64_t>(w_size) * s_w;
+    const int64_t s_t = static_cast<int64_t>(h_size) * s_h;
+    const int64_t s_b = static_cast<int64_t>(t_size) * s_t;
+
+    // Non-causal kernels clamp to the axis length, which NATTEN would reject.
+    const int ckt = causal_t ? kt : (kt < t_size ? kt : t_size);
+    const int ckh = causal_h ? kh : (kh < h_size ? kh : h_size);
+    const int ckw = causal_w ? kw : (kw < w_size ? kw : w_size);
+
+    if (dtype_code == 1) {
+        launch_na3d_typed<MmaF16>(q, k, v, out, batch, t_size, h_size, w_size, num_heads,
+                                  head_dim, s_b, s_t, s_h, s_w, s_n, ckt, ckh, ckw,
+                                  causal_t != 0, causal_h != 0, causal_w != 0, scale, stream);
+    } else if (dtype_code == 2) {
+        launch_na3d_typed<MmaBf16>(q, k, v, out, batch, t_size, h_size, w_size, num_heads,
+                                   head_dim, s_b, s_t, s_h, s_w, s_n, ckt, ckh, ckw,
+                                   causal_t != 0, causal_h != 0, causal_w != 0, scale, stream);
+    } else {
+        throw std::runtime_error("na3d supports FP16/BF16 only, got dtype code " +
+                                 std::to_string(dtype_code));
+    }
+}

--- a/comfy_kitchen/backends/hip/ops/w4a8_requant.hip
+++ b/comfy_kitchen/backends/hip/ops/w4a8_requant.hip
@@ -1,0 +1,282 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Fused W4A8 requantize: an already ConvRot-rotated weight becomes packed int4 +
+// fp8 s_rel + f32 s_channel in one launch (codebook assign, two ALS scale
+// iterations, per-channel scale, optional stochastic rounding, pack). The
+// rotated weight is read in its own dtype, so the kernel sees exactly the values
+// the eager path sees. group_size is fixed at 16: one block per row, each thread
+// owns whole 16-wide groups.
+#include <stdexcept>
+#include <string>
+
+#include "../fp8_utils.h"
+#include "../launchers.h"
+
+namespace comfy::hip_backend {
+
+// Group scales live in dynamic LDS, one float per group, so K is bounded per
+// device the way the ConvRot row buffer is. The wrappers fall back to eager past
+// the budget rather than launching something that cannot fit.
+constexpr int kRequantGroup = 16;
+constexpr int kRequantThreads = 256;
+constexpr size_t kRequantStaticLds = (16 + kRequantThreads) * sizeof(float);
+
+int w4a8_requant_max_k() {
+    int device = 0;
+    if (hipGetDevice(&device) != hipSuccess) {
+        return 0;
+    }
+    int lds = 0;
+    if (hipDeviceGetAttribute(&lds, hipDeviceAttributeMaxSharedMemoryPerBlock, device) !=
+            hipSuccess ||
+        lds <= static_cast<int>(kRequantStaticLds)) {
+        return 0;
+    }
+    const size_t groups = (static_cast<size_t>(lds) - kRequantStaticLds) / sizeof(float);
+    return static_cast<int>(groups * kRequantGroup);
+}
+
+namespace {
+
+__forceinline__ __device__ float rq_to_float(float v) { return v; }
+__forceinline__ __device__ float rq_to_float(__half v) { return __half2float(v); }
+__forceinline__ __device__ float rq_to_float(__bf16 v) { return static_cast<float>(v); }
+
+// PCG hash over the element's index within the launch, xored with the seed. The
+// caller shifts the seed by the block's first row, so the draw is reproducible for a
+// given row-block size rather than independent of it. Same scheme as the CUDA kernel
+// and the eager packer, which decorrelate their chunks the same way.
+__forceinline__ __device__ uint32_t rq_pcg(uint32_t x) {
+    x = x * 747796405u + 2891336453u;
+    const uint32_t w = ((x >> ((x >> 28u) + 4u)) ^ x) * 277803737u;
+    return (w >> 22u) ^ w;
+}
+
+__forceinline__ __device__ float rq_uniform(int64_t idx, uint64_t seed) {
+    const uint32_t h = rq_pcg(static_cast<uint32_t>(idx) ^ static_cast<uint32_t>(seed) ^
+                              static_cast<uint32_t>(seed >> 32));
+    return static_cast<float>(h >> 8) * (1.0f / 16777216.0f);
+}
+
+// Nearest of 16 ascending levels, lowest index on a tie, which is how eager's
+// searchsorted-plus-neighbour-compare resolves one. The array is taken by
+// reference, not as a pointer: a pointer to the caller's private level table
+// forces it out to scratch even after inlining.
+__forceinline__ __device__ int rq_nearest(float x, const float (&levels)[16]) {
+    int best = 0;
+    float bd = fabsf(x - levels[0]);
+    #pragma unroll
+    for (int j = 1; j < 16; ++j) {
+        const float d = fabsf(x - levels[j]);
+        if (d < bd) {
+            bd = d;
+            best = j;
+        }
+    }
+    return best;
+}
+
+// Stochastic pick between the two levels bracketing x: take the upper one when x
+// clears a uniform-random point inside the bracket, so a delta below the int4 step
+// survives in expectation. levels is ascending, so the last one at or below x is
+// the lower bound.
+__forceinline__ __device__ int rq_stochastic(float x, const float (&levels)[16], int64_t idx,
+                                             uint64_t seed) {
+    int lo = 0;
+    #pragma unroll
+    for (int j = 0; j < 16; ++j) {
+        if (levels[j] <= x) {
+            lo = j;
+        }
+    }
+    lo = lo > 14 ? 14 : lo;
+    // Selected rather than indexed: a dynamic index into a private array would push
+    // the level table out to scratch.
+    float lo_v = levels[0];
+    float hi_v = levels[1];
+    #pragma unroll
+    for (int j = 1; j < 15; ++j) {
+        if (j == lo) {
+            lo_v = levels[j];
+            hi_v = levels[j + 1];
+        }
+    }
+    const float thr = lo_v + rq_uniform(idx, seed) * (hi_v - lo_v);
+    return lo + (x > thr ? 1 : 0);
+}
+
+template <typename InputT, bool STOCHASTIC>
+__global__ __launch_bounds__(kRequantThreads) void quantize_w4a8_convrot_kernel(
+    const InputT* __restrict__ rotated,     // [N, K]
+    const float* __restrict__ codebook,     // [16]
+    int8_t* __restrict__ packed,            // [N, K/2]
+    uint8_t* __restrict__ s_rel,            // [N, K/16], raw e4m3 bytes
+    float* __restrict__ s_channel,          // [N]
+    int k, uint64_t seed) {
+
+    constexpr int G = kRequantGroup;
+    const int row = blockIdx.x;
+    const int t = threadIdx.x;
+    const int groups = k / G;
+    const int64_t row_off = static_cast<int64_t>(row) * k;
+
+    __shared__ float cb[16];
+    __shared__ float red[kRequantThreads];
+    extern __shared__ float gscale[];  // [groups]
+
+    if (t < 16) {
+        cb[t] = codebook[t];
+    }
+    __syncthreads();
+
+    // Per-group ALS group scale, accumulating the row's shifted amax on the way.
+    float thread_amax = 0.0f;
+    for (int g = t; g < groups; g += kRequantThreads) {
+        const int64_t base = row_off + static_cast<int64_t>(g) * G;
+        float w[G];
+        float amax = 0.0f;
+        #pragma unroll
+        for (int i = 0; i < G; ++i) {
+            w[i] = rq_to_float(rotated[base + i]);
+            amax = fmaxf(amax, fabsf(w[i]));
+        }
+        float gs = fmaxf(amax, 1e-8f);
+        int idx[G];
+        #pragma unroll
+        for (int i = 0; i < G; ++i) {
+            idx[i] = rq_nearest(w[i] / gs, cb);
+        }
+        #pragma unroll
+        for (int it = 0; it < 2; ++it) {  // matches eager _ALS_ITERS
+            float num = 0.0f;
+            float den = 0.0f;
+            #pragma unroll
+            for (int i = 0; i < G; ++i) {
+                const float c = cb[idx[i]];
+                num += w[i] * c;
+                den += c * c;
+            }
+            gs = fmaxf(num / fmaxf(den, 1e-8f), 1e-8f);
+            #pragma unroll
+            for (int i = 0; i < G; ++i) {
+                idx[i] = rq_nearest(w[i] / gs, cb);
+            }
+        }
+        gscale[g] = gs;
+        #pragma unroll
+        for (int i = 0; i < G; ++i) {
+            thread_amax = fmaxf(thread_amax, fabsf(cb[idx[i]] * gs));
+        }
+    }
+
+    // Block max -> s_channel = row_amax / 127. An LDS tree rather than shuffles,
+    // so nothing here depends on the wave width.
+    red[t] = thread_amax;
+    __syncthreads();
+    for (int s = kRequantThreads / 2; s > 0; s >>= 1) {
+        if (t < s) {
+            red[t] = fmaxf(red[t], red[t + s]);
+        }
+        __syncthreads();
+    }
+    const float sc = fmaxf(red[0] / 127.0f, 1e-8f);
+    if (t == 0) {
+        s_channel[row] = sc;
+    }
+
+    // s_rel through fp8, then int8 levels, assign, pack. The levels are built
+    // from the roundtripped s_rel, which is the value the decode side reads back.
+    const int64_t prow_off = static_cast<int64_t>(row) * (k / 2);
+    const int64_t srow_off = static_cast<int64_t>(row) * groups;
+    for (int g = t; g < groups; g += kRequantThreads) {
+        const uint8_t srel_bits = pack_fp8(gscale[g] / sc, kFp8E4M3Code);
+        s_rel[srow_off + g] = srel_bits;
+        const float srel = fp8_to_float(srel_bits);
+        float lv[16];
+        #pragma unroll
+        for (int j = 0; j < 16; ++j) {
+            // rintf is round-half-to-even, matching torch.round.
+            lv[j] = fminf(127.0f, fmaxf(-127.0f, rintf(cb[j] * srel)));
+        }
+        const int64_t base = row_off + static_cast<int64_t>(g) * G;
+        const int64_t base_p = prow_off + static_cast<int64_t>(g) * (G / 2);
+        // Packed a pair at a time rather than assigning all 16 first: holding the
+        // whole group's codes alongside the level table costs enough registers to
+        // spill the fp32 and fp16 instantiations.
+        #pragma unroll
+        for (int p = 0; p < G / 2; ++p) {
+            int code[2];
+            #pragma unroll
+            for (int h = 0; h < 2; ++h) {
+                const int64_t at = base + 2 * p + h;
+                const float x = rq_to_float(rotated[at]) / sc;
+                if constexpr (STOCHASTIC) {
+                    const int a = rq_stochastic(x, lv, at, seed);
+                    code[h] = a > 15 ? 15 : a;
+                } else {
+                    code[h] = rq_nearest(x, lv);
+                }
+            }
+            packed[base_p + p] =
+                static_cast<int8_t>((code[0] & 0xF) | ((code[1] & 0xF) << 4));
+        }
+    }
+}
+
+}  // namespace
+}  // namespace comfy::hip_backend
+
+// in_dtype_code is a DTYPE_TO_CODE value: 0 float32, 1 float16, 2 bfloat16.
+// s_rel is written as raw e4m3 bytes.
+extern "C" void launch_quantize_w4a8_convrot_kernel(
+    const void* rotated, const void* codebook, void* packed, void* s_rel, void* s_channel,
+    int64_t n, int64_t k, int in_dtype_code, bool stochastic, uint64_t seed, hipStream_t stream) {
+
+    using namespace comfy::hip_backend;
+    if (k % kRequantGroup != 0) {
+        throw std::runtime_error("quantize_w4a8_convrot: K must be a multiple of 16");
+    }
+    const int max_k = w4a8_requant_max_k();
+    if (max_k <= 0 || k > max_k) {
+        throw std::runtime_error("quantize_w4a8_convrot: K=" + std::to_string(k) +
+                                 " does not fit in LDS (max " + std::to_string(max_k) + ")");
+    }
+    if (n == 0) {
+        return;  // a zero-block launch is hipErrorInvalidConfiguration
+    }
+
+    const size_t shmem = static_cast<size_t>(k / kRequantGroup) * sizeof(float);
+    const unsigned int blocks = static_cast<unsigned int>(n);
+    const int kk = static_cast<int>(k);
+
+#define COMFY_REQUANT_LAUNCH(InputT)                                                          \
+    do {                                                                                      \
+        if (stochastic) {                                                                     \
+            quantize_w4a8_convrot_kernel<InputT, true>                                        \
+                <<<blocks, kRequantThreads, shmem, stream>>>(                                 \
+                    static_cast<const InputT*>(rotated), static_cast<const float*>(codebook), \
+                    static_cast<int8_t*>(packed), static_cast<uint8_t*>(s_rel),               \
+                    static_cast<float*>(s_channel), kk, seed);                                \
+        } else {                                                                              \
+            quantize_w4a8_convrot_kernel<InputT, false>                                       \
+                <<<blocks, kRequantThreads, shmem, stream>>>(                                 \
+                    static_cast<const InputT*>(rotated), static_cast<const float*>(codebook), \
+                    static_cast<int8_t*>(packed), static_cast<uint8_t*>(s_rel),               \
+                    static_cast<float*>(s_channel), kk, 0);                                   \
+        }                                                                                     \
+    } while (0)
+
+    if (in_dtype_code == 0) {
+        COMFY_REQUANT_LAUNCH(float);
+    } else if (in_dtype_code == 1) {
+        COMFY_REQUANT_LAUNCH(__half);
+    } else if (in_dtype_code == 2) {
+        COMFY_REQUANT_LAUNCH(__bf16);
+    } else {
+        throw std::runtime_error("quantize_w4a8_convrot: unsupported input dtype code");
+    }
+#undef COMFY_REQUANT_LAUNCH
+}
+
+extern "C" int w4a8_requant_max_k_kernel() { return comfy::hip_backend::w4a8_requant_max_k(); }

--- a/tests/test_hip_dispatch.py
+++ b/tests/test_hip_dispatch.py
@@ -153,6 +153,8 @@ def test_hip_drops_gemms_without_matrix_cores():
     # would pass while any single one was missing from the constraints.
     assert set(with_wmma) >= hip_backend._WMMA_ONLY_OPS
     assert not (hip_backend._WMMA_ONLY_OPS & set(without))
+    # na3d is a matrix-core kernel: without one it traps rather than answers.
+    assert "na3d" in hip_backend._WMMA_ONLY_OPS
     # The elementwise kernels need no matrix cores and must survive.
     for op in ("apply_rope", "apply_rope_", "rms_rope", "rms_rope_split_half1_", "adaln",
                "rms_adaln", "quantize_per_tensor_fp8", "gemv_awq_w4a16",

--- a/tests/test_hip_dispatch.py
+++ b/tests/test_hip_dispatch.py
@@ -159,6 +159,9 @@ def test_hip_drops_gemms_without_matrix_cores():
                "dequantize_int8_simple_dtype",
                "dequantize_int8_convrot_weight_dtype"):
         assert op in without
+    # The fused W4A8 requantize is elementwise too: it packs weights and never
+    # reaches a matrix core, so RDNA2 must keep it.
+    assert "quantize_w4a8_int8_weight" in without
 
 
 def test_hip_advertises_every_inplace_rope_entry():

--- a/tests/test_hip_wmma.py
+++ b/tests/test_hip_wmma.py
@@ -13,6 +13,9 @@ from comfy_kitchen.backends.eager.convrot_w4a4 import _unpack_int4_row_major
 from comfy_kitchen.backends.eager.quantization import (
     quantize_and_rotate_rowwise as eager_quantize_and_rotate_rowwise,
 )
+from comfy_kitchen.backends.eager.quantization import (
+    rotate_int8_convrot_weight as eager_rotate_int8_convrot_weight,
+)
 from comfy_kitchen.registry import registry
 from comfy_kitchen.tensor import AsymW4A8Int8Layout, QuantizedTensor
 from comfy_kitchen.tensor.int8_utils import _build_hadamard
@@ -602,6 +605,222 @@ def test_w4a8_consumes_a_row_chunked_quantize(hip):
 
     scale = ref.float().abs().max().item()
     assert (out.float() - ref.float()).abs().max().item() < 0.05 * scale
+
+
+# ---------------------------------------------------------------------------
+# Fused W4A8 requantize
+# ---------------------------------------------------------------------------
+
+
+def _requant_inputs(n, k, dtype=torch.bfloat16, seed=0):
+    torch.manual_seed(seed)
+    w = torch.randn(n, k, device=DEV, dtype=dtype) * 0.02
+    cb = eager_w4a8._decide_codebook(w, eager_rotate_int8_convrot_weight, 16, 256)
+    return w, cb
+
+
+def _requires_fused_requant(hip, w):
+    """The wrapper falls back to the eager packer when the device's LDS budget declines
+    this K, which would leave a test exercising eager under the kernel's name."""
+    assert hip._requant_supported(w.shape[1], w.device, w.dtype)
+
+
+def _assert_same_packed(out, ref):
+    """Bit equality across the packed tuple, reaching the fp8 scales through uint8."""
+    for got, want in zip(out, ref, strict=True):
+        if want is None:
+            assert got is None
+        elif want.dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
+            assert torch.equal(got.view(torch.uint8), want.view(torch.uint8))
+        else:
+            assert torch.equal(got, want)
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize(("n", "k"), [(64, 256), (33, 512), (128, 1024), (96, 4096)])
+def test_w4a8_fused_quantize_matches_eager(hip, dtype, n, k):
+    """The kernel repeats eager's arithmetic on the same rotated values, so it has to
+    reproduce eager's codes, not merely land near them.
+
+    The one thing it cannot reproduce is the summation order of eager's 16-wide
+    reductions, which is torch's, not a sequential accumulate. That moves an ALS group
+    scale by an ulp, and an ulp is visible only where the scale sat on an e4m3 rounding
+    boundary -- so a handful of groups shift one e4m3 code, and the weights in those
+    groups shift at most one int4 level. Anything wider than that is a real divergence.
+    """
+    w, cb = _requant_inputs(n, k, dtype)
+    _requires_fused_requant(hip, w)
+    ref = eager_w4a8.quantize_w4a8_int8_weight(w, 16, convrot_groupsize=256, codebook_tensor=cb)
+    out = hip.quantize_w4a8_int8_weight(w, 16, convrot_groupsize=256, codebook_tensor=cb)
+
+    # Adjacency is the real assertion; the counts are a second guard against a
+    # systematic divergence, which would flip a large fraction rather than a few.
+    # Measured over these cases: at most 1 group and 0 weights differ, and the
+    # smallest shapes differ nowhere, so the floor keeps their bound a handful wide
+    # instead of exactly one.
+    srel_delta = (out[1].view(torch.uint8).int() - ref[1].view(torch.uint8).int()).abs()
+    assert srel_delta.max() <= 1
+    assert srel_delta.count_nonzero() <= max(8, srel_delta.numel() // 1000)
+
+    code_delta = (
+        _unpack_int4_row_major(out[0]).int() - _unpack_int4_row_major(ref[0]).int()
+    ).abs()
+    assert code_delta.max() <= 1
+    assert code_delta.count_nonzero() <= max(8, code_delta.numel() // 10000)
+
+    torch.testing.assert_close(out[2], ref[2], rtol=1e-6, atol=0)
+    assert out[3] is None and ref[3] is None
+
+    # ...and the decode is no less faithful to the weight than eager's.
+    def rel(packed):
+        decoded = ck.dequantize_w4a8_int8_weight(
+            packed[0], packed[1], packed[2], packed[4], None, 16, 256, torch.float32
+        )
+        return ((decoded - w.float()).norm() / w.float().norm()).item()
+
+    assert rel(out) <= rel(ref) * 1.01
+
+
+def test_w4a8_fused_quantize_does_not_depend_on_the_row_block(hip, monkeypatch):
+    """Rows are rotated a block at a time to cap peak memory. Every output is per-row
+    and the kernel reduces only within a row, so the packed result must be the same
+    whether a row block covers the tensor or a ragged tail closes it.
+
+    The stochastic draw is the documented exception. The kernel keys it on the element
+    index within its launch and the caller shifts the seed by the block's first row, so
+    the draw is reproducible for a given block size and deliberately decorrelated
+    across blocks. Both other backends do this; pinned here so a "fix" that keys the
+    draw globally has to change a test that says why.
+
+    The rotation ahead of the kernel is an eager matmul, and its tiling follows the
+    row count, so a row comes out of it up to an ulp apart between blockings on some
+    cards. Every blocking is handed the same rotated rows, which leaves the kernel as
+    the only thing the comparison can fail on; the stub checks the rows it is asked to
+    rotate, so the caller's slicing is still under test.
+    """
+    n, k = 700, 512
+    w, cb = _requant_inputs(n, k)
+    _requires_fused_requant(hip, w)
+    kwargs = {"convrot_groupsize": 256, "codebook_tensor": cb}
+
+    rotated = eager_rotate_int8_convrot_weight(w, 256)
+    cursor = [0]
+
+    def rotate_rows(block, groupsize):
+        r0, r1 = cursor[0], cursor[0] + block.shape[0]
+        assert groupsize == 256 and torch.equal(block, w[r0:r1])
+        cursor[0] = r1
+        return rotated[r0:r1]
+
+    monkeypatch.setattr(hip._eager, "rotate_int8_convrot_weight", rotate_rows)
+
+    def quantize(budget, **extra):
+        monkeypatch.setattr(hip, "_QUANT_ROW_ELEM_BUDGET", budget)
+        cursor[0] = 0
+        return hip.quantize_w4a8_int8_weight(w, 16, **kwargs, **extra)
+
+    whole = quantize(n * k)
+    chunked = quantize(128 * k)  # 5 blocks + a 60-row tail
+
+    assert torch.equal(whole[0], chunked[0])
+    assert torch.equal(whole[1].view(torch.uint8), chunked[1].view(torch.uint8))
+    assert torch.equal(whole[2], chunked[2])
+
+    assert not torch.equal(quantize(n * k, stochastic_rounding=7)[0],
+                           quantize(128 * k, stochastic_rounding=7)[0])
+
+
+@pytest.mark.parametrize(
+    ("tag", "kwargs"),
+    [
+        ("asymmetric", {"symmetric": False}),
+        ("uniform", {"codebook": False}),
+        ("fp32_scale", {"scale_dtype": torch.float32}),
+        ("group_size_32", {"group_size": 32}),
+    ],
+)
+def test_w4a8_fused_quantize_declines_off_the_default_layout(hip, tag, kwargs, monkeypatch):
+    """The kernel implements one layout. Everything else has to reach the shared
+    packer unchanged, not a near-miss fast path.
+
+    The fused entry is stubbed rather than inferred from output equality: the two
+    paths happen to agree to an ulp today, so equality alone would keep passing if
+    the gate ever let one of these layouts through.
+    """
+    w, _ = _requant_inputs(64, 512)
+    kwargs = {"convrot_groupsize": 256, **kwargs}
+
+    def _refuse(*_args, **_kwargs):
+        raise AssertionError(f"fused path taken for {tag}")
+
+    monkeypatch.setattr(hip, "_fused_quantize_w4a8", _refuse)
+    ref = eager_w4a8.quantize_w4a8_int8_weight(w, **kwargs)
+    out = hip.quantize_w4a8_int8_weight(w, **kwargs)
+
+    _assert_same_packed(out, ref)
+
+
+def test_w4a8_fused_quantize_declines_a_row_wider_than_lds(hip, monkeypatch):
+    """Group scales sit in LDS, so K is bounded per device. Past the budget the
+    wrapper must fall back instead of launching something that cannot fit.
+
+    Declining the budget and consulting it are two claims: the fused entry is
+    stubbed so the second one is asserted rather than inferred from a shape the two
+    paths happen to agree on.
+    """
+    w, cb = _requant_inputs(8, 512)
+    monkeypatch.setattr(hip, "_w4a8_requant_max_k", {})
+    monkeypatch.setattr(hip._C, "w4a8_requant_max_k", lambda: 256)
+    assert not hip._requant_supported(512, w.device, w.dtype)
+
+    def _refuse(*_args, **_kwargs):
+        raise AssertionError("fused path taken for a row wider than the LDS budget")
+
+    monkeypatch.setattr(hip, "_fused_quantize_w4a8", _refuse)
+    ref = eager_w4a8.quantize_w4a8_int8_weight(w, 16, convrot_groupsize=256, codebook_tensor=cb)
+    out = hip.quantize_w4a8_int8_weight(w, 16, convrot_groupsize=256, codebook_tensor=cb)
+    _assert_same_packed(out, ref)
+
+
+def test_w4a8_fused_quantize_stochastic_rounding_is_seeded(hip):
+    """A seed has to reproduce, and two seeds have to disagree, or the draw is not
+    doing the job it was added for."""
+    w, cb = _requant_inputs(128, 512)
+    _requires_fused_requant(hip, w)
+    kwargs = {"convrot_groupsize": 256, "codebook_tensor": cb}
+    a = hip.quantize_w4a8_int8_weight(w, 16, stochastic_rounding=7, **kwargs)[0]
+    b = hip.quantize_w4a8_int8_weight(w, 16, stochastic_rounding=7, **kwargs)[0]
+    c = hip.quantize_w4a8_int8_weight(w, 16, stochastic_rounding=8, **kwargs)[0]
+
+    assert torch.equal(a, b)
+    assert not torch.equal(a, c)
+
+
+def test_w4a8_fused_quantize_stochastic_rounding_is_unbiased(hip):
+    """Round-to-nearest carries a fixed per-weight bias: the same weight always lands
+    on the same code, so a merged delta smaller than the int4 step rounds away every
+    time. The seeded draw is unbiased instead, so averaging decodes over seeds closes
+    on the original weight where a single nearest decode cannot."""
+    w, cb = _requant_inputs(128, 512)
+    _requires_fused_requant(hip, w)
+    kwargs = {"convrot_groupsize": 256, "codebook_tensor": cb}
+    reference = w.float()
+
+    def decode(packed):
+        return ck.dequantize_w4a8_int8_weight(
+            packed[0], packed[1], packed[2], packed[4], None, 16, 256, torch.float32
+        )
+
+    def rel(decoded):
+        return ((decoded - reference).norm() / reference.norm()).item()
+
+    nearest = decode(hip.quantize_w4a8_int8_weight(w, 16, **kwargs))
+    draws = torch.zeros_like(reference)
+    seeds = 32
+    for seed in range(1, seeds + 1):
+        draws += decode(hip.quantize_w4a8_int8_weight(w, 16, stochastic_rounding=seed, **kwargs))
+
+    assert rel(draws / seeds) < 0.6 * rel(nearest)
 
 
 @needs_wmma

--- a/tests/test_hip_wmma.py
+++ b/tests/test_hip_wmma.py
@@ -16,6 +16,7 @@ from comfy_kitchen.backends.eager.quantization import (
 from comfy_kitchen.backends.eager.quantization import (
     rotate_int8_convrot_weight as eager_rotate_int8_convrot_weight,
 )
+from comfy_kitchen.constraints import validate_function_call
 from comfy_kitchen.registry import registry
 from comfy_kitchen.tensor import AsymW4A8Int8Layout, QuantizedTensor
 from comfy_kitchen.tensor.int8_utils import _build_hadamard
@@ -2141,3 +2142,160 @@ def test_convrot_launcher_rejects_unsupported_group_size(hip, group_size):
         hip._C.convrot_quant_int4(
             hip._dl(x), hip._dl(q), hip._dl(scales), 8, 128, group_size, hip._stream(x)
         )
+
+
+# ---------------------------------------------------------------------------
+# Neighborhood attention
+# ---------------------------------------------------------------------------
+
+
+def _na_window(i, kernel, length, causal):
+    if causal:
+        return max(0, i - kernel + 1), i + 1
+    kernel = min(kernel, length)
+    s = min(max(i - kernel // 2, 0), length - kernel)
+    return s, s + kernel
+
+
+def _ref_na3d(q, k, v, kernel_size, is_causal, scale):
+    """Per-query loop over the NATTEN window, accumulated and returned in fp32.
+
+    Upstream's copy of this reference rounds each window result back to the input
+    dtype. Keeping it in fp32 costs nothing and stops a fifth of the bf16 tolerance
+    budget going on a rounding the reference never had to do.
+    """
+    b, t, h, w, nh, hd = q.shape
+    if scale is None:
+        scale = hd ** -0.5
+    out = torch.empty(q.shape, device=q.device, dtype=torch.float32)
+    for ti in range(t):
+        t0, t1 = _na_window(ti, kernel_size[0], t, is_causal[0])
+        for hi in range(h):
+            h0, h1 = _na_window(hi, kernel_size[1], h, is_causal[1])
+            for wi in range(w):
+                w0, w1 = _na_window(wi, kernel_size[2], w, is_causal[2])
+                kk = k[:, t0:t1, h0:h1, w0:w1].reshape(b, -1, nh, hd)
+                vv = v[:, t0:t1, h0:h1, w0:w1].reshape(b, -1, nh, hd)
+                s = torch.einsum("bnd,bknd->bnk", q[:, ti, hi, wi].float(), kk.float()) * scale
+                a = torch.softmax(s, dim=-1)
+                out[:, ti, hi, wi] = torch.einsum("bnk,bknd->bnd", a, vv.float())
+    return out
+
+
+NA_CASES = [
+    ((1, 5, 9, 12, 2, 64), (3, 7, 7), (False, False, False)),
+    ((1, 12, 13, 15, 2, 64), (11, 11, 11), (False, False, False)),
+    ((2, 6, 8, 8, 4, 64), (5, 5, 5), (True, False, False)),
+    ((1, 3, 6, 6, 2, 64), (5, 5, 5), (True, False, False)),    # kernel > dims, causal T
+    ((1, 2, 5, 5, 2, 64), (3, 7, 7), (False, False, False)),   # kernel > dims -> clamp
+    ((1, 1, 16, 16, 2, 64), (1, 5, 5), (False, False, False)),  # single frame (na2d shape)
+    ((1, 4, 7, 40, 2, 32), (3, 5, 5), (False, False, False)),
+    ((1, 2, 3, 65, 2, 64), (3, 3, 5), (False, False, False)),  # ragged tail query block
+    ((1, 2, 3, 96, 1, 64), (1, 3, 33), (False, False, False)),  # window wider than a key tile
+    ((1, 3, 4, 34, 2, 16), (3, 3, 5), (False, False, False)),
+    ((1, 3, 4, 34, 2, 48), (3, 3, 5), (False, False, False)),  # head_dim not a power of 2
+    ((1, 4, 6, 20, 2, 64), (3, 5, 7), (False, False, True)),   # causal W
+    ((1, 4, 6, 20, 2, 64), (3, 5, 7), (False, True, False)),   # causal H
+    ((1, 4, 6, 20, 2, 64), (3, 5, 7), (True, True, True)),
+    ((2, 3, 4, 18, 3, 32), (3, 3, 5), (False, False, False)),  # batch and heads > 1
+]
+
+
+@pytest.mark.parametrize(("shape", "kernel", "causal"), NA_CASES)
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("scale", [None, 1.0])
+@needs_wmma
+def test_na3d_matches_the_windowed_reference(hip, shape, kernel, causal, dtype, scale):
+    torch.manual_seed(0)
+    q = torch.randn(shape, device=DEV, dtype=dtype)
+    k = torch.randn(shape, device=DEV, dtype=dtype)
+    v = torch.randn(shape, device=DEV, dtype=dtype)
+
+    out = hip.na3d(q, k, v, list(kernel), list(causal), scale)
+    ref = _ref_na3d(q, k, v, kernel, causal, scale)
+
+    assert out.shape == q.shape
+    torch.testing.assert_close(out.float(), ref.float(), rtol=2e-2, atol=2e-2)
+
+
+@needs_wmma
+def test_na3d_reads_a_non_contiguous_input(hip):
+    """The kernel indexes off bare pointers with contiguous strides, so a permuted
+    view has to be materialised rather than read at its own strides."""
+    torch.manual_seed(0)
+    shape = (1, 4, 6, 20, 2, 64)
+    kernel, causal = (3, 5, 5), (False, False, False)
+    # A head slice, so the head stride no longer packs. All three operands get one:
+    # the kernel reads each off a bare pointer, so a copy dropped from any of them
+    # would leave that one read at packed strides.
+    views = [
+        torch.randn(1, 4, 6, 20, 4, 64, device=DEV, dtype=torch.bfloat16)[:, :, :, :, :2]
+        for _ in range(3)
+    ]
+    assert all(x.shape == shape and not x.is_contiguous() for x in views)
+
+    torch.testing.assert_close(
+        hip.na3d(*views, list(kernel), list(causal), None).float(),
+        hip.na3d(*(x.contiguous() for x in views), list(kernel), list(causal), None).float(),
+        rtol=0,
+        atol=0,
+    )
+
+
+@needs_wmma
+def test_na3d_dispatches_to_hip(hip):
+    """fp32 has no 16-bit matrix path and must not reach the kernel; the half types
+    must, or the op silently needs triton at runtime."""
+    constraints = hip._build_constraints(has_wmma=True)["na3d"]
+    shape = (1, 4, 6, 20, 2, 64)
+    for dtype, expected in ((torch.bfloat16, True), (torch.float16, True), (torch.float32, False)):
+        x = torch.zeros(shape, device=DEV, dtype=dtype)
+        kwargs = {"q": x, "k": x, "v": x, "kernel_size": [3, 5, 5], "is_causal": None}
+        assert validate_function_call(constraints, kwargs).success is expected
+
+    # head_dim is bounded by the WMMA K-step and the register-resident accumulators.
+    for head_dim, expected in ((16, True), (48, True), (64, True), (80, False), (24, False)):
+        x = torch.zeros(1, 2, 3, 8, 2, head_dim, device=DEV, dtype=torch.bfloat16)
+        kwargs = {"q": x, "k": x, "v": x, "kernel_size": [1, 3, 3], "is_causal": None}
+        assert validate_function_call(constraints, kwargs).success is expected
+
+    # Both grid dims at their boundary, off a stride-0 view so the rejected shape
+    # costs no memory. The reason is read back as well, or a shape some other rule
+    # happens to decline would pass this for the wrong branch.
+    base = torch.zeros(1, 1, 1, 1, 1, 64, device=DEV, dtype=torch.bfloat16)
+    for fits, over in (
+        ((1, 65535, 1, 1, 1, 64), (1, 65536, 1, 1, 1, 64)),  # blocks over T*H
+        ((65535, 1, 1, 1, 1, 64), (65536, 1, 1, 1, 1, 64)),  # blocks over B*heads
+    ):
+        def call(shape):
+            x = base.expand(shape)
+            return validate_function_call(
+                constraints,
+                {"q": x, "k": x, "v": x, "kernel_size": [1, 1, 1], "is_causal": None},
+            )
+
+        assert call(fits).success
+        assert call(over).failure_reason == "grid dims exceed HIP limits"
+
+
+@needs_wmma
+def test_na3d_launcher_rejects_a_mismatched_operand(hip):
+    """_C is importable, so the size checks cannot be left to the Python layer: the
+    kernel reads k and v with q's extents."""
+    q = torch.zeros(1, 2, 3, 16, 2, 64, device=DEV, dtype=torch.bfloat16)
+    short = torch.zeros(1, 2, 3, 8, 2, 64, device=DEV, dtype=torch.bfloat16)
+    out = torch.empty_like(q)
+    # Codes come from the shared table the wrapper dispatches on, so a change there
+    # cannot leave this test asserting against a stale literal.
+    extents = (1, 2, 3, 16, 2, 64, 1, 3, 3, 0, 0, 0, 0.125)
+    stream = 0
+
+    # Both operands are read with q's extents, so both slots are checked: a launcher
+    # that validates one and forgets the other reads past the end of the other.
+    for k_arg, v_arg in ((short, q), (q, short)):
+        with pytest.raises(RuntimeError, match="needs at least"):
+            hip._C.na3d(hip._dl(q), hip._dl(k_arg), hip._dl(v_arg), hip._dl(out),
+                        *extents, hip.DTYPE_TO_CODE[torch.bfloat16], stream)
+    with pytest.raises(RuntimeError, match="float16 or bfloat16"):
+        hip._C.na3d(hip._dl(q.float()), hip._dl(q), hip._dl(q), hip._dl(out),
+                    *extents, hip.DTYPE_TO_CODE[torch.float32], stream)


### PR DESCRIPTION
Catch-up for the two kernels added since #97, one commit each. All numbers on gfx1200, ROCm 10.1, PyTorch 2.14.

## HIP port of #99: fused W4A8 requantize

Performance port. `stochastic_rounding` is backend-agnostic and already reached HIP through the shared eager packer, so nothing was broken. What was missing is the kernel: HIP registered no `quantize_w4a8_int8_weight`, so every weight prepare and LoRA-merge requantize ran eager torch.

`ops/w4a8_requant.hip` mirrors `ops/w4a8_gemm.cu`, with the same PCG draw keyed by the element's global index, so a HIP requantize and a CUDA one produce identical stochastic results. The row max is an LDS tree instead of a shuffle reduction, so it
does not depend on the wave width. Two deliberate differences:

- ConvRot rotation stays on eager on purpose. Eager rotates with a batched matmul against the 256x256 Hadamard, which runs on the matrix cores: 0.42 ms at 5120x5120. HIP's butterfly ConvRot is LDS-bound and does rotate plus an int8 quantize in 1.03 ms, so a rotate-only kernel carved out of it would be slower than what it replaces, and its rounding differs from the matmul's (about 8 percent of int8 codes land one level apart), which would cost the eager parity below.
- The K bound is read from the device rather than assumed: `_C.w4a8_requant_max_k()` reports the LDS budget of the card the weight lives on, and the wrapper falls back to the chunked eager packer past it. Asymmetric, uniform, fp32-scale and non-16 group sizes reach that packer unchanged.

bf16 weights, ms. SR is the same call with `stochastic_rounding` set, which is the LoRA-merge path #99 added:

| shape | eager | HIP | | eager, SR | HIP, SR | |
|---|---|---|---|---|---|---|
| 3072 x 3072 | 27.3 | 0.98 | 28x | 27.2 | 1.09 | 25x |
| 5120 x 5120 | 77.4 | 2.52 | 31x | 77.0 | 2.68 | 29x |
| 13824 x 5120 | 211 | 5.59 | 38x | 210 | 6.02 | 35x |

The gap is memory traffic, not arithmetic. Eager materialises the weight in fp32 and runs the codebook assign, two ALS iterations and the level assign as separate full-tensor elementwise passes; the kernel keeps a 16-wide group in registers and
reads the rotated weight twice in total.

Not bit-exact with eager, by one ulp. The kernel cannot reproduce the summation order of eager's 16-wide reductions, which is torch's and not a sequential accumulate. That moves an ALS group scale by an ulp, visible only where the scale sat on an e4m3 rounding boundary: over 2.6M nibbles at 2560 x 2048, 4 group scales one e4m3 code apart and 12 nibbles one int4 level apart. The tests bound both, require every mismatch to be an adjacent code, and require a decode no less faithful to the weight than eager's. The CUDA kernel has the same property.

## HIP port of #95: na3d / na2d

Coverage port. na3d landed with no HIP entry, so on ROCm it fell through to triton or eager. Triton is not a fallback the backend can lean on: ComfyUI gates it behind `--enable-triton-backend` and some installs have no triton, which left na3d on the eager SDPA-with-mask path there.

`ops/na3d.hip` follows the flash-attention-2 shape of `ops/na3d.cu`: one wave covers 16 queries along W at a fixed (t, h) and sweeps that block's key span 16 keys at a time. Two things differ, both forced by the instruction. RDNA's `16x16x16` WMMA hands each lane one accumulator column over 8 rows while the A operand wants one row of the K-step, so the probability tile round-trips through LDS rather than being repacked in registers the way `mma.m16n8k16` allows; and both matmuls contract
`A @ B^T`, so V is staged transposed.

`mma.h` gains `MmaBf16`/`MmaF16` for both matrix-core generations, so the kernel addresses fragments through the existing `frag_row`/`acc_row`/`acc_col` abstraction. The gfx12 layout it assumes was checked against a CPU reference with a standalone
probe rather than read off a table: exact match. LDS rows are padded to 9 dwords, so with 32 four-byte banks and gcd(9, 32) = 1 the 16 row-strided lanes of a fragment read reach 16 distinct banks; 8 or 12 dwords collapse them onto 4 or 8 and cost 12
to 20 percent.

fp32 has no 16-bit matrix path and is left to triton/eager, matching the CUDA entry. na2d needs nothing of its own.

bf16, ms. Eager is measured with `TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL=1`, which lets its SDPA use Flash via AOTriton on gfx1200 and is worth about 7x; without it the eager column is 277 / 127 / 26.0 ms:

| shape | kernel | HIP | triton | eager |
|---|---|---|---|---|
| (1, 21, 30, 52, 12, 64) | (3, 7, 7) | 8.38 | 13.67 (1.63x) | 36.2 (4.3x) |
| (1, 16, 32, 32, 8, 64) | (5, 5, 5) | 2.88 | 4.52 (1.57x) | 16.6 (5.8x) |
| (1, 1, 64, 64, 8, 64) | (1, 13, 13) | 0.41 | 0.75 (1.84x) | 4.80 (11.7x) |

The triton column is what a ROCm user gets only with triton installed and enabled; the eager column is what everyone else was getting, and only if they set that flag on architectures that are only experimentally supported by AOTriton.

## Tests

83 added, in `tests/test_hip_wmma.py` and `tests/test_hip_dispatch.py` (`tests/test_na.py`'s `get_capable_backends` enumerates only cuda/triton/eager, so it does not reach HIP). na3d is checked against a per-query loop over the NATTEN window in fp32 across the same 15 cases #95 uses, crossed with fp16/bf16 and both scale modes. Requantize covers eager parity across three dtypes, row-block independence, the four layouts that must decline, the LDS-budget fallback, and the draw's reproducibility and unbiasedness.

Full suite against an `origin/main` worktree, comparing per-test outcome maps rather than counts: 83 added and passing, 0 removed, 0 changed outcomes. The 102 pre-existing failures (triton-on-AMD compiler bugs, bf16 tolerance in triton/eager rope, torch ROCm MX gemm) are on `origin/main` too.

## Architecture coverage

All 17 targets in `architectures.json` compile; gfx1200 is run-verified.

| | RDNA2 | RDNA3 / 3.5 | RDNA4 |
|---|---|---|---|
| W4A8 requantize | registers, elementwise | compile-verified | run-verified |
| na3d / na2d | withheld, no matrix cores | compile-verified | run-verified |

gfx1100 and gfx1151 each emit 40 `v_wmma` for na3d with no traps and no scratch, so they take the real path and not the stub. na3d joins `_WMMA_ONLY_OPS`, pinned by an assertion rather than left implicit.
