### PR TITLE
Add fused HIP ConvRot INT8 activation quant with global spill for G=256 (RDNA3/3.5/4)

### DIFF
--- a/comfy_kitchen/backends/hip/__init__.py
+++ b/comfy_kitchen/backends/hip/__init__.py
@@ -554,7 +554,7 @@ def _rotate_quant_int8(
     # check_convrot_k queries the current device's LDS budget, so pin it to the
     # operand's device rather than trusting the caller thread's current device.
     with torch.cuda.device(x2d.device):
-        if group_size == 256 and _C.convrot_int8_needs_spill(m, k):
+        if group_size == 256 and _C.convrot_int8_needs_spill(m, k, DTYPE_TO_CODE[x2d.dtype]):
             spill_rotated = torch.empty((m, k), dtype=x2d.dtype, device=x2d.device)
             spill_partials = torch.empty((m, k // 256), dtype=torch.float32, device=x2d.device)
         _C.quantize_int8_convrot(

--- a/comfy_kitchen/backends/hip/__init__.py
+++ b/comfy_kitchen/backends/hip/__init__.py
@@ -512,22 +512,23 @@ _convrot_max_k: dict[tuple[int, torch.dtype], int] = {}
 
 
 def _convrot_supported(
-    k: int, group_size: int, device: torch.device, dtype: torch.dtype
+    k: int, group_size: int, device: torch.device, dtype: torch.dtype,
+    *, int8_global_spill: bool = False,
 ) -> bool:
-    """Whether the fused rotation can take a row of this width on ``device``.
+    """Whether the HIP ConvRot quantizer can handle a row of this width on ``device``.
 
-    It stages the whole row in LDS, which bounds K per device, and it rotates K/G
-    whole groups while reading back all K entries, so a partial trailing group
-    would quantize uninitialized LDS.
-
-    The budget is read for the operand's own device, not the process-current one:
-    the kernels launch on the operand's stream, so in a multi-GPU process the two
-    can be different cards with different budgets.
+    INT8 G=256 with ``int8_global_spill`` uses fused LDS or global spill; K need only
+    divide the group size. Other paths stage the whole row in LDS (K bounded per device).
+    The kernel rotates K/G whole groups; a partial trailing group would quantize
+    uninitialized LDS. The LDS budget is read for the operand's device, not the
+    process-current one.
     """
     if group_size not in (16, 64, 256) or k % group_size != 0:
         return False
     if dtype not in (torch.float32, torch.float16, torch.bfloat16):
         return False
+    if group_size == 256 and int8_global_spill:
+        return True
 
     index = device.index if device.index is not None else torch.cuda.current_device()
     key = (index, dtype)
@@ -570,7 +571,7 @@ def quantize_and_rotate_rowwise(
     argument is accepted and unused.
     """
     if stochastic_rounding or not _convrot_supported(
-        x.shape[-1], group_size, x.device, x.dtype
+        x.shape[-1], group_size, x.device, x.dtype, int8_global_spill=True
     ):
         return _eager.quantize_and_rotate_rowwise(
             x, h, group_size, stochastic_rounding=stochastic_rounding
@@ -591,7 +592,7 @@ def quantize_int8_convrot_weight(
     Uses the same fused kernel as the activation path.
     """
     if stochastic_rounding or not _convrot_supported(
-        weight.shape[-1], group_size, weight.device, weight.dtype
+        weight.shape[-1], group_size, weight.device, weight.dtype, int8_global_spill=True
     ):
         return _eager.quantize_int8_convrot_weight(
             weight, group_size, stochastic_rounding=stochastic_rounding
@@ -646,7 +647,9 @@ def int8_linear(
             raise ValueError(
                 f"ConvRot group size {convrot_groupsize} does not divide input features {k}"
             )
-        if not _convrot_supported(k, convrot_groupsize, x.device, x.dtype):
+        if not _convrot_supported(
+            k, convrot_groupsize, x.device, x.dtype, int8_global_spill=True
+        ):
             return _eager.int8_linear(
                 x, weight, weight_scale, bias, out_dtype, convrot, convrot_groupsize,
                 input_act=input_act,
@@ -1004,10 +1007,12 @@ def w4a8_int8_linear(
         )
         return torch.nn.functional.linear(x, weight, bias).to(out_dtype)
 
-    # The layout allows any ConvRot group that divides K; the fused activation
-    # quantizer takes only the three it has butterfly stages for, and its LDS
-    # budget bounds K. int8_linear applies the same test before its own fast path.
-    if not _convrot_supported(x.shape[-1], convrot_groupsize, x.device, x.dtype):
+    # The layout allows any ConvRot group that divides K; INT8 G=256 can spill to
+    # global memory when K exceeds the fused LDS budget. int8_linear applies the
+    # same test before its own fast path.
+    if not _convrot_supported(
+        x.shape[-1], convrot_groupsize, x.device, x.dtype, int8_global_spill=True
+    ):
         int8_weight = _dequant_int4_grouped_to_int8(qdata, s_rel, codebook, group_size)
         return _eager.int8_linear(
             x, int8_weight, s_channel, bias, out_dtype, True, convrot_groupsize

--- a/comfy_kitchen/backends/hip/__init__.py
+++ b/comfy_kitchen/backends/hip/__init__.py
@@ -551,12 +551,12 @@ def _rotate_quant_int8(
     x_arg = _operand(x2d, x2d.device, "x2d")
     spill_rotated = None
     spill_partials = None
-    if group_size == 256:
-        spill_rotated = torch.empty((m, k), dtype=x2d.dtype, device=x2d.device)
-        spill_partials = torch.empty((m, k // 256), dtype=torch.float32, device=x2d.device)
     # check_convrot_k queries the current device's LDS budget, so pin it to the
     # operand's device rather than trusting the caller thread's current device.
     with torch.cuda.device(x2d.device):
+        if group_size == 256 and _C.convrot_int8_needs_spill(m, k):
+            spill_rotated = torch.empty((m, k), dtype=x2d.dtype, device=x2d.device)
+            spill_partials = torch.empty((m, k // 256), dtype=torch.float32, device=x2d.device)
         _C.quantize_int8_convrot(
             _dl(x_arg),
             _dl(q),

--- a/comfy_kitchen/backends/hip/__init__.py
+++ b/comfy_kitchen/backends/hip/__init__.py
@@ -548,12 +548,26 @@ def _rotate_quant_int8(
     k = k_in // _input_act_width(input_act)
     q = torch.empty((m, k), dtype=torch.int8, device=x2d.device)
     scales = torch.empty((m,), dtype=torch.float32, device=x2d.device)
+    x_arg = _operand(x2d, x2d.device, "x2d")
+    spill_rotated = None
+    spill_partials = None
+    if group_size == 256:
+        spill_rotated = torch.empty((m, k), dtype=x2d.dtype, device=x2d.device)
+        spill_partials = torch.empty((m, k // 256), dtype=torch.float32, device=x2d.device)
     # check_convrot_k queries the current device's LDS budget, so pin it to the
     # operand's device rather than trusting the caller thread's current device.
     with torch.cuda.device(x2d.device):
         _C.quantize_int8_convrot(
-            _dl(x2d), _dl(q), _dl(scales), m, k, group_size,
-            _input_act_code(input_act), _stream(x2d),
+            _dl(x_arg),
+            _dl(q),
+            _dl(scales),
+            None if spill_rotated is None else _dl(spill_rotated),
+            None if spill_partials is None else _dl(spill_partials),
+            m,
+            k,
+            group_size,
+            _input_act_code(input_act),
+            _stream(x2d),
         )
     return q, scales
 

--- a/comfy_kitchen/backends/hip/dlpack_bindings.cpp
+++ b/comfy_kitchen/backends/hip/dlpack_bindings.cpp
@@ -403,7 +403,7 @@ void quantize_int8_rowwise(nb::ndarray<> x, nb::ndarray<> q, nb::ndarray<> scale
 
 // act_code folds an elementwise activation into the rotation's load.
 void quantize_int8_convrot(nb::ndarray<> x, nb::ndarray<> q, nb::ndarray<> scales,
-                           nb::object spill_rotated, nb::object spill_partials, int M, int K,
+                           OptArray spill_rotated, OptArray spill_partials, int M, int K,
                            int group_size, int act_code, uintptr_t stream_ptr) {
     constexpr const char* kFn = "quantize_int8_convrot";
     require_nonneg(M, kFn, "M");
@@ -419,20 +419,18 @@ void quantize_int8_convrot(nb::ndarray<> x, nb::ndarray<> q, nb::ndarray<> scale
 
     void* spill_rotated_ptr = nullptr;
     void* spill_partials_ptr = nullptr;
-    if (!spill_rotated.is_none()) {
-        auto rotated = nb::cast<nb::ndarray<>>(spill_rotated);
-        require_dtype(rotated, 0, 2, kFn, "spill_rotated");
-        require_len(rotated, static_cast<int64_t>(M) * K, kFn, "spill_rotated");
-        if (map_dtype_to_code(rotated.dtype()) != map_dtype_to_code(x.dtype())) {
+    if (spill_rotated.has_value()) {
+        require_dtype(*spill_rotated, 0, 2, kFn, "spill_rotated");
+        require_len(*spill_rotated, static_cast<int64_t>(M) * K, kFn, "spill_rotated");
+        if (map_dtype_to_code(spill_rotated->dtype()) != map_dtype_to_code(x.dtype())) {
             throw std::runtime_error(std::string(kFn) + ": spill_rotated dtype must match x");
         }
-        spill_rotated_ptr = rotated.data();
+        spill_rotated_ptr = spill_rotated->data();
     }
-    if (!spill_partials.is_none()) {
-        auto partials = nb::cast<nb::ndarray<>>(spill_partials);
-        require_dtype(partials, 0, 0, kFn, "spill_partials");
-        require_len(partials, static_cast<int64_t>(M) * (K / 256), kFn, "spill_partials");
-        spill_partials_ptr = partials.data();
+    if (spill_partials.has_value()) {
+        require_dtype(*spill_partials, 0, 0, kFn, "spill_partials");
+        require_len(*spill_partials, static_cast<int64_t>(M) * (K / 256), kFn, "spill_partials");
+        spill_partials_ptr = spill_partials->data();
     }
 
     launch_quantize_int8_convrot_kernel(x.data(), map_dtype_to_code(x.dtype()), q.data(),

--- a/comfy_kitchen/backends/hip/dlpack_bindings.cpp
+++ b/comfy_kitchen/backends/hip/dlpack_bindings.cpp
@@ -59,7 +59,7 @@ void launch_dequantize_int8_convrot_weight_kernel(const void*, const void*, void
 void launch_convrot_quant_int4_kernel(const void*, int, void*, void*, int, int, int, hipStream_t);
 void launch_unpack_int4_kernel(const void*, void*, int64_t, hipStream_t);
 int convrot_max_k_host(int);
-int convrot_int8_needs_spill_host(int, int);
+int convrot_int8_needs_spill_host(int, int, int);
 
 void launch_quantize_w4a8_convrot_kernel(const void*, const void*, void*, void*, void*, int64_t,
                                          int64_t, int, bool, uint64_t, hipStream_t);
@@ -1380,7 +1380,8 @@ NB_MODULE(_C, m) {
     m.def("dequantize_int8_convrot_weight", &dequantize_int8_convrot_weight);
     m.def("convrot_quant_int4", &convrot_quant_int4);
     m.def("convrot_max_k", &convrot_max_k_host);
-    m.def("convrot_int8_needs_spill", &convrot_int8_needs_spill_host);
+    m.def("convrot_int8_needs_spill", &convrot_int8_needs_spill_host, nb::arg("m"),
+          nb::arg("k"), nb::arg("in_code"));
     m.def("unpack_int4", &unpack_int4);
     m.def("dequant_int4_grouped_to_int8", &dequant_int4_grouped_to_int8);
     m.def("quantize_w4a8_convrot", &quantize_w4a8_convrot);

--- a/comfy_kitchen/backends/hip/dlpack_bindings.cpp
+++ b/comfy_kitchen/backends/hip/dlpack_bindings.cpp
@@ -48,8 +48,8 @@ void launch_convrot_w4a4_gemm_kernel(const void*, const void*, void*, const void
                                      const void*, int, int, int, int, int, hipStream_t);
 
 void launch_quantize_int8_rowwise_kernel(const void*, int, void*, void*, int, int, hipStream_t);
-void launch_quantize_int8_convrot_kernel(const void*, int, void*, void*, int, int, int, int,
-                                         hipStream_t);
+void launch_quantize_int8_convrot_kernel(const void*, int, void*, void*, void*, void*, int, int,
+                                         int, int, hipStream_t);
 void launch_quantize_int8_tensorwise_kernel(const void*, int, void*, void*, void*, int64_t,
                                             hipStream_t);
 void launch_dequantize_int8_simple_kernel(const void*, const void*, void*, int64_t, int64_t, int,
@@ -401,7 +401,8 @@ void quantize_int8_rowwise(nb::ndarray<> x, nb::ndarray<> q, nb::ndarray<> scale
 }
 
 // act_code folds an elementwise activation into the rotation's load.
-void quantize_int8_convrot(nb::ndarray<> x, nb::ndarray<> q, nb::ndarray<> scales, int M, int K,
+void quantize_int8_convrot(nb::ndarray<> x, nb::ndarray<> q, nb::ndarray<> scales,
+                           nb::object spill_rotated, nb::object spill_partials, int M, int K,
                            int group_size, int act_code, uintptr_t stream_ptr) {
     constexpr const char* kFn = "quantize_int8_convrot";
     require_nonneg(M, kFn, "M");
@@ -415,8 +416,29 @@ void quantize_int8_convrot(nb::ndarray<> x, nb::ndarray<> q, nb::ndarray<> scale
     require_len(q, static_cast<int64_t>(M) * K, kFn, "q");
     require_scale_len(scales, static_cast<size_t>(M), kFn, "scales");
 
+    void* spill_rotated_ptr = nullptr;
+    void* spill_partials_ptr = nullptr;
+    if (!spill_rotated.is_none()) {
+        auto rotated = nb::cast<nb::ndarray<>>(spill_rotated);
+        require_dtype(rotated, 0, 2, kFn, "spill_rotated");
+        require_len(rotated, static_cast<int64_t>(M) * K, kFn, "spill_rotated");
+        spill_rotated_ptr = rotated.data();
+    }
+    if (!spill_partials.is_none()) {
+        auto partials = nb::cast<nb::ndarray<>>(spill_partials);
+        require_dtype(partials, 0, 0, kFn, "spill_partials");
+        require_len(partials, static_cast<int64_t>(M) * (K / 256), kFn, "spill_partials");
+        spill_partials_ptr = partials.data();
+    }
+    if (group_size == 256 && (spill_rotated_ptr == nullptr || spill_partials_ptr == nullptr)) {
+        throw std::runtime_error(
+            std::string(kFn) +
+            ": spill_rotated and spill_partials are required for group_size=256");
+    }
+
     launch_quantize_int8_convrot_kernel(x.data(), map_dtype_to_code(x.dtype()), q.data(),
-                                        scales.data(), M, K, group_size, act_code,
+                                        scales.data(), spill_rotated_ptr, spill_partials_ptr, M, K,
+                                        group_size, act_code,
                                         reinterpret_cast<hipStream_t>(stream_ptr));
     check_hip_launch();
 }

--- a/comfy_kitchen/backends/hip/dlpack_bindings.cpp
+++ b/comfy_kitchen/backends/hip/dlpack_bindings.cpp
@@ -59,6 +59,7 @@ void launch_dequantize_int8_convrot_weight_kernel(const void*, const void*, void
 void launch_convrot_quant_int4_kernel(const void*, int, void*, void*, int, int, int, hipStream_t);
 void launch_unpack_int4_kernel(const void*, void*, int64_t, hipStream_t);
 int convrot_max_k_host(int);
+int convrot_int8_needs_spill_host(int, int);
 
 void launch_quantize_w4a8_convrot_kernel(const void*, const void*, void*, void*, void*, int64_t,
                                          int64_t, int, bool, uint64_t, hipStream_t);
@@ -422,6 +423,9 @@ void quantize_int8_convrot(nb::ndarray<> x, nb::ndarray<> q, nb::ndarray<> scale
         auto rotated = nb::cast<nb::ndarray<>>(spill_rotated);
         require_dtype(rotated, 0, 2, kFn, "spill_rotated");
         require_len(rotated, static_cast<int64_t>(M) * K, kFn, "spill_rotated");
+        if (map_dtype_to_code(rotated.dtype()) != map_dtype_to_code(x.dtype())) {
+            throw std::runtime_error(std::string(kFn) + ": spill_rotated dtype must match x");
+        }
         spill_rotated_ptr = rotated.data();
     }
     if (!spill_partials.is_none()) {
@@ -429,11 +433,6 @@ void quantize_int8_convrot(nb::ndarray<> x, nb::ndarray<> q, nb::ndarray<> scale
         require_dtype(partials, 0, 0, kFn, "spill_partials");
         require_len(partials, static_cast<int64_t>(M) * (K / 256), kFn, "spill_partials");
         spill_partials_ptr = partials.data();
-    }
-    if (group_size == 256 && (spill_rotated_ptr == nullptr || spill_partials_ptr == nullptr)) {
-        throw std::runtime_error(
-            std::string(kFn) +
-            ": spill_rotated and spill_partials are required for group_size=256");
     }
 
     launch_quantize_int8_convrot_kernel(x.data(), map_dtype_to_code(x.dtype()), q.data(),
@@ -1383,6 +1382,7 @@ NB_MODULE(_C, m) {
     m.def("dequantize_int8_convrot_weight", &dequantize_int8_convrot_weight);
     m.def("convrot_quant_int4", &convrot_quant_int4);
     m.def("convrot_max_k", &convrot_max_k_host);
+    m.def("convrot_int8_needs_spill", &convrot_int8_needs_spill_host);
     m.def("unpack_int4", &unpack_int4);
     m.def("dequant_int4_grouped_to_int8", &dequant_int4_grouped_to_int8);
     m.def("quantize_w4a8_convrot", &quantize_w4a8_convrot);

--- a/comfy_kitchen/backends/hip/hadamard.h
+++ b/comfy_kitchen/backends/hip/hadamard.h
@@ -33,6 +33,7 @@ inline void check_convrot_group_size(int group_size) {
 
 // The kernel's static LDS: butterfly workspace + row absmax reduction (up to 1024 threads).
 constexpr size_t kConvrotStaticLds = 2 * 1024 * sizeof(float);
+constexpr int kConvRotGroup256 = 256;
 
 // convrot_quant_kernel stages the whole rotated row in dynamic LDS, preserving
 // the input dtype's rounding contract. K is therefore bounded by both the
@@ -64,34 +65,55 @@ inline int convrot_max_k(int in_dtype) {
                             element_size);
 }
 
-// Max K for INT8 G=256 fused quant in LDS; larger K uses the global spill path.
-// 0 if the device LDS budget is unknown or too small (dtype-independent: fused widens to float).
-inline int convrot_fused_lds_max_k() {
-    int device = 0;
-    if (hipGetDevice(&device) != hipSuccess) {
-        return 0;
+inline int convrot_quant_fused_block_threads(int M, int K) {
+    if (M == 1) {
+        return 512;
     }
+    if (K == kConvRotGroup256) {
+        return 64;
+    }
+    if (K == 2560) {
+        return 640;
+    }
+    if (K == 6144) {
+        return 768;
+    }
+    return 1024;
+}
+
+inline bool convrot_fused_lds_fits(int K, int block_threads) {
+    if (block_threads <= 0 || (block_threads % 64) != 0) {
+        return false;
+    }
+    int device = 0;
     int lds = 0;
-    if (hipDeviceGetAttribute(&lds, hipDeviceAttributeMaxSharedMemoryPerBlock, device) !=
+    if (hipGetDevice(&device) != hipSuccess ||
+        hipDeviceGetAttribute(&lds, hipDeviceAttributeMaxSharedMemoryPerBlock, device) !=
             hipSuccess ||
         lds <= 0) {
-        return 0;
+        return false;
     }
-    // Fused path uses 1024-thread blocks for most shapes (including K=3840); that block
-    // size has the largest tmp footprint.
-    constexpr int kBlockThreads = 1024;
-    constexpr int kWarps = kBlockThreads / 32;
-    const size_t static_lds = kWarps * sizeof(float) + sizeof(float);
-    if (static_cast<size_t>(lds) <= static_lds) {
-        return 0;
+    const int groups_in_flight = block_threads / 64;
+    const size_t need =
+        (static_cast<size_t>(block_threads / 32) + 1) * sizeof(float) +
+        (static_cast<size_t>(K) + static_cast<size_t>(groups_in_flight) * 2 * kConvRotGroup256) *
+            sizeof(float);
+    return need <= static_cast<size_t>(lds);
+}
+
+// Heuristic block first, then narrower blocks before global spill. Returns 0 to spill.
+inline int convrot_pick_fused_block_threads(int M, int K) {
+    const int preferred = convrot_quant_fused_block_threads(M, K);
+    if (convrot_fused_lds_fits(K, preferred)) {
+        return preferred;
     }
-    const size_t budget = static_cast<size_t>(lds) - static_lds;
-    const int groups_in_flight = kBlockThreads / 64;
-    const size_t overhead = static_cast<size_t>(groups_in_flight) * 2 * 256 * sizeof(float);
-    if (budget <= overhead) {
-        return 0;
+    static constexpr int kFallbackBlocks[] = {768, 640, 512, 64};
+    for (int block_threads : kFallbackBlocks) {
+        if (block_threads != preferred && convrot_fused_lds_fits(K, block_threads)) {
+            return block_threads;
+        }
     }
-    return static_cast<int>((budget - overhead) / sizeof(float));
+    return 0;
 }
 
 inline void check_convrot_k(int k, int group_size, int in_dtype, bool int8_quant = false) {
@@ -219,7 +241,6 @@ __forceinline__ __device__ float load_row_value<__half>(__half v) {
     return __half2float(v);
 }
 
-constexpr int kConvRotGroup256 = 256;
 constexpr int kWarpSize = 32;
 
 __forceinline__ __device__ float warp_reduce_max(float v) {
@@ -548,22 +569,6 @@ __global__ __launch_bounds__(BLOCK_THREADS) void convrot_quant_fused_kernel(
     }
 }
 
-inline int convrot_quant_fused_block_threads(int M, int K) {
-    if (M == 1) {
-        return 512;
-    }
-    if (K == kConvRotGroup256) {
-        return 64;
-    }
-    if (K == 2560) {
-        return 640;
-    }
-    if (K == 6144) {
-        return 768;
-    }
-    return 1024;
-}
-
 template <typename RowT, int ACT, int BLOCK_THREADS>
 inline void launch_convrot_quant_fused_impl(
     const void* x, int in_dtype, int8_t* qout, float* scaleout, int M, int K,
@@ -763,13 +768,17 @@ inline void launch_convrot_quant(
     const void* x, int in_dtype, int8_t* qout, float* scaleout,
     int M, int K, int group_size, hipStream_t stream) {
 
-    // INT8 G=256: fused single-kernel quant when K fits in LDS, else global spill.
+    // INT8 G=256: fused when (M, K) fits in LDS, else global spill.
     if (!PACK_INT4 && group_size == 256) {
-        if (K > convrot_fused_lds_max_k()) {
+        const int block_threads = convrot_pick_fused_block_threads(M, K);
+        if (block_threads > 0) {
+            dispatch_convrot_row_type(
+                in_dtype,
+                LaunchConvrotQuantFusedForRow<ACT>{
+                    x, in_dtype, qout, scaleout, M, K, stream, block_threads});
+        } else {
             launch_convrot_quant_global_managed<ACT>(
                 x, in_dtype, qout, scaleout, M, K, stream);
-        } else {
-            launch_convrot_quant_fused<ACT>(x, in_dtype, qout, scaleout, M, K, stream);
         }
         return;
     }

--- a/comfy_kitchen/backends/hip/hadamard.h
+++ b/comfy_kitchen/backends/hip/hadamard.h
@@ -79,6 +79,10 @@ inline int convrot_quant_fused_block_threads(int M, int K) {
     if (K == 6144) {
         return 768;
     }
+    // Empirical block-size tuning for K=10240 (640 over default).
+    if (K == 10240) {
+        return 640;
+    }
     return 1024;
 }
 
@@ -103,8 +107,12 @@ inline int convrot_device_lds_limit() {
     return cached_lds;
 }
 
-inline bool convrot_fused_lds_fits(int K, int block_threads) {
+inline bool convrot_fused_lds_fits(int K, int block_threads, int in_dtype) {
     if (block_threads <= 0 || (block_threads % 64) != 0) {
+        return false;
+    }
+    const size_t row_element_size = convrot_row_element_size(in_dtype);
+    if (row_element_size == 0) {
         return false;
     }
     const int lds = convrot_device_lds_limit();
@@ -114,20 +122,20 @@ inline bool convrot_fused_lds_fits(int K, int block_threads) {
     const int groups_in_flight = block_threads / 64;
     const size_t need =
         (static_cast<size_t>(block_threads / 32) + 1) * sizeof(float) +
-        (static_cast<size_t>(K) + static_cast<size_t>(groups_in_flight) * 2 * kConvRotGroup256) *
-            sizeof(float);
+        static_cast<size_t>(K) * row_element_size +
+        static_cast<size_t>(groups_in_flight) * 2 * kConvRotGroup256 * sizeof(float);
     return need <= static_cast<size_t>(lds);
 }
 
 // Heuristic block first, then narrower blocks before global spill. Returns 0 to spill.
-inline int convrot_pick_fused_block_threads(int M, int K) {
+inline int convrot_pick_fused_block_threads(int M, int K, int in_dtype) {
     const int preferred = convrot_quant_fused_block_threads(M, K);
-    if (convrot_fused_lds_fits(K, preferred)) {
+    if (convrot_fused_lds_fits(K, preferred, in_dtype)) {
         return preferred;
     }
     static constexpr int kFallbackBlocks[] = {768, 640, 512, 64};
     for (int block_threads : kFallbackBlocks) {
-        if (block_threads < preferred && convrot_fused_lds_fits(K, block_threads)) {
+        if (block_threads < preferred && convrot_fused_lds_fits(K, block_threads, in_dtype)) {
             return block_threads;
         }
     }
@@ -788,7 +796,7 @@ inline void launch_convrot_quant(
 
     // INT8 G=256: fused when (M, K) fits in LDS, else caller-owned global spill.
     if (!PACK_INT4 && group_size == 256) {
-        const int block_threads = convrot_pick_fused_block_threads(M, K);
+        const int block_threads = convrot_pick_fused_block_threads(M, K, in_dtype);
         if (block_threads > 0) {
             bool launched = false;
             dispatch_convrot_row_type(

--- a/comfy_kitchen/backends/hip/hadamard.h
+++ b/comfy_kitchen/backends/hip/hadamard.h
@@ -338,7 +338,11 @@ __forceinline__ __device__ float convrot_fht_stage64_store_absmax_typed(
     output[base + S] = store_row_value<RowT>(y1);
     output[base + 2 * S] = store_row_value<RowT>(y2);
     output[base + 3 * S] = store_row_value<RowT>(y3);
-    return fmaxf(fmaxf(fabsf(y0), fabsf(y1)), fmaxf(fabsf(y2), fabsf(y3)));
+    const float a0 = fabsf(load_row_value(output[base]));
+    const float a1 = fabsf(load_row_value(output[base + S]));
+    const float a2 = fabsf(load_row_value(output[base + 2 * S]));
+    const float a3 = fabsf(load_row_value(output[base + 3 * S]));
+    return fmaxf(fmaxf(a0, a1), fmaxf(a2, a3));
 }
 
 template <typename RowT>
@@ -495,7 +499,7 @@ void launch_convrot_quant_global_managed(
     void* spill_rotated, void* spill_partials);
 
 // Fused single-kernel path: FHT in LDS, vectorized loads, warp-shuffle absmax.
-// One block per row; the rotated row stays in shared memory as float.
+// One block per row; the rotated row stays in shared memory as RowT.
 template <typename RowT, int BLOCK_THREADS, int ACT>
 __global__ __launch_bounds__(BLOCK_THREADS) void convrot_quant_fused_kernel(
     const void* __restrict__ x, int in_dtype, int8_t* __restrict__ qout,
@@ -505,9 +509,9 @@ __global__ __launch_bounds__(BLOCK_THREADS) void convrot_quant_fused_kernel(
     constexpr int kGroupsInFlight = BLOCK_THREADS / kGroupThreads;
     constexpr int kWarps = BLOCK_THREADS / kWarpSize;
 
-    extern __shared__ float smem[];
-    float* row_buf = smem;
-    float* tmp = smem + K;
+    extern __shared__ unsigned char smem_raw[];
+    RowT* row_buf = reinterpret_cast<RowT*>(smem_raw);
+    float* tmp = reinterpret_cast<float*>(smem_raw + static_cast<size_t>(K) * sizeof(RowT));
 
     __shared__ float warp_smem[kWarps];
     __shared__ float block_smem;
@@ -567,7 +571,9 @@ __global__ __launch_bounds__(BLOCK_THREADS) void convrot_quant_fused_kernel(
 
         if (active) {
             abs_max = fmaxf(
-                abs_max, convrot_fht_stage64_store_absmax<64>(buf1, row_buf + group_col, lane));
+                abs_max,
+                convrot_fht_stage64_store_absmax_typed<64, RowT>(
+                    buf1, row_buf + group_col, lane));
         }
         __syncthreads();
     }
@@ -581,7 +587,7 @@ __global__ __launch_bounds__(BLOCK_THREADS) void convrot_quant_fused_kernel(
     }
 
     for (int col = tid; col < K; col += BLOCK_THREADS) {
-        const float v = row_buf[col];
+        const float v = load_row_value(row_buf[col]);
         int q = static_cast<int>(rintf(v * inv));
         q = q < -127 ? -127 : (q > 127 ? 127 : q);
         qout[row_offset + col] = static_cast<int8_t>(q);
@@ -594,8 +600,8 @@ inline bool launch_convrot_quant_fused_impl(
     hipStream_t stream) {
     const int groups_in_flight = BLOCK_THREADS / 64;
     const size_t shmem =
-        (static_cast<size_t>(K) + static_cast<size_t>(groups_in_flight) * 2 * kConvRotGroup256) *
-        sizeof(float);
+        static_cast<size_t>(K) * sizeof(RowT) +
+        static_cast<size_t>(groups_in_flight) * 2 * kConvRotGroup256 * sizeof(float);
     auto kernel = convrot_quant_fused_kernel<RowT, BLOCK_THREADS, ACT>;
     const hipError_t attr_err = hipFuncSetAttribute(
         reinterpret_cast<const void*>(kernel), hipFuncAttributeMaxDynamicSharedMemorySize,

--- a/comfy_kitchen/backends/hip/hadamard.h
+++ b/comfy_kitchen/backends/hip/hadamard.h
@@ -7,13 +7,15 @@
 // factors into log4(G) radix-4 butterfly stages over the base-4 digits of the
 // index, matching the eager _rotate_activation reference.
 //
-// One block per row: transform each G-group in LDS, track the row absmax, then
-// quantize. INT4 output packs two nibbles per byte (low nibble = even index),
-// which is the layout the iu4 A-fragment consumes directly.
+// INT8 G=256: fused single-kernel path when K fits in LDS, otherwise a global
+// rotate + quantize split. Legacy G=16/64 and int4 paths stage the whole row in
+// LDS (one block per row). INT4 output packs two nibbles per byte (low nibble =
+// even index), which is the layout the iu4 A-fragment consumes directly.
 #pragma once
 
 #include <stdexcept>
 #include <string>
+#include <type_traits>
 
 #include <hip/hip_fp16.h>
 #include <hip/hip_runtime.h>
@@ -29,8 +31,8 @@ inline void check_convrot_group_size(int group_size) {
     }
 }
 
-// The kernel's static LDS: the g[256] and red[256] reductions below.
-constexpr size_t kConvrotStaticLds = 2 * 256 * sizeof(float);
+// The kernel's static LDS: butterfly workspace + row absmax reduction (up to 1024 threads).
+constexpr size_t kConvrotStaticLds = 2 * 1024 * sizeof(float);
 
 // convrot_quant_kernel stages the whole rotated row in dynamic LDS, preserving
 // the input dtype's rounding contract. K is therefore bounded by both the
@@ -62,17 +64,82 @@ inline int convrot_max_k(int in_dtype) {
                             element_size);
 }
 
-inline void check_convrot_k(int k, int group_size, int in_dtype) {
+// Max K for INT8 G=256 fused quant in LDS; larger K uses the global spill path.
+// 0 if the device LDS budget is unknown or too small (dtype-independent: fused widens to float).
+inline int convrot_fused_lds_max_k() {
+    int device = 0;
+    if (hipGetDevice(&device) != hipSuccess) {
+        return 0;
+    }
+    int lds = 0;
+    if (hipDeviceGetAttribute(&lds, hipDeviceAttributeMaxSharedMemoryPerBlock, device) !=
+            hipSuccess ||
+        lds <= 0) {
+        return 0;
+    }
+    // Fused path uses 1024-thread blocks for most shapes (including K=3840); that block
+    // size has the largest tmp footprint.
+    constexpr int kBlockThreads = 1024;
+    constexpr int kWarps = kBlockThreads / 32;
+    const size_t static_lds = kWarps * sizeof(float) + sizeof(float);
+    if (static_cast<size_t>(lds) <= static_lds) {
+        return 0;
+    }
+    const size_t budget = static_cast<size_t>(lds) - static_lds;
+    const int groups_in_flight = kBlockThreads / 64;
+    const size_t overhead = static_cast<size_t>(groups_in_flight) * 2 * 256 * sizeof(float);
+    if (budget <= overhead) {
+        return 0;
+    }
+    return static_cast<int>((budget - overhead) / sizeof(float));
+}
+
+inline void check_convrot_k(int k, int group_size, int in_dtype, bool int8_quant = false) {
     // The kernel rotates K/G whole groups but reads back all K entries of the row
     // buffer, so a partial trailing group would quantize uninitialized LDS.
     if (group_size <= 0 || k % group_size != 0) {
         throw std::runtime_error("convrot: K=" + std::to_string(k) +
                                  " is not divisible by group_size=" + std::to_string(group_size));
     }
+    // INT8 G=256 uses fused LDS or global spill; int4 and G=16/64 still stage the
+    // whole row in dynamic LDS and are bounded by convrot_max_k().
+    if (int8_quant && group_size == 256) {
+        return;
+    }
     const int max_k = convrot_max_k(in_dtype);
     if (max_k <= 0 || k > max_k) {
         throw std::runtime_error("convrot: K=" + std::to_string(k) +
                                  " does not fit in LDS (max " + std::to_string(max_k) + ")");
+    }
+}
+
+// Runtime in_dtype (0/1/2) -> RowT template dispatch for convrot launchers.
+template <typename Fn>
+inline void dispatch_convrot_row_type(int in_dtype, Fn fn) {
+    if (in_dtype == 0) {
+        fn.template operator()<float>();
+    } else if (in_dtype == 1) {
+        fn.template operator()<__half>();
+    } else if (in_dtype == 2) {
+        fn.template operator()<__bf16>();
+    } else {
+        throw std::runtime_error("convrot: unsupported input dtype code");
+    }
+}
+
+// Pick fused-kernel block width from convrot_quant_fused_block_threads().
+template <typename Fn>
+inline void dispatch_convrot_fused_block_threads(int block_threads, Fn fn) {
+    if (block_threads == 64) {
+        fn.template operator()<64>();
+    } else if (block_threads == 512) {
+        fn.template operator()<512>();
+    } else if (block_threads == 640) {
+        fn.template operator()<640>();
+    } else if (block_threads == 768) {
+        fn.template operator()<768>();
+    } else {
+        fn.template operator()<1024>();
     }
 }
 
@@ -121,6 +188,17 @@ __forceinline__ __device__ float load_input_act(
     }
 }
 
+__forceinline__ __device__ void load_input_act4_bf16(
+    const void* x, int64_t in_row, int col, float& o0, float& o1, float& o2, float& o3) {
+    const __bf16* row = static_cast<const __bf16*>(x) + in_row + col;
+    const uint64_t pack = *reinterpret_cast<const uint64_t*>(row);
+    const __bf16* elems = reinterpret_cast<const __bf16*>(&pack);
+    o0 = static_cast<float>(elems[0]);
+    o1 = static_cast<float>(elems[1]);
+    o2 = static_cast<float>(elems[2]);
+    o3 = static_cast<float>(elems[3]);
+}
+
 template <typename RowT>
 __forceinline__ __device__ RowT store_row_value(float v) {
     return static_cast<RowT>(v);
@@ -141,15 +219,426 @@ __forceinline__ __device__ float load_row_value<__half>(__half v) {
     return __half2float(v);
 }
 
-template <typename RowT, bool PACK_INT4, int ACT = kActNone>
-__global__ __launch_bounds__(256) void convrot_quant_kernel(
+constexpr int kConvRotGroup256 = 256;
+constexpr int kWarpSize = 32;
+
+__forceinline__ __device__ float warp_reduce_max(float v) {
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1) {
+        v = fmaxf(v, __shfl_down(v, offset));
+    }
+    return v;
+}
+
+template <int NUM_WARPS>
+__forceinline__ __device__ float block_reduce_max(float v, float* warp_smem, float* block_smem) {
+    const int lane = threadIdx.x & (kWarpSize - 1);
+    const int wid = threadIdx.x >> 5;
+    v = warp_reduce_max(v);
+    if (lane == 0) {
+        warp_smem[wid] = v;
+    }
+    __syncthreads();
+    if (wid == 0) {
+        float total = lane < NUM_WARPS ? warp_smem[lane] : 0.0f;
+        total = warp_reduce_max(total);
+        if (lane == 0) {
+            *block_smem = total;
+        }
+    }
+    __syncthreads();
+    return *block_smem;
+}
+
+template <int S>
+__forceinline__ __device__ void convrot_fht_stage64(
+    const float* __restrict__ src, float* __restrict__ dst, int lane) {
+    const int base = (lane % S) + (lane / S) * (4 * S);
+    const float x0 = src[base];
+    const float x1 = src[base + S];
+    const float x2 = src[base + 2 * S];
+    const float x3 = src[base + 3 * S];
+    dst[base] = 0.5f * (x0 + x1 + x2 - x3);
+    dst[base + S] = 0.5f * (x0 + x1 - x2 + x3);
+    dst[base + 2 * S] = 0.5f * (x0 - x1 + x2 + x3);
+    dst[base + 3 * S] = 0.5f * (-x0 + x1 + x2 + x3);
+}
+
+template <int S>
+__forceinline__ __device__ float convrot_fht_stage64_store_absmax(
+    const float* __restrict__ src, float* __restrict__ row_buf, int lane) {
+    const int base = (lane % S) + (lane / S) * (4 * S);
+    const float x0 = src[base];
+    const float x1 = src[base + S];
+    const float x2 = src[base + 2 * S];
+    const float x3 = src[base + 3 * S];
+    const float y0 = 0.5f * (x0 + x1 + x2 - x3);
+    const float y1 = 0.5f * (x0 + x1 - x2 + x3);
+    const float y2 = 0.5f * (x0 - x1 + x2 + x3);
+    const float y3 = 0.5f * (-x0 + x1 + x2 + x3);
+    row_buf[base] = y0;
+    row_buf[base + S] = y1;
+    row_buf[base + 2 * S] = y2;
+    row_buf[base + 3 * S] = y3;
+    return fmaxf(fmaxf(fabsf(y0), fabsf(y1)), fmaxf(fabsf(y2), fabsf(y3)));
+}
+
+template <int S, typename RowT>
+__forceinline__ __device__ float convrot_fht_stage64_store_absmax_typed(
+    const float* __restrict__ src, RowT* __restrict__ output, int lane) {
+    const int base = (lane % S) + (lane / S) * (4 * S);
+    const float x0 = src[base];
+    const float x1 = src[base + S];
+    const float x2 = src[base + 2 * S];
+    const float x3 = src[base + 3 * S];
+    const float y0 = 0.5f * (x0 + x1 + x2 - x3);
+    const float y1 = 0.5f * (x0 + x1 - x2 + x3);
+    const float y2 = 0.5f * (x0 - x1 + x2 + x3);
+    const float y3 = 0.5f * (-x0 + x1 + x2 + x3);
+    output[base] = store_row_value<RowT>(y0);
+    output[base + S] = store_row_value<RowT>(y1);
+    output[base + 2 * S] = store_row_value<RowT>(y2);
+    output[base + 3 * S] = store_row_value<RowT>(y3);
+    return fmaxf(fmaxf(fabsf(y0), fabsf(y1)), fmaxf(fabsf(y2), fabsf(y3)));
+}
+
+template <typename RowT>
+__forceinline__ __device__ float finite_absmax_for_quant(float abs_max) {
+    if constexpr (std::is_same_v<RowT, __bf16>) {
+        return fminf(abs_max, 3.38953139e38f);
+    }
+    if constexpr (std::is_same_v<RowT, __half>) {
+        return fminf(abs_max, 65504.0f);
+    }
+    return abs_max;
+}
+
+constexpr int kConvrotGlobalGroupsPerBlock = 8;
+constexpr int kConvrotGlobalBlockThreads = kConvrotGlobalGroupsPerBlock * 64;
+constexpr size_t kConvrotGlobalSmemBytes =
+    static_cast<size_t>(kConvrotGlobalGroupsPerBlock) * 2 * kConvRotGroup256 * sizeof(float);
+
+// Large K: rotate 8 groups/block into global memory, record per-group absmax, then
+// quantize in a second kernel. Fixed 16 KiB LDS regardless of K.
+template <int GROUPS_PER_BLOCK, typename RowT, int ACT>
+__global__ __launch_bounds__(GROUPS_PER_BLOCK* 64) void convrot_rotate_groups64_amax_kernel(
+    const void* __restrict__ x, int in_dtype, RowT* __restrict__ rotated,
+    float* __restrict__ partial_absmax, int K) {
+    constexpr int kGroupThreads = 64;
+    extern __shared__ float smem[];
+
+    const int sub = threadIdx.x / kGroupThreads;
+    const int lane = threadIdx.x % kGroupThreads;
+    const int group = static_cast<int>(blockIdx.y) * GROUPS_PER_BLOCK + sub;
+    const int64_t row = blockIdx.x;
+    const int n_groups = K / kConvRotGroup256;
+    const bool active = group < n_groups;
+    const int64_t row_offset = row * K;
+    constexpr int kInWidth = (ACT == kActSwiGLU) ? 2 : 1;
+    const int64_t in_row_offset = row_offset * kInWidth;
+    const int group_col = group * kConvRotGroup256;
+
+    float* buf0 = smem + sub * (2 * kConvRotGroup256);
+    float* buf1 = buf0 + kConvRotGroup256;
+
+    const int base = lane * 4;
+    const int col = group_col + base;
+    float xv0 = 0.0f;
+    float xv1 = 0.0f;
+    float xv2 = 0.0f;
+    float xv3 = 0.0f;
+    if (active) {
+        if constexpr (ACT == kActNone) {
+            if (in_dtype == 2) {
+                load_input_act4_bf16(x, in_row_offset, col, xv0, xv1, xv2, xv3);
+            } else {
+                xv0 = load_input_act<ACT>(x, in_row_offset, col, K, in_dtype);
+                xv1 = load_input_act<ACT>(x, in_row_offset, col + 1, K, in_dtype);
+                xv2 = load_input_act<ACT>(x, in_row_offset, col + 2, K, in_dtype);
+                xv3 = load_input_act<ACT>(x, in_row_offset, col + 3, K, in_dtype);
+            }
+        } else {
+            xv0 = load_input_act<ACT>(x, in_row_offset, col, K, in_dtype);
+            xv1 = load_input_act<ACT>(x, in_row_offset, col + 1, K, in_dtype);
+            xv2 = load_input_act<ACT>(x, in_row_offset, col + 2, K, in_dtype);
+            xv3 = load_input_act<ACT>(x, in_row_offset, col + 3, K, in_dtype);
+        }
+    }
+    buf1[base] = 0.5f * (xv0 + xv1 + xv2 - xv3);
+    buf1[base + 1] = 0.5f * (xv0 + xv1 - xv2 + xv3);
+    buf1[base + 2] = 0.5f * (xv0 - xv1 + xv2 + xv3);
+    buf1[base + 3] = 0.5f * (-xv0 + xv1 + xv2 + xv3);
+    __syncthreads();
+
+    convrot_fht_stage64<4>(buf1, buf0, lane);
+    __syncthreads();
+    convrot_fht_stage64<16>(buf0, buf1, lane);
+    __syncthreads();
+
+    float local_max = 0.0f;
+    if (active) {
+        local_max = convrot_fht_stage64_store_absmax_typed<64, RowT>(
+            buf1, rotated + row_offset + group_col, lane);
+    }
+    buf0[lane] = local_max;
+    __syncthreads();
+
+    if (lane < 32) {
+        float v = fmaxf(buf0[lane], buf0[lane + 32]);
+        v = warp_reduce_max(v);
+        if (lane == 0 && active) {
+            partial_absmax[static_cast<int64_t>(row) * n_groups + group] = v;
+        }
+    }
+}
+
+// Global spill pass 2: fold per-group absmax into the row scale, then quantize the
+// rotated row already in global memory (pass 1 is convrot_rotate_groups64_amax_kernel).
+template <typename RowT, int BLOCK_THREADS>
+__global__ __launch_bounds__(BLOCK_THREADS) void convrot_quant_from_partials_kernel(
+    const RowT* __restrict__ rotated, const float* __restrict__ partial_absmax,
+    int8_t* __restrict__ qout, float* __restrict__ scaleout, int K) {
+    constexpr int kWarps = BLOCK_THREADS / kWarpSize;
+    __shared__ float warp_smem[kWarps];
+    __shared__ float block_smem;
+
+    const int row = blockIdx.x;
+    const int tid = threadIdx.x;
+    const int n_groups = K / kConvRotGroup256;
+    const int64_t row_offset = static_cast<int64_t>(row) * K;
+    const float* row_partials = partial_absmax + static_cast<int64_t>(row) * n_groups;
+
+    float abs_max = 0.0f;
+    for (int g = tid; g < n_groups; g += BLOCK_THREADS) {
+        abs_max = fmaxf(abs_max, row_partials[g]);
+    }
+    abs_max = block_reduce_max<kWarps>(abs_max, warp_smem, &block_smem);
+    const float rowmax = fmaxf(finite_absmax_for_quant<RowT>(abs_max), 1e-10f);
+    const float scale = rowmax / 127.0f;
+    const float inv = 127.0f / rowmax;
+    if (tid == 0) {
+        scaleout[row] = scale;
+    }
+
+    for (int col = tid; col < K; col += BLOCK_THREADS) {
+        const float v = load_row_value<RowT>(rotated[row_offset + col]);
+        int q = static_cast<int>(rintf(v * inv));
+        q = q < -127 ? -127 : (q > 127 ? 127 : q);
+        qout[row_offset + col] = static_cast<int8_t>(q);
+    }
+}
+
+template <typename RowT, int ACT>
+inline void launch_convrot_quant_global(
+    const void* x, int in_dtype, int8_t* qout, float* scaleout, int M, int K,
+    RowT* rotated, float* partial_absmax, hipStream_t stream) {
+    const int n_groups = K / kConvRotGroup256;
+    const int group_blocks =
+        (n_groups + kConvrotGlobalGroupsPerBlock - 1) / kConvrotGlobalGroupsPerBlock;
+    const dim3 rotate_grid(static_cast<unsigned int>(M), static_cast<unsigned int>(group_blocks));
+    convrot_rotate_groups64_amax_kernel<kConvrotGlobalGroupsPerBlock, RowT, ACT>
+        <<<rotate_grid, kConvrotGlobalBlockThreads, kConvrotGlobalSmemBytes, stream>>>(
+            x, in_dtype, rotated, partial_absmax, K);
+
+    const int quant_threads = K >= 4096 ? 512 : 256;
+    if (quant_threads == 512) {
+        convrot_quant_from_partials_kernel<RowT, 512>
+            <<<M, 512, 0, stream>>>(rotated, partial_absmax, qout, scaleout, K);
+    } else {
+        convrot_quant_from_partials_kernel<RowT, 256>
+            <<<M, 256, 0, stream>>>(rotated, partial_absmax, qout, scaleout, K);
+    }
+}
+
+template <int ACT>
+void launch_convrot_quant_global_managed(
+    const void* x, int in_dtype, int8_t* qout, float* scaleout, int M, int K, hipStream_t stream);
+
+// Fused single-kernel path: FHT in LDS, vectorized loads, warp-shuffle absmax.
+// One block per row; the rotated row stays in shared memory as float.
+template <typename RowT, int BLOCK_THREADS, int ACT>
+__global__ __launch_bounds__(BLOCK_THREADS) void convrot_quant_fused_kernel(
+    const void* __restrict__ x, int in_dtype, int8_t* __restrict__ qout,
+    float* __restrict__ scaleout, int M, int K) {
+
+    constexpr int kGroupThreads = 64;
+    constexpr int kGroupsInFlight = BLOCK_THREADS / kGroupThreads;
+    constexpr int kWarps = BLOCK_THREADS / kWarpSize;
+
+    extern __shared__ float smem[];
+    float* row_buf = smem;
+    float* tmp = smem + K;
+
+    __shared__ float warp_smem[kWarps];
+    __shared__ float block_smem;
+
+    const int row = blockIdx.x;
+    const int tid = threadIdx.x;
+    const int sub = tid / kGroupThreads;
+    const int lane = tid % kGroupThreads;
+    const int64_t row_offset = static_cast<int64_t>(row) * K;
+    constexpr int kInWidth = (ACT == kActSwiGLU) ? 2 : 1;
+    const int64_t in_row_offset = row_offset * kInWidth;
+    const int n_groups = K / kConvRotGroup256;
+
+    float* buf0 = tmp + sub * (2 * kConvRotGroup256);
+    float* buf1 = buf0 + kConvRotGroup256;
+    float abs_max = 0.0f;
+
+    const int iters = (n_groups + kGroupsInFlight - 1) / kGroupsInFlight;
+    for (int it = 0; it < iters; ++it) {
+        const int group = it * kGroupsInFlight + sub;
+        const bool active = group < n_groups;
+        const int base = lane * 4;
+        const int group_col = group * kConvRotGroup256;
+        const int col = group_col + base;
+
+        float xv0 = 0.0f;
+        float xv1 = 0.0f;
+        float xv2 = 0.0f;
+        float xv3 = 0.0f;
+        if (active) {
+            if constexpr (ACT == kActNone) {
+                if (in_dtype == 2) {
+                    load_input_act4_bf16(x, in_row_offset, col, xv0, xv1, xv2, xv3);
+                } else {
+                    xv0 = load_input_act<ACT>(x, in_row_offset, col, K, in_dtype);
+                    xv1 = load_input_act<ACT>(x, in_row_offset, col + 1, K, in_dtype);
+                    xv2 = load_input_act<ACT>(x, in_row_offset, col + 2, K, in_dtype);
+                    xv3 = load_input_act<ACT>(x, in_row_offset, col + 3, K, in_dtype);
+                }
+            } else {
+                xv0 = load_input_act<ACT>(x, in_row_offset, col, K, in_dtype);
+                xv1 = load_input_act<ACT>(x, in_row_offset, col + 1, K, in_dtype);
+                xv2 = load_input_act<ACT>(x, in_row_offset, col + 2, K, in_dtype);
+                xv3 = load_input_act<ACT>(x, in_row_offset, col + 3, K, in_dtype);
+            }
+        }
+        buf1[base] = 0.5f * (xv0 + xv1 + xv2 - xv3);
+        buf1[base + 1] = 0.5f * (xv0 + xv1 - xv2 + xv3);
+        buf1[base + 2] = 0.5f * (xv0 - xv1 + xv2 + xv3);
+        buf1[base + 3] = 0.5f * (-xv0 + xv1 + xv2 + xv3);
+        __syncthreads();
+
+        convrot_fht_stage64<4>(buf1, buf0, lane);
+        __syncthreads();
+        convrot_fht_stage64<16>(buf0, buf1, lane);
+        __syncthreads();
+
+        if (active) {
+            abs_max = fmaxf(
+                abs_max, convrot_fht_stage64_store_absmax<64>(buf1, row_buf + group_col, lane));
+        }
+        __syncthreads();
+    }
+
+    abs_max = block_reduce_max<kWarps>(abs_max, warp_smem, &block_smem);
+    const float rowmax = fmaxf(finite_absmax_for_quant<RowT>(abs_max), 1e-10f);
+    const float scale = rowmax / 127.0f;
+    const float inv = 127.0f / rowmax;
+    if (tid == 0) {
+        scaleout[row] = scale;
+    }
+
+    for (int col = tid; col < K; col += BLOCK_THREADS) {
+        const float v = row_buf[col];
+        int q = static_cast<int>(rintf(v * inv));
+        q = q < -127 ? -127 : (q > 127 ? 127 : q);
+        qout[row_offset + col] = static_cast<int8_t>(q);
+    }
+}
+
+inline int convrot_quant_fused_block_threads(int M, int K) {
+    if (M == 1) {
+        return 512;
+    }
+    if (K == kConvRotGroup256) {
+        return 64;
+    }
+    if (K == 2560) {
+        return 640;
+    }
+    if (K == 6144) {
+        return 768;
+    }
+    return 1024;
+}
+
+template <typename RowT, int ACT, int BLOCK_THREADS>
+inline void launch_convrot_quant_fused_impl(
+    const void* x, int in_dtype, int8_t* qout, float* scaleout, int M, int K,
+    hipStream_t stream) {
+    const int groups_in_flight = BLOCK_THREADS / 64;
+    const size_t shmem =
+        (static_cast<size_t>(K) + static_cast<size_t>(groups_in_flight) * 2 * kConvRotGroup256) *
+        sizeof(float);
+    auto kernel = convrot_quant_fused_kernel<RowT, BLOCK_THREADS, ACT>;
+    const hipError_t attr_err = hipFuncSetAttribute(
+        reinterpret_cast<const void*>(kernel), hipFuncAttributeMaxDynamicSharedMemorySize,
+        static_cast<int>(shmem));
+    if (attr_err != hipSuccess) {
+        throw std::runtime_error(
+            std::string("convrot fused: shared memory request (") + std::to_string(shmem) +
+            " bytes) failed: " + hipGetErrorString(attr_err));
+    }
+    kernel<<<M, BLOCK_THREADS, shmem, stream>>>(x, in_dtype, qout, scaleout, M, K);
+}
+
+template <typename RowT, int ACT>
+struct LaunchConvrotQuantFusedForBlock {
+    const void* x;
+    int in_dtype;
+    int8_t* qout;
+    float* scaleout;
+    int M;
+    int K;
+    hipStream_t stream;
+
+    template <int BLOCK_THREADS>
+    void operator()() const {
+        launch_convrot_quant_fused_impl<RowT, ACT, BLOCK_THREADS>(
+            x, in_dtype, qout, scaleout, M, K, stream);
+    }
+};
+
+template <int ACT>
+struct LaunchConvrotQuantFusedForRow {
+    const void* x;
+    int in_dtype;
+    int8_t* qout;
+    float* scaleout;
+    int M;
+    int K;
+    hipStream_t stream;
+    int block_threads;
+
+    template <typename RowT>
+    void operator()() const {
+        dispatch_convrot_fused_block_threads(
+            block_threads,
+            LaunchConvrotQuantFusedForBlock<RowT, ACT>{x, in_dtype, qout, scaleout, M, K, stream});
+    }
+};
+
+template <int ACT>
+inline void launch_convrot_quant_fused(
+    const void* x, int in_dtype, int8_t* qout, float* scaleout, int M, int K,
+    hipStream_t stream) {
+    const int block_threads = convrot_quant_fused_block_threads(M, K);
+    dispatch_convrot_row_type(
+        in_dtype,
+        LaunchConvrotQuantFusedForRow<ACT>{x, in_dtype, qout, scaleout, M, K, stream, block_threads});
+}
+
+template <typename RowT, bool PACK_INT4, int ACT, int BLOCK_THREADS>
+__global__ __launch_bounds__(BLOCK_THREADS) void convrot_quant_kernel(
     const void* __restrict__ x, int in_dtype,
     int8_t* __restrict__ qout, float* __restrict__ scaleout,
     int M, int K, int G) {
 
     const float h4[4][4] = {{1, 1, 1, -1}, {1, 1, -1, 1}, {1, -1, 1, 1}, {-1, 1, 1, 1}};
-    __shared__ float g[256];
-    __shared__ float red[256];
+    __shared__ float g[1024];
+    __shared__ float red[1024];
     extern __shared__ unsigned char rowbuf_raw[];
     RowT* rowbuf = reinterpret_cast<RowT*>(rowbuf_raw);  // K entries: the rotated row
 
@@ -159,9 +648,9 @@ __global__ __launch_bounds__(256) void convrot_quant_kernel(
     int nstages = 0;
     while ((1 << (2 * nstages)) < G) nstages++;  // log4(G)
 
-    const int gpw = 256 / G;      // groups handled per pass
-    const int glocal = t / G;     // this thread's group within the pass
-    const int e = t % G;          // element within the group
+    const int gpw = BLOCK_THREADS / G;           // groups handled per pass
+    const int glocal = t / G;                    // this thread's group within the pass
+    const int e = t % G;                         // element within the group
     const int gbase_idx = glocal * G;
     const float norm = rsqrtf(static_cast<float>(G));
     const int ngrp = K / G;
@@ -198,7 +687,7 @@ __global__ __launch_bounds__(256) void convrot_quant_kernel(
 
     red[t] = lmax;
     __syncthreads();
-    for (int s = 128; s > 0; s >>= 1) {
+    for (int s = BLOCK_THREADS / 2; s > 0; s >>= 1) {
         if (t < s) red[t] = fmaxf(red[t], red[t + s]);
         __syncthreads();
     }
@@ -211,7 +700,7 @@ __global__ __launch_bounds__(256) void convrot_quant_kernel(
 
     if constexpr (PACK_INT4) {
         const int Kp = K / 2;
-        for (int jb = t; jb < Kp; jb += 256) {
+        for (int jb = t; jb < Kp; jb += BLOCK_THREADS) {
             const float a = load_row_value(rowbuf[2 * jb]);
             const float b = load_row_value(rowbuf[2 * jb + 1]);
             int qa = static_cast<int>(rintf(a * inv));
@@ -222,7 +711,7 @@ __global__ __launch_bounds__(256) void convrot_quant_kernel(
                 static_cast<int8_t>(((qa & 0xF) | ((qb & 0xF) << 4)) & 0xFF);
         }
     } else {
-        for (int j = t; j < K; j += 256) {
+        for (int j = t; j < K; j += BLOCK_THREADS) {
             const float v = load_row_value(rowbuf[j]);
             int q = static_cast<int>(rintf(v * inv));
             q = q < -127 ? -127 : (q > 127 ? 127 : q);
@@ -231,23 +720,69 @@ __global__ __launch_bounds__(256) void convrot_quant_kernel(
     }
 }
 
+template <typename RowT, bool PACK_INT4, int ACT, int BLOCK_THREADS>
+inline void launch_convrot_quant_impl(
+    const void* x, int in_dtype, int8_t* qout, float* scaleout,
+    int M, int K, int group_size, hipStream_t stream) {
+
+    const size_t shmem = static_cast<size_t>(K) * convrot_row_element_size(in_dtype);
+    convrot_quant_kernel<RowT, PACK_INT4, ACT, BLOCK_THREADS><<<M, BLOCK_THREADS, shmem, stream>>>(
+        x, in_dtype, qout, scaleout, M, K, group_size);
+}
+
+template <bool PACK_INT4, int ACT, int BLOCK_THREADS>
+struct LaunchConvrotQuantLegacyForBlock {
+    const void* x;
+    int in_dtype;
+    int8_t* qout;
+    float* scaleout;
+    int M;
+    int K;
+    int group_size;
+    hipStream_t stream;
+
+    template <typename RowT>
+    void operator()() const {
+        launch_convrot_quant_impl<RowT, PACK_INT4, ACT, BLOCK_THREADS>(
+            x, in_dtype, qout, scaleout, M, K, group_size, stream);
+    }
+};
+
+template <bool PACK_INT4, int ACT, int BLOCK_THREADS>
+inline void launch_convrot_quant_for_block(
+    const void* x, int in_dtype, int8_t* qout, float* scaleout,
+    int M, int K, int group_size, hipStream_t stream) {
+    dispatch_convrot_row_type(
+        in_dtype,
+        LaunchConvrotQuantLegacyForBlock<PACK_INT4, ACT, BLOCK_THREADS>{
+            x, in_dtype, qout, scaleout, M, K, group_size, stream});
+}
+
 template <bool PACK_INT4, int ACT = kActNone>
 inline void launch_convrot_quant(
     const void* x, int in_dtype, int8_t* qout, float* scaleout,
     int M, int K, int group_size, hipStream_t stream) {
 
-    const size_t shmem = static_cast<size_t>(K) * convrot_row_element_size(in_dtype);
-    if (in_dtype == 0) {
-        convrot_quant_kernel<float, PACK_INT4, ACT><<<M, 256, shmem, stream>>>(
-            x, in_dtype, qout, scaleout, M, K, group_size);
-    } else if (in_dtype == 1) {
-        convrot_quant_kernel<__half, PACK_INT4, ACT><<<M, 256, shmem, stream>>>(
-            x, in_dtype, qout, scaleout, M, K, group_size);
-    } else if (in_dtype == 2) {
-        convrot_quant_kernel<__bf16, PACK_INT4, ACT><<<M, 256, shmem, stream>>>(
-            x, in_dtype, qout, scaleout, M, K, group_size);
+    // INT8 G=256: fused single-kernel quant when K fits in LDS, else global spill.
+    if (!PACK_INT4 && group_size == 256) {
+        if (K > convrot_fused_lds_max_k()) {
+            launch_convrot_quant_global_managed<ACT>(
+                x, in_dtype, qout, scaleout, M, K, stream);
+        } else {
+            launch_convrot_quant_fused<ACT>(x, in_dtype, qout, scaleout, M, K, stream);
+        }
+        return;
+    }
+
+    // G=256 with K>=512: 1024-thread blocks process 4 Hadamard groups/pass (15->4
+    // passes at K=3840). Smaller configs keep 256 threads for occupancy on narrow K.
+    const int block_threads = (group_size == 256 && K >= 512) ? 1024 : 256;
+    if (block_threads == 1024) {
+        launch_convrot_quant_for_block<PACK_INT4, ACT, 1024>(
+            x, in_dtype, qout, scaleout, M, K, group_size, stream);
     } else {
-        throw std::runtime_error("convrot: unsupported input dtype code");
+        launch_convrot_quant_for_block<PACK_INT4, ACT, 256>(
+            x, in_dtype, qout, scaleout, M, K, group_size, stream);
     }
 }
 

--- a/comfy_kitchen/backends/hip/hadamard.h
+++ b/comfy_kitchen/backends/hip/hadamard.h
@@ -31,9 +31,11 @@ inline void check_convrot_group_size(int group_size) {
     }
 }
 
-// Legacy convrot_quant_kernel static LDS: butterfly workspace + row absmax reduction.
-// Sized for 256-thread blocks; the kernel uses g[BLOCK_THREADS] / red[BLOCK_THREADS].
-constexpr size_t kConvrotStaticLds = 2 * 256 * sizeof(float);
+// Legacy convrot_quant_kernel static LDS: g[BLOCK_THREADS] + red[BLOCK_THREADS].
+inline size_t convrot_static_lds_bytes(int block_threads) {
+    return 2 * static_cast<size_t>(block_threads) * sizeof(float);
+}
+
 constexpr int kConvRotGroup256 = 256;
 
 // convrot_quant_kernel stages the whole rotated row in dynamic LDS, preserving
@@ -47,9 +49,9 @@ inline size_t convrot_row_element_size(int in_dtype) {
     return 0;
 }
 
-inline int convrot_max_k(int in_dtype) {
+inline int convrot_max_k(int in_dtype, int block_threads = 256) {
     const size_t element_size = convrot_row_element_size(in_dtype);
-    if (element_size == 0) {
+    if (element_size == 0 || block_threads <= 0) {
         return 0;
     }
     int device = 0;
@@ -58,12 +60,14 @@ inline int convrot_max_k(int in_dtype) {
     }
     int lds = 0;
     if (hipDeviceGetAttribute(&lds, hipDeviceAttributeMaxSharedMemoryPerBlock, device) !=
-            hipSuccess ||
-        lds <= static_cast<int>(kConvrotStaticLds)) {
+            hipSuccess) {
         return 0;
     }
-    return static_cast<int>((static_cast<size_t>(lds) - kConvrotStaticLds) /
-                            element_size);
+    const size_t static_lds = convrot_static_lds_bytes(block_threads);
+    if (lds <= static_cast<int>(static_lds)) {
+        return 0;
+    }
+    return static_cast<int>((static_cast<size_t>(lds) - static_lds) / element_size);
 }
 
 inline int convrot_quant_fused_block_threads(int M, int K) {
@@ -87,24 +91,17 @@ inline int convrot_quant_fused_block_threads(int M, int K) {
 }
 
 inline int convrot_device_lds_limit() {
-    static int cached_device = -1;
-    static int cached_lds = 0;
     int device = 0;
     if (hipGetDevice(&device) != hipSuccess) {
         return 0;
     }
-    if (device != cached_device) {
-        int lds = 0;
-        if (hipDeviceGetAttribute(&lds, hipDeviceAttributeMaxSharedMemoryPerBlock, device) !=
-                hipSuccess ||
-            lds <= 0) {
-            cached_lds = 0;
-        } else {
-            cached_lds = lds;
-        }
-        cached_device = device;
+    int lds = 0;
+    if (hipDeviceGetAttribute(&lds, hipDeviceAttributeMaxSharedMemoryPerBlock, device) !=
+            hipSuccess ||
+        lds <= 0) {
+        return 0;
     }
-    return cached_lds;
+    return lds;
 }
 
 inline bool convrot_fused_lds_fits(int K, int block_threads, int in_dtype) {
@@ -142,6 +139,18 @@ inline int convrot_pick_fused_block_threads(int M, int K, int in_dtype) {
     return 0;
 }
 
+// Mirrors launch_convrot_quant() spill fallback for Python buffer allocation.
+inline bool convrot_int8_needs_spill_buffers(int M, int K, int in_dtype) {
+    if (M <= 0 || K <= 0 || (K % kConvRotGroup256) != 0) {
+        return false;
+    }
+    if (convrot_row_element_size(in_dtype) == 0 || convrot_device_lds_limit() <= 0) {
+        return true;
+    }
+    const int block = convrot_pick_fused_block_threads(M, K, in_dtype);
+    return block == 0 || !convrot_fused_lds_fits(K, block, in_dtype);
+}
+
 inline void check_convrot_k(int k, int group_size, int in_dtype, bool int8_quant = false) {
     // The kernel rotates K/G whole groups but reads back all K entries of the row
     // buffer, so a partial trailing group would quantize uninitialized LDS.
@@ -154,7 +163,8 @@ inline void check_convrot_k(int k, int group_size, int in_dtype, bool int8_quant
     if (int8_quant && group_size == 256) {
         return;
     }
-    const int max_k = convrot_max_k(in_dtype);
+    const int legacy_bt = (group_size == 256 && k >= 512) ? 1024 : 256;
+    const int max_k = convrot_max_k(in_dtype, legacy_bt);
     if (max_k <= 0 || k > max_k) {
         throw std::runtime_error("convrot: K=" + std::to_string(k) +
                                  " does not fit in LDS (max " + std::to_string(max_k) + ")");

--- a/comfy_kitchen/backends/hip/hadamard.h
+++ b/comfy_kitchen/backends/hip/hadamard.h
@@ -31,8 +31,9 @@ inline void check_convrot_group_size(int group_size) {
     }
 }
 
-// The kernel's static LDS: butterfly workspace + row absmax reduction (up to 1024 threads).
-constexpr size_t kConvrotStaticLds = 2 * 1024 * sizeof(float);
+// Legacy convrot_quant_kernel static LDS: butterfly workspace + row absmax reduction.
+// Sized for 256-thread blocks; the kernel uses g[BLOCK_THREADS] / red[BLOCK_THREADS].
+constexpr size_t kConvrotStaticLds = 2 * 256 * sizeof(float);
 constexpr int kConvRotGroup256 = 256;
 
 // convrot_quant_kernel stages the whole rotated row in dynamic LDS, preserving
@@ -81,16 +82,33 @@ inline int convrot_quant_fused_block_threads(int M, int K) {
     return 1024;
 }
 
+inline int convrot_device_lds_limit() {
+    static int cached_device = -1;
+    static int cached_lds = 0;
+    int device = 0;
+    if (hipGetDevice(&device) != hipSuccess) {
+        return 0;
+    }
+    if (device != cached_device) {
+        int lds = 0;
+        if (hipDeviceGetAttribute(&lds, hipDeviceAttributeMaxSharedMemoryPerBlock, device) !=
+                hipSuccess ||
+            lds <= 0) {
+            cached_lds = 0;
+        } else {
+            cached_lds = lds;
+        }
+        cached_device = device;
+    }
+    return cached_lds;
+}
+
 inline bool convrot_fused_lds_fits(int K, int block_threads) {
     if (block_threads <= 0 || (block_threads % 64) != 0) {
         return false;
     }
-    int device = 0;
-    int lds = 0;
-    if (hipGetDevice(&device) != hipSuccess ||
-        hipDeviceGetAttribute(&lds, hipDeviceAttributeMaxSharedMemoryPerBlock, device) !=
-            hipSuccess ||
-        lds <= 0) {
+    const int lds = convrot_device_lds_limit();
+    if (lds <= 0) {
         return false;
     }
     const int groups_in_flight = block_threads / 64;
@@ -109,7 +127,7 @@ inline int convrot_pick_fused_block_threads(int M, int K) {
     }
     static constexpr int kFallbackBlocks[] = {768, 640, 512, 64};
     for (int block_threads : kFallbackBlocks) {
-        if (block_threads != preferred && convrot_fused_lds_fits(K, block_threads)) {
+        if (block_threads < preferred && convrot_fused_lds_fits(K, block_threads)) {
             return block_threads;
         }
     }
@@ -473,7 +491,8 @@ inline void launch_convrot_quant_global(
 
 template <int ACT>
 void launch_convrot_quant_global_managed(
-    const void* x, int in_dtype, int8_t* qout, float* scaleout, int M, int K, hipStream_t stream);
+    const void* x, int in_dtype, int8_t* qout, float* scaleout, int M, int K, hipStream_t stream,
+    void* spill_rotated, void* spill_partials);
 
 // Fused single-kernel path: FHT in LDS, vectorized loads, warp-shuffle absmax.
 // One block per row; the rotated row stays in shared memory as float.
@@ -570,7 +589,7 @@ __global__ __launch_bounds__(BLOCK_THREADS) void convrot_quant_fused_kernel(
 }
 
 template <typename RowT, int ACT, int BLOCK_THREADS>
-inline void launch_convrot_quant_fused_impl(
+inline bool launch_convrot_quant_fused_impl(
     const void* x, int in_dtype, int8_t* qout, float* scaleout, int M, int K,
     hipStream_t stream) {
     const int groups_in_flight = BLOCK_THREADS / 64;
@@ -582,11 +601,10 @@ inline void launch_convrot_quant_fused_impl(
         reinterpret_cast<const void*>(kernel), hipFuncAttributeMaxDynamicSharedMemorySize,
         static_cast<int>(shmem));
     if (attr_err != hipSuccess) {
-        throw std::runtime_error(
-            std::string("convrot fused: shared memory request (") + std::to_string(shmem) +
-            " bytes) failed: " + hipGetErrorString(attr_err));
+        return false;
     }
     kernel<<<M, BLOCK_THREADS, shmem, stream>>>(x, in_dtype, qout, scaleout, M, K);
+    return hipGetLastError() == hipSuccess;
 }
 
 template <typename RowT, int ACT>
@@ -598,10 +616,11 @@ struct LaunchConvrotQuantFusedForBlock {
     int M;
     int K;
     hipStream_t stream;
+    bool* launched;
 
     template <int BLOCK_THREADS>
     void operator()() const {
-        launch_convrot_quant_fused_impl<RowT, ACT, BLOCK_THREADS>(
+        *launched = launch_convrot_quant_fused_impl<RowT, ACT, BLOCK_THREADS>(
             x, in_dtype, qout, scaleout, M, K, stream);
     }
 };
@@ -616,24 +635,16 @@ struct LaunchConvrotQuantFusedForRow {
     int K;
     hipStream_t stream;
     int block_threads;
+    bool* launched;
 
     template <typename RowT>
     void operator()() const {
         dispatch_convrot_fused_block_threads(
             block_threads,
-            LaunchConvrotQuantFusedForBlock<RowT, ACT>{x, in_dtype, qout, scaleout, M, K, stream});
+            LaunchConvrotQuantFusedForBlock<RowT, ACT>{
+                x, in_dtype, qout, scaleout, M, K, stream, launched});
     }
 };
-
-template <int ACT>
-inline void launch_convrot_quant_fused(
-    const void* x, int in_dtype, int8_t* qout, float* scaleout, int M, int K,
-    hipStream_t stream) {
-    const int block_threads = convrot_quant_fused_block_threads(M, K);
-    dispatch_convrot_row_type(
-        in_dtype,
-        LaunchConvrotQuantFusedForRow<ACT>{x, in_dtype, qout, scaleout, M, K, stream, block_threads});
-}
 
 template <typename RowT, bool PACK_INT4, int ACT, int BLOCK_THREADS>
 __global__ __launch_bounds__(BLOCK_THREADS) void convrot_quant_kernel(
@@ -642,8 +653,8 @@ __global__ __launch_bounds__(BLOCK_THREADS) void convrot_quant_kernel(
     int M, int K, int G) {
 
     const float h4[4][4] = {{1, 1, 1, -1}, {1, 1, -1, 1}, {1, -1, 1, 1}, {-1, 1, 1, 1}};
-    __shared__ float g[1024];
-    __shared__ float red[1024];
+    __shared__ float g[BLOCK_THREADS];
+    __shared__ float red[BLOCK_THREADS];
     extern __shared__ unsigned char rowbuf_raw[];
     RowT* rowbuf = reinterpret_cast<RowT*>(rowbuf_raw);  // K entries: the rotated row
 
@@ -766,25 +777,34 @@ inline void launch_convrot_quant_for_block(
 template <bool PACK_INT4, int ACT = kActNone>
 inline void launch_convrot_quant(
     const void* x, int in_dtype, int8_t* qout, float* scaleout,
-    int M, int K, int group_size, hipStream_t stream) {
+    int M, int K, int group_size, hipStream_t stream,
+    void* spill_rotated = nullptr, void* spill_partials = nullptr) {
 
-    // INT8 G=256: fused when (M, K) fits in LDS, else global spill.
+    // INT8 G=256: fused when (M, K) fits in LDS, else caller-owned global spill.
     if (!PACK_INT4 && group_size == 256) {
         const int block_threads = convrot_pick_fused_block_threads(M, K);
         if (block_threads > 0) {
+            bool launched = false;
             dispatch_convrot_row_type(
                 in_dtype,
                 LaunchConvrotQuantFusedForRow<ACT>{
-                    x, in_dtype, qout, scaleout, M, K, stream, block_threads});
-        } else {
-            launch_convrot_quant_global_managed<ACT>(
-                x, in_dtype, qout, scaleout, M, K, stream);
+                    x, in_dtype, qout, scaleout, M, K, stream, block_threads, &launched});
+            if (launched) {
+                return;
+            }
         }
+        if (spill_rotated == nullptr || spill_partials == nullptr) {
+            throw std::runtime_error(
+                "convrot global spill requires caller-provided workspace buffers");
+        }
+        launch_convrot_quant_global_managed<ACT>(
+            x, in_dtype, qout, scaleout, M, K, stream, spill_rotated, spill_partials);
         return;
     }
 
-    // G=256 with K>=512: 1024-thread blocks process 4 Hadamard groups/pass (15->4
-    // passes at K=3840). Smaller configs keep 256 threads for occupancy on narrow K.
+    // INT4 G=256 with K>=512: 1024-thread blocks process 4 Hadamard groups/pass
+    // (15->4 passes at K=3840). INT8 G=256 returns above. Smaller configs keep
+    // 256 threads for occupancy on narrow K.
     const int block_threads = (group_size == 256 && K >= 512) ? 1024 : 256;
     if (block_threads == 1024) {
         launch_convrot_quant_for_block<PACK_INT4, ACT, 1024>(

--- a/comfy_kitchen/backends/hip/ops/quantize_int8.hip
+++ b/comfy_kitchen/backends/hip/ops/quantize_int8.hip
@@ -177,50 +177,6 @@ __global__ __launch_bounds__(256) void dequantize_int8_convrot_weight_kernel(
 
 }  // namespace comfy::hip_backend
 
-// Global spill buffers for convrot quant when K exceeds convrot_fused_lds_max_k() in
-// hadamard.h. hipMalloc lives in this translation unit; kernels stay header-only.
-namespace {
-
-// Process-lifetime workspace passed to launch_convrot_quant_global() in hadamard.h.
-struct ConvrotGlobalWorkspace {
-    void* rotated = nullptr;         // M x K rotated row (input element size)
-    void* partial_absmax = nullptr;  // M x (K / 256) per-group absmax (float)
-    size_t rotated_bytes = 0;
-    size_t partials_bytes = 0;
-};
-
-ConvrotGlobalWorkspace g_convrot_global_ws;
-
-// Grow-only: realloc when a larger (M, K) appears; never shrinks between calls.
-void ensure_convrot_global_workspace(size_t rotated_bytes, size_t partials_bytes) {
-    if (rotated_bytes > g_convrot_global_ws.rotated_bytes) {
-        if (g_convrot_global_ws.rotated != nullptr) {
-            hipFree(g_convrot_global_ws.rotated);
-        }
-        hipError_t err = hipMalloc(&g_convrot_global_ws.rotated, rotated_bytes);
-        if (err != hipSuccess) {
-            throw std::runtime_error(
-                std::string("convrot global: rotated workspace alloc failed: ") +
-                hipGetErrorString(err));
-        }
-        g_convrot_global_ws.rotated_bytes = rotated_bytes;
-    }
-    if (partials_bytes > g_convrot_global_ws.partials_bytes) {
-        if (g_convrot_global_ws.partial_absmax != nullptr) {
-            hipFree(g_convrot_global_ws.partial_absmax);
-        }
-        hipError_t err = hipMalloc(&g_convrot_global_ws.partial_absmax, partials_bytes);
-        if (err != hipSuccess) {
-            throw std::runtime_error(
-                std::string("convrot global: partial absmax alloc failed: ") +
-                hipGetErrorString(err));
-        }
-        g_convrot_global_ws.partials_bytes = partials_bytes;
-    }
-}
-
-}  // namespace
-
 namespace comfy::hip_backend {
 
 template <int ACT>
@@ -232,31 +188,25 @@ struct LaunchConvrotQuantGlobalManaged {
     int M;
     int K;
     hipStream_t stream;
-    void* rotated;
-    void* partial_absmax;
+    void* spill_rotated;
+    void* spill_partials;
 
     template <typename RowT>
     void operator()() const {
         launch_convrot_quant_global<RowT, ACT>(
             x, in_dtype, qout, scaleout, M, K,
-            static_cast<RowT*>(rotated),
-            static_cast<float*>(partial_absmax), stream);
+            static_cast<RowT*>(spill_rotated),
+            static_cast<float*>(spill_partials), stream);
     }
 };
 
-// Host wrapper: size global buffers, then run rotate + quantize kernels from hadamard.h.
 template <int ACT>
 void launch_convrot_quant_global_managed(
-    const void* x, int in_dtype, int8_t* qout, float* scaleout, int M, int K,
-    hipStream_t stream) {
-    const size_t elem_size = convrot_row_element_size(in_dtype);
-    if (elem_size == 0) {
-        throw std::runtime_error("convrot global: unsupported input dtype code");
+    const void* x, int in_dtype, int8_t* qout, float* scaleout, int M, int K, hipStream_t stream,
+    void* spill_rotated, void* spill_partials) {
+    if (spill_rotated == nullptr || spill_partials == nullptr) {
+        throw std::runtime_error("convrot global spill requires caller-provided workspace buffers");
     }
-    const size_t rotated_bytes = static_cast<size_t>(M) * static_cast<size_t>(K) * elem_size;
-    const size_t partials_bytes =
-        static_cast<size_t>(M) * static_cast<size_t>(K / kConvRotGroup256) * sizeof(float);
-    ensure_convrot_global_workspace(rotated_bytes, partials_bytes);
 
     dispatch_convrot_row_type(
         in_dtype,
@@ -268,16 +218,16 @@ void launch_convrot_quant_global_managed(
             M,
             K,
             stream,
-            g_convrot_global_ws.rotated,
-            g_convrot_global_ws.partial_absmax});
+            spill_rotated,
+            spill_partials});
 }
 
 template void launch_convrot_quant_global_managed<kActNone>(
-    const void*, int, int8_t*, float*, int, int, hipStream_t);
+    const void*, int, int8_t*, float*, int, int, hipStream_t, void*, void*);
 template void launch_convrot_quant_global_managed<kActGeluTanh>(
-    const void*, int, int8_t*, float*, int, int, hipStream_t);
+    const void*, int, int8_t*, float*, int, int, hipStream_t, void*, void*);
 template void launch_convrot_quant_global_managed<kActSwiGLU>(
-    const void*, int, int8_t*, float*, int, int, hipStream_t);
+    const void*, int, int8_t*, float*, int, int, hipStream_t, void*, void*);
 
 }  // namespace comfy::hip_backend
 
@@ -295,7 +245,7 @@ extern "C" void launch_quantize_int8_rowwise_kernel(
 // Fused ConvRot rotation + rowwise int8 quantize. act_code: 0 none, 1 gelu tanh,
 // 2 swiglu. K is the activated (written) width; swiglu reads a row twice as wide.
 extern "C" void launch_quantize_int8_convrot_kernel(
-    const void* x, int in_code, void* q, void* scales,
+    const void* x, int in_code, void* q, void* scales, void* spill_rotated, void* spill_partials,
     int M, int K, int group_size, int act_code, hipStream_t stream) {
 
     using namespace comfy::hip_backend;
@@ -308,15 +258,15 @@ extern "C" void launch_quantize_int8_convrot_kernel(
     if (act_code == kActGeluTanh) {
         launch_convrot_quant<false, kActGeluTanh>(
             x, in_code, static_cast<int8_t*>(q), static_cast<float*>(scales),
-            M, K, group_size, stream);
+            M, K, group_size, stream, spill_rotated, spill_partials);
     } else if (act_code == kActSwiGLU) {
         launch_convrot_quant<false, kActSwiGLU>(
             x, in_code, static_cast<int8_t*>(q), static_cast<float*>(scales),
-            M, K, group_size, stream);
+            M, K, group_size, stream, spill_rotated, spill_partials);
     } else {
         launch_convrot_quant<false, kActNone>(
             x, in_code, static_cast<int8_t*>(q), static_cast<float*>(scales),
-            M, K, group_size, stream);
+            M, K, group_size, stream, spill_rotated, spill_partials);
     }
 }
 

--- a/comfy_kitchen/backends/hip/ops/quantize_int8.hip
+++ b/comfy_kitchen/backends/hip/ops/quantize_int8.hip
@@ -270,13 +270,13 @@ extern "C" void launch_quantize_int8_convrot_kernel(
     }
 }
 
-// Returns 1 when INT8 G=256 must use the global spill path for (M, K) on this device.
-extern "C" int convrot_int8_needs_spill_host(int M, int K) {
+// Returns 1 when INT8 G=256 must use the global spill path for (M, K, in_dtype).
+extern "C" int convrot_int8_needs_spill_host(int M, int K, int in_code) {
     using namespace comfy::hip_backend;
     if (M <= 0 || K <= 0 || (K % kConvRotGroup256) != 0) {
         return 0;
     }
-    return convrot_pick_fused_block_threads(M, K) == 0 ? 1 : 0;
+    return convrot_pick_fused_block_threads(M, K, in_code) == 0 ? 1 : 0;
 }
 
 // scratch is a 4-byte device buffer, pre-zeroed by the caller.

--- a/comfy_kitchen/backends/hip/ops/quantize_int8.hip
+++ b/comfy_kitchen/backends/hip/ops/quantize_int8.hip
@@ -177,6 +177,110 @@ __global__ __launch_bounds__(256) void dequantize_int8_convrot_weight_kernel(
 
 }  // namespace comfy::hip_backend
 
+// Global spill buffers for convrot quant when K exceeds convrot_fused_lds_max_k() in
+// hadamard.h. hipMalloc lives in this translation unit; kernels stay header-only.
+namespace {
+
+// Process-lifetime workspace passed to launch_convrot_quant_global() in hadamard.h.
+struct ConvrotGlobalWorkspace {
+    void* rotated = nullptr;         // M x K rotated row (input element size)
+    void* partial_absmax = nullptr;  // M x (K / 256) per-group absmax (float)
+    size_t rotated_bytes = 0;
+    size_t partials_bytes = 0;
+};
+
+ConvrotGlobalWorkspace g_convrot_global_ws;
+
+// Grow-only: realloc when a larger (M, K) appears; never shrinks between calls.
+void ensure_convrot_global_workspace(size_t rotated_bytes, size_t partials_bytes) {
+    if (rotated_bytes > g_convrot_global_ws.rotated_bytes) {
+        if (g_convrot_global_ws.rotated != nullptr) {
+            hipFree(g_convrot_global_ws.rotated);
+        }
+        hipError_t err = hipMalloc(&g_convrot_global_ws.rotated, rotated_bytes);
+        if (err != hipSuccess) {
+            throw std::runtime_error(
+                std::string("convrot global: rotated workspace alloc failed: ") +
+                hipGetErrorString(err));
+        }
+        g_convrot_global_ws.rotated_bytes = rotated_bytes;
+    }
+    if (partials_bytes > g_convrot_global_ws.partials_bytes) {
+        if (g_convrot_global_ws.partial_absmax != nullptr) {
+            hipFree(g_convrot_global_ws.partial_absmax);
+        }
+        hipError_t err = hipMalloc(&g_convrot_global_ws.partial_absmax, partials_bytes);
+        if (err != hipSuccess) {
+            throw std::runtime_error(
+                std::string("convrot global: partial absmax alloc failed: ") +
+                hipGetErrorString(err));
+        }
+        g_convrot_global_ws.partials_bytes = partials_bytes;
+    }
+}
+
+}  // namespace
+
+namespace comfy::hip_backend {
+
+template <int ACT>
+struct LaunchConvrotQuantGlobalManaged {
+    const void* x;
+    int in_dtype;
+    int8_t* qout;
+    float* scaleout;
+    int M;
+    int K;
+    hipStream_t stream;
+    void* rotated;
+    void* partial_absmax;
+
+    template <typename RowT>
+    void operator()() const {
+        launch_convrot_quant_global<RowT, ACT>(
+            x, in_dtype, qout, scaleout, M, K,
+            static_cast<RowT*>(rotated),
+            static_cast<float*>(partial_absmax), stream);
+    }
+};
+
+// Host wrapper: size global buffers, then run rotate + quantize kernels from hadamard.h.
+template <int ACT>
+void launch_convrot_quant_global_managed(
+    const void* x, int in_dtype, int8_t* qout, float* scaleout, int M, int K,
+    hipStream_t stream) {
+    const size_t elem_size = convrot_row_element_size(in_dtype);
+    if (elem_size == 0) {
+        throw std::runtime_error("convrot global: unsupported input dtype code");
+    }
+    const size_t rotated_bytes = static_cast<size_t>(M) * static_cast<size_t>(K) * elem_size;
+    const size_t partials_bytes =
+        static_cast<size_t>(M) * static_cast<size_t>(K / kConvRotGroup256) * sizeof(float);
+    ensure_convrot_global_workspace(rotated_bytes, partials_bytes);
+
+    dispatch_convrot_row_type(
+        in_dtype,
+        LaunchConvrotQuantGlobalManaged<ACT>{
+            x,
+            in_dtype,
+            qout,
+            scaleout,
+            M,
+            K,
+            stream,
+            g_convrot_global_ws.rotated,
+            g_convrot_global_ws.partial_absmax});
+}
+
+template void launch_convrot_quant_global_managed<kActNone>(
+    const void*, int, int8_t*, float*, int, int, hipStream_t);
+template void launch_convrot_quant_global_managed<kActGeluTanh>(
+    const void*, int, int8_t*, float*, int, int, hipStream_t);
+template void launch_convrot_quant_global_managed<kActSwiGLU>(
+    const void*, int, int8_t*, float*, int, int, hipStream_t);
+
+}  // namespace comfy::hip_backend
+
 extern "C" void launch_quantize_int8_rowwise_kernel(
     const void* x, int in_code, void* q, void* scales, int M, int K, hipStream_t stream) {
 
@@ -196,7 +300,7 @@ extern "C" void launch_quantize_int8_convrot_kernel(
 
     using namespace comfy::hip_backend;
     check_convrot_group_size(group_size);
-    check_convrot_k(K, group_size, in_code);
+    check_convrot_k(K, group_size, in_code, /*int8_quant=*/true);
     check_convrot_act(act_code);
     if (M == 0) {
         return;  // a zero-block launch is hipErrorInvalidConfiguration

--- a/comfy_kitchen/backends/hip/ops/quantize_int8.hip
+++ b/comfy_kitchen/backends/hip/ops/quantize_int8.hip
@@ -270,6 +270,15 @@ extern "C" void launch_quantize_int8_convrot_kernel(
     }
 }
 
+// Returns 1 when INT8 G=256 must use the global spill path for (M, K) on this device.
+extern "C" int convrot_int8_needs_spill_host(int M, int K) {
+    using namespace comfy::hip_backend;
+    if (M <= 0 || K <= 0 || (K % kConvRotGroup256) != 0) {
+        return 0;
+    }
+    return convrot_pick_fused_block_threads(M, K) == 0 ? 1 : 0;
+}
+
 // scratch is a 4-byte device buffer, pre-zeroed by the caller.
 extern "C" void launch_quantize_int8_tensorwise_kernel(
     const void* x, int in_code, void* q, void* scale, void* scratch,

--- a/comfy_kitchen/backends/hip/ops/quantize_int8.hip
+++ b/comfy_kitchen/backends/hip/ops/quantize_int8.hip
@@ -273,10 +273,7 @@ extern "C" void launch_quantize_int8_convrot_kernel(
 // Returns 1 when INT8 G=256 must use the global spill path for (M, K, in_dtype).
 extern "C" int convrot_int8_needs_spill_host(int M, int K, int in_code) {
     using namespace comfy::hip_backend;
-    if (M <= 0 || K <= 0 || (K % kConvRotGroup256) != 0) {
-        return 0;
-    }
-    return convrot_pick_fused_block_threads(M, K, in_code) == 0 ? 1 : 0;
+    return convrot_int8_needs_spill_buffers(M, K, in_code) ? 1 : 0;
 }
 
 // scratch is a 4-byte device buffer, pre-zeroed by the caller.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ import comfy_kitchen as ck
 def pytest_configure(config):
     config.addinivalue_line("markers", "cuda: mark test as requiring CUDA")
     config.addinivalue_line("markers", "slow: mark test as slow running")
+    config.addinivalue_line("markers", "performance: mark test as a GPU timing benchmark")
     config.addinivalue_line("markers", "cupy: mark test as requiring CuPy")
 
 

--- a/tests/test_hip_convrot_perf.py
+++ b/tests/test_hip_convrot_perf.py
@@ -14,6 +14,9 @@ import pytest
 import torch
 
 from comfy_kitchen.backends.eager.quantization import (
+    DTYPE_TO_CODE,
+)
+from comfy_kitchen.backends.eager.quantization import (
     quantize_and_rotate_rowwise as eager_quantize_and_rotate_rowwise,
 )
 from comfy_kitchen.tensor.int8_utils import _build_hadamard
@@ -107,7 +110,7 @@ def _bench_hip_convrot_quant(
     with torch.cuda.device(x.device):
         spill_rotated = None
         spill_partials = None
-        if hip._C.convrot_int8_needs_spill(m, k):
+        if hip._C.convrot_int8_needs_spill(m, k, DTYPE_TO_CODE[x.dtype]):
             spill_rotated = torch.empty((m, k), dtype=x.dtype, device=x.device)
             spill_partials = torch.empty((m, k // 256), dtype=torch.float32, device=x.device)
         for _ in range(warmup):

--- a/tests/test_hip_convrot_perf.py
+++ b/tests/test_hip_convrot_perf.py
@@ -105,40 +105,42 @@ def _bench_hip_convrot_quant(
     m, k = x.shape
     q = torch.empty((m, k), dtype=torch.int8, device=x.device)
     scales = torch.empty((m,), dtype=torch.float32, device=x.device)
-    spill_rotated = None
-    spill_partials = None
-    if hip._C.convrot_int8_needs_spill(m, k):
-        spill_rotated = torch.empty((m, k), dtype=x.dtype, device=x.device)
-        spill_partials = torch.empty((m, k // 256), dtype=torch.float32, device=x.device)
-    for _ in range(warmup):
-        hip._C.quantize_int8_convrot(
-            hip._dl(x),
-            hip._dl(q),
-            hip._dl(scales),
-            None if spill_rotated is None else hip._dl(spill_rotated),
-            None if spill_partials is None else hip._dl(spill_partials),
-            m,
-            k,
-            group_size,
-            0,
-            hip._stream(x),
-        )
+    with torch.cuda.device(x.device):
+        spill_rotated = None
+        spill_partials = None
+        if hip._C.convrot_int8_needs_spill(m, k):
+            spill_rotated = torch.empty((m, k), dtype=x.dtype, device=x.device)
+            spill_partials = torch.empty((m, k // 256), dtype=torch.float32, device=x.device)
+        for _ in range(warmup):
+            hip._C.quantize_int8_convrot(
+                hip._dl(x),
+                hip._dl(q),
+                hip._dl(scales),
+                None if spill_rotated is None else hip._dl(spill_rotated),
+                None if spill_partials is None else hip._dl(spill_partials),
+                m,
+                k,
+                group_size,
+                0,
+                hip._stream(x),
+            )
     _sync(x.device)
     times: list[float] = []
     for _ in range(iters):
         t0 = time.perf_counter()
-        hip._C.quantize_int8_convrot(
-            hip._dl(x),
-            hip._dl(q),
-            hip._dl(scales),
-            None if spill_rotated is None else hip._dl(spill_rotated),
-            None if spill_partials is None else hip._dl(spill_partials),
-            m,
-            k,
-            group_size,
-            0,
-            hip._stream(x),
-        )
+        with torch.cuda.device(x.device):
+            hip._C.quantize_int8_convrot(
+                hip._dl(x),
+                hip._dl(q),
+                hip._dl(scales),
+                None if spill_rotated is None else hip._dl(spill_rotated),
+                None if spill_partials is None else hip._dl(spill_partials),
+                m,
+                k,
+                group_size,
+                0,
+                hip._stream(x),
+            )
         _sync(x.device)
         times.append(time.perf_counter() - t0)
     return _mean_ms(times)

--- a/tests/test_hip_convrot_perf.py
+++ b/tests/test_hip_convrot_perf.py
@@ -105,15 +105,18 @@ def _bench_hip_convrot_quant(
     m, k = x.shape
     q = torch.empty((m, k), dtype=torch.int8, device=x.device)
     scales = torch.empty((m,), dtype=torch.float32, device=x.device)
-    spill_rotated = torch.empty((m, k), dtype=x.dtype, device=x.device)
-    spill_partials = torch.empty((m, k // 256), dtype=torch.float32, device=x.device)
+    spill_rotated = None
+    spill_partials = None
+    if hip._C.convrot_int8_needs_spill(m, k):
+        spill_rotated = torch.empty((m, k), dtype=x.dtype, device=x.device)
+        spill_partials = torch.empty((m, k // 256), dtype=torch.float32, device=x.device)
     for _ in range(warmup):
         hip._C.quantize_int8_convrot(
             hip._dl(x),
             hip._dl(q),
             hip._dl(scales),
-            hip._dl(spill_rotated),
-            hip._dl(spill_partials),
+            None if spill_rotated is None else hip._dl(spill_rotated),
+            None if spill_partials is None else hip._dl(spill_partials),
             m,
             k,
             group_size,
@@ -128,8 +131,8 @@ def _bench_hip_convrot_quant(
             hip._dl(x),
             hip._dl(q),
             hip._dl(scales),
-            hip._dl(spill_rotated),
-            hip._dl(spill_partials),
+            None if spill_rotated is None else hip._dl(spill_rotated),
+            None if spill_partials is None else hip._dl(spill_partials),
             m,
             k,
             group_size,

--- a/tests/test_hip_convrot_perf.py
+++ b/tests/test_hip_convrot_perf.py
@@ -34,7 +34,7 @@ pytestmark = [
 # Z-Image Turbo INT8 activation quant shapes (G=256 bf16).
 ZIMAGE_FUSED_SHAPE = (4128, 3840)       # fused LDS path on RDNA4
 ZIMAGE_LARGE_K_SHAPE = (4128, 10240)    # large K; often still fused on dGPU (64 KB LDS)
-ZIMAGE_SPILL_SHAPE = (4128, 17408)      # K above fused LDS ceiling -> global spill
+ZIMAGE_SPILL_SHAPE = (4128, 32768)      # K above any fused fallback on 64 KiB LDS
 
 COL_FUSED_GLOBAL = "Fused/global"
 COL_EAGER_CONVROT = "Eager ConvRot"
@@ -180,9 +180,9 @@ def hip():
     [
         (ZIMAGE_FUSED_SHAPE, "fused_k3840"),
         (ZIMAGE_LARGE_K_SHAPE, "large_k10240"),
-        (ZIMAGE_SPILL_SHAPE, "spill_k17408"),
+        (ZIMAGE_SPILL_SHAPE, "spill_k32768"),
     ],
-    ids=["fused_k3840", "large_k10240", "spill_k17408"],
+    ids=["fused_k3840", "large_k10240", "spill_k32768"],
 )
 def test_convrot_quant_hip_faster_than_eager(hip, shape, label):
     """HIP fused/global ConvRot quant should beat the eager Python path on Z-Image shapes."""

--- a/tests/test_hip_convrot_perf.py
+++ b/tests/test_hip_convrot_perf.py
@@ -17,7 +17,6 @@ from comfy_kitchen.backends.eager.quantization import (
     quantize_and_rotate_rowwise as eager_quantize_and_rotate_rowwise,
 )
 from comfy_kitchen.tensor.int8_utils import _build_hadamard
-
 from tests.test_hip_wmma import DEV, _unavailable_reason, needs_wmma
 
 _UNAVAILABLE = _unavailable_reason()

--- a/tests/test_hip_convrot_perf.py
+++ b/tests/test_hip_convrot_perf.py
@@ -6,6 +6,7 @@ the eager Python ``quantize_and_rotate_rowwise`` path on Z-Image Turbo INT8 shap
 
 from __future__ import annotations
 
+import os
 import statistics
 import time
 
@@ -29,8 +30,9 @@ pytestmark = [
 ]
 
 # Z-Image Turbo INT8 activation quant shapes (G=256 bf16).
-ZIMAGE_FUSED_SHAPE = (4128, 3840)   # fused LDS path on RDNA4
-ZIMAGE_GLOBAL_SHAPE = (4128, 10240)  # global spill path
+ZIMAGE_FUSED_SHAPE = (4128, 3840)       # fused LDS path on RDNA4
+ZIMAGE_LARGE_K_SHAPE = (4128, 10240)    # large K; often still fused on dGPU (64 KB LDS)
+ZIMAGE_SPILL_SHAPE = (4128, 17408)      # K above fused LDS ceiling -> global spill
 
 COL_FUSED_GLOBAL = "Fused/global"
 COL_EAGER_CONVROT = "Eager ConvRot"
@@ -103,11 +105,15 @@ def _bench_hip_convrot_quant(
     m, k = x.shape
     q = torch.empty((m, k), dtype=torch.int8, device=x.device)
     scales = torch.empty((m,), dtype=torch.float32, device=x.device)
+    spill_rotated = torch.empty((m, k), dtype=x.dtype, device=x.device)
+    spill_partials = torch.empty((m, k // 256), dtype=torch.float32, device=x.device)
     for _ in range(warmup):
         hip._C.quantize_int8_convrot(
             hip._dl(x),
             hip._dl(q),
             hip._dl(scales),
+            hip._dl(spill_rotated),
+            hip._dl(spill_partials),
             m,
             k,
             group_size,
@@ -122,6 +128,8 @@ def _bench_hip_convrot_quant(
             hip._dl(x),
             hip._dl(q),
             hip._dl(scales),
+            hip._dl(spill_rotated),
+            hip._dl(spill_partials),
             m,
             k,
             group_size,
@@ -161,14 +169,15 @@ def hip():
 
 
 @pytest.mark.parametrize(
-    ("shape", "label", "min_speedup"),
+    ("shape", "label"),
     [
-        (ZIMAGE_FUSED_SHAPE, "fused_k3840", 1.25),
-        (ZIMAGE_GLOBAL_SHAPE, "global_k10240", 1.15),
+        (ZIMAGE_FUSED_SHAPE, "fused_k3840"),
+        (ZIMAGE_LARGE_K_SHAPE, "large_k10240"),
+        (ZIMAGE_SPILL_SHAPE, "spill_k17408"),
     ],
-    ids=["fused_k3840", "global_k10240"],
+    ids=["fused_k3840", "large_k10240", "spill_k17408"],
 )
-def test_convrot_quant_hip_faster_than_eager(hip, shape, label, min_speedup):
+def test_convrot_quant_hip_faster_than_eager(hip, shape, label):
     """HIP fused/global ConvRot quant should beat the eager Python path on Z-Image shapes."""
     m, k = shape
     torch.manual_seed(0)
@@ -193,7 +202,12 @@ def test_convrot_quant_hip_faster_than_eager(hip, shape, label, min_speedup):
         col_left=COL_FUSED_GLOBAL,
         col_right=COL_EAGER_CONVROT,
     )
-    assert speedup >= min_speedup, (
-        f"expected fused/global quant >= {min_speedup:.2f}x faster than eager ConvRot for {label}, "
-        f"got {speedup:.2f}x (fused/global={fused_ms:.2f} ms, eager={eager_ms:.2f} ms)"
-    )
+
+    min_speedup = os.environ.get("CONVROT_PERF_MIN_SPEEDUP")
+    if min_speedup is not None:
+        threshold = float(min_speedup)
+        assert speedup >= threshold, (
+            f"expected fused/global quant >= {threshold:.2f}x faster than eager ConvRot for "
+            f"{label}, got {speedup:.2f}x (fused/global={fused_ms:.2f} ms, "
+            f"eager={eager_ms:.2f} ms)"
+        )

--- a/tests/test_hip_convrot_perf.py
+++ b/tests/test_hip_convrot_perf.py
@@ -1,0 +1,199 @@
+"""Performance microbenchmarks for HIP ConvRot INT8 quant (fused/global vs eager).
+
+Runs on HIP hardware without external models. Compares the HIP C++ kernel against
+the eager Python ``quantize_and_rotate_rowwise`` path on Z-Image Turbo INT8 shapes.
+"""
+
+from __future__ import annotations
+
+import statistics
+import time
+
+import pytest
+import torch
+
+from comfy_kitchen.backends.eager.quantization import (
+    quantize_and_rotate_rowwise as eager_quantize_and_rotate_rowwise,
+)
+from comfy_kitchen.tensor.int8_utils import _build_hadamard
+
+from tests.test_hip_wmma import DEV, _unavailable_reason, needs_wmma
+
+_UNAVAILABLE = _unavailable_reason()
+
+pytestmark = [
+    pytest.mark.skipif(_UNAVAILABLE is not None, reason=_UNAVAILABLE or ""),
+    pytest.mark.performance,
+    pytest.mark.slow,
+    needs_wmma,
+]
+
+# Z-Image Turbo INT8 activation quant shapes (G=256 bf16).
+ZIMAGE_FUSED_SHAPE = (4128, 3840)   # fused LDS path on RDNA4
+ZIMAGE_GLOBAL_SHAPE = (4128, 10240)  # global spill path
+
+COL_FUSED_GLOBAL = "Fused/global"
+COL_EAGER_CONVROT = "Eager ConvRot"
+
+
+def _sync(device: torch.device | str = DEV) -> None:
+    if torch.cuda.is_available():
+        torch.cuda.synchronize(device)
+
+
+def _mean_ms(times_s: list[float]) -> float:
+    return statistics.mean(times_s) * 1000.0
+
+
+def _uplift_pct(baseline: float, improved: float, *, lower_is_better: bool = True) -> float:
+    if baseline <= 0:
+        return 0.0
+    if lower_is_better:
+        return (baseline - improved) / baseline * 100.0
+    return (improved - baseline) / baseline * 100.0
+
+
+def _speedup(baseline: float, improved: float, *, lower_is_better: bool = True) -> float:
+    if improved <= 0:
+        return 0.0
+    if lower_is_better:
+        return baseline / improved
+    return improved / baseline
+
+
+def _print_uplift_table(
+    title: str,
+    rows: list[dict[str, str]],
+    *,
+    col_left: str,
+    col_right: str,
+) -> None:
+    headers = ("Benchmark", col_left, col_right, "Uplift")
+    col_widths = [
+        max(len(headers[0]), *(len(r["name"]) for r in rows)),
+        max(len(headers[1]), *(len(r["left"]) for r in rows)),
+        max(len(headers[2]), *(len(r["right"]) for r in rows)),
+        max(len(headers[3]), *(len(r["uplift"]) for r in rows)),
+    ]
+
+    def _row(cells: tuple[str, str, str, str]) -> str:
+        return (
+            f"| {cells[0]:<{col_widths[0]}} | "
+            f"{cells[1]:>{col_widths[1]}} | "
+            f"{cells[2]:>{col_widths[2]}} | "
+            f"{cells[3]:>{col_widths[3]}} |"
+        )
+
+    rule = "|-" + "-|-".join("-" * w for w in col_widths) + "-|"
+    print(f"\n## {title}")
+    print(_row(headers))
+    print(rule)
+    for row in rows:
+        print(_row((row["name"], row["left"], row["right"], row["uplift"])))
+
+
+def _bench_hip_convrot_quant(
+    hip,
+    x: torch.Tensor,
+    group_size: int,
+    *,
+    warmup: int,
+    iters: int,
+) -> float:
+    m, k = x.shape
+    q = torch.empty((m, k), dtype=torch.int8, device=x.device)
+    scales = torch.empty((m,), dtype=torch.float32, device=x.device)
+    for _ in range(warmup):
+        hip._C.quantize_int8_convrot(
+            hip._dl(x),
+            hip._dl(q),
+            hip._dl(scales),
+            m,
+            k,
+            group_size,
+            0,
+            hip._stream(x),
+        )
+    _sync(x.device)
+    times: list[float] = []
+    for _ in range(iters):
+        t0 = time.perf_counter()
+        hip._C.quantize_int8_convrot(
+            hip._dl(x),
+            hip._dl(q),
+            hip._dl(scales),
+            m,
+            k,
+            group_size,
+            0,
+            hip._stream(x),
+        )
+        _sync(x.device)
+        times.append(time.perf_counter() - t0)
+    return _mean_ms(times)
+
+
+def _bench_eager_convrot_quant(
+    x: torch.Tensor,
+    group_size: int,
+    *,
+    warmup: int,
+    iters: int,
+) -> float:
+    h = _build_hadamard(group_size, device=x.device, dtype=x.dtype)
+    for _ in range(warmup):
+        eager_quantize_and_rotate_rowwise(x, h, group_size)
+    _sync(x.device)
+    times: list[float] = []
+    for _ in range(iters):
+        t0 = time.perf_counter()
+        eager_quantize_and_rotate_rowwise(x, h, group_size)
+        _sync(x.device)
+        times.append(time.perf_counter() - t0)
+    return _mean_ms(times)
+
+
+@pytest.fixture
+def hip():
+    from comfy_kitchen.backends import hip as hip_backend
+
+    return hip_backend
+
+
+@pytest.mark.parametrize(
+    ("shape", "label", "min_speedup"),
+    [
+        (ZIMAGE_FUSED_SHAPE, "fused_k3840", 1.25),
+        (ZIMAGE_GLOBAL_SHAPE, "global_k10240", 1.15),
+    ],
+    ids=["fused_k3840", "global_k10240"],
+)
+def test_convrot_quant_hip_faster_than_eager(hip, shape, label, min_speedup):
+    """HIP fused/global ConvRot quant should beat the eager Python path on Z-Image shapes."""
+    m, k = shape
+    torch.manual_seed(0)
+    x = torch.randn(m, k, device=DEV, dtype=torch.bfloat16)
+
+    warmup, iters = 10, 30
+    fused_ms = _bench_hip_convrot_quant(hip, x, 256, warmup=warmup, iters=iters)
+    eager_ms = _bench_eager_convrot_quant(x, 256, warmup=warmup, iters=iters)
+    speedup = _speedup(eager_ms, fused_ms)
+    uplift_pct = _uplift_pct(eager_ms, fused_ms)
+
+    _print_uplift_table(
+        f"ConvRot quant microbench ({label}, M={m} K={k} G=256)",
+        [
+            {
+                "name": "Quant latency",
+                "left": f"{fused_ms:.2f} ms",
+                "right": f"{eager_ms:.2f} ms",
+                "uplift": f"{uplift_pct:+.1f}% ({speedup:.2f}x)",
+            }
+        ],
+        col_left=COL_FUSED_GLOBAL,
+        col_right=COL_EAGER_CONVROT,
+    )
+    assert speedup >= min_speedup, (
+        f"expected fused/global quant >= {min_speedup:.2f}x faster than eager ConvRot for {label}, "
+        f"got {speedup:.2f}x (fused/global={fused_ms:.2f} ms, eager={eager_ms:.2f} ms)"
+    )

--- a/tests/test_hip_wmma.py
+++ b/tests/test_hip_wmma.py
@@ -2141,6 +2141,29 @@ def test_convrot_falls_back_to_eager_past_the_lds_bound(hip, dtype):
         )
 
 
+def test_convrot_spill_rotated_dtype_must_match_x(hip):
+    """spill_rotated is written as RowT derived from x; dtype must match."""
+    m, k = 2, 256
+    x = torch.randn(m, k, device=DEV, dtype=torch.float32)
+    q = torch.zeros(m, k, dtype=torch.int8, device=DEV)
+    scales = torch.zeros(m, dtype=torch.float32, device=DEV)
+    spill_rotated = torch.empty(m, k, dtype=torch.bfloat16, device=DEV)
+    spill_partials = torch.empty(m, k // 256, dtype=torch.float32, device=DEV)
+    with pytest.raises(RuntimeError, match="spill_rotated dtype must match x"):
+        hip._C.quantize_int8_convrot(
+            hip._dl(x),
+            hip._dl(q),
+            hip._dl(scales),
+            hip._dl(spill_rotated),
+            hip._dl(spill_partials),
+            m,
+            k,
+            256,
+            0,
+            hip._stream(x),
+        )
+
+
 def test_convrot_lds_bound_accounts_for_row_dtype(hip):
     max_fp32 = hip._C.convrot_max_k(hip.DTYPE_TO_CODE[torch.float32])
     max_fp16 = hip._C.convrot_max_k(hip.DTYPE_TO_CODE[torch.float16])

--- a/tests/test_hip_wmma.py
+++ b/tests/test_hip_wmma.py
@@ -147,9 +147,9 @@ def test_int8_linear_convrot_matches_eager():
 
 
 @needs_wmma
-@pytest.mark.parametrize("k", [3840, 10240, 17408])
+@pytest.mark.parametrize("k", [3840, 10240, 32768])
 def test_int8_linear_convrot_large_k_matches_eager(k):
-    """G=256 INT8 convrot: fused (3840, 10240), global spill (17408) vs eager."""
+    """G=256 INT8 convrot: fused (3840, 10240), global spill (32768) vs eager."""
     torch.manual_seed(k)
     m, n = 64, 256
     x = torch.randn(m, k, device=DEV, dtype=torch.bfloat16)
@@ -2172,7 +2172,7 @@ def test_convrot_int8_needs_spill_probe(hip):
     in_code = hip.DTYPE_TO_CODE[torch.bfloat16]
     with torch.cuda.device(DEV):
         assert not hip._C.convrot_int8_needs_spill(4128, 10240, in_code)
-        assert hip._C.convrot_int8_needs_spill(4128, 17408, in_code)
+        assert hip._C.convrot_int8_needs_spill(4128, 32768, in_code)
 
 
 def test_convrot_lds_bound_accounts_for_row_dtype(hip):

--- a/tests/test_hip_wmma.py
+++ b/tests/test_hip_wmma.py
@@ -146,6 +146,27 @@ def test_int8_linear_convrot_matches_eager():
     assert (out.float() - ref.float()).abs().max().item() < 0.05 * scale
 
 
+@needs_wmma
+@pytest.mark.parametrize("k", [3840, 10240])
+def test_int8_linear_convrot_large_k_matches_eager(k):
+    """G=256 INT8 convrot: fused LDS (3840) and global spill (10240) vs eager."""
+    torch.manual_seed(k)
+    m, n = 64, 256
+    x = torch.randn(m, k, device=DEV, dtype=torch.bfloat16)
+    w = torch.randn(n, k, device=DEV, dtype=torch.bfloat16)
+    wq, ws = ck.quantize_int8_rowwise(w)
+
+    with ck.use_backend("hip"):
+        out = ck.int8_linear(x, wq, ws.reshape(-1), None, torch.bfloat16, convrot=True,
+                             convrot_groupsize=256)
+    with ck.use_backend("eager"):
+        ref = ck.int8_linear(x, wq, ws.reshape(-1), None, torch.bfloat16, convrot=True,
+                             convrot_groupsize=256)
+
+    scale = ref.float().abs().max().item()
+    assert (out.float() - ref.float()).abs().max().item() < 0.05 * scale
+
+
 def _offset_copy(t: torch.Tensor) -> torch.Tensor:
     """A contiguous copy of ``t`` deliberately based off a 16-byte boundary."""
     flat = t.reshape(-1)

--- a/tests/test_hip_wmma.py
+++ b/tests/test_hip_wmma.py
@@ -380,20 +380,23 @@ def test_convrot_quantizer_folds_the_activation_in(hip):
     assert fused_s.shape == (x.shape[0],)
 
 
+@pytest.mark.parametrize("group_size", [16, 256])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
-def test_convrot_int8_preserves_input_dtype_precision(hip, dtype):
-    """The fused row buffer must not introduce a BF16-only rounding stage."""
-    group = 16
-    x = torch.zeros(2, 64, device=DEV, dtype=dtype)
+def test_convrot_int8_preserves_input_dtype_precision(hip, dtype, group_size):
+    """The fused row buffer must round to the input dtype before absmax, like legacy."""
+    k = group_size if group_size == 256 else group_size * 4
+    idx1 = group_size if group_size == 16 else group_size // 4
+    norm = (1.0 / float(group_size)) ** 0.5
+    x = torch.zeros(2, k, device=DEV, dtype=dtype)
     x[0, 0] = 1.001
-    x[1, 16] = 3.141
-    h = _build_hadamard(group, device=DEV, dtype=dtype)
+    x[1, idx1] = 3.141
+    h = _build_hadamard(group_size, device=DEV, dtype=dtype)
 
-    q_hip, scales_hip = hip.quantize_and_rotate_rowwise(x, h, group)
-    q_eager, scales_eager = eager_quantize_and_rotate_rowwise(x, h, group)
+    q_hip, scales_hip = hip.quantize_and_rotate_rowwise(x, h, group_size)
+    q_eager, scales_eager = eager_quantize_and_rotate_rowwise(x, h, group_size)
 
-    values = torch.stack((x[0, 0], x[1, 16]))
-    expected_rowmax = (values.float() * 0.25).to(dtype).float().abs()
+    values = torch.stack((x[0, 0], x[1, idx1]))
+    expected_rowmax = (values.float() * norm).to(dtype).float().abs()
     torch.testing.assert_close(scales_hip.reshape(-1) * 127.0, expected_rowmax, rtol=1e-6, atol=0)
     torch.testing.assert_close(scales_hip, scales_eager, rtol=1e-6, atol=0)
     assert (q_hip.int() - q_eager.int()).abs().max().item() <= 1

--- a/tests/test_hip_wmma.py
+++ b/tests/test_hip_wmma.py
@@ -147,9 +147,9 @@ def test_int8_linear_convrot_matches_eager():
 
 
 @needs_wmma
-@pytest.mark.parametrize("k", [3840, 10240])
+@pytest.mark.parametrize("k", [3840, 10240, 17408])
 def test_int8_linear_convrot_large_k_matches_eager(k):
-    """G=256 INT8 convrot: fused LDS (3840) and global spill (10240) vs eager."""
+    """G=256 INT8 convrot: fused LDS (3840), large K (10240), global spill (17408) vs eager."""
     torch.manual_seed(k)
     m, n = 64, 256
     x = torch.randn(m, k, device=DEV, dtype=torch.bfloat16)
@@ -2137,7 +2137,7 @@ def test_convrot_falls_back_to_eager_past_the_lds_bound(hip, dtype):
     sb = torch.zeros(2, dtype=torch.float32, device=DEV)
     with pytest.raises(RuntimeError, match="LDS"):
         hip._C.quantize_int8_convrot(
-            hip._dl(x), hip._dl(qb), hip._dl(sb), 2, k, 64, 0, hip._stream(x)
+            hip._dl(x), hip._dl(qb), hip._dl(sb), None, None, 2, k, 64, 0, hip._stream(x)
         )
 
 

--- a/tests/test_hip_wmma.py
+++ b/tests/test_hip_wmma.py
@@ -149,7 +149,7 @@ def test_int8_linear_convrot_matches_eager():
 @needs_wmma
 @pytest.mark.parametrize("k", [3840, 10240, 17408])
 def test_int8_linear_convrot_large_k_matches_eager(k):
-    """G=256 INT8 convrot: fused LDS (3840), large K (10240), global spill (17408) vs eager."""
+    """G=256 INT8 convrot: fused (3840, 10240), global spill (17408) vs eager."""
     torch.manual_seed(k)
     m, n = 64, 256
     x = torch.randn(m, k, device=DEV, dtype=torch.bfloat16)
@@ -2165,6 +2165,14 @@ def test_convrot_spill_rotated_dtype_must_match_x(hip):
             0,
             hip._stream(x),
         )
+
+
+@needs_wmma
+def test_convrot_int8_needs_spill_probe(hip):
+    in_code = hip.DTYPE_TO_CODE[torch.bfloat16]
+    with torch.cuda.device(DEV):
+        assert not hip._C.convrot_int8_needs_spill(4128, 10240, in_code)
+        assert hip._C.convrot_int8_needs_spill(4128, 17408, in_code)
 
 
 def test_convrot_lds_bound_accounts_for_row_dtype(hip):


### PR DESCRIPTION
## Summary

Adds a fused HIP GPU path for INT8 ConvRot G=256 activation quantization on WMMA-capable **RDNA3 / RDNA3.5 / RDNA4** GPUs: a fused single-kernel path when the rotated row fits in LDS, and a global spill path when it does not.

Replaces slow **legacy HIP** and **eager Python** Hadamard + quant paths for large-K layers (e.g. Z-Image Turbo INT8 at K=3840/10240).

- **Fused single-kernel** path when the rotated row fits in LDS (typical K=3840).
- **Global spill** when no fused block configuration fits in LDS.
- **Shape-aware dispatch**: picks block size (64/512/640/768/1024) by per-(M,K) LDS fit, trying narrower blocks before spilling — keeps K=10240 on a **single fused kernel** on RDNA dGPUs (e.g. 512-thread config on gfx1201) instead of 2-kernel spill.

Target workload: `int8_linear(..., convrot=True, convrot_groupsize=256)`

## Changes

- **`hadamard.h`**: fused `convrot_quant_fused_kernel` (FHT stage64, G=256); global spill kernels; legacy G=16/64/int4 unchanged; `convrot_pick_fused_block_threads()` for LDS-aware dispatch.
- **`quantize_int8.hip`**: global spill workspace (`hipMalloc`) for large K when fused does not fit.
- **`hip/__init__.py`**: route INT8 ConvRot G=256 through fused/spill via `_rotate_quant_int8`; `int8_global_spill` in `_convrot_supported` so Python no longer rejects large K.
- **Tests**: correctness K=3840/10240; microbench vs eager; `performance` pytest marker.

## Running tests

**Correctness** — fused LDS (K=3840) and large K (K=10240) vs eager:

```bash
pytest tests/test_hip_wmma.py::test_int8_linear_convrot_large_k_matches_eager -v
```

**Performance** — Z-Image Turbo INT8 shapes (M=4128, K=3840/10240, G=256); prints timing tables with `-s`:

```bash
pytest tests/test_hip_convrot_perf.py -v -s
```

## Benchmarks (Windows)

**Setup**
- **PR branch** = fused FHT kernel or global spill (this PR).
- **main** = legacy HIP ConvRot kernel and/or eager Python fallback.
- **Microbench “Eager ConvRot”** = Python Hadamard + quant in the PR checkout.
- **Z-Image:** PR vs `main` built checkouts, ComfyUI Z-Image Turbo INT8, 8 steps @ 1024², n=1.

### gfx1201 (Navi 48 XTX, RDNA4)

#### Z-Image Turbo INT8

| Benchmark | PR branch | main | Uplift (speedup) |
|-----------|-----------|------|------------------|
| Quant / step | 57.0 ms | 103.6 ms | +45.0% (1.82x) |
| E2E it/s | 1.78 it/s | 1.64 it/s | +8.6% (1.09x) |

#### Microbench

| Shape | HIP fused/spill | Eager ConvRot | Uplift (speedup) |
|-------|-----------------|---------------|------------------|
| K=3840 (M=4128, G=256) | 0.25 ms | 0.65 ms | +61.1% (2.57x) |
| K=10240 (M=4128, G=256) | 0.42 ms | 2.05 ms | +79.3% (4.83x) |

### gfx1100 (7900 XTX, RDNA3)

#### Z-Image Turbo INT8

| Benchmark | PR branch | main | Uplift (speedup) |
|-----------|-----------|------|------------------|
| Quant / step | 57.6 ms | 85.9 ms | +32.9% (1.49x) |
| E2E it/s | 1.28 it/s | 1.21 it/s | +5.3% (1.06x) |

#### Microbench

| Shape | HIP fused/spill | Eager ConvRot | Uplift (speedup) |
|-------|-----------------|---------------|------------------|
| K=3840 (M=4128, G=256) | 0.31 ms | 0.75 ms | +58.6% (2.41x) |
| K=10240 (M=4128, G=256) | 0.35 ms | 1.61 ms | +78.5% (4.66x) |

### gfx1151 (Strix Halo, RDNA3.5)

#### Z-Image Turbo INT8

| Benchmark | PR branch | main | Uplift (speedup) |
|-----------|-----------|------|------------------|
| Quant / step | 95.4 ms | 151.8 ms | +37.2% (1.59x) |
| E2E it/s | 0.54 it/s | 0.52 it/s | +2.9% (1.04x) |

#### Microbench

| Shape | HIP fused/spill | Eager ConvRot | Uplift (speedup) |
|-------|-----------------|---------------|------------------|
| K=3840 (M=4128, G=256) | 0.37 ms | 1.81 ms | +79.4% (4.87x) |
| K=10240 (M=4128, G=256) | 0.79 ms | 5.29 ms | +85.0% (6.66x) |

### gfx1150 (Strix Point APU, RDNA3.5)

#### Z-Image Turbo INT8

| Benchmark | PR branch | main | Uplift (speedup) |
|-----------|-----------|------|------------------|
| Quant / step | 265.7 ms | 340.3 ms | +21.9% (1.28x) |
| E2E it/s | 0.16 it/s | 0.16 it/s | +2.3% (1.02x) |

#### Microbench

| Shape | HIP fused/spill | Eager ConvRot | Uplift (speedup) |
|-------|-----------------|---------------|------------------|
| K=3840 (M=4128, G=256) | 0.83 ms | 5.56 ms | +85.0% (6.67x) |
| K=10240 (M=4128, G=256) | 4.19 ms | 12.85 ms | +67.4% (3.07x) |