### PR TITLE
Add MPS fallback for INT8 linear

### DIFF
--- a/comfy_kitchen/backends/eager/mps_int8.py
+++ b/comfy_kitchen/backends/eager/mps_int8.py
@@ -1,0 +1,230 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Metal 4 fused INT8 linear kernels for Apple silicon."""
+
+from __future__ import annotations
+
+import math
+import threading
+
+import torch
+
+
+class FusedMPSUnsupportedError(RuntimeError):
+    """Raised when the fused path cannot handle an input safely."""
+
+
+_SHADER = r"""
+#include <metal_stdlib>
+#include <MetalPerformancePrimitives/MetalPerformancePrimitives.h>
+
+using namespace metal;
+
+kernel void quantize_rowwise_bf16(
+    device const bfloat* input [[buffer(0)]],
+    device int8_t* output [[buffer(1)]],
+    device float* scales [[buffer(2)]],
+    constant int& rows [[buffer(3)]],
+    constant int& columns [[buffer(4)]],
+    uint row [[threadgroup_position_in_grid]],
+    uint tid [[thread_index_in_threadgroup]],
+    uint lane [[thread_index_in_simdgroup]],
+    uint simdgroup [[simdgroup_index_in_threadgroup]],
+    uint threads_per_group [[threads_per_threadgroup]]) {
+  threadgroup float maxima[32];
+  float local_max = 0.0f;
+  int base = int(row) * columns;
+  for (int column = int(tid); column < columns; column += int(threads_per_group)) {
+    local_max = max(local_max, abs(float(input[base + column])));
+  }
+  local_max = simd_max(local_max);
+  if (lane == 0) {
+    maxima[simdgroup] = local_max;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  if (simdgroup == 0) {
+    uint simdgroup_count = (threads_per_group + 31) / 32;
+    float group_max = lane < simdgroup_count ? maxima[lane] : 0.0f;
+    group_max = simd_max(group_max);
+    if (lane == 0) {
+      maxima[0] = max(group_max / 127.0f, 1.0e-30f);
+      scales[row] = maxima[0];
+    }
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  bfloat scale = bfloat(maxima[0]);
+  for (int column = int(tid); column < columns; column += int(threads_per_group)) {
+    bfloat scaled = bfloat(input[base + column] / scale);
+    float value = rint(float(scaled));
+    output[base + column] = int8_t(clamp(value, -128.0f, 127.0f));
+  }
+}
+
+kernel void int8_linear_mpp_bf16(
+    device int8_t* activation [[buffer(0)]],
+    device int8_t* weight [[buffer(1)]],
+    device float* row_scale [[buffer(2)]],
+    device float* weight_scale [[buffer(3)]],
+    device bfloat* output [[buffer(4)]],
+    device bfloat* bias [[buffer(5)]],
+    constant int& rows [[buffer(6)]],
+    constant int& inner [[buffer(7)]],
+    constant int& columns [[buffer(8)]],
+    constant int& scale_count [[buffer(9)]],
+    constant int& has_bias [[buffer(10)]],
+    uint2 tgid [[threadgroup_position_in_grid]]) {
+  constexpr int BM = 64;
+  constexpr int BN = 32;
+  constexpr auto descriptor = mpp::tensor_ops::matmul2d_descriptor(
+      BM,
+      BN,
+      static_cast<int>(dynamic_extent),
+      false,
+      true,
+      false,
+      mpp::tensor_ops::matmul2d_descriptor::mode::multiply);
+  mpp::tensor_ops::matmul2d<descriptor, execution_simdgroups<4>> op;
+
+  tensor<device int8_t, dextents<int32_t, 2>, tensor_inline> a(
+      activation,
+      dextents<int32_t, 2>(inner, rows),
+      array<int32_t, 2>{1, inner});
+  tensor<device int8_t, dextents<int32_t, 2>, tensor_inline> b(
+      weight,
+      dextents<int32_t, 2>(inner, columns),
+      array<int32_t, 2>{1, inner});
+
+  auto a_tile = a.slice(0, tgid.y * BM);
+  auto b_tile = b.slice(0, tgid.x * BN);
+  auto accum = op.get_destination_cooperative_tensor<decltype(a_tile), decltype(b_tile), int32_t>();
+
+  #pragma clang loop unroll(full)
+  for (uint16_t i = 0; i < accum.get_capacity(); ++i) {
+    if (accum.is_valid_element(i)) {
+      accum[i] = 0;
+    }
+  }
+
+  op.run(a_tile, b_tile, accum);
+
+  #pragma clang loop unroll(full)
+  for (uint16_t i = 0; i < accum.get_capacity(); ++i) {
+    if (accum.is_valid_element(i)) {
+      auto index = accum.get_multidimensional_index(i);
+      int column = int(tgid.x) * BN + index[0];
+      int row = int(tgid.y) * BM + index[1];
+      if (row < rows && column < columns) {
+        float scale = row_scale[row] * weight_scale[scale_count == 1 ? 0 : column];
+        bfloat value = bfloat(float(accum[i]) * scale);
+        if (has_bias != 0) {
+          value = bfloat(value + bias[column]);
+        }
+        output[row * columns + column] = value;
+      }
+    }
+  }
+}
+"""
+
+
+_compile_lock = threading.Lock()
+_kernels: tuple[object, object] | None = None
+_compile_error: Exception | None = None
+
+
+def _get_kernels() -> tuple[object, object]:
+    global _kernels, _compile_error
+    if _kernels is not None:
+        return _kernels
+    if _compile_error is not None:
+        raise FusedMPSUnsupportedError("Metal 4 fused kernels are unavailable") from _compile_error
+    with _compile_lock:
+        if _kernels is not None:
+            return _kernels
+        try:
+            library = torch.mps.compile_shader(_SHADER)
+            _kernels = (library.quantize_rowwise_bf16, library.int8_linear_mpp_bf16)
+        except Exception as error:
+            _compile_error = error
+            raise FusedMPSUnsupportedError("Metal 4 fused kernels failed to compile") from error
+    return _kernels
+
+
+def int8_linear_bf16(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    bias: torch.Tensor | None,
+) -> torch.Tensor:
+    """Run row-wise activation quantization and INT8 linear in two Metal kernels."""
+    if x.device.type != "mps" or x.dtype != torch.bfloat16:
+        raise FusedMPSUnsupportedError("the fused path currently requires BF16 MPS activations")
+    if weight.dtype != torch.int8 or weight.dim() != 2:
+        raise FusedMPSUnsupportedError("the fused path requires a 2D INT8 weight")
+    if x.shape[-1] != weight.shape[-1]:
+        raise ValueError(
+            f"Input and weight inner dimensions must match, got {x.shape[-1]} and {weight.shape[-1]}"
+        )
+
+    original_shape = x.shape
+    inner = x.shape[-1]
+    rows = x.numel() // inner
+    columns = weight.shape[0]
+    if rows == 0 or inner == 0 or columns == 0:
+        raise FusedMPSUnsupportedError("empty matrices use the floating-point fallback")
+    int32_max = torch.iinfo(torch.int32).max
+    if rows > int32_max or inner > int32_max or columns > int32_max:
+        raise FusedMPSUnsupportedError("matrix dimensions exceed Metal tensor index limits")
+
+    x_2d = x.reshape(rows, inner).contiguous()
+    weight_mps = weight.to(device=x.device).contiguous()
+    scale_mps = weight_scale.to(device=x.device, dtype=torch.float32).reshape(-1).contiguous()
+    if scale_mps.numel() not in (1, columns):
+        raise ValueError(
+            f"INT8 weight scale must be scalar or per-output-channel, got {tuple(scale_mps.shape)} "
+            f"for weight shape {tuple(weight.shape)}"
+        )
+    bias_mps = (
+        None
+        if bias is None
+        else bias.to(device=x.device, dtype=torch.bfloat16).reshape(-1).contiguous()
+    )
+    if bias_mps is not None and bias_mps.numel() != columns:
+        raise ValueError(f"bias must have {columns} values, got {bias_mps.numel()}")
+
+    quantize_kernel, linear_kernel = _get_kernels()
+    quantized = torch.empty_like(x_2d, dtype=torch.int8)
+    row_scale = torch.empty((rows, 1), device=x.device, dtype=torch.float32)
+    output = torch.empty((rows, columns), device=x.device, dtype=torch.bfloat16)
+
+    quantize_kernel(
+        x_2d,
+        quantized,
+        row_scale,
+        rows,
+        inner,
+        threads=rows * 256,
+        group_size=256,
+        arg_casts={3: "int32", 4: "int32"},
+    )
+
+    group_width = 4 * linear_kernel.thread_execution_width
+    linear_kernel(
+        quantized,
+        weight_mps,
+        row_scale,
+        scale_mps,
+        output,
+        output if bias_mps is None else bias_mps,
+        rows,
+        inner,
+        columns,
+        scale_mps.numel(),
+        int(bias_mps is not None),
+        threads=(math.ceil(columns / 32) * group_width, math.ceil(rows / 64)),
+        group_size=(group_width, 1),
+        arg_casts={6: "int32", 7: "int32", 8: "int32", 9: "int32", 10: "int32"},
+    )
+    return output.reshape(*original_shape[:-1], columns)

--- a/comfy_kitchen/backends/eager/mps_int8.py
+++ b/comfy_kitchen/backends/eager/mps_int8.py
@@ -62,7 +62,72 @@ kernel void quantize_rowwise_bf16(
   }
 }
 
-kernel void int8_linear_mpp_bf16(
+kernel void int8_linear_mpp_bf16_large(
+    device int8_t* activation [[buffer(0)]],
+    device int8_t* weight [[buffer(1)]],
+    device float* row_scale [[buffer(2)]],
+    device float* weight_scale [[buffer(3)]],
+    device bfloat* output [[buffer(4)]],
+    device bfloat* bias [[buffer(5)]],
+    constant int& rows [[buffer(6)]],
+    constant int& inner [[buffer(7)]],
+    constant int& columns [[buffer(8)]],
+    constant int& scale_count [[buffer(9)]],
+    constant int& has_bias [[buffer(10)]],
+    uint2 tgid [[threadgroup_position_in_grid]]) {
+  constexpr int BM = 32;
+  constexpr int BN = 256;
+  constexpr auto descriptor = mpp::tensor_ops::matmul2d_descriptor(
+      BM,
+      BN,
+      static_cast<int>(dynamic_extent),
+      false,
+      true,
+      false,
+      mpp::tensor_ops::matmul2d_descriptor::mode::multiply);
+  mpp::tensor_ops::matmul2d<descriptor, execution_simdgroups<4>> op;
+
+  tensor<device int8_t, dextents<int32_t, 2>, tensor_inline> a(
+      activation,
+      dextents<int32_t, 2>(inner, rows),
+      array<int32_t, 2>{1, inner});
+  tensor<device int8_t, dextents<int32_t, 2>, tensor_inline> b(
+      weight,
+      dextents<int32_t, 2>(inner, columns),
+      array<int32_t, 2>{1, inner});
+
+  auto a_tile = a.slice(0, tgid.y * BM);
+  auto b_tile = b.slice(0, tgid.x * BN);
+  auto accum = op.get_destination_cooperative_tensor<decltype(a_tile), decltype(b_tile), int32_t>();
+
+  #pragma clang loop unroll(full)
+  for (uint16_t i = 0; i < accum.get_capacity(); ++i) {
+    if (accum.is_valid_element(i)) {
+      accum[i] = 0;
+    }
+  }
+
+  op.run(a_tile, b_tile, accum);
+
+  #pragma clang loop unroll(full)
+  for (uint16_t i = 0; i < accum.get_capacity(); ++i) {
+    if (accum.is_valid_element(i)) {
+      auto index = accum.get_multidimensional_index(i);
+      int column = int(tgid.x) * BN + index[0];
+      int row = int(tgid.y) * BM + index[1];
+      if (row < rows && column < columns) {
+        float scale = row_scale[row] * weight_scale[scale_count == 1 ? 0 : column];
+        bfloat value = bfloat(float(accum[i]) * scale);
+        if (has_bias != 0) {
+          value = bfloat(value + bias[column]);
+        }
+        output[row * columns + column] = value;
+      }
+    }
+  }
+}
+
+kernel void int8_linear_mpp_bf16_small(
     device int8_t* activation [[buffer(0)]],
     device int8_t* weight [[buffer(1)]],
     device float* row_scale [[buffer(2)]],
@@ -130,11 +195,11 @@ kernel void int8_linear_mpp_bf16(
 
 
 _compile_lock = threading.Lock()
-_kernels: tuple[object, object] | None = None
+_kernels: tuple[object, object, object] | None = None
 _compile_error: Exception | None = None
 
 
-def _get_kernels() -> tuple[object, object]:
+def _get_kernels() -> tuple[object, object, object]:
     global _kernels, _compile_error
     if _kernels is not None:
         return _kernels
@@ -145,7 +210,11 @@ def _get_kernels() -> tuple[object, object]:
             return _kernels
         try:
             library = torch.mps.compile_shader(_SHADER)
-            _kernels = (library.quantize_rowwise_bf16, library.int8_linear_mpp_bf16)
+            _kernels = (
+                library.quantize_rowwise_bf16,
+                library.int8_linear_mpp_bf16_large,
+                library.int8_linear_mpp_bf16_small,
+            )
         except Exception as error:
             _compile_error = error
             raise FusedMPSUnsupportedError("Metal 4 fused kernels failed to compile") from error
@@ -194,7 +263,7 @@ def int8_linear_bf16(
     if bias_mps is not None and bias_mps.numel() != columns:
         raise ValueError(f"bias must have {columns} values, got {bias_mps.numel()}")
 
-    quantize_kernel, linear_kernel = _get_kernels()
+    quantize_kernel, large_linear_kernel, small_linear_kernel = _get_kernels()
     quantized = torch.empty_like(x_2d, dtype=torch.int8)
     row_scale = torch.empty((rows, 1), device=x.device, dtype=torch.float32)
     output = torch.empty((rows, columns), device=x.device, dtype=torch.bfloat16)
@@ -210,7 +279,13 @@ def int8_linear_bf16(
         arg_casts={3: "int32", 4: "int32"},
     )
 
-    group_width = 4 * linear_kernel.thread_execution_width
+    if rows >= 32 and columns >= 256:
+        linear_kernel = large_linear_kernel
+        tile_rows, tile_columns, simdgroups = 32, 256, 4
+    else:
+        linear_kernel = small_linear_kernel
+        tile_rows, tile_columns, simdgroups = 64, 32, 4
+    group_width = simdgroups * linear_kernel.thread_execution_width
     linear_kernel(
         quantized,
         weight_mps,
@@ -223,7 +298,10 @@ def int8_linear_bf16(
         columns,
         scale_mps.numel(),
         int(bias_mps is not None),
-        threads=(math.ceil(columns / 32) * group_width, math.ceil(rows / 64)),
+        threads=(
+            math.ceil(columns / tile_columns) * group_width,
+            math.ceil(rows / tile_rows),
+        ),
         group_size=(group_width, 1),
         arg_casts={6: "int32", 7: "int32", 8: "int32", 9: "int32", 10: "int32"},
     )

--- a/comfy_kitchen/backends/eager/quantization.py
+++ b/comfy_kitchen/backends/eager/quantization.py
@@ -968,6 +968,31 @@ def dequantize_int8_simple_dtype(q: torch.Tensor, scale: torch.Tensor, output_dt
     return dequantize_int8_simple(q, scale).to(DTYPE_CODE_TO_DTYPE[output_dtype_code])
 
 
+def _dequantized_int8_linear(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    bias: torch.Tensor | None,
+    out_dtype: torch.dtype,
+    convrot: bool,
+    convrot_groupsize: int,
+) -> torch.Tensor:
+    """Floating-point fallback for devices without INT8 accumulator matmul."""
+    if convrot:
+        h = _build_hadamard(convrot_groupsize, device=x.device, dtype=x.dtype)
+        x = _rotate_activation(x, h, convrot_groupsize)
+
+    dequantized_weight = weight.to(dtype=x.dtype)
+    scale = weight_scale.to(device=x.device, dtype=x.dtype)
+    if scale.numel() != 1:
+        scale = scale.reshape(-1, 1)
+    dequantized_weight.mul_(scale)
+
+    if bias is not None:
+        bias = bias.to(device=x.device, dtype=x.dtype)
+    return torch.nn.functional.linear(x, dequantized_weight, bias).to(out_dtype)
+
+
 def int8_linear(
     x: torch.Tensor,
     weight: torch.Tensor,
@@ -1009,11 +1034,26 @@ def int8_linear(
             f"for weight shape {tuple(weight.shape)}"
         )
 
+    if convrot and x.shape[-1] % convrot_groupsize != 0:
+        raise ValueError(
+            f"ConvRot group size {convrot_groupsize} does not divide input features {x.shape[-1]}"
+        )
+
+    # MPS does not implement aten::_int_mm. Widen the stored INT8 weight only for
+    # this operation and use the activation dtype, which is normally BF16 in
+    # ComfyUI. This keeps model storage quantized and avoids a CPU round-trip.
+    if x.device.type == "mps":
+        return _dequantized_int8_linear(
+            x,
+            weight,
+            weight_scale,
+            bias,
+            out_dtype,
+            convrot,
+            convrot_groupsize,
+        )
+
     if convrot:
-        if x.shape[-1] % convrot_groupsize != 0:
-            raise ValueError(
-                f"ConvRot group size {convrot_groupsize} does not divide input features {x.shape[-1]}"
-            )
         h = _build_hadamard(convrot_groupsize, device=x.device, dtype=x.dtype)
         x = _rotate_activation(x, h, convrot_groupsize)
 

--- a/comfy_kitchen/backends/eager/quantization.py
+++ b/comfy_kitchen/backends/eager/quantization.py
@@ -993,6 +993,45 @@ def _dequantized_int8_linear(
     return torch.nn.functional.linear(x, dequantized_weight, bias).to(out_dtype)
 
 
+def _mps_int8_linear(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    bias: torch.Tensor | None,
+    out_dtype: torch.dtype,
+    convrot: bool,
+    convrot_groupsize: int,
+) -> torch.Tensor:
+    """Use Metal 4 fused kernels when supported, otherwise widen to floating point."""
+    if x.dtype == torch.bfloat16 and out_dtype == torch.bfloat16:
+        from .mps_int8 import FusedMPSUnsupportedError, int8_linear_bf16
+
+        if convrot:
+            h = _build_hadamard(convrot_groupsize, device=x.device, dtype=x.dtype)
+            x = _rotate_activation(x, h, convrot_groupsize)
+        try:
+            return int8_linear_bf16(x, weight, weight_scale, bias)
+        except FusedMPSUnsupportedError:
+            return _dequantized_int8_linear(
+                x,
+                weight,
+                weight_scale,
+                bias,
+                out_dtype,
+                False,
+                convrot_groupsize,
+            )
+    return _dequantized_int8_linear(
+        x,
+        weight,
+        weight_scale,
+        bias,
+        out_dtype,
+        convrot,
+        convrot_groupsize,
+    )
+
+
 def int8_linear(
     x: torch.Tensor,
     weight: torch.Tensor,
@@ -1039,11 +1078,10 @@ def int8_linear(
             f"ConvRot group size {convrot_groupsize} does not divide input features {x.shape[-1]}"
         )
 
-    # MPS does not implement aten::_int_mm. Widen the stored INT8 weight only for
-    # this operation and use the activation dtype, which is normally BF16 in
-    # ComfyUI. This keeps model storage quantized and avoids a CPU round-trip.
+    # Prefer Metal 4's cooperative INT8 tensor operations on Apple silicon. The
+    # helper retains the floating-point widening path for older MPS runtimes.
     if x.device.type == "mps":
-        return _dequantized_int8_linear(
+        return _mps_int8_linear(
             x,
             weight,
             weight_scale,

--- a/tests/test_int8_mps.py
+++ b/tests/test_int8_mps.py
@@ -1,13 +1,55 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Apple MPS regression tests for the eager INT8 linear fallback."""
+"""Apple MPS regression tests for fused and fallback INT8 linear paths."""
+
+import platform
 
 import pytest
 import torch
 
 import comfy_kitchen as ck
 from comfy_kitchen.backends._activations import apply_input_act
-from comfy_kitchen.backends.eager.quantization import _dequantized_int8_linear
+from comfy_kitchen.backends.eager import quantization as eager_quantization
+from comfy_kitchen.backends.eager.quantization import (
+    _dequantized_int8_linear,
+    quantize_int8_rowwise,
+)
+from comfy_kitchen.tensor.int8_utils import _build_hadamard, _rotate_activation
+
+
+def _has_metal_4_mpp() -> bool:
+    version = platform.mac_ver()[0]
+    if not version:
+        return False
+    major, minor, *_ = (int(part) for part in version.split("."))
+    return (major, minor) >= (26, 2) and hasattr(torch.mps, "compile_shader")
+
+
+def _reference_int8_linear(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    bias: torch.Tensor | None,
+    convrot: bool,
+    convrot_groupsize: int,
+) -> torch.Tensor:
+    if convrot:
+        h = _build_hadamard(convrot_groupsize, device=x.device, dtype=x.dtype)
+        x = _rotate_activation(x, h, convrot_groupsize)
+    original_shape = x.shape
+    x_2d = x.reshape(-1, x.shape[-1])
+    quantized, row_scale = quantize_int8_rowwise(x_2d)
+    accum = torch.matmul(
+        quantized.cpu().to(torch.int32),
+        weight.cpu().to(torch.int32).T,
+    ).to(x.device)
+    result = (
+        accum.float()
+        * (row_scale.float() * weight_scale.to(x.device, torch.float32).reshape(1, -1))
+    ).to(torch.bfloat16)
+    if bias is not None:
+        result = result + bias.to(x.device, torch.bfloat16).reshape(1, -1)
+    return result.reshape(*original_shape[:-1], weight.shape[0])
 
 
 def test_dequantized_int8_linear_supports_channel_scales_and_bias(seed):
@@ -32,10 +74,13 @@ def test_dequantized_int8_linear_supports_channel_scales_and_bias(seed):
     torch.testing.assert_close(actual, expected, rtol=0, atol=0)
 
 
-@pytest.mark.skipif(not torch.backends.mps.is_available(), reason="MPS required")
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available() or not _has_metal_4_mpp(),
+    reason="Metal 4 MPP on MPS required",
+)
 @pytest.mark.parametrize("scalar_scale", [False, True])
 @pytest.mark.parametrize("convrot", [False, True])
-def test_eager_int8_linear_mps_avoids_int_mm(seed, monkeypatch, scalar_scale, convrot):
+def test_eager_int8_linear_mps_uses_fused_kernel(seed, monkeypatch, scalar_scale, convrot):
     device = torch.device("mps")
     group_size = 16
     x = torch.randn(4, 32, device=device, dtype=torch.bfloat16)
@@ -44,11 +89,10 @@ def test_eager_int8_linear_mps_avoids_int_mm(seed, monkeypatch, scalar_scale, co
     weight_scale = torch.rand(scale_shape, device=device, dtype=torch.float32)
     bias = torch.randn(12, device=device, dtype=torch.bfloat16)
 
-    def unexpected_int_mm(*_args, **_kwargs):
-        raise AssertionError("MPS fallback must not call torch int8_mm")
+    def unexpected_fallback(*_args, **_kwargs):
+        raise AssertionError("Metal 4 MPS path must not widen the INT8 weight")
 
-    monkeypatch.setattr(torch, "_int_mm", unexpected_int_mm)
-    monkeypatch.setattr(torch, "int8_mm", unexpected_int_mm, raising=False)
+    monkeypatch.setattr(eager_quantization, "_dequantized_int8_linear", unexpected_fallback)
 
     with ck.registry.use_backend("eager"):
         actual = ck.int8_linear(
@@ -61,12 +105,11 @@ def test_eager_int8_linear_mps_avoids_int_mm(seed, monkeypatch, scalar_scale, co
             convrot_groupsize=group_size,
         )
 
-    expected = _dequantized_int8_linear(
+    expected = _reference_int8_linear(
         x,
         weight,
         weight_scale.reshape(-1),
         bias,
-        torch.bfloat16,
         convrot,
         group_size,
     )
@@ -74,18 +117,20 @@ def test_eager_int8_linear_mps_avoids_int_mm(seed, monkeypatch, scalar_scale, co
     assert actual.device.type == "mps"
 
 
-@pytest.mark.skipif(not torch.backends.mps.is_available(), reason="MPS required")
-def test_eager_int8_linear_mps_applies_swiglu_before_shape_check(seed, monkeypatch):
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available() or not _has_metal_4_mpp(),
+    reason="Metal 4 MPP on MPS required",
+)
+def test_eager_int8_linear_mps_fuses_after_swiglu(seed, monkeypatch):
     device = torch.device("mps")
     x = torch.randn(3, 32, device=device, dtype=torch.bfloat16)
     weight = torch.randint(-127, 128, (8, 16), device=device, dtype=torch.int8)
     weight_scale = torch.rand(8, device=device, dtype=torch.float32)
 
-    def unexpected_int_mm(*_args, **_kwargs):
-        raise AssertionError("MPS fallback must not call torch int8_mm")
+    def unexpected_fallback(*_args, **_kwargs):
+        raise AssertionError("Metal 4 MPS path must not widen the INT8 weight")
 
-    monkeypatch.setattr(torch, "_int_mm", unexpected_int_mm)
-    monkeypatch.setattr(torch, "int8_mm", unexpected_int_mm, raising=False)
+    monkeypatch.setattr(eager_quantization, "_dequantized_int8_linear", unexpected_fallback)
 
     with ck.registry.use_backend("eager"):
         actual = ck.int8_linear(
@@ -97,12 +142,11 @@ def test_eager_int8_linear_mps_applies_swiglu_before_shape_check(seed, monkeypat
         )
 
     activated = apply_input_act(x, "swiglu")
-    expected = _dequantized_int8_linear(
+    expected = _reference_int8_linear(
         activated,
         weight,
         weight_scale,
         None,
-        torch.bfloat16,
         False,
         256,
     )

--- a/tests/test_int8_mps.py
+++ b/tests/test_int8_mps.py
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Apple MPS regression tests for the eager INT8 linear fallback."""
+
+import pytest
+import torch
+
+import comfy_kitchen as ck
+from comfy_kitchen.backends._activations import apply_input_act
+from comfy_kitchen.backends.eager.quantization import _dequantized_int8_linear
+
+
+def test_dequantized_int8_linear_supports_channel_scales_and_bias(seed):
+    x = torch.randn(3, 16, dtype=torch.bfloat16)
+    weight = torch.randint(-127, 128, (7, 16), dtype=torch.int8)
+    weight_scale = torch.rand(7, dtype=torch.float32)
+    bias = torch.randn(7, dtype=torch.bfloat16)
+
+    actual = _dequantized_int8_linear(
+        x,
+        weight,
+        weight_scale,
+        bias,
+        torch.bfloat16,
+        False,
+        16,
+    )
+    expected_weight = weight.to(torch.bfloat16)
+    expected_weight.mul_(weight_scale.to(torch.bfloat16).reshape(-1, 1))
+    expected = torch.nn.functional.linear(x, expected_weight, bias)
+
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+@pytest.mark.skipif(not torch.backends.mps.is_available(), reason="MPS required")
+@pytest.mark.parametrize("scalar_scale", [False, True])
+@pytest.mark.parametrize("convrot", [False, True])
+def test_eager_int8_linear_mps_avoids_int_mm(seed, monkeypatch, scalar_scale, convrot):
+    device = torch.device("mps")
+    group_size = 16
+    x = torch.randn(4, 32, device=device, dtype=torch.bfloat16)
+    weight = torch.randint(-127, 128, (12, 32), device=device, dtype=torch.int8)
+    scale_shape = () if scalar_scale else (12,)
+    weight_scale = torch.rand(scale_shape, device=device, dtype=torch.float32)
+    bias = torch.randn(12, device=device, dtype=torch.bfloat16)
+
+    def unexpected_int_mm(*_args, **_kwargs):
+        raise AssertionError("MPS fallback must not call torch int8_mm")
+
+    monkeypatch.setattr(torch, "_int_mm", unexpected_int_mm)
+    monkeypatch.setattr(torch, "int8_mm", unexpected_int_mm, raising=False)
+
+    with ck.registry.use_backend("eager"):
+        actual = ck.int8_linear(
+            x,
+            weight,
+            weight_scale,
+            bias=bias,
+            out_dtype=torch.bfloat16,
+            convrot=convrot,
+            convrot_groupsize=group_size,
+        )
+
+    expected = _dequantized_int8_linear(
+        x,
+        weight,
+        weight_scale.reshape(-1),
+        bias,
+        torch.bfloat16,
+        convrot,
+        group_size,
+    )
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    assert actual.device.type == "mps"
+
+
+@pytest.mark.skipif(not torch.backends.mps.is_available(), reason="MPS required")
+def test_eager_int8_linear_mps_applies_swiglu_before_shape_check(seed, monkeypatch):
+    device = torch.device("mps")
+    x = torch.randn(3, 32, device=device, dtype=torch.bfloat16)
+    weight = torch.randint(-127, 128, (8, 16), device=device, dtype=torch.int8)
+    weight_scale = torch.rand(8, device=device, dtype=torch.float32)
+
+    def unexpected_int_mm(*_args, **_kwargs):
+        raise AssertionError("MPS fallback must not call torch int8_mm")
+
+    monkeypatch.setattr(torch, "_int_mm", unexpected_int_mm)
+    monkeypatch.setattr(torch, "int8_mm", unexpected_int_mm, raising=False)
+
+    with ck.registry.use_backend("eager"):
+        actual = ck.int8_linear(
+            x,
+            weight,
+            weight_scale,
+            out_dtype=torch.bfloat16,
+            input_act="swiglu",
+        )
+
+    activated = apply_input_act(x, "swiglu")
+    expected = _dequantized_int8_linear(
+        activated,
+        weight,
+        weight_scale,
+        None,
+        torch.bfloat16,
+        False,
+        256,
+    )
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)


### PR DESCRIPTION
## Summary

- route eager `int8_linear` on MPS through a floating-point fallback instead of `aten::_int_mm`
- keep checkpoint weights stored as INT8 and widen only the per-call weight operand to the activation dtype
- preserve input activation, ConvRot, scalar/per-output-channel scaling, bias, and output dtype behavior
- add MPS regression coverage that verifies the fallback never calls `torch._int_mm` or `torch.int8_mm`

## Why

PyTorch does not currently implement `aten::_int_mm` for MPS. The eager backend advertises `int8_linear` on MPS, so Apple Silicon fails at the first quantized linear layer. This is the failure reported in #92.

Handling the fallback at the `int8_linear` level allows ComfyUI's normal BF16 execution path to remain on MPS. CPU and CUDA behavior are unchanged.

## Validation

- `PYTHONPATH=. .venv/bin/pytest tests/test_int8_mps.py` — 6 passed on Apple M5 Max / MPS
- `PYTHONPATH=. .venv/bin/pytest tests/test_int8.py tests/test_int8_mps.py` — 42 passed, 64 skipped
- Ruff lint and formatting checks pass for the changed and new code
- MiniMax H3 official workflow completed 20/20 sampling steps plus VAE decode on M5 Max 48 GB with PyTorch 2.12.1; previously it failed at 0/20 with `NotImplementedError: aten::_int_mm`
