### PR TITLE
Fix int8 attention rejecting batch-one inputs on PyTorch 2.9 and older

### DIFF
--- a/comfy_kitchen/backends/cuda/sage_attention/quant_qk_int8.cu
+++ b/comfy_kitchen/backends/cuda/sage_attention/quant_qk_int8.cu
@@ -710,17 +710,25 @@ extern "C" void launch_quant_qk_per_thread_int8(
     throw std::runtime_error(
         "quant_qk_per_thread_int8: anchor_indices scratch is required");
   }
+  // An extent of one is exempt: its index is always zero, so the stride never
+  // reaches an address, and PyTorch rewrites such a stride to 1 on the way
+  // through DLPack (ATen/DLConvertor.cpp, gh-83069) on 2.9 and older, which no
+  // caller can prevent.
   const size_t element_size = input_dtype_code == 0 ? sizeof(float) : sizeof(half);
   const size_t vector_size = 4 * element_size;
-  const auto is_vector_aligned = [vector_size](const void *ptr, int64_t stride_b,
-                                                int64_t stride_h,
-                                                int64_t stride_n) {
-    return stride_b > 0 && stride_h > 0 && stride_n > 0 &&
-           reinterpret_cast<uintptr_t>(ptr) % vector_size == 0 &&
-           stride_b % 4 == 0 && stride_h % 4 == 0 && stride_n % 4 == 0;
+  const auto stride_ok = [](int64_t stride, int extent) {
+    return extent < 2 || (stride > 0 && stride % 4 == 0);
   };
-  if (!is_vector_aligned(q, q_stride_b, q_stride_h, q_stride_n) ||
-      !is_vector_aligned(k, k_stride_b, k_stride_h, k_stride_n)) {
+  const auto is_vector_aligned = [vector_size, &stride_ok](const void *ptr, int64_t stride_b,
+                                                            int64_t stride_h, int64_t stride_n,
+                                                            int extent_b, int extent_h,
+                                                            int extent_n) {
+    return reinterpret_cast<uintptr_t>(ptr) % vector_size == 0 &&
+           stride_ok(stride_b, extent_b) && stride_ok(stride_h, extent_h) &&
+           stride_ok(stride_n, extent_n);
+  };
+  if (!is_vector_aligned(q, q_stride_b, q_stride_h, q_stride_n, B, H_q, Lq) ||
+      !is_vector_aligned(k, k_stride_b, k_stride_h, k_stride_n, B, H_kv, Lk)) {
     throw std::runtime_error(
         "quant_qk_per_thread_int8: Q/K base pointers and B/H/N strides must preserve 4-element alignment");
   }

--- a/comfy_kitchen/backends/cuda/sage_attention/quant_v_int8.cu
+++ b/comfy_kitchen/backends/cuda/sage_attention/quant_v_int8.cu
@@ -177,11 +177,16 @@ extern "C" void launch_quant_v_int8_kernel(const void *v, void *out, void *scale
                                           int padded_N, int64_t sb, int64_t sh,
                                           int64_t sn, int input_dtype_code,
                                           cudaStream_t stream) {
+  // An extent of one forms no offset, and PyTorch rewrites such a stride to 1 on
+  // the way through DLPack (ATen/DLConvertor.cpp, gh-83069) on 2.9 and older, so
+  // policing it would reject a tensor the caller has no way to hand over
+  // differently.
   const size_t element_size = input_dtype_code == 0 ? sizeof(float) : sizeof(half);
-  if (reinterpret_cast<uintptr_t>(v) % 16 != 0 ||
-      (static_cast<size_t>(sb) * element_size) % 16 != 0 ||
-      (static_cast<size_t>(sh) * element_size) % 16 != 0 ||
-      (static_cast<size_t>(sn) * element_size) % 16 != 0) {
+  const auto stride_ok = [element_size](int64_t stride, int extent) {
+    return extent < 2 || (static_cast<size_t>(stride) * element_size) % 16 == 0;
+  };
+  if (reinterpret_cast<uintptr_t>(v) % 16 != 0 || !stride_ok(sb, B) ||
+      !stride_ok(sh, H) || !stride_ok(sn, N)) {
     throw std::runtime_error(
         "quant_v_int8: V base pointer and B/H/N strides must be 16-byte aligned");
   }

--- a/comfy_kitchen/backends/hip/sage_attention/quant_qk_int8.hip
+++ b/comfy_kitchen/backends/hip/sage_attention/quant_qk_int8.hip
@@ -468,16 +468,22 @@ extern "C" void launch_sage_quant_qk_int8(const void* q, void* q_int8, void* q_s
     }
 
     // The quantizers read four elements at a time from every row, so the base
-    // pointer and all three strides have to keep that group aligned.
+    // pointer and all three strides have to keep that group aligned. An extent of
+    // one is exempt: its index is always zero, so the stride never reaches the
+    // address, and PyTorch rewrites such a stride to 1 on the way through DLPack
+    // (ATen/DLConvertor.cpp, gh-83069), which no caller can prevent.
     const size_t element_size = input_dtype_code == 0 ? sizeof(float) : sizeof(__half);
     const size_t vector_size = 4 * element_size;
-    const auto vector_aligned = [vector_size](const void* p, int64_t sb, int64_t sh, int64_t sn) {
-        return sb > 0 && sh > 0 && sn > 0 &&
-               reinterpret_cast<uintptr_t>(p) % vector_size == 0 && sb % 4 == 0 && sh % 4 == 0 &&
-               sn % 4 == 0;
+    const auto stride_ok = [](int64_t stride, int extent) {
+        return extent < 2 || (stride > 0 && stride % 4 == 0);
     };
-    if (!vector_aligned(q, q_stride_b, q_stride_h, q_stride_n) ||
-        !vector_aligned(k, k_stride_b, k_stride_h, k_stride_n)) {
+    const auto vector_aligned = [vector_size, &stride_ok](const void* p, int64_t sb, int64_t sh,
+                                                          int64_t sn, int nb, int nh, int nn) {
+        return reinterpret_cast<uintptr_t>(p) % vector_size == 0 && stride_ok(sb, nb) &&
+               stride_ok(sh, nh) && stride_ok(sn, nn);
+    };
+    if (!vector_aligned(q, q_stride_b, q_stride_h, q_stride_n, B, H_q, Lq) ||
+        !vector_aligned(k, k_stride_b, k_stride_h, k_stride_n, B, H_kv, Lk)) {
         throw std::runtime_error(
             "sage int8 attention: Q/K base pointers and B/H/N strides must preserve 4-element "
             "alignment");

--- a/comfy_kitchen/backends/hip/sage_attention/quant_v_int8.hip
+++ b/comfy_kitchen/backends/hip/sage_attention/quant_v_int8.hip
@@ -163,12 +163,16 @@ extern "C" void launch_sage_quant_v_int8(const void* v, void* out, void* scale, 
                                          int64_t stride_h, int64_t stride_n, int input_dtype_code,
                                          hipStream_t stream) {
     // The kernel loads V 16 bytes at a time, so the base pointer and every row
-    // offset it can form have to be 16-byte aligned.
+    // offset it can form have to be 16-byte aligned. An extent of one forms no
+    // offset, and PyTorch rewrites such a stride to 1 on the way through DLPack
+    // (ATen/DLConvertor.cpp, gh-83069), so policing it would reject a tensor the
+    // caller has no way to hand over differently.
     const size_t element_size = input_dtype_code == 0 ? sizeof(float) : sizeof(__half);
-    if (reinterpret_cast<uintptr_t>(v) % 16 != 0 ||
-        (static_cast<size_t>(stride_b) * element_size) % 16 != 0 ||
-        (static_cast<size_t>(stride_h) * element_size) % 16 != 0 ||
-        (static_cast<size_t>(stride_n) * element_size) % 16 != 0) {
+    const auto stride_ok = [element_size](int64_t stride, int extent) {
+        return extent < 2 || (static_cast<size_t>(stride) * element_size) % 16 == 0;
+    };
+    if (reinterpret_cast<uintptr_t>(v) % 16 != 0 || !stride_ok(stride_b, B) ||
+        !stride_ok(stride_h, H) || !stride_ok(stride_n, N)) {
         throw std::runtime_error(
             "sage int8 attention: V base pointer and B/H/N strides must be 16-byte aligned");
     }

--- a/tests/test_int8_attention.py
+++ b/tests/test_int8_attention.py
@@ -422,3 +422,31 @@ def test_rotation_handles_outliers():
     actual = ck.int8_attention(q, k, v)
 
     assert _nrmse(actual, expected) < 0.03
+
+
+@requires_int8_attention
+def test_int8_attention_accepts_dlpack_normalized_batch_stride():
+    """A size-one extent carries no address, so its stride must not be policed.
+
+    PyTorch rewrites the stride of any size-one dimension to 1 on the way out
+    through DLPack (ATen/DLConvertor.cpp, gh-83069), so a batch-one attention
+    input arrives with stride 1 no matter what the caller built.
+    """
+    torch.manual_seed(0)
+    length, heads, head_dim = 372, 8, 128
+    packed = [
+        torch.randn(length, heads, head_dim, dtype=torch.bfloat16, device="cuda")
+        for _ in range(3)
+    ]
+    reported = [t.transpose(0, 1).unsqueeze(0) for t in packed]
+    normalized = [
+        torch.as_strided(t, (1, heads, length, head_dim), (1, head_dim, heads * head_dim, 1))
+        for t in packed
+    ]
+    assert normalized[0].stride(0) == 1
+    assert torch.equal(reported[0], normalized[0])
+
+    expected = ck.int8_attention_from_prequantized(ck.prequantize_int8_attention(*reported))
+    actual = ck.int8_attention_from_prequantized(ck.prequantize_int8_attention(*normalized))
+
+    assert torch.equal(actual, expected)


### PR DESCRIPTION
Correctness fix for the int8 attention host-side guards, in both the CUDA and the HIP backend. Reported in #110 on gfx1151 with `torch 2.9.1+rocm7.2.1`, where every MiniMax H3 workflow fails at the first attention call with `sage int8 attention: Q/K base pointers and B/H/N strides must preserve 4-element alignment`. Updating PyTorch resolves the issue.

### Cause

PyTorch 2.9.1 normalizes DLPack strides for size-one dimensions to `1`. MiniMax H3 passes `q` with shape `[1, 56, 372, 128]` and strides `(7168, 128, 7168, 1)`, but the DLPack capsule becomes `(1, 128, 7168, 1)`. The guard sees `stride_b = 1` and incorrectly rejects it as misaligned.

A size-one dimension is only indexed at zero, so its stride cannot affect addressing or alignment. This affects torch 2.9.x and older.

### Change

The Q/K and V int8 quantization guards now skip stride-alignment checks for dimensions with extent `< 2`. Alignment checks for real extents and base pointers remain unchanged.

### Verification

- HIP: Run-verified on gfx1200; compile-verified on gfx1100, gfx1151, and gfx1200.
- Normalized DLPack strides are accepted and produce bit-identical results.
- Genuine misalignment is still rejected.
- V broadcast with `stride_b == 0` remains supported.
- Tests: `61 passed, 5 skipped` (one new regression test).
- CUDA: Compile-verified by CI. Not hardware-tested due to no NVIDIA GPU/`nvcc`. The edited guards compile cleanly with `-std=c++17 -Wall -Wextra`, and standalone tests matched HIP behavior.