### PR TITLE
Fix Triton HIP backend crash: libdevice.rint missing on ROCm

### DIFF
--- a/comfy_kitchen/backends/triton/quantization.py
+++ b/comfy_kitchen/backends/triton/quantization.py
@@ -26,6 +26,17 @@ from comfy_kitchen.float_utils import (
 from comfy_kitchen.tensor.int8_utils import _build_hadamard, _rotate_activation
 from triton.language.extra import libdevice
 
+# ROCm/HIP's libdevice has no rint(), only nearbyint() (same rounding
+# semantics, differs only in floating-point exception flags). The generic
+# `triton.language.extra.libdevice` dispatcher always exposes `rint` as a
+# symbol regardless of active backend (it resolves at trace time), so
+# hasattr() on it is useless here -- check the concrete backend module.
+if torch.version.hip is not None:
+    from triton.language.extra.hip import libdevice as _libdevice_backend
+else:
+    from triton.language.extra.cuda import libdevice as _libdevice_backend
+_rint = _libdevice_backend.rint if hasattr(_libdevice_backend, "rint") else _libdevice_backend.nearbyint
+
 
 @triton.jit
 def quantize_fp8_kernel_tl(
@@ -808,7 +819,7 @@ def _quantize_rowwise_kernel(
         q_f = x / scale
 
     # Round and Clamp
-    q_i = tl.clamp(libdevice.rint(q_f.to(tl.float32)), -128.0, 127.0).to(tl.int32)
+    q_i = tl.clamp(_rint(q_f.to(tl.float32)), -128.0, 127.0).to(tl.int32)
 
     # 4. Store
     tl.store(y_row_ptr + offsets, q_i.to(tl.int8), mask=mask)

--- a/comfy_kitchen/backends/triton/w4a8_int8.py
+++ b/comfy_kitchen/backends/triton/w4a8_int8.py
@@ -20,6 +20,18 @@ from triton.language.extra import libdevice
 
 from .quantization import int8_linear
 
+# ROCm/HIP's libdevice has no rint() (round-half-to-even), only nearbyint()
+# (same rounding semantics, differs only in floating-point exception flags,
+# which is irrelevant here). CUDA's libdevice does have rint(). The generic
+# `triton.language.extra.libdevice` dispatcher always exposes `rint` as a
+# symbol regardless of active backend (it resolves at trace time), so
+# hasattr() on it is useless here -- check the concrete backend module.
+if torch.version.hip is not None:
+    from triton.language.extra.hip import libdevice as _libdevice_backend
+else:
+    from triton.language.extra.cuda import libdevice as _libdevice_backend
+_rint = _libdevice_backend.rint if hasattr(_libdevice_backend, "rint") else _libdevice_backend.nearbyint
+
 
 @triton.jit
 def _dequant_int4_grouped_to_int8_kernel(
@@ -60,8 +72,8 @@ def _dequant_int4_grouped_to_int8_kernel(
         v_low = (low - 8).to(tl.float32)                    # symmetric uniform levels
         v_high = (high - 8).to(tl.float32)
 
-    q_low = tl.clamp(libdevice.rint(v_low * s), -127.0, 127.0).to(tl.int8)
-    q_high = tl.clamp(libdevice.rint(v_high * s), -127.0, 127.0).to(tl.int8)
+    q_low = tl.clamp(_rint(v_low * s), -127.0, 127.0).to(tl.int8)
+    q_high = tl.clamp(_rint(v_high * s), -127.0, 127.0).to(tl.int8)
 
     tl.store(out_ptr + rows[:, None] * stride_on + (2 * bcols)[None, :] * stride_ok, q_low, mask=m)
     tl.store(out_ptr + rows[:, None] * stride_on + (2 * bcols + 1)[None, :] * stride_ok, q_high, mask=m)


### PR DESCRIPTION
## Summary
- `triton.language.extra.hip.libdevice` has no `rint()` (round-half-to-even), only `nearbyint()` with equivalent rounding semantics (differs only in floating-point exception flags, irrelevant for these int8 quantization kernels). The CUDA `libdevice` does have `rint()`.
- The generic `triton.language.extra.libdevice` dispatcher module always exposes `rint` as an attribute regardless of the active backend — it resolves the concrete implementation at kernel trace/compile time, not at Python import time. So a naive `hasattr(libdevice, "rint")` check on that dispatcher is always `True` and can't be used to detect the missing symbol; the concrete backend submodule (`triton.language.extra.hip.libdevice`) must be checked instead.
- Without this fix, any `AsymW4A8Int8` model (e.g. quantized diffusion models loaded via `UNETLoader`) crashes on the first sampling step on ROCm with:
  ```
  AttributeError: module 'triton.language.extra.hip.libdevice' has no attribute 'rint'
  ```

## Test plan
- Tested on an AMD Radeon RX 9060 XT (`gfx1200`, ROCm 6.4, PyTorch `2.8.0+rocm6.4`, Triton `3.4.0`).
- Before this fix: sampling crashed immediately on the first step with the `AttributeError` above.
- After this fix: a full 20-step MiniMax H3 image-to-video generation (w4a8-quantized diffusion model) completes successfully end-to-end, no crash, no numerical/OOM issues observed.
- CUDA path unaffected — `torch.version.hip is None` on CUDA systems, so the `cuda.libdevice` branch (unchanged behavior, still uses `rint`) is taken.