### PR TITLE
add minimal bf16 flash attention for seqlen capability

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          submodules: recursive
+          submodules: true
 
       - name: Restore compiler cache
         uses: actions/cache@v4
@@ -233,7 +233,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          submodules: recursive
+          submodules: true
 
       - name: Restore compiler cache
         uses: actions/cache@v4
@@ -360,7 +360,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          submodules: recursive
+          submodules: true
 
       - name: Restore compiler cache
         uses: actions/cache@v4
@@ -570,7 +570,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          submodules: recursive
+          submodules: true
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
@@ -617,7 +617,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          submodules: recursive
+          submodules: true
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
@@ -663,7 +663,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          submodules: recursive
+          submodules: true
 
       - name: Restore compiler cache
         uses: actions/cache@v4
@@ -943,7 +943,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          submodules: recursive
+          submodules: true
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v5

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "third_party/cutlass"]
 	path = third_party/cutlass
 	url = https://github.com/NVIDIA/cutlass.git
+[submodule "third_party/flash-attention"]
+	path = third_party/flash-attention
+	url = https://github.com/Dao-AILab/flash-attention.git

--- a/NOTICE
+++ b/NOTICE
@@ -41,6 +41,15 @@ Website: https://github.com/wjakob/nanobind
 nanobind is used at build time to create Python bindings for C++/CUDA code.
 
 --------------------------------------------------------------------------------
+FlashAttention
+--------------------------------------------------------------------------------
+Copyright (c) 2022, the respective contributors, as shown by the AUTHORS file.
+License: BSD-3-Clause
+Website: https://github.com/Dao-AILab/flash-attention
+
+The fixed-cache decode kernel uses FlashAttention 2.7.4.
+
+--------------------------------------------------------------------------------
 PyTorch AO (torchao)
 --------------------------------------------------------------------------------
 Copyright (c) Meta Platforms, Inc. and affiliates.

--- a/comfy_kitchen/__init__.py
+++ b/comfy_kitchen/__init__.py
@@ -13,6 +13,7 @@ from .exceptions import (
     BackendNotImplementedError,
     NoCapableBackendError,
 )
+from .flash_attention import flash_attention_decode
 from .float_utils import from_blocked, swap_nibbles, to_blocked
 from .registry import registry
 from .sage_attention import (
@@ -56,6 +57,7 @@ __all__ = [
     "int8_attention_from_prequantized",
     "int8_attention_is_available",
     "prequantize_int8_attention",
+    "flash_attention_decode",
     "na2d",
     "na3d",
     # Quantization / dequantization

--- a/comfy_kitchen/backends/cuda/CMakeLists.txt
+++ b/comfy_kitchen/backends/cuda/CMakeLists.txt
@@ -137,6 +137,7 @@ set(CUDA_SOURCES
     ops/awq_w4a16.cu
     ops/w4a8_gemm.cu
     ops/adaln.cu
+    ops/flash_decode.cu
     sage_attention/quant_v_int8.cu
     sage_attention/quant_qk_int8.cu
     sage_attention/sage_attn_launcher.cu
@@ -157,6 +158,9 @@ target_compile_options(comfy_kitchen_cuda_kernels PRIVATE
 target_include_directories(comfy_kitchen_cuda_kernels PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/sage_attention
+    ${CMAKE_CURRENT_SOURCE_DIR}/flash_compat
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../third_party/flash-attention/csrc/flash_attn/src
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../third_party/flash-attention/csrc/cutlass/include
     ${CUDAToolkit_INCLUDE_DIRS}
 )
 

--- a/comfy_kitchen/backends/cuda/CMakeLists.txt
+++ b/comfy_kitchen/backends/cuda/CMakeLists.txt
@@ -160,7 +160,7 @@ target_include_directories(comfy_kitchen_cuda_kernels PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/sage_attention
     ${CMAKE_CURRENT_SOURCE_DIR}/flash_compat
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../third_party/flash-attention/csrc/flash_attn/src
-    ${CMAKE_CURRENT_SOURCE_DIR}/../../../third_party/flash-attention/csrc/cutlass/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../third_party/cutlass/include
     ${CUDAToolkit_INCLUDE_DIRS}
 )
 

--- a/comfy_kitchen/backends/cuda/dlpack_bindings.cpp
+++ b/comfy_kitchen/backends/cuda/dlpack_bindings.cpp
@@ -1843,6 +1843,14 @@ extern "C" {
         int output_dtype_code,
         cudaStream_t stream);
 
+    void launch_flash_decode(
+        const void* q, const void* k, const void* v, const int* kv_lengths,
+        void* output, float* softmax_lse, float* softmax_lse_accum, float* output_accum,
+        int batch, int query_length, int heads, int kv_capacity, int num_splits,
+        int64_t q_batch_stride, int64_t q_row_stride, int64_t q_head_stride,
+        int64_t k_batch_stride, int64_t k_row_stride, int64_t k_head_stride,
+        cudaStream_t stream);
+
 }
 
 // Nanobind wrapper for cublas_gemm_int8
@@ -3122,6 +3130,50 @@ void dequantize_int8_convrot_weight(
         stream);
 }
 
+void flash_attention_decode(
+    nb::ndarray<nb::ndim<3>, nb::device::cuda> q,
+    nb::ndarray<nb::ndim<4>, nb::device::cuda> k,
+    nb::ndarray<nb::ndim<4>, nb::device::cuda> v,
+    nb::ndarray<int32_t, nb::ndim<1>, nb::device::cuda> kv_lengths,
+    nb::ndarray<nb::ndim<3>, nb::device::cuda> output,
+    nb::ndarray<float, nb::device::cuda> softmax_lse,
+    nb::ndarray<float, nb::device::cuda> softmax_lse_accum,
+    nb::ndarray<float, nb::device::cuda> output_accum,
+    int num_splits,
+    uintptr_t stream_ptr) {
+    const int batch = k.shape(0);
+    const int kv_capacity = k.shape(1);
+    const int heads = k.shape(2);
+    const int query_length = q.shape(0) / batch;
+    if (batch <= 0 || kv_capacity <= 0 || heads <= 0 || query_length <= 0 || q.shape(0) != batch * query_length || q.shape(1) != heads || q.shape(2) != 128) {
+        throw std::runtime_error("Invalid Flash Attention decode dimensions");
+    }
+    if (v.shape(0) != batch || v.shape(1) != kv_capacity || v.shape(2) != heads || v.shape(3) != 128 || k.shape(3) != 128) {
+        throw std::runtime_error("Flash Attention k/v shape mismatch");
+    }
+    if (output.shape(0) != q.shape(0) || output.shape(1) != heads || output.shape(2) != 128 || kv_lengths.size() != static_cast<size_t>(batch)) {
+        throw std::runtime_error("Flash Attention output or length shape mismatch");
+    }
+    if (map_dtype_to_code(q.dtype()) != 2 || map_dtype_to_code(k.dtype()) != 2 || map_dtype_to_code(v.dtype()) != 2 || map_dtype_to_code(output.dtype()) != 2) {
+        throw std::runtime_error("Flash Attention tensors must have bfloat16 dtype");
+    }
+    const size_t lse_size = static_cast<size_t>(batch) * heads * query_length;
+    if (softmax_lse.size() != lse_size || num_splits < 1 || num_splits > 32 || (num_splits > 1 && (softmax_lse_accum.size() != lse_size * num_splits || output_accum.size() != lse_size * 128 * num_splits))) {
+        throw std::runtime_error("Invalid Flash Attention split workspace");
+    }
+    if (k.stride(0) != v.stride(0) || k.stride(1) != v.stride(1) || k.stride(2) != v.stride(2) || k.stride(3) != 1 || v.stride(3) != 1 || q.stride(2) != 1 || output.stride(2) != 1) {
+        throw std::runtime_error("Unsupported Flash Attention tensor strides");
+    }
+
+    launch_flash_decode(
+        q.data(), k.data(), v.data(), kv_lengths.data(), output.data(), softmax_lse.data(),
+        num_splits > 1 ? softmax_lse_accum.data() : nullptr,
+        num_splits > 1 ? output_accum.data() : nullptr,
+        batch, query_length, heads, kv_capacity, num_splits,
+        q.stride(0) * query_length, q.stride(0), q.stride(1),
+        k.stride(0), k.stride(1), k.stride(2), reinterpret_cast<cudaStream_t>(stream_ptr));
+}
+
 NB_MODULE(_C, m) {
     m.doc() = "comfy_kitchen CUDA kernels - nanobind + DLPack interface (NO PyTorch C++ dependencies)";
     
@@ -3647,6 +3699,12 @@ NB_MODULE(_C, m) {
           nb::arg("kt"), nb::arg("kh"), nb::arg("kw"),
           nb::arg("causal_t"), nb::arg("causal_h"), nb::arg("causal_w"),
           nb::arg("scale"), nb::arg("dtype_code"), nb::arg("stream_ptr"));
+
+    m.def("flash_attention_decode", &flash_attention_decode,
+          "Flash Attention decode over a fixed-capacity variable-length KV cache",
+          nb::arg("q"), nb::arg("k"), nb::arg("v"), nb::arg("kv_lengths"),
+          nb::arg("output"), nb::arg("softmax_lse"), nb::arg("softmax_lse_accum"),
+          nb::arg("output_accum"), nb::arg("num_splits"), nb::arg("stream_ptr"));
 
     m.def("adaln", &adaln,
           "Fused AdaLN: layernorm(x) * (1 + scale) + shift",

--- a/comfy_kitchen/backends/cuda/flash_compat/ATen/cuda/CUDAGeneratorImpl.h
+++ b/comfy_kitchen/backends/cuda/flash_compat/ATen/cuda/CUDAGeneratorImpl.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <cstdint>
+
+namespace at {
+
+struct PhiloxCudaState {
+    uint64_t seed = 0;
+    uint64_t offset = 0;
+};
+
+} // namespace at

--- a/comfy_kitchen/backends/cuda/flash_compat/ATen/cuda/detail/UnpackRaw.cuh
+++ b/comfy_kitchen/backends/cuda/flash_compat/ATen/cuda/detail/UnpackRaw.cuh
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <tuple>
+
+namespace at::cuda::philox {
+
+__host__ __device__ __forceinline__ std::tuple<uint64_t, uint64_t> unpack(at::PhiloxCudaState state) {
+    return {state.seed, state.offset};
+}
+
+} // namespace at::cuda::philox

--- a/comfy_kitchen/backends/cuda/ops/flash_decode.cu
+++ b/comfy_kitchen/backends/cuda/ops/flash_decode.cu
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <cuda_runtime.h>
+
+#include "utils.cuh"
+#include "flash.h"
+#include "flash_fwd_kernel.h"
+
+namespace flash {
+
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
+#define COMFY_FLASH_BODY(...) __VA_ARGS__
+#define COMFY_FLASH_PARAM __grid_constant__
+#else
+#define COMFY_FLASH_BODY(...)
+#define COMFY_FLASH_PARAM
+#endif
+
+using Traits = Flash_fwd_kernel_traits<128, 64, 128, 4, false, false, cutlass::bfloat16_t>;
+
+template<bool Split>
+__global__ void flash_decode_kernel(COMFY_FLASH_PARAM const Flash_fwd_params params) {
+    COMFY_FLASH_BODY((compute_attn_splitkv<Traits, false, false, false, false, true, false, Split, false>(params));)
+}
+
+template<int LogMaxSplits>
+__global__ void flash_decode_combine_kernel(COMFY_FLASH_PARAM const Flash_fwd_params params) {
+    COMFY_FLASH_BODY((combine_attn_seqk_parallel<Traits, 4, LogMaxSplits, true>(params));)
+}
+
+void launch_flash_decode_typed(Flash_fwd_params& params, cudaStream_t stream) {
+    constexpr size_t smem_size = Traits::kSmemSize;
+    dim3 grid(1, params.num_splits > 1 ? params.num_splits : params.b, params.num_splits > 1 ? params.b * params.h : params.h);
+
+    if (params.num_splits > 1) {
+        auto kernel = &flash_decode_kernel<true>;
+        CUDA_CHECK(cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+        kernel<<<grid, Traits::kNThreads, smem_size, stream>>>(params);
+
+        const dim3 combine_grid((params.b * params.h * params.seqlen_q + 3) / 4);
+        if (params.num_splits <= 2) {
+            flash_decode_combine_kernel<1><<<combine_grid, Traits::kNThreads, 0, stream>>>(params);
+        } else if (params.num_splits <= 4) {
+            flash_decode_combine_kernel<2><<<combine_grid, Traits::kNThreads, 0, stream>>>(params);
+        } else if (params.num_splits <= 8) {
+            flash_decode_combine_kernel<3><<<combine_grid, Traits::kNThreads, 0, stream>>>(params);
+        } else if (params.num_splits <= 16) {
+            flash_decode_combine_kernel<4><<<combine_grid, Traits::kNThreads, 0, stream>>>(params);
+        } else {
+            flash_decode_combine_kernel<5><<<combine_grid, Traits::kNThreads, 0, stream>>>(params);
+        }
+    } else {
+        auto kernel = &flash_decode_kernel<false>;
+        CUDA_CHECK(cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+        kernel<<<grid, Traits::kNThreads, smem_size, stream>>>(params);
+    }
+    CUDA_CHECK(cudaGetLastError());
+}
+
+} // namespace flash
+
+extern "C" void launch_flash_decode(
+    const void* q, const void* k, const void* v, const int* kv_lengths,
+    void* output, float* softmax_lse, float* softmax_lse_accum, float* output_accum,
+    int batch, int query_length, int heads, int kv_capacity, int num_splits,
+    int64_t q_batch_stride, int64_t q_row_stride, int64_t q_head_stride,
+    int64_t k_batch_stride, int64_t k_row_stride, int64_t k_head_stride,
+    cudaStream_t stream) {
+    flash::Flash_fwd_params params{};
+    params.q_ptr = const_cast<void*>(q);
+    params.k_ptr = const_cast<void*>(k);
+    params.v_ptr = const_cast<void*>(v);
+    params.o_ptr = output;
+    params.softmax_lse_ptr = softmax_lse;
+    params.softmax_lseaccum_ptr = softmax_lse_accum;
+    params.oaccum_ptr = output_accum;
+    params.q_batch_stride = q_batch_stride;
+    params.q_row_stride = q_row_stride;
+    params.q_head_stride = q_head_stride;
+    params.o_batch_stride = q_batch_stride;
+    params.o_row_stride = q_row_stride;
+    params.o_head_stride = q_head_stride;
+    params.k_batch_stride = params.v_batch_stride = k_batch_stride;
+    params.k_row_stride = params.v_row_stride = k_row_stride;
+    params.k_head_stride = params.v_head_stride = k_head_stride;
+    params.seqused_k = const_cast<int*>(kv_lengths);
+    params.b = batch;
+    params.h = params.h_k = heads;
+    params.h_h_k_ratio = 1;
+    params.seqlen_q = query_length;
+    params.seqlen_k = kv_capacity;
+    params.d = params.d_rounded = 128;
+    params.seqlen_q_rounded = ((query_length + 127) / 128) * 128;
+    params.total_q = batch * query_length;
+    params.scale_softmax = 0.08838834764831845f;
+    params.scale_softmax_log2 = 0.12751743082871335f;
+    params.window_size_left = params.window_size_right = -1;
+    params.num_splits = num_splits;
+    params.is_bf16 = true;
+
+    flash::launch_flash_decode_typed(params, stream);
+}

--- a/comfy_kitchen/backends/cuda/ops/flash_decode.cu
+++ b/comfy_kitchen/backends/cuda/ops/flash_decode.cu
@@ -3,6 +3,11 @@
 #include <cuda_runtime.h>
 
 #include "utils.cuh"
+
+#ifndef M_LOG2E
+#define M_LOG2E 1.4426950408889634074
+#endif
+
 #include "flash.h"
 #include "flash_fwd_kernel.h"
 

--- a/comfy_kitchen/flash_attention.py
+++ b/comfy_kitchen/flash_attention.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import math
+
+import torch
+
+from .backends import cuda as _cuda_backend
+
+
+def _num_splits(batch_heads: int, kv_capacity: int, multiprocessors: int) -> int:
+    blocks = (kv_capacity + 127) // 128
+    max_splits = min(32, multiprocessors * 2, blocks)
+    best = 0.0
+    efficiencies = []
+    for splits in range(1, max_splits + 1):
+        eligible = splits == 1 or math.ceil(blocks / splits) != math.ceil(
+            blocks / (splits - 1)
+        )
+        efficiency = batch_heads * splits / (multiprocessors * 2)
+        efficiency = efficiency / math.ceil(efficiency) if eligible else 0.0
+        efficiencies.append(efficiency)
+        best = max(best, efficiency)
+    return next(
+        splits
+        for splits, efficiency in enumerate(efficiencies, 1)
+        if efficiency >= 0.85 * best
+    )
+
+
+def flash_attention_decode(
+    q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, kv_lengths: torch.Tensor
+) -> torch.Tensor:
+    """Decode attention for BF16 [batch, length, heads, 128] tensors."""
+    batch, query_length, query_heads, head_dim = q.shape
+    _, kv_capacity, kv_heads, _ = k.shape
+    if not _cuda_backend._EXT_AVAILABLE or torch.cuda.get_device_capability(q.device) < (8, 0):
+        raise RuntimeError("flash_attention_decode requires the CUDA extension on SM80 or newer")
+
+    groups = query_heads // kv_heads
+    query = (
+        q.reshape(batch, kv_heads, groups, head_dim)
+        .transpose(1, 2)
+        .reshape(batch * groups, kv_heads, head_dim)
+    )
+    output = torch.empty_like(query)
+    num_splits = _num_splits(
+        batch * kv_heads,
+        kv_capacity,
+        torch.cuda.get_device_properties(q.device).multi_processor_count,
+    )
+    softmax_lse = torch.empty(batch * kv_heads * groups, dtype=torch.float32, device=q.device)
+    if num_splits > 1:
+        softmax_lse_accum = torch.empty(
+            num_splits, batch, kv_heads, groups, dtype=torch.float32, device=q.device
+        )
+        output_accum = torch.empty(
+            num_splits,
+            batch,
+            kv_heads,
+            groups,
+            head_dim,
+            dtype=torch.float32,
+            device=q.device,
+        )
+    else:
+        softmax_lse_accum = output_accum = softmax_lse[:0]
+    _cuda_backend._C.flash_attention_decode(
+        *map(
+            _cuda_backend._wrap_for_dlpack,
+            (query, k, v, kv_lengths, output, softmax_lse, softmax_lse_accum, output_accum),
+        ),
+        num_splits,
+        torch.cuda.current_stream(q.device).cuda_stream,
+    )
+    return output.view(batch, groups, kv_heads, head_dim).transpose(1, 2).reshape_as(q)

--- a/comfy_kitchen/flash_attention.py
+++ b/comfy_kitchen/flash_attention.py
@@ -31,7 +31,7 @@ def flash_attention_decode(
     q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, kv_lengths: torch.Tensor
 ) -> torch.Tensor:
     """Decode attention for BF16 [batch, length, heads, 128] tensors."""
-    batch, query_length, query_heads, head_dim = q.shape
+    batch, _, query_heads, head_dim = q.shape
     _, kv_capacity, kv_heads, _ = k.shape
     if not _cuda_backend._EXT_AVAILABLE or torch.cuda.get_device_capability(q.device) < (8, 0):
         raise RuntimeError("flash_attention_decode requires the CUDA extension on SM80 or newer")

--- a/tests/test_flash_attention.py
+++ b/tests/test_flash_attention.py
@@ -1,0 +1,55 @@
+import pytest
+import torch
+
+import comfy_kitchen as ck
+from comfy_kitchen.backends import cuda as cuda_backend
+
+
+requires_flash_decode = pytest.mark.skipif(
+    not torch.cuda.is_available()
+    or not cuda_backend._EXT_AVAILABLE
+    or torch.cuda.get_device_capability() < (8, 0),
+    reason="requires the CUDA extension on SM80 or newer",
+)
+
+
+def _reference(q, k, v, lengths):
+    groups = q.shape[2] // k.shape[2]
+    outputs = []
+    for batch, length in enumerate(lengths.tolist()):
+        query = q[batch].transpose(0, 1).unsqueeze(0)
+        key = k[batch, :length].transpose(0, 1).repeat_interleave(groups, dim=0).unsqueeze(0)
+        value = v[batch, :length].transpose(0, 1).repeat_interleave(groups, dim=0).unsqueeze(0)
+        output = torch.nn.functional.scaled_dot_product_attention(query, key, value)
+        outputs.append(output.squeeze(0).transpose(0, 1))
+    return torch.stack(outputs)
+
+
+@requires_flash_decode
+def test_flash_attention_decode():
+    torch.manual_seed(0)
+    q = torch.randn(3, 1, 8, 128, device="cuda", dtype=torch.bfloat16)
+    k = torch.randn(3, 257, 2, 128, device="cuda", dtype=torch.bfloat16)
+    v = torch.randn_like(k)
+    lengths = torch.tensor([1, 73, 257], device="cuda", dtype=torch.int32)
+    actual = ck.flash_attention_decode(q, k, v, lengths)
+    torch.testing.assert_close(actual, _reference(q, k, v, lengths), atol=2e-3, rtol=1e-2)
+
+
+@requires_flash_decode
+def test_flash_attention_decode_cuda_graph_dynamic_lengths():
+    q = torch.randn(2, 1, 8, 128, device="cuda", dtype=torch.bfloat16)
+    k = torch.randn(2, 512, 2, 128, device="cuda", dtype=torch.bfloat16)
+    v = torch.randn_like(k)
+    lengths = torch.tensor([128, 512], device="cuda", dtype=torch.int32)
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        ck.flash_attention_decode(q, k, v, lengths)
+    torch.cuda.current_stream().wait_stream(stream)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        actual = ck.flash_attention_decode(q, k, v, lengths)
+    lengths.copy_(torch.tensor([17, 333], device="cuda", dtype=torch.int32))
+    graph.replay()
+    torch.testing.assert_close(actual, _reference(q, k, v, lengths), atol=2e-3, rtol=1e-2)

--- a/tests/test_flash_attention.py
+++ b/tests/test_flash_attention.py
@@ -4,7 +4,6 @@ import torch
 import comfy_kitchen as ck
 from comfy_kitchen.backends import cuda as cuda_backend
 
-
 requires_flash_decode = pytest.mark.skipif(
     not torch.cuda.is_available()
     or not cuda_backend._EXT_AVAILABLE


### PR DESCRIPTION
AR attention needs a performant seqlen capable attention kernel. Pytorch hides this option in its internals. Just use flash attention with the seqlen stuff on the API.

The seqlen variable allows cuda-graphing through the attention kernel as the CPU does not need to manage the iteration variable for sequence length increment as the AR attention iterates.