### PR TITLE
Optimize HIP ConvRot and deep-K INT8 kernels

### DIFF
--- a/comfy_kitchen/backends/hip/hadamard.h
+++ b/comfy_kitchen/backends/hip/hadamard.h
@@ -112,10 +112,10 @@ template <int ACT>
 __forceinline__ __device__ float load_input_act(
     const void* x, int64_t in_row, int col, int K, int code) {
     if constexpr (ACT == kActSwiGLU) {
-        // SwiGLU computes silu(gate) * up.
+        // Matches torch silu(gate) * up.
         const float gate = load_in(x, in_row + col, code);
         const float up = load_in(x, in_row + K + col, code);
-        return (gate / (1.0f + __expf(-gate))) * up;
+        return (gate / (1.0f + expf(-gate))) * up;
     } else {
         return apply_input_act<ACT>(load_in(x, in_row + col, code));
     }

--- a/comfy_kitchen/backends/hip/hadamard.h
+++ b/comfy_kitchen/backends/hip/hadamard.h
@@ -257,6 +257,7 @@ inline void launch_convrot_quant(
     const void* x, int in_dtype, int8_t* qout, float* scaleout,
     int M, int K, int group_size, hipStream_t stream) {
 
+    check_convrot_group_size(group_size);
     if (group_size == 16) {
         launch_convrot_quant_group<PACK_INT4, ACT, 16>(
             x, in_dtype, qout, scaleout, M, K, stream);

--- a/comfy_kitchen/backends/hip/hadamard.h
+++ b/comfy_kitchen/backends/hip/hadamard.h
@@ -29,7 +29,7 @@ inline void check_convrot_group_size(int group_size) {
     }
 }
 
-// The kernel's static LDS: the g[256] and red[256] reductions below.
+// The kernel's static LDS: two 256-element butterfly buffers below.
 constexpr size_t kConvrotStaticLds = 2 * 256 * sizeof(float);
 
 // convrot_quant_kernel stages the whole rotated row in dynamic LDS, preserving
@@ -112,10 +112,10 @@ template <int ACT>
 __forceinline__ __device__ float load_input_act(
     const void* x, int64_t in_row, int col, int K, int code) {
     if constexpr (ACT == kActSwiGLU) {
-        // Matches torch silu(gate) * up.
+        // SwiGLU computes silu(gate) * up.
         const float gate = load_in(x, in_row + col, code);
         const float up = load_in(x, in_row + K + col, code);
-        return (gate / (1.0f + expf(-gate))) * up;
+        return (gate / (1.0f + __expf(-gate))) * up;
     } else {
         return apply_input_act<ACT>(load_in(x, in_row + col, code));
     }
@@ -141,23 +141,21 @@ __forceinline__ __device__ float load_row_value<__half>(__half v) {
     return __half2float(v);
 }
 
-template <typename RowT, bool PACK_INT4, int ACT = kActNone>
+template <typename RowT, bool PACK_INT4, int ACT, int G>
 __global__ __launch_bounds__(256) void convrot_quant_kernel(
     const void* __restrict__ x, int in_dtype,
     int8_t* __restrict__ qout, float* __restrict__ scaleout,
-    int M, int K, int G) {
+    int M, int K) {
 
     const float h4[4][4] = {{1, 1, 1, -1}, {1, 1, -1, 1}, {1, -1, 1, 1}, {-1, 1, 1, 1}};
-    __shared__ float g[256];
-    __shared__ float red[256];
+    __shared__ float g[2][256];
     extern __shared__ unsigned char rowbuf_raw[];
     RowT* rowbuf = reinterpret_cast<RowT*>(rowbuf_raw);  // K entries: the rotated row
 
     const int row = blockIdx.x;
     const int t = threadIdx.x;
 
-    int nstages = 0;
-    while ((1 << (2 * nstages)) < G) nstages++;  // log4(G)
+    constexpr int nstages = G == 16 ? 2 : (G == 64 ? 3 : 4);
 
     const int gpw = 256 / G;      // groups handled per pass
     const int glocal = t / G;     // this thread's group within the pass
@@ -173,38 +171,41 @@ __global__ __launch_bounds__(256) void convrot_quant_kernel(
     for (int gbase = 0; gbase < ngrp; gbase += gpw) {
         const int grp = gbase + glocal;
         const bool active = grp < ngrp;
-        g[t] = active ? load_input_act<ACT>(x, in_row, grp * G + e, K, in_dtype) : 0.0f;
+        g[0][t] = active ? load_input_act<ACT>(x, in_row, grp * G + e, K, in_dtype) : 0.0f;
         __syncthreads();
 
+        int src = 0;
+#pragma unroll
         for (int stage = 0; stage < nstages; ++stage) {
             const int stride = 1 << (2 * stage);
             const int ds = (e / stride) & 3;
             const int b = gbase_idx + (e - ds * stride);
-            const float v0 = g[b], v1 = g[b + stride], v2 = g[b + 2 * stride], v3 = g[b + 3 * stride];
-            const float nv = h4[ds][0] * v0 + h4[ds][1] * v1 + h4[ds][2] * v2 + h4[ds][3] * v3;
+            const float v0 = g[src][b], v1 = g[src][b + stride];
+            const float v2 = g[src][b + 2 * stride], v3 = g[src][b + 3 * stride];
+            const float v = h4[ds][0] * v0 + h4[ds][1] * v1 + h4[ds][2] * v2 + h4[ds][3] * v3;
+            const int dst = src ^ 1;
+            g[dst][t] = v;
             __syncthreads();
-            g[t] = nv;
-            __syncthreads();
+            src = dst;
         }
 
         if (active) {
-            const float tv = g[t] * norm;
+            const float tv = g[src][t] * norm;
             const RowT stored = store_row_value<RowT>(tv);
             rowbuf[static_cast<int64_t>(grp) * G + e] = stored;
             lmax = fmaxf(lmax, fabsf(load_row_value(stored)));
         }
-        __syncthreads();
     }
 
-    red[t] = lmax;
+    g[0][t] = lmax;
     __syncthreads();
     for (int s = 128; s > 0; s >>= 1) {
-        if (t < s) red[t] = fmaxf(red[t], red[t + s]);
+        if (t < s) g[0][t] = fmaxf(g[0][t], g[0][t + s]);
         __syncthreads();
     }
 
     constexpr float kQMax = PACK_INT4 ? 7.0f : 127.0f;
-    const float rowmax = fmaxf(red[0], 1e-10f);
+    const float rowmax = fmaxf(g[0][0], 1e-10f);
     const float scale = rowmax / kQMax;
     const float inv = kQMax / rowmax;
     if (t == 0) scaleout[row] = scale;
@@ -231,23 +232,40 @@ __global__ __launch_bounds__(256) void convrot_quant_kernel(
     }
 }
 
+template <bool PACK_INT4, int ACT, int G>
+inline void launch_convrot_quant_group(
+    const void* x, int in_dtype, int8_t* qout, float* scaleout,
+    int M, int K, hipStream_t stream) {
+
+    const size_t shmem = static_cast<size_t>(K) * convrot_row_element_size(in_dtype);
+    if (in_dtype == 0) {
+        convrot_quant_kernel<float, PACK_INT4, ACT, G><<<M, 256, shmem, stream>>>(
+            x, in_dtype, qout, scaleout, M, K);
+    } else if (in_dtype == 1) {
+        convrot_quant_kernel<__half, PACK_INT4, ACT, G><<<M, 256, shmem, stream>>>(
+            x, in_dtype, qout, scaleout, M, K);
+    } else if (in_dtype == 2) {
+        convrot_quant_kernel<__bf16, PACK_INT4, ACT, G><<<M, 256, shmem, stream>>>(
+            x, in_dtype, qout, scaleout, M, K);
+    } else {
+        throw std::runtime_error("convrot: unsupported input dtype code");
+    }
+}
+
 template <bool PACK_INT4, int ACT = kActNone>
 inline void launch_convrot_quant(
     const void* x, int in_dtype, int8_t* qout, float* scaleout,
     int M, int K, int group_size, hipStream_t stream) {
 
-    const size_t shmem = static_cast<size_t>(K) * convrot_row_element_size(in_dtype);
-    if (in_dtype == 0) {
-        convrot_quant_kernel<float, PACK_INT4, ACT><<<M, 256, shmem, stream>>>(
-            x, in_dtype, qout, scaleout, M, K, group_size);
-    } else if (in_dtype == 1) {
-        convrot_quant_kernel<__half, PACK_INT4, ACT><<<M, 256, shmem, stream>>>(
-            x, in_dtype, qout, scaleout, M, K, group_size);
-    } else if (in_dtype == 2) {
-        convrot_quant_kernel<__bf16, PACK_INT4, ACT><<<M, 256, shmem, stream>>>(
-            x, in_dtype, qout, scaleout, M, K, group_size);
+    if (group_size == 16) {
+        launch_convrot_quant_group<PACK_INT4, ACT, 16>(
+            x, in_dtype, qout, scaleout, M, K, stream);
+    } else if (group_size == 64) {
+        launch_convrot_quant_group<PACK_INT4, ACT, 64>(
+            x, in_dtype, qout, scaleout, M, K, stream);
     } else {
-        throw std::runtime_error("convrot: unsupported input dtype code");
+        launch_convrot_quant_group<PACK_INT4, ACT, 256>(
+            x, in_dtype, qout, scaleout, M, K, stream);
     }
 }
 

--- a/comfy_kitchen/backends/hip/ops/gemm_int8.hip
+++ b/comfy_kitchen/backends/hip/ops/gemm_int8.hip
@@ -56,7 +56,7 @@ static void launch_int8(const int8_t* A, const int8_t* B, OutT* C, int M, int N,
         return;
     }
     if (M >= 512 && N >= 128 && K > N) {
-        constexpr int BM = 256, BN = 128, BKB = 64;
+        constexpr int BM = 256, BN = 128, BKB = 128;
         dim3 grid((N + BN - 1) / BN, (M + BM - 1) / BM);
         gemm_wmma_kernel<MmaInt8, EpiRowwise, OutT, BM, BN, BKB, 4, 2, 4, 4>
             <<<grid, 256, 0, stream>>>(Au, Bu, C, M, N, K, ldc, epi);

--- a/tests/test_hip_wmma.py
+++ b/tests/test_hip_wmma.py
@@ -272,11 +272,12 @@ def test_int8_linear_swiglu_matches_the_eager_chain(tag, shape, kwargs):
 
 
 @needs_wmma
-def test_int8_linear_h3_swiglu_convrot_matches_eager():
+def test_int8_linear_h3_swiglu_convrot_matches_eager(hip):
     """Cover the fused quantizer and deep-K tile at a MiniMax H3 MLP width."""
     torch.manual_seed(0)
     m, n, k = 512, 256, 14336
     x = torch.randn(m, 2 * k, device=DEV, dtype=torch.bfloat16)
+    assert hip._convrot_supported(k, 256, x.device, x.dtype)
     wq = torch.randint(-127, 128, (n, k), device=DEV, dtype=torch.int8)
     ws = torch.rand(n, device=DEV, dtype=torch.float32) * 0.01 + 0.001
 
@@ -285,6 +286,24 @@ def test_int8_linear_h3_swiglu_convrot_matches_eager():
         out = ck.int8_linear(x, wq, ws, None, torch.bfloat16, **kwargs)
     with ck.use_backend("eager"):
         ref = ck.int8_linear(x, wq, ws, None, torch.bfloat16, **kwargs)
+
+    scale = ref.float().abs().max().item()
+    assert (out.float() - ref.float()).abs().max().item() < 0.05 * scale
+
+
+@needs_wmma
+def test_int8_linear_deep_k_tail_matches_eager():
+    """Cover the BKB=128 tail with a K divisible by 16 but not by 128."""
+    torch.manual_seed(0)
+    m, n, k = 512, 256, 14400
+    x = torch.randn(m, k, device=DEV, dtype=torch.bfloat16)
+    wq = torch.randint(-127, 128, (n, k), device=DEV, dtype=torch.int8)
+    ws = torch.rand(n, device=DEV, dtype=torch.float32) * 0.01 + 0.001
+
+    with ck.use_backend("hip"):
+        out = ck.int8_linear(x, wq, ws, None, torch.bfloat16, convrot=False)
+    with ck.use_backend("eager"):
+        ref = ck.int8_linear(x, wq, ws, None, torch.bfloat16, convrot=False)
 
     scale = ref.float().abs().max().item()
     assert (out.float() - ref.float()).abs().max().item() < 0.05 * scale

--- a/tests/test_hip_wmma.py
+++ b/tests/test_hip_wmma.py
@@ -272,6 +272,25 @@ def test_int8_linear_swiglu_matches_the_eager_chain(tag, shape, kwargs):
 
 
 @needs_wmma
+def test_int8_linear_h3_swiglu_convrot_matches_eager():
+    """Cover the fused quantizer and deep-K tile at a MiniMax H3 MLP width."""
+    torch.manual_seed(0)
+    m, n, k = 512, 256, 14336
+    x = torch.randn(m, 2 * k, device=DEV, dtype=torch.bfloat16)
+    wq = torch.randint(-127, 128, (n, k), device=DEV, dtype=torch.int8)
+    ws = torch.rand(n, device=DEV, dtype=torch.float32) * 0.01 + 0.001
+
+    kwargs = {"convrot": True, "convrot_groupsize": 256, "input_act": "swiglu"}
+    with ck.use_backend("hip"):
+        out = ck.int8_linear(x, wq, ws, None, torch.bfloat16, **kwargs)
+    with ck.use_backend("eager"):
+        ref = ck.int8_linear(x, wq, ws, None, torch.bfloat16, **kwargs)
+
+    scale = ref.float().abs().max().item()
+    assert (out.float() - ref.float()).abs().max().item() < 0.05 * scale
+
+
+@needs_wmma
 def test_swiglu_quantizer_is_at_least_as_accurate_as_the_chain(hip):
     """Fusing the gate into the rotation's load must not lose accuracy against
     materializing silu(gate) * up in bf16 first."""


### PR DESCRIPTION
## Summary

- specialize the HIP ConvRot group size at compile time and unroll its radix-4 stages
- use ping-pong LDS buffers to remove the read/write barrier from each butterfly stage
- use the HIP fast exponential in the fused SwiGLU load
- double the deep-K INT8 WMMA K block from 64 to 128
- cover the fused quantizer and deep-K GEMM with a representative MiniMax H3 MLP test

## Performance

Measured on an AMD Radeon 8060S (`gfx1151`) on Windows with PyTorch `2.12.0+rocm10.1.0a20260811` from the ROCm 10.1 Nightly 2026-08-11 package set (`torch.version.hip == 7.16.26315`). Inputs use BF16 raw SwiGLU `[M, 28672]`, INT8 weights `[256, 14336]`, and ConvRot group size 256.

Each value is the median of three independent run medians. Each run used 10 warmups and 40 HIP-event-timed iterations. The baseline is the published 0.2.30 wheel under the same Python/ROCm process setup.

| M | Operation | 0.2.30 | This PR | Reduction |
|---:|---|---:|---:|---:|
| 4,096 | fused SwiGLU + ConvRot quantizer | 4.0015 ms | 3.1761 ms | 20.6% |
| 4,096 | deep-K INT8 GEMM | 1.1796 ms | 0.9896 ms | 16.1% |
| 4,096 | public `int8_linear` | 5.1741 ms | 4.0788 ms | 21.2% |
| 16,500 | fused SwiGLU + ConvRot quantizer | 15.6379 ms | 12.4303 ms | 20.5% |
| 16,500 | deep-K INT8 GEMM | 5.1023 ms | 3.7009 ms | 27.5% |
| 16,500 | public `int8_linear` | 21.2995 ms | 15.9544 ms | 25.1% |

These performance results are specific to `gfx1151`; other WMMA-capable AMD targets were not benchmarked here.

## Validation

- built the HIP extension for `gfx1151` with the ROCm 10.1 Nightly toolchain
- `pytest tests/test_hip_wmma.py -q`: 337 passed
- `ruff check tests/test_hip_wmma.py`
- Magpie correctness analysis: `hadamard` 1.00 and `gemm_int8` 1.00
- ComfyUI startup/API smoke test with the built extension on the same GPU
