### PR TITLE
HIP port of #111: bf16 flash attention decode

### DIFF
--- a/comfy_kitchen/backends/hip/CMakeLists.txt
+++ b/comfy_kitchen/backends/hip/CMakeLists.txt
@@ -164,6 +164,7 @@ set(HIP_SOURCES
     sage_attention/quant_v_int8.hip
     sage_attention/int8_attn.hip
     ops/apply_rope.hip
+    ops/flash_decode.hip
     ops/rms_rope.hip
     ops/gemv_awq.hip
     ops/svdquant_w4a4.hip

--- a/comfy_kitchen/backends/hip/__init__.py
+++ b/comfy_kitchen/backends/hip/__init__.py
@@ -66,6 +66,8 @@ __all__ = [
     "has_wmma",
     "int8_linear",
     "int8_attention_is_available",
+    "flash_attention_decode_is_available",
+    "flash_decode",
     "is_available",
     "sage_int8_attend",
     "sage_int8_quantize",
@@ -2048,6 +2050,49 @@ def int8_attention_is_available() -> bool:
     RDNA2 declines it the way it declines the GEMMs.
     """
     return has_wmma()
+
+
+def flash_attention_decode_is_available() -> bool:
+    """Whether the BF16 decode attention kernel can run here.
+
+    The kernel uses no matrix cores, so is_available() would be the natural
+    gate, but RDNA2 has no bf16 and a caller that asks it to run there builds
+    the KV cache in another dtype, which this kernel declines. has_wmma() marks
+    the line where bf16 arrives, the same line the CUDA backend draws at SM80.
+    The attribute test catches an extension built before the kernel existed,
+    which is otherwise an AttributeError at dispatch.
+    """
+    return has_wmma() and hasattr(_C, "flash_attention_decode")
+
+
+def flash_decode(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    kv_lengths: torch.Tensor,
+    output: torch.Tensor,
+    softmax_lse: torch.Tensor,
+    softmax_lse_accum: torch.Tensor,
+    output_accum: torch.Tensor,
+    num_splits: int,
+) -> None:
+    """Decode attention into ``output``. See ops/flash_decode.hip.
+
+    The caller owns the reshaping and the split workspace; this is the raw
+    launch so both backends can share comfy_kitchen/flash_attention.py.
+    """
+    _C.flash_attention_decode(
+        _dl(q),
+        _dl(k),
+        _dl(v),
+        _dl(kv_lengths),
+        _dl(output),
+        _dl(softmax_lse),
+        _dl(softmax_lse_accum),
+        _dl(output_accum),
+        num_splits,
+        _stream(q),
+    )
 
 
 def _sage_buffers(q: torch.Tensor, k: torch.Tensor, cta_k: int):

--- a/comfy_kitchen/backends/hip/dlpack_bindings.cpp
+++ b/comfy_kitchen/backends/hip/dlpack_bindings.cpp
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
+#include <cstdint>
 #include <cstring>
 #include <optional>
 #include <stdexcept>
@@ -1346,6 +1347,134 @@ void sage_sdpa_prequantized(nb::ndarray<> q_int8, nb::ndarray<> k_int8, nb::ndar
                 reinterpret_cast<hipStream_t>(stream_ptr), kFn);
 }
 
+
+// BF16 decode attention. Every extent below is derived from the operands rather
+// than taken from the caller, and the kernel indexes with the strides passed
+// here, so a mismatch is an out-of-bounds device access. Mirrors the checks in
+// the CUDA binding and adds the two the HIP kernel needs: it reads four
+// elements at a time, and it addresses the output with q's strides.
+void flash_attention_decode(nb::ndarray<> q, nb::ndarray<> k, nb::ndarray<> v,
+                            nb::ndarray<> kv_lengths, nb::ndarray<> output,
+                            nb::ndarray<> softmax_lse, nb::ndarray<> softmax_lse_accum,
+                            nb::ndarray<> output_accum, int num_splits, uintptr_t stream_ptr) {
+    constexpr const char* kFn = "flash_attention_decode";
+    constexpr int kHeadDim = 128;
+    constexpr int kElemsPerLoad = 4;
+    if (q.ndim() != 3 || k.ndim() != 4 || v.ndim() != 4 || output.ndim() != 3 ||
+        kv_lengths.ndim() != 1) {
+        throw std::runtime_error(std::string(kFn) + ": operand rank mismatch");
+    }
+    const int batch = static_cast<int>(k.shape(0));
+    const int kv_capacity = static_cast<int>(k.shape(1));
+    const int heads = static_cast<int>(k.shape(2));
+    require_positive(batch, kFn, "batch");
+    require_positive(kv_capacity, kFn, "kv_capacity");
+    require_positive(heads, kFn, "heads");
+    const int query_length = static_cast<int>(q.shape(0)) / batch;
+    require_positive(query_length, kFn, "query_length");
+    if (static_cast<int64_t>(q.shape(0)) != static_cast<int64_t>(batch) * query_length ||
+        static_cast<int>(q.shape(1)) != heads || static_cast<int>(q.shape(2)) != kHeadDim ||
+        static_cast<int>(k.shape(3)) != kHeadDim) {
+        throw std::runtime_error(std::string(kFn) + ": invalid q/k dimensions");
+    }
+    if (static_cast<int>(v.shape(0)) != batch || static_cast<int>(v.shape(1)) != kv_capacity ||
+        static_cast<int>(v.shape(2)) != heads || static_cast<int>(v.shape(3)) != kHeadDim) {
+        throw std::runtime_error(std::string(kFn) + ": k/v shape mismatch");
+    }
+    if (output.shape(0) != q.shape(0) || static_cast<int>(output.shape(1)) != heads ||
+        static_cast<int>(output.shape(2)) != kHeadDim ||
+        kv_lengths.size() != static_cast<size_t>(batch)) {
+        throw std::runtime_error(std::string(kFn) + ": output or length shape mismatch");
+    }
+    require_dtype(q, 2, 2, kFn, "q");
+    require_dtype(k, 2, 2, kFn, "k");
+    require_dtype(v, 2, 2, kFn, "v");
+    require_dtype(output, 2, 2, kFn, "output");
+    if (map_dtype_to_code(kv_lengths.dtype()) != -1 ||
+        kv_lengths.dtype().code != static_cast<uint8_t>(nb::dlpack::dtype_code::Int) ||
+        kv_lengths.dtype().bits != 32) {
+        throw std::runtime_error(std::string(kFn) + ": kv_lengths must be int32");
+    }
+
+    const size_t lse_size = static_cast<size_t>(batch) * heads * query_length;
+    if (softmax_lse.size() != lse_size || num_splits < 1 || num_splits > 32 ||
+        (num_splits > 1 &&
+         (softmax_lse_accum.size() != lse_size * num_splits ||
+          output_accum.size() != lse_size * kHeadDim * num_splits))) {
+        throw std::runtime_error(std::string(kFn) + ": invalid split workspace");
+    }
+    require_dtype(softmax_lse, 0, 0, kFn, "softmax_lse");
+    // The lengths and the split workspace are indexed linearly off their base
+    // pointers, so a strided view of the right size is read as though packed.
+    require_packed_contiguous(kv_lengths, kFn, "kv_lengths");
+    require_packed_contiguous(softmax_lse, kFn, "softmax_lse");
+    if (num_splits > 1) {
+        require_dtype(softmax_lse_accum, 0, 0, kFn, "softmax_lse_accum");
+        require_dtype(output_accum, 0, 0, kFn, "output_accum");
+        require_packed_contiguous(softmax_lse_accum, kFn, "softmax_lse_accum");
+        require_packed_contiguous(output_accum, kFn, "output_accum");
+    }
+
+    if (k.stride(0) != v.stride(0) || k.stride(1) != v.stride(1) || k.stride(2) != v.stride(2) ||
+        k.stride(3) != 1 || v.stride(3) != 1 || q.stride(2) != 1 || output.stride(2) != 1) {
+        throw std::runtime_error(std::string(kFn) + ": unsupported tensor strides");
+    }
+    // The kernel writes the output off q's strides, the way the CUDA launcher
+    // does. Here that is checked rather than assumed.
+    if (output.stride(0) != q.stride(0) || output.stride(1) != q.stride(1)) {
+        throw std::runtime_error(std::string(kFn) + ": output strides must match q");
+    }
+    // Rows are read four elements at a time, so every row start has to stay on
+    // that boundary.
+    const int64_t vectored[] = {q.stride(0), q.stride(1), k.stride(0), k.stride(1), k.stride(2)};
+    for (int64_t stride : vectored) {
+        if (stride % kElemsPerLoad != 0) {
+            throw std::runtime_error(std::string(kFn) + ": strides must be a multiple of 4");
+        }
+    }
+    // A view carries a byte offset, so operands with aligned strides can still
+    // begin off the boundary the four-element load needs.
+    constexpr uintptr_t kLoadBytes = kElemsPerLoad * sizeof(uint16_t);
+    const void* row_starts[] = {q.data(), k.data(), v.data(), output.data()};
+    for (const void* base : row_starts) {
+        if (reinterpret_cast<uintptr_t>(base) % kLoadBytes != 0) {
+            throw std::runtime_error(std::string(kFn) + ": q, k, v and output must be 8-byte aligned");
+        }
+    }
+    // The launcher takes raw pointers, so anything but ROCm device memory would
+    // be dereferenced on the device as though it were. The CUDA binding gets
+    // this from its nb::device::cuda operand types; this one takes plain
+    // ndarrays and has to ask. Testing for "not kDLCPU" is not enough: pinned
+    // host memory reports kDLCUDAHost and is still a host pointer.
+    constexpr int kDeviceRocm = nb::device::rocm::value;
+    const nb::ndarray<>* operands[] = {&q,      &k,          &v,
+                                       &output, &kv_lengths, &softmax_lse};
+    for (const nb::ndarray<>* t : operands) {
+        if (t->device_type() != kDeviceRocm || t->device_id() != q.device_id()) {
+            throw std::runtime_error(std::string(kFn) +
+                                     ": every operand must be ROCm device memory on q's device");
+        }
+    }
+    if (num_splits > 1 &&
+        (softmax_lse_accum.device_type() != kDeviceRocm ||
+         output_accum.device_type() != kDeviceRocm ||
+         softmax_lse_accum.device_id() != q.device_id() ||
+         output_accum.device_id() != q.device_id())) {
+        throw std::runtime_error(std::string(kFn) +
+                                 ": split workspace must be ROCm device memory on q's device");
+    }
+
+    launch_flash_decode(
+        q.data(), k.data(), v.data(), static_cast<const int*>(kv_lengths.data()), output.data(),
+        static_cast<float*>(softmax_lse.data()),
+        num_splits > 1 ? static_cast<float*>(output_accum.data()) : nullptr,
+        num_splits > 1 ? static_cast<float*>(softmax_lse_accum.data()) : nullptr, batch,
+        query_length, heads, kv_capacity, num_splits, q.stride(0) * query_length, q.stride(0),
+        q.stride(1), k.stride(0), k.stride(1), k.stride(2),
+        reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
 NB_MODULE(_C, m) {
     m.doc() = "ComfyKitchen HIP backend native operations (RDNA2-RDNA4, WMMA on gfx11/gfx12)";
     m.def("quantize_per_tensor_fp8", &quantize_per_tensor_fp8);
@@ -1367,6 +1496,10 @@ NB_MODULE(_C, m) {
     m.def("w4a8_requant_max_k", &w4a8_requant_max_k_kernel);
     m.def("w4a8_int8_gemm_chunked", &w4a8_int8_gemm_chunked);
     m.def("na3d", &na3d);
+    m.def("flash_attention_decode", &flash_attention_decode, nb::arg("q"), nb::arg("k"),
+          nb::arg("v"), nb::arg("kv_lengths"), nb::arg("output"), nb::arg("softmax_lse"),
+          nb::arg("softmax_lse_accum"), nb::arg("output_accum"), nb::arg("num_splits"),
+          nb::arg("stream_ptr"));
     m.def("sage_sdpa", &sage_sdpa, nb::arg("q"), nb::arg("k"), nb::arg("v"), nb::arg("o"),
           nb::arg("q_int8"), nb::arg("q_scale"), nb::arg("k_int8"), nb::arg("k_scale"),
           nb::arg("v_int8"), nb::arg("v_scale"), nb::arg("anchor_indices"), nb::arg("sm_scale"),

--- a/comfy_kitchen/backends/hip/launchers.h
+++ b/comfy_kitchen/backends/hip/launchers.h
@@ -20,6 +20,17 @@ void launch_na3d_kernel(const void* q, const void* k, const void* v, void* out, 
                         int kh, int kw, int causal_t, int causal_h, int causal_w, float scale,
                         int dtype_code, hipStream_t stream);
 
+// BF16 decode attention over a fixed-capacity KV cache. query_length is the GQA
+// group count folded into the query sequence dimension by the Python layer, and
+// head_dim is fixed at 128. out_accum and lse_accum are read only when
+// num_splits > 1. See ops/flash_decode.hip.
+void launch_flash_decode(const void* q, const void* k, const void* v, const int* kv_lengths,
+                         void* out, float* softmax_lse, float* out_accum, float* lse_accum,
+                         int batch, int query_length, int heads, int kv_capacity, int num_splits,
+                         int64_t q_batch_stride, int64_t q_row_stride, int64_t q_head_stride,
+                         int64_t k_batch_stride, int64_t k_row_stride, int64_t k_head_stride,
+                         hipStream_t stream);
+
 // ldc is c's row stride, so a caller writing an N-column slice of a wider output
 // passes that output's width; a whole GEMM passes N.
 void launch_int8_gemm_kernel(const void* a, const void* b, void* c, const void* scale_a,

--- a/comfy_kitchen/backends/hip/ops/flash_decode.hip
+++ b/comfy_kitchen/backends/hip/ops/flash_decode.hip
@@ -1,0 +1,366 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// BF16 decode attention over a fixed-capacity KV cache. The CUDA counterpart
+// reuses FlashAttention 2.7.4's split-KV kernels, so nothing there translates;
+// this is an independent kernel behind the same launcher and the same
+// split-then-combine structure.
+//
+// The Python layer folds the GQA group count into the query sequence dimension:
+// query_length == groups, one KV head per query row, no mask, no window.
+//
+// Arithmetic intensity is `groups` FLOP per byte of K and V, so the shape is
+// picked for those reads: a wave walks one key row at a time, keeping every
+// load coalesced, and closes the dot product with a butterfly reduction. The
+// dot product is plain FMA, so this needs no matrix cores.
+#include <hip/hip_runtime.h>
+
+#include <cfloat>
+#include <cstdint>
+
+#include "../launchers.h"
+#include "../mma.h"
+
+namespace comfy::hip_backend {
+namespace {
+
+constexpr int kHeadDim = 128;
+constexpr int kDimPerLane = kHeadDim / kWave;
+constexpr int kCombineThreads = kHeadDim;
+
+// wave_sum below is a fixed wave32 DPP sequence, and four elements per lane is
+// what makes the head dimension divide evenly.
+static_assert(kWave == 32, "the reduction and the lane layout assume wave32");
+static_assert(kDimPerLane == 4, "a lane holds four elements of the head dim");
+
+// One wave per (batch, head, split) leaves too few waves to cover a cache miss,
+// and the split count is the caller's and capped. The waves of a block share a
+// key range instead and merge their running softmax at the end. Eight measured
+// best: four costs 24%, sixteen exceeds LDS at the widest group tile.
+constexpr int kWavesPerBlock = 8;
+constexpr int kBlockThreads = kWavesPerBlock * kWave;
+
+// Keys in flight per wave, measured. Wider group tiles reuse each row more and
+// cannot spare the registers. Halving costs 5% at the narrowest tile, doubling
+// is within noise, doubling twice spills and costs 2.6x.
+template <int GroupsPerPass>
+constexpr int keys_per_iter() {
+    return GroupsPerPass >= 8 ? 4 : (GroupsPerPass >= 4 ? 8 : 16);
+}
+
+// 1/sqrt(128) folded into log2 so the softmax can use exp2. Mirrors
+// scale_softmax_log2 in the CUDA launcher.
+constexpr float kSoftmaxScaleLog2 = 0.12751743082871335f;
+constexpr float kLn2 = 0.693147180559945309417f;
+
+// Finite, not -inf: under -ffast-math the first m - m would be NaN.
+constexpr float kNegInf = -FLT_MAX / 4.0f;
+
+typedef __bf16 v4bf __attribute__((ext_vector_type(4)));
+typedef float v4f __attribute__((ext_vector_type(4)));
+
+__forceinline__ __device__ v4f zero4() { return v4f{0.0f, 0.0f, 0.0f, 0.0f}; }
+
+__forceinline__ __device__ v4f load_bf16x4(const __bf16* p) {
+    const v4bf raw = *reinterpret_cast<const v4bf*>(p);
+    return v4f{static_cast<float>(raw[0]), static_cast<float>(raw[1]),
+               static_cast<float>(raw[2]), static_cast<float>(raw[3])};
+}
+
+// Sum across the wave without touching LDS. mma.h's wave_reduce_sum lowers
+// __shfl_xor to ds_bpermute plus an LDS wait, five times per key per group,
+// which dominates once the group tile is wide. Bit-identical to that butterfly:
+// each step equalizes a wider span, so the next mirror acts as an xor swap.
+template <int Ctrl>
+__forceinline__ __device__ float dpp_add(float v) {
+    const int bits = __builtin_bit_cast(int, v);
+    return v + __builtin_bit_cast(float, __builtin_amdgcn_update_dpp(0, bits, Ctrl, 0xf, 0xf, true));
+}
+
+__forceinline__ __device__ float wave_sum(float v) {
+    v = dpp_add<0xB1>(v);
+    v = dpp_add<0x4E>(v);
+    v = dpp_add<0x141>(v);
+    v = dpp_add<0x140>(v);
+    const int bits = __builtin_bit_cast(int, v);
+    return v + __builtin_bit_cast(
+                   float, __builtin_amdgcn_permlanex16(bits, bits, 0x76543210, 0xfedcba98, false,
+                                                       false));
+}
+
+// Splits partition [0, length). A split past the end still runs the epilogue:
+// the combine pass reads every slot and would otherwise read uninitialized
+// memory.
+__forceinline__ __device__ void split_range(int length, int split, int num_splits, int* begin,
+                                            int* end) {
+    const int per_split = (length + num_splits - 1) / num_splits;
+    const int lo = split * per_split;
+    const int hi = lo + per_split;
+    *begin = lo < length ? lo : length;
+    *end = hi < length ? hi : length;
+}
+
+// GroupsPerPass query rows share every K and V read. Templated because the
+// per-group state has to stay in registers; a runtime bound spills it.
+template <int GroupsPerPass, bool Split>
+__global__ __launch_bounds__(kBlockThreads) void flash_decode_kernel(
+    const __bf16* __restrict__ q, const __bf16* __restrict__ k, const __bf16* __restrict__ v,
+    const int* __restrict__ kv_lengths, __bf16* __restrict__ out,
+    float* __restrict__ softmax_lse, float* __restrict__ out_accum,
+    float* __restrict__ lse_accum, int rows, int query_length, int heads, int kv_capacity,
+    int num_splits,
+    int64_t q_batch_stride, int64_t q_row_stride, int64_t q_head_stride, int64_t k_batch_stride,
+    int64_t k_row_stride, int64_t k_head_stride) {
+    constexpr int kKeysPerIter = keys_per_iter<GroupsPerPass>();
+    const int lane = static_cast<int>(threadIdx.x) % kWave;
+    const int wave = static_cast<int>(threadIdx.x) / kWave;
+    const int group_base = static_cast<int>(blockIdx.x) * GroupsPerPass;
+    const int split = static_cast<int>(blockIdx.y);
+    const int bh = static_cast<int>(blockIdx.z);
+    const int b = bh / heads;
+    const int h = bh - b * heads;
+
+    // A device value the caller may rewrite between graph replays.
+    int length = kv_lengths[b];
+    length = length < 0 ? 0 : (length > kv_capacity ? kv_capacity : length);
+
+    int begin = 0;
+    int end = length;
+    if constexpr (Split) split_range(length, split, num_splits, &begin, &end);
+
+    const int64_t q_base = static_cast<int64_t>(b) * q_batch_stride +
+                           static_cast<int64_t>(h) * q_head_stride + lane * kDimPerLane;
+
+    v4f q_vec[GroupsPerPass];
+    v4f o_acc[GroupsPerPass];
+    float m_run[GroupsPerPass];
+    float d_run[GroupsPerPass];
+#pragma unroll
+    for (int i = 0; i < GroupsPerPass; ++i) {
+        const int g = group_base + i;
+        q_vec[i] = g < query_length ? load_bf16x4(q + q_base + g * q_row_stride) : zero4();
+        o_acc[i] = zero4();
+        m_run[i] = kNegInf;
+        d_run[i] = 0.0f;
+    }
+
+    const int64_t kv_base = static_cast<int64_t>(b) * k_batch_stride +
+                            static_cast<int64_t>(h) * k_head_stride + lane * kDimPerLane;
+
+    const int stride = kWavesPerBlock * kKeysPerIter;
+    for (int j0 = begin + wave * kKeysPerIter; j0 < end; j0 += stride) {
+        // This prefetch is the only memory-level parallelism available. The
+        // index is clamped rather than predicated so no load sits behind a
+        // branch the scheduler cannot hoist past.
+        v4f k_vec[kKeysPerIter];
+        v4f v_vec[kKeysPerIter];
+#pragma unroll
+        for (int c = 0; c < kKeysPerIter; ++c) {
+            const int j = j0 + c;
+            const int clamped = j < end ? j : end - 1;
+            const int64_t off = kv_base + static_cast<int64_t>(clamped) * k_row_stride;
+            k_vec[c] = load_bf16x4(k + off);
+            v_vec[c] = load_bf16x4(v + off);
+        }
+
+#pragma unroll
+        for (int c = 0; c < kKeysPerIter; ++c) {
+            const bool valid = (j0 + c) < end;
+#pragma unroll
+            for (int i = 0; i < GroupsPerPass; ++i) {
+                float dot = 0.0f;
+#pragma unroll
+                for (int d = 0; d < kDimPerLane; ++d) dot += q_vec[i][d] * k_vec[c][d];
+                dot = wave_sum(dot) * kSoftmaxScaleLog2;
+
+                // A padded key must not raise the running maximum, and needs
+                // probability zero rather than exp2(0).
+                const float score = valid ? dot : kNegInf;
+                const float m_new = fmaxf(m_run[i], score);
+                const float rescale = exp2f(m_run[i] - m_new);
+                const float p = valid ? exp2f(score - m_new) : 0.0f;
+                d_run[i] = fmaf(d_run[i], rescale, p);
+#pragma unroll
+                for (int d = 0; d < kDimPerLane; ++d) {
+                    o_acc[i][d] = fmaf(o_acc[i][d], rescale, p * v_vec[c][d]);
+                }
+                m_run[i] = m_new;
+            }
+        }
+    }
+
+    // Merge the waves' running softmaxes. Each covered a disjoint key set, so
+    // this is the same rescale-by-exp2 the split combine does.
+    __shared__ float s_max[kWavesPerBlock][GroupsPerPass];
+    __shared__ float s_denominator[kWavesPerBlock][GroupsPerPass];
+    __shared__ float s_out[kWavesPerBlock][GroupsPerPass][kHeadDim];
+#pragma unroll
+    for (int i = 0; i < GroupsPerPass; ++i) {
+        if (lane == 0) {
+            s_max[wave][i] = m_run[i];
+            s_denominator[wave][i] = d_run[i];
+        }
+#pragma unroll
+        for (int d = 0; d < kDimPerLane; ++d) {
+            s_out[wave][i][lane * kDimPerLane + d] = o_acc[i][d];
+        }
+    }
+    __syncthreads();
+    if (wave != 0) return;
+
+#pragma unroll
+    for (int i = 0; i < GroupsPerPass; ++i) {
+        float m = s_max[0][i];
+#pragma unroll
+        for (int w = 1; w < kWavesPerBlock; ++w) m = fmaxf(m, s_max[w][i]);
+        float denominator = 0.0f;
+        v4f accum = zero4();
+#pragma unroll
+        for (int w = 0; w < kWavesPerBlock; ++w) {
+            const float rescale = exp2f(s_max[w][i] - m);
+            denominator = fmaf(s_denominator[w][i], rescale, denominator);
+#pragma unroll
+            for (int d = 0; d < kDimPerLane; ++d) {
+                accum[d] = fmaf(s_out[w][i][lane * kDimPerLane + d], rescale, accum[d]);
+            }
+        }
+
+        const int g = group_base + i;
+        if (g >= query_length) continue;
+        // An empty range leaves the denominator at zero; write zeros, not 0/0.
+        const float inv = denominator > 0.0f ? 1.0f / denominator : 0.0f;
+        const int row = (b * heads + h) * query_length + g;
+        if constexpr (Split) {
+            const int64_t slot = static_cast<int64_t>(split) * rows + row;
+            float* dst = out_accum + slot * kHeadDim + lane * kDimPerLane;
+#pragma unroll
+            for (int d = 0; d < kDimPerLane; ++d) dst[d] = accum[d] * inv;
+            if (lane == 0) {
+                lse_accum[slot] = denominator > 0.0f ? m + log2f(denominator) : kNegInf;
+            }
+        } else {
+            __bf16* dst = out + b * q_batch_stride + g * q_row_stride + h * q_head_stride +
+                          lane * kDimPerLane;
+#pragma unroll
+            for (int d = 0; d < kDimPerLane; ++d) dst[d] = static_cast<__bf16>(accum[d] * inv);
+            // Natural log, matching the CUDA path, though the softmax is base 2.
+            if (lane == 0) {
+                softmax_lse[row] =
+                    denominator > 0.0f ? (m + log2f(denominator)) * kLn2 : -FLT_MAX;
+            }
+        }
+    }
+}
+
+// One block per output row, one lane per head dimension.
+__global__ __launch_bounds__(kCombineThreads) void flash_decode_combine_kernel(
+    const float* __restrict__ out_accum, const float* __restrict__ lse_accum,
+    __bf16* __restrict__ out, float* __restrict__ softmax_lse, int num_splits, int rows,
+    int query_length, int heads, int64_t q_batch_stride, int64_t q_row_stride,
+    int64_t q_head_stride) {
+    const int row = static_cast<int>(blockIdx.x);
+    const int d = static_cast<int>(threadIdx.x);
+
+    float m = kNegInf;
+    for (int s = 0; s < num_splits; ++s) {
+        m = fmaxf(m, lse_accum[static_cast<int64_t>(s) * rows + row]);
+    }
+
+    float denominator = 0.0f;
+    float numerator = 0.0f;
+    for (int s = 0; s < num_splits; ++s) {
+        const int64_t slot = static_cast<int64_t>(s) * rows + row;
+        const float weight = exp2f(lse_accum[slot] - m);
+        denominator += weight;
+        numerator = fmaf(weight, out_accum[slot * kHeadDim + d], numerator);
+    }
+
+    const int g = row % query_length;
+    const int h = (row / query_length) % heads;
+    const int b = row / (query_length * heads);
+    out[b * q_batch_stride + g * q_row_stride + h * q_head_stride + d] =
+        static_cast<__bf16>(denominator > 0.0f ? numerator / denominator : 0.0f);
+    if (d == 0) {
+        softmax_lse[row] = denominator > 0.0f ? (m + log2f(denominator)) * kLn2 : -FLT_MAX;
+    }
+}
+
+// Largest power of two up to kMaxGroupsPerPass dividing query_length, so no
+// pass has to mask a partial group tile.
+constexpr int kMaxGroupsPerPass = 8;
+
+int groups_per_pass(int query_length) {
+    int gpp = 1;
+    while (gpp < kMaxGroupsPerPass && query_length % (gpp * 2) == 0) gpp *= 2;
+    return gpp;
+}
+
+template <int GroupsPerPass>
+void launch_typed(const void* q, const void* k, const void* v, const int* kv_lengths, void* out,
+                  float* softmax_lse, float* out_accum, float* lse_accum, int batch,
+                  int query_length, int heads, int kv_capacity, int num_splits,
+                  int64_t q_batch_stride, int64_t q_row_stride, int64_t q_head_stride,
+                  int64_t k_batch_stride, int64_t k_row_stride, int64_t k_head_stride,
+                  hipStream_t stream) {
+    const dim3 grid(query_length / GroupsPerPass, num_splits, batch * heads);
+    const int rows = batch * heads * query_length;
+    const bool split = num_splits > 1;
+    if (split) {
+        flash_decode_kernel<GroupsPerPass, true><<<grid, kBlockThreads, 0, stream>>>(
+            static_cast<const __bf16*>(q), static_cast<const __bf16*>(k),
+            static_cast<const __bf16*>(v), kv_lengths, static_cast<__bf16*>(out), softmax_lse,
+            out_accum, lse_accum, rows, query_length, heads, kv_capacity, num_splits,
+            q_batch_stride, q_row_stride, q_head_stride, k_batch_stride, k_row_stride,
+            k_head_stride);
+        flash_decode_combine_kernel<<<rows, kCombineThreads, 0, stream>>>(
+            out_accum, lse_accum, static_cast<__bf16*>(out), softmax_lse, num_splits, rows,
+            query_length, heads, q_batch_stride, q_row_stride, q_head_stride);
+    } else {
+        flash_decode_kernel<GroupsPerPass, false><<<grid, kBlockThreads, 0, stream>>>(
+            static_cast<const __bf16*>(q), static_cast<const __bf16*>(k),
+            static_cast<const __bf16*>(v), kv_lengths, static_cast<__bf16*>(out), softmax_lse,
+            out_accum, lse_accum, rows, query_length, heads, kv_capacity, num_splits,
+            q_batch_stride, q_row_stride, q_head_stride, k_batch_stride, k_row_stride,
+            k_head_stride);
+    }
+}
+
+}  // namespace
+}  // namespace comfy::hip_backend
+
+extern "C" void launch_flash_decode(const void* q, const void* k, const void* v,
+                                    const int* kv_lengths, void* out, float* softmax_lse,
+                                    float* out_accum, float* lse_accum, int batch,
+                                    int query_length, int heads, int kv_capacity, int num_splits,
+                                    int64_t q_batch_stride, int64_t q_row_stride,
+                                    int64_t q_head_stride, int64_t k_batch_stride,
+                                    int64_t k_row_stride, int64_t k_head_stride,
+                                    hipStream_t stream) {
+    using namespace comfy::hip_backend;
+    switch (groups_per_pass(query_length)) {
+        case 8:
+            launch_typed<8>(q, k, v, kv_lengths, out, softmax_lse, out_accum, lse_accum, batch,
+                            query_length, heads, kv_capacity, num_splits, q_batch_stride,
+                            q_row_stride, q_head_stride, k_batch_stride, k_row_stride,
+                            k_head_stride, stream);
+            break;
+        case 4:
+            launch_typed<4>(q, k, v, kv_lengths, out, softmax_lse, out_accum, lse_accum, batch,
+                            query_length, heads, kv_capacity, num_splits, q_batch_stride,
+                            q_row_stride, q_head_stride, k_batch_stride, k_row_stride,
+                            k_head_stride, stream);
+            break;
+        case 2:
+            launch_typed<2>(q, k, v, kv_lengths, out, softmax_lse, out_accum, lse_accum, batch,
+                            query_length, heads, kv_capacity, num_splits, q_batch_stride,
+                            q_row_stride, q_head_stride, k_batch_stride, k_row_stride,
+                            k_head_stride, stream);
+            break;
+        default:
+            launch_typed<1>(q, k, v, kv_lengths, out, softmax_lse, out_accum, lse_accum, batch,
+                            query_length, heads, kv_capacity, num_splits, q_batch_stride,
+                            q_row_stride, q_head_stride, k_batch_stride, k_row_stride,
+                            k_head_stride, stream);
+            break;
+    }
+}

--- a/comfy_kitchen/flash_attention.py
+++ b/comfy_kitchen/flash_attention.py
@@ -6,13 +6,26 @@ import torch
 
 from .backends import cuda as _cuda_backend
 
+if getattr(torch.version, "hip", None):
+    from .backends import hip as _hip_backend
+else:
+    _hip_backend = None
+
 _MINIMUM_CAPABILITY = (8, 0)
 
 
 def is_available(device: torch.device | int | None = None) -> bool:
     """Return whether flash attention decode is available on this GPU."""
-    if not torch.cuda.is_available() or getattr(torch.version, "hip", None):
+    if not torch.cuda.is_available():
         return False
+    if _hip_backend is not None:
+        # torch.cuda is the ROCm API here, and get_device_capability reports
+        # something SM-shaped for a gfx part, so the compute capability test
+        # below would wave AMD hardware through to a CUDA extension that never
+        # loaded. Ask the HIP backend instead, which answers for the process
+        # rather than for one device: its arch gates take the intersection over
+        # every visible device, the way int8 attention and the op registry do.
+        return _hip_backend.flash_attention_decode_is_available()
     if (
         not _cuda_backend._EXT_AVAILABLE
         or _cuda_backend._C is None
@@ -49,7 +62,12 @@ def flash_attention_decode(
     batch, _, query_heads, head_dim = q.shape
     _, kv_capacity, kv_heads, _ = k.shape
     if not is_available(q.device):
-        raise RuntimeError("flash_attention_decode requires the CUDA extension on SM80 or newer")
+        raise RuntimeError(
+            "flash_attention_decode requires the HIP extension on an AMD device "
+            "with bf16 support (RDNA3 or newer)"
+            if _hip_backend is not None
+            else "flash_attention_decode requires the CUDA extension on SM80 or newer"
+        )
 
     groups = query_heads // kv_heads
     query = (
@@ -79,12 +97,18 @@ def flash_attention_decode(
         )
     else:
         softmax_lse_accum = output_accum = softmax_lse[:0]
-    _cuda_backend._C.flash_attention_decode(
-        *map(
-            _cuda_backend._wrap_for_dlpack,
-            (query, k, v, kv_lengths, output, softmax_lse, softmax_lse_accum, output_accum),
-        ),
-        num_splits,
-        torch.cuda.current_stream(q.device).cuda_stream,
-    )
+    if _hip_backend is not None:
+        _hip_backend.flash_decode(
+            query, k, v, kv_lengths, output, softmax_lse, softmax_lse_accum, output_accum,
+            num_splits,
+        )
+    else:
+        _cuda_backend._C.flash_attention_decode(
+            *map(
+                _cuda_backend._wrap_for_dlpack,
+                (query, k, v, kv_lengths, output, softmax_lse, softmax_lse_accum, output_accum),
+            ),
+            num_splits,
+            torch.cuda.current_stream(q.device).cuda_stream,
+        )
     return output.view(batch, groups, kv_heads, head_dim).transpose(1, 2).reshape_as(q)

--- a/tests/test_flash_attention.py
+++ b/tests/test_flash_attention.py
@@ -9,6 +9,78 @@ requires_flash_decode = pytest.mark.skipif(
     reason="requires the CUDA extension on SM80 or newer",
 )
 
+# The HIP binding takes plain ndarrays rather than device-typed ones, so it has
+# to reject a host operand and an off-boundary base itself.
+requires_hip_flash_decode = pytest.mark.skipif(
+    not ck.flash_attention_decode_is_available() or not getattr(torch.version, "hip", None),
+    reason="requires the HIP flash decode kernel",
+)
+
+
+def _decode_operands(batch=2, capacity=256, kv_heads=2, groups=4):
+    heads = kv_heads * groups
+    q = torch.randn(batch, 1, heads, 128, device="cuda", dtype=torch.bfloat16)
+    k = torch.randn(batch, capacity, kv_heads, 128, device="cuda", dtype=torch.bfloat16)
+    v = torch.randn_like(k)
+    lengths = torch.full((batch,), capacity, device="cuda", dtype=torch.int32)
+    return q, k, v, lengths
+
+
+@requires_hip_flash_decode
+def test_flash_attention_decode_rejects_host_lengths():
+    q, k, v, lengths = _decode_operands()
+    with pytest.raises(RuntimeError, match="must be ROCm device memory"):
+        ck.flash_attention_decode(q, k, v, lengths.cpu())
+    # The rejection must leave the context usable.
+    assert torch.isfinite(ck.flash_attention_decode(q, k, v, lengths).float()).all()
+
+
+@requires_hip_flash_decode
+def test_flash_attention_decode_rejects_pinned_host_memory():
+    # Pinned host memory reports kDLCUDAHost rather than kDLCPU, so a check for
+    # "not the CPU device" would wave these host pointers through. The launch
+    # goes through _C directly because the Python wrapper's stream lookup
+    # rejects a host tensor before the binding sees it.
+    from comfy_kitchen.backends import hip as hip_backend
+
+    batch, capacity, kv_heads, groups = 2, 128, 2, 4
+    pinned = [
+        torch.randn(batch * groups, kv_heads, 128, dtype=torch.bfloat16).pin_memory(),
+        torch.randn(batch, capacity, kv_heads, 128, dtype=torch.bfloat16).pin_memory(),
+        torch.randn(batch, capacity, kv_heads, 128, dtype=torch.bfloat16).pin_memory(),
+        torch.full((batch,), capacity, dtype=torch.int32).pin_memory(),
+        torch.empty(batch * groups, kv_heads, 128, dtype=torch.bfloat16).pin_memory(),
+        torch.empty(batch * kv_heads * groups, dtype=torch.float32).pin_memory(),
+    ]
+    assert pinned[0].__dlpack_device__()[0] != 1
+    empty = pinned[-1][:0]
+    args = [hip_backend._dl(t) for t in (*pinned, empty, empty)]
+    with pytest.raises(RuntimeError, match="must be ROCm device memory"):
+        hip_backend._C.flash_attention_decode(*args, 1, 0)
+
+
+@requires_hip_flash_decode
+def test_flash_attention_decode_rejects_strided_lengths():
+    # Read linearly off the base pointer, so a strided view of the right size
+    # would silently be taken as packed.
+    q, k, v, lengths = _decode_operands()
+    strided = torch.stack([lengths, torch.zeros_like(lengths)], dim=1).flatten()[::2]
+    assert not strided.is_contiguous() and strided.numel() == lengths.numel()
+    with pytest.raises(RuntimeError, match="must be contiguous"):
+        ck.flash_attention_decode(q, k, v, strided)
+
+
+@requires_hip_flash_decode
+def test_flash_attention_decode_rejects_misaligned_operand():
+    q, k, v, lengths = _decode_operands()
+    elements = k.numel()
+    storage = torch.randn(elements + 8, device="cuda", dtype=torch.bfloat16)
+    misaligned = storage[1 : 1 + elements].view_as(k)
+    assert misaligned.is_contiguous() and misaligned.data_ptr() % 8
+    with pytest.raises(RuntimeError, match="8-byte aligned"):
+        ck.flash_attention_decode(q, misaligned, v, lengths)
+
+
 
 def _reference(q, k, v, lengths):
     groups = q.shape[2] // k.shape[2]
@@ -56,8 +128,44 @@ def test_flash_attention_decode_availability_checks_capability_and_kernel(
     assert flash_attention_module.is_available() is expected
 
 
+@pytest.mark.parametrize("has_wmma", [True, False])
+def test_flash_attention_decode_hip_gate_follows_bf16_arch(monkeypatch, has_wmma):
+    """On ROCm the gate is the arch's bf16 support, not a compute capability.
+
+    torch.cuda is the ROCm API there and reports an SM-shaped capability for a
+    gfx part, so the CUDA test above would wave RDNA2 through. RDNA2 has no
+    bf16, and a caller that drops to another dtype there arrives with a KV
+    cache this kernel declines. WMMA marks the same line: gfx11 and newer.
+    """
+    if not getattr(torch.version, "hip", None):
+        pytest.skip("requires a ROCm PyTorch runtime")
+    if not flash_attention_module._hip_backend._EXT_AVAILABLE:
+        pytest.skip("requires the built HIP extension")
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(
+        flash_attention_module._hip_backend, "has_wmma", lambda: has_wmma
+    )
+    assert flash_attention_module.is_available() is has_wmma
+
+
 @requires_flash_decode
 def test_flash_attention_decode():
+    torch.manual_seed(0)
+    q = torch.randn(3, 1, 8, 128, device="cuda", dtype=torch.bfloat16)
+    k = torch.randn(3, 257, 2, 128, device="cuda", dtype=torch.bfloat16)
+    v = torch.randn_like(k)
+    lengths = torch.tensor([1, 73, 257], device="cuda", dtype=torch.int32)
+    actual = ck.flash_attention_decode(q, k, v, lengths)
+    torch.testing.assert_close(actual, _reference(q, k, v, lengths), atol=2e-3, rtol=1e-2)
+
+
+@requires_flash_decode
+@pytest.mark.parametrize("num_splits", [1, 2, 5, 32])
+def test_flash_attention_decode_split_counts(monkeypatch, num_splits):
+    # num_splits comes from a heuristic over multi_processor_count, so on a wide
+    # enough GPU it returns 1 and the split accumulators, the combine pass and
+    # its row decomposition never run. Pin it instead of hoping.
+    monkeypatch.setattr(flash_attention_module, "_num_splits", lambda *_, **__: num_splits)
     torch.manual_seed(0)
     q = torch.randn(3, 1, 8, 128, device="cuda", dtype=torch.bfloat16)
     k = torch.randn(3, 257, 2, 128, device="cuda", dtype=torch.bfloat16)


### PR DESCRIPTION
Adds `flash_attention_decode` to the HIP backend as an independent performance port of #111. It keeps the same launcher signature, split-then-combine structure, and Python API as CUDA, with a native HIP kernel in `ops/flash_decode.hip`.

`comfy_kitchen/flash_attention.py` now selects the backend like `sage_attention.py`. The GQA reshape, split heuristic, and workspace allocation remain shared.

## Kernel

The kernel targets GQA decode, which is primarily bandwidth- and latency-bound.

Key optimizations:

- 8 waves per block: Improves latency hiding. Benchmarks across 11 shapes showed 8 waves are 1.24x faster than 4 on average. 16 waves exceed the LDS limit at the widest tile.
- Branch-free prefetch: Uses a measured 4-16 key prefetch depth depending on tile size.
- DPP wave reduction: Replaces the LDS-based `ds_bpermute` reduction with a bit-identical DPP sequence, improving GQA performance by 1.7-2.2x.
- No WMMA: plain FMA, no matrix cores. Gated to RDNA 3 and RDNA 4, since RDNA 2 has no bf16.

## Performance

Compared with `scaled_dot_product_attention(enable_gqa)`, BF16, head_dim 128:

| batch | KV heads | groups | length | kernel | SDPA | speedup |
| --- | --- | --- | --- | --- | --- | --- |
| 1 | 8 | 4 | 4096 | 0.120 ms | 0.160 ms | 1.34x |
| 1 | 8 | 4 | 16384 | 0.291 ms | 0.661 ms | 2.28x |
| 1 | 8 | 4 | 32768 | 0.506 ms | 1.270 ms | 2.51x |
| 4 | 8 | 4 | 4096 | 0.275 ms | 0.387 ms | 1.41x |
| 4 | 8 | 4 | 16384 | 0.943 ms | 1.439 ms | 1.53x |
| 8 | 8 | 4 | 8192 | 0.912 ms | 1.398 ms | 1.53x |
| 1 | 32 | 1 | 8192 | 0.532 ms | 0.451 ms | 0.85x |
| 4 | 32 | 1 | 8192 | 1.872 ms | 1.737 ms | 0.93x |
| 1 | 4 | 8 | 16384 | 0.266 ms | 0.558 ms | 2.10x |

The main gains come from GQA reuse and avoiding unnecessary cache reads.

Variable-length decode shows larger gains because SDPA must process the full cache capacity:

| Fill | Kernel | SDPA | Speedup |
| --- | --- | --- | --- |
| 256 | 0.198 ms | 2.831 ms | 14.3x |
| 1024 | 0.202 ms | 2.831 ms | 14.0x |
| 4096 | 0.266 ms | 2.831 ms | 10.6x |
| 16384 | 0.939 ms | 2.831 ms | 3.0x |
| 32768 | 1.842 ms | 2.831 ms | 1.5x |

## Correctness

- Upstream flash-attention tests now run on ROCm, including graph capture.
- 54 shapes x 5 split configurations = 270 configurations, with zero failures.
- Worst relative max-abs error: 0.0035, consistent with BF16 rounding.
- All 17 targets build into the fat binary.
- Compile-verified on gfx1030, gfx1100, gfx1151, and gfx1200.
- Run-verified on 1200.
- Zero scratch usage and zero `ds_bpermute`.
- Full-suite failure set is unchanged: 107 pre-existing ROCm failures.
- Installed wheel tests: 64 passed, 9 skipped, up from 62 passed and 11 skipped.