### PR TITLE
Document the actual PyTorch minimum (>=2.7.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ python setup.py build_ext --debug-build --lineinfo bdist_wheel
 ### Requirements
 
 - **Python**: ≥3.10
-- **PyTorch**: ≥2.5.0
+- **PyTorch**: ≥2.7.0
 - **CUDA Runtime** (for CUDA wheels): ≥13.0
   - Pre-built wheels require NVIDIA Driver r580+
   - Building from source requires CUDA Toolkit ≥12.8 and `CUDA_HOME` environment variable


### PR DESCRIPTION
The README lists `**PyTorch**: ≥2.5.0`, but as of 0.2.28 two things run at import time that need 2.7.0:

- **`backends/eager/na.py:163`** registers `comfy_kitchen::na3d` with PEP 585 annotations (`kernel_size: list[int]`, `is_causal: list[bool]`). `torch.library.infer_schema` only accepts builtin generics from 2.7.0 — `derived_types` gained the `GenericAlias(list, ...)` entries in v2.7.0 and they are absent in v2.6.0. On 2.5/2.6 the decorator raises `ValueError` at import.
- **`backends/eager/__init__.py:542`** references `torch.float8_e8m0fnu` inside `_build_constraints()`, which is called at module scope (line 586). That dtype landed in 2.7.0 (`c10/core/ScalarType.h`: 0 occurrences at v2.6.0, 6 at v2.7.0).

Both blow up on `import comfy_kitchen` itself rather than at first use, so the package is unusable below 2.7.0 regardless of backend or device — including CPU-only setups that never touch a kernel.

Verified on clean venvs:

| torch | `import comfy_kitchen` (0.2.28) |
|---|---|
| 2.6.0 | `ValueError: infer_schema(func): Parameter kernel_size has unsupported type list[int]` |
| 2.7.0+cpu | OK — eager backend available |

Docs-only change; no code or behavior is affected. Assumes the higher floor is intended, so this just makes the README match.

Possible follow-ups, out of scope here: `pyproject.toml` has `dependencies = []`, so nothing enforces the floor at install time, and the repo has no CI job that imports the package at the documented minimum.