### PR TITLE
Occupancy-aware HIP WMMA GEMM tile selection and vectorized fp8 elementwise kernels

### DIFF
--- a/comfy_kitchen/backends/hip/fp8_utils.h
+++ b/comfy_kitchen/backends/hip/fp8_utils.h
@@ -17,6 +17,22 @@ namespace comfy::hip_backend {
 // dtype codes match comfy_kitchen.backends.eager.quantization.DTYPE_TO_CODE
 constexpr int kFp8E4M3Code = 5;
 
+// Enough elements per thread for a lane to move a whole 16-byte fp8 chunk, so a
+// wave writes 512 contiguous bytes rather than 32.
+constexpr int kVecElems = 16;
+
+// The alignment is what lets the accesses widen to dwordx4.
+template <typename T>
+struct alignas(16) VecChunk {
+    T v[kVecElems];
+};
+
+// A contiguous tensor can still be a mid-buffer view, whose base carries the
+// offset and is not 16-byte aligned.
+__forceinline__ __host__ __device__ bool vec_aligned(const void* p) {
+    return (reinterpret_cast<uintptr_t>(p) & 15u) == 0;
+}
+
 __forceinline__ __device__ float fp8_clamp(float v, float lo, float hi) {
     return fminf(hi, fmaxf(lo, v));
 }

--- a/comfy_kitchen/backends/hip/gemm_wmma.h
+++ b/comfy_kitchen/backends/hip/gemm_wmma.h
@@ -18,6 +18,8 @@
 // registers before the current tile's math.
 #pragma once
 
+#include <atomic>
+
 #include "mma.h"
 
 namespace comfy::hip_backend {
@@ -215,6 +217,82 @@ __global__ __launch_bounds__(WARPS_M* WARPS_N* kWave) void gemm_wmma_kernel(
                 crow[col] = static_cast<OutT>(epi(r, col, Mma::get(acc[i][j], e)));
             }
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tile selection, shared by the fp8 and int8 launchers.
+// ---------------------------------------------------------------------------
+
+// hipDeviceAttributeMultiprocessorCount reports WGPs on RDNA, not CUs (32 on a
+// 64-CU gfx1201), and a workgroup schedules onto a WGP, so WGPs are the unit the
+// grid-coverage test needs. Cached per ordinal to keep the query off the launch
+// path; the fallback only mis-sizes that test, never a result.
+inline int device_wgp_count() {
+    constexpr int kMaxDevices = 16;
+    // A GEMM can be launched from several host threads at once. Racing threads
+    // write the same value and nothing is published through the cache, so relaxed.
+    static std::atomic<int> cache[kMaxDevices] = {};
+    int dev = 0;
+    if (hipGetDevice(&dev) != hipSuccess || dev < 0 || dev >= kMaxDevices) return 16;
+    int n = cache[dev].load(std::memory_order_relaxed);
+    if (n == 0) {
+        if (hipDeviceGetAttribute(&n, hipDeviceAttributeMultiprocessorCount, dev) != hipSuccess ||
+            n <= 0) {
+            n = 16;
+        }
+        cache[dev].store(n, std::memory_order_relaxed);
+    }
+    return n;
+}
+
+// Pick and launch a tile for C[M, N] = A[M, K] @ B[N, K]^T, selecting on grid
+// coverage, K depth and warp grid. 128x128 has the best arithmetic intensity but
+// wastes the device when it yields fewer blocks than there are WGPs; BKB=128
+// halves the LDS round trips per K element once K amortizes the coarser tail.
+// The thresholds are tuned on RDNA4 and govern tile choice only, never
+// correctness. kbytes is bytes of K, equal to K only for the 8-bit policies, so
+// an int4 caller passing K/2 fires at twice the K these read as.
+template <typename Mma, typename Epi, typename OutT>
+void launch_gemm_wmma(const uint8_t* A, const uint8_t* B, OutT* C, int M, int N, int kbytes,
+                      int ldc, Epi epi, hipStream_t stream) {
+    const int blocks_128 = ((M + 127) / 128) * ((N + 127) / 128);
+
+    const int wgps = device_wgp_count();
+
+    // Zero padding the block count cannot see: at M <= 64 the 128-row tile is at
+    // least half empty, and the finer 64x64 grid recovers the wasted MMAs.
+    const bool skinny = (M <= 64 || N <= 64);
+
+    if (!skinny && blocks_128 >= wgps) {
+        if (kbytes >= 4096) {
+            constexpr int BM = 128, BN = 128, BKB = 128;
+            dim3 grid((N + BN - 1) / BN, (M + BM - 1) / BM);
+            // With few blocks per WGP there is nothing to interleave across, so
+            // the 16-wave grid hides latency within a block instead.
+            if (blocks_128 <= 4 * wgps) {
+                gemm_wmma_kernel<Mma, Epi, OutT, BM, BN, BKB, 4, 4, 2, 2>
+                    <<<grid, 512, 0, stream>>>(A, B, C, M, N, kbytes, ldc, epi);
+            } else {
+                gemm_wmma_kernel<Mma, Epi, OutT, BM, BN, BKB, 4, 2, 2, 4>
+                    <<<grid, 256, 0, stream>>>(A, B, C, M, N, kbytes, ldc, epi);
+            }
+        } else {
+            constexpr int BM = 128, BN = 128, BKB = 64;
+            dim3 grid((N + BN - 1) / BN, (M + BM - 1) / BM);
+            gemm_wmma_kernel<Mma, Epi, OutT, BM, BN, BKB, 4, 2, 2, 4>
+                <<<grid, 256, 0, stream>>>(A, B, C, M, N, kbytes, ldc, epi);
+        }
+    } else if (kbytes >= 2048) {
+        constexpr int BM = 64, BN = 64, BKB = 128;
+        dim3 grid((N + BN - 1) / BN, (M + BM - 1) / BM);
+        gemm_wmma_kernel<Mma, Epi, OutT, BM, BN, BKB, 2, 2, 2, 2>
+            <<<grid, 128, 0, stream>>>(A, B, C, M, N, kbytes, ldc, epi);
+    } else {
+        constexpr int BM = 64, BN = 64, BKB = 64;
+        dim3 grid((N + BN - 1) / BN, (M + BM - 1) / BM);
+        gemm_wmma_kernel<Mma, Epi, OutT, BM, BN, BKB, 2, 2, 2, 2>
+            <<<grid, 128, 0, stream>>>(A, B, C, M, N, kbytes, ldc, epi);
     }
 }
 

--- a/comfy_kitchen/backends/hip/ops/gemm_fp8.hip
+++ b/comfy_kitchen/backends/hip/ops/gemm_fp8.hip
@@ -56,26 +56,7 @@ static void launch_fp8(const uint8_t* A, const uint8_t* B, OutT* C, int M, int N
         gemv_fp8_kernel<OutT><<<grid, block, 0, stream>>>(A, B, C, M, N, K, epi);
         return;
     }
-    // A 256x128 block reads (256+128)*K bytes per output tile against
-    // (128+128)*K for 128x128, i.e. 25% less global traffic per output. Selected
-    // for deep-K shapes, which are bandwidth bound; wide-N shapes have enough
-    // reuse and prefer the larger grid of the squarer tile.
-    if (M >= 512 && N >= 128 && K > N) {
-        constexpr int BM = 256, BN = 128, BKB = 64;
-        dim3 grid((N + BN - 1) / BN, (M + BM - 1) / BM);
-        gemm_wmma_kernel<MmaFp8, EpiTensorwise, OutT, BM, BN, BKB, 4, 2, 4, 4>
-            <<<grid, 256, 0, stream>>>(A, B, C, M, N, K, N, epi);
-    } else if (M >= 96 && N >= 96) {
-        constexpr int BM = 128, BN = 128, BKB = 64;
-        dim3 grid((N + BN - 1) / BN, (M + BM - 1) / BM);
-        gemm_wmma_kernel<MmaFp8, EpiTensorwise, OutT, BM, BN, BKB, 4, 2, 2, 4>
-            <<<grid, 256, 0, stream>>>(A, B, C, M, N, K, N, epi);
-    } else {
-        constexpr int BM = 64, BN = 64, BKB = 64;
-        dim3 grid((N + BN - 1) / BN, (M + BM - 1) / BM);
-        gemm_wmma_kernel<MmaFp8, EpiTensorwise, OutT, BM, BN, BKB, 2, 2, 2, 2>
-            <<<grid, 128, 0, stream>>>(A, B, C, M, N, K, N, epi);
-    }
+    launch_gemm_wmma<MmaFp8, EpiTensorwise, OutT>(A, B, C, M, N, K, N, epi, stream);
 }
 
 }  // namespace comfy::hip_backend

--- a/comfy_kitchen/backends/hip/ops/gemm_int8.hip
+++ b/comfy_kitchen/backends/hip/ops/gemm_int8.hip
@@ -55,22 +55,7 @@ static void launch_int8(const int8_t* A, const int8_t* B, OutT* C, int M, int N,
         gemv_int8_kernel<OutT><<<grid, block, 0, stream>>>(A, B, C, M, N, K, ldc, epi);
         return;
     }
-    if (M >= 512 && N >= 128 && K > N) {
-        constexpr int BM = 256, BN = 128, BKB = 64;
-        dim3 grid((N + BN - 1) / BN, (M + BM - 1) / BM);
-        gemm_wmma_kernel<MmaInt8, EpiRowwise, OutT, BM, BN, BKB, 4, 2, 4, 4>
-            <<<grid, 256, 0, stream>>>(Au, Bu, C, M, N, K, ldc, epi);
-    } else if (M >= 96 && N >= 96) {
-        constexpr int BM = 128, BN = 128, BKB = 64;
-        dim3 grid((N + BN - 1) / BN, (M + BM - 1) / BM);
-        gemm_wmma_kernel<MmaInt8, EpiRowwise, OutT, BM, BN, BKB, 4, 2, 2, 4>
-            <<<grid, 256, 0, stream>>>(Au, Bu, C, M, N, K, ldc, epi);
-    } else {
-        constexpr int BM = 64, BN = 64, BKB = 64;
-        dim3 grid((N + BN - 1) / BN, (M + BM - 1) / BM);
-        gemm_wmma_kernel<MmaInt8, EpiRowwise, OutT, BM, BN, BKB, 2, 2, 2, 2>
-            <<<grid, 128, 0, stream>>>(Au, Bu, C, M, N, K, ldc, epi);
-    }
+    launch_gemm_wmma<MmaInt8, EpiRowwise, OutT>(Au, Bu, C, M, N, K, ldc, epi, stream);
 }
 
 }  // namespace comfy::hip_backend

--- a/comfy_kitchen/backends/hip/ops/per_tensor_fp8.hip
+++ b/comfy_kitchen/backends/hip/ops/per_tensor_fp8.hip
@@ -16,17 +16,6 @@ namespace comfy::hip_backend {
 
 constexpr int kThreads = 256;
 
-// Elements per thread on the vectorized path: enough for a lane to move a whole
-// 16-byte fp8 chunk, so a wave writes 512 contiguous bytes rather than 32.
-constexpr int kVecElems = 16;
-
-// Register staging for one thread's run. The alignment is what lets the accesses
-// widen to dwordx4.
-template <typename T>
-struct alignas(16) VecChunk {
-    T v[kVecElems];
-};
-
 template<typename T>
 __forceinline__ __device__ T from_float_as(float value) {
     return static_cast<T>(value);
@@ -134,12 +123,6 @@ __global__ void dequantize_per_tensor_fp8_vec_kernel(
             store_value<OutputType>(output, i, unpack_fp8(input[i], input_dtype_code) * s);
         }
     }
-}
-
-// Gates the vectorized path: a contiguous tensor can still be a mid-buffer view,
-// whose base carries the offset and is not 16-byte aligned.
-__forceinline__ static bool vec_aligned(const void* p) {
-    return (reinterpret_cast<uintptr_t>(p) & 15u) == 0;
 }
 
 } // namespace comfy::hip_backend

--- a/comfy_kitchen/backends/hip/ops/per_tensor_fp8.hip
+++ b/comfy_kitchen/backends/hip/ops/per_tensor_fp8.hip
@@ -16,14 +16,32 @@ namespace comfy::hip_backend {
 
 constexpr int kThreads = 256;
 
+// Elements per thread on the vectorized path: enough for a lane to move a whole
+// 16-byte fp8 chunk, so a wave writes 512 contiguous bytes rather than 32.
+constexpr int kVecElems = 16;
+
+// Register staging for one thread's run. The alignment is what lets the accesses
+// widen to dwordx4.
+template <typename T>
+struct alignas(16) VecChunk {
+    T v[kVecElems];
+};
+
 template<typename T>
-__forceinline__ __device__ void store_value(void* dst, int64_t idx, float value) {
-    reinterpret_cast<T*>(dst)[idx] = static_cast<T>(value);
+__forceinline__ __device__ T from_float_as(float value) {
+    return static_cast<T>(value);
 }
 
 template<>
-__forceinline__ __device__ void store_value<__half>(void* dst, int64_t idx, float value) {
-    reinterpret_cast<__half*>(dst)[idx] = __float2half(value);
+__forceinline__ __device__ __half from_float_as<__half>(float value) {
+    return __float2half(value);
+}
+
+// Delegates so a kernel's vectorized body and scalar tail cannot drift onto
+// different float->T conversions.
+template<typename T>
+__forceinline__ __device__ void store_value(void* dst, int64_t idx, float value) {
+    reinterpret_cast<T*>(dst)[idx] = from_float_as<T>(value);
 }
 
 template<typename InputType>
@@ -57,6 +75,73 @@ __global__ void dequantize_per_tensor_fp8_kernel(
     store_value<OutputType>(output, idx, unpack_fp8(input[idx], input_dtype_code) * scale[0]);
 }
 
+// Vectorized counterparts. The per-element arithmetic is identical to the scalar
+// kernels above, so both paths give bit-for-bit the same result.
+template<typename InputType>
+__global__ void quantize_per_tensor_fp8_vec_kernel(
+    const InputType* __restrict__ input,
+    const float* __restrict__ scale,
+    uint8_t* __restrict__ output,
+    int64_t numel,
+    int output_dtype_code) {
+
+    const int64_t i0 = (static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x) * kVecElems;
+    if (i0 >= numel) {
+        return;
+    }
+    const float s = scale[0];
+
+    if (i0 + kVecElems <= numel) {
+        const VecChunk<InputType> in = *reinterpret_cast<const VecChunk<InputType>*>(input + i0);
+        VecChunk<uint8_t> out;
+        #pragma unroll
+        for (int i = 0; i < kVecElems; ++i) {
+            out.v[i] = pack_fp8(to_float(in.v[i]) / s, output_dtype_code);
+        }
+        *reinterpret_cast<VecChunk<uint8_t>*>(output + i0) = out;
+    } else {
+        for (int64_t i = i0; i < numel; ++i) {
+            output[i] = pack_fp8(to_float(input[i]) / s, output_dtype_code);
+        }
+    }
+}
+
+template<typename OutputType>
+__global__ void dequantize_per_tensor_fp8_vec_kernel(
+    const uint8_t* __restrict__ input,
+    const float* __restrict__ scale,
+    void* __restrict__ output,
+    int64_t numel,
+    int input_dtype_code) {
+
+    const int64_t i0 = (static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x) * kVecElems;
+    if (i0 >= numel) {
+        return;
+    }
+    const float s = scale[0];
+    OutputType* out_typed = reinterpret_cast<OutputType*>(output);
+
+    if (i0 + kVecElems <= numel) {
+        const VecChunk<uint8_t> in = *reinterpret_cast<const VecChunk<uint8_t>*>(input + i0);
+        VecChunk<OutputType> out;
+        #pragma unroll
+        for (int i = 0; i < kVecElems; ++i) {
+            out.v[i] = from_float_as<OutputType>(unpack_fp8(in.v[i], input_dtype_code) * s);
+        }
+        *reinterpret_cast<VecChunk<OutputType>*>(out_typed + i0) = out;
+    } else {
+        for (int64_t i = i0; i < numel; ++i) {
+            store_value<OutputType>(output, i, unpack_fp8(input[i], input_dtype_code) * s);
+        }
+    }
+}
+
+// Gates the vectorized path: a contiguous tensor can still be a mid-buffer view,
+// whose base carries the offset and is not 16-byte aligned.
+__forceinline__ static bool vec_aligned(const void* p) {
+    return (reinterpret_cast<uintptr_t>(p) & 15u) == 0;
+}
+
 } // namespace comfy::hip_backend
 
 extern "C" {
@@ -74,16 +159,36 @@ void launch_quantize_per_tensor_fp8_kernel(
         return;  // a zero-block launch is hipErrorInvalidConfiguration
     }
 
-    const int blocks = static_cast<int>((numel + comfy::hip_backend::kThreads - 1) / comfy::hip_backend::kThreads);
+    using namespace comfy::hip_backend;
+
+    const bool vec = vec_aligned(input) && vec_aligned(output);
+    const int64_t per_thread = vec ? kVecElems : 1;
+    const int blocks =
+        static_cast<int>((numel + per_thread * kThreads - 1) / (per_thread * kThreads));
+
+#define COMFY_LAUNCH_QUANT(T)                                                                     \
+    do {                                                                                          \
+        if (vec) {                                                                                \
+            quantize_per_tensor_fp8_vec_kernel<T><<<blocks, kThreads, 0, stream>>>(               \
+                static_cast<const T*>(input), static_cast<const float*>(scale),                   \
+                static_cast<uint8_t*>(output), numel, output_dtype_code);                         \
+        } else {                                                                                  \
+            quantize_per_tensor_fp8_kernel<T><<<blocks, kThreads, 0, stream>>>(                   \
+                static_cast<const T*>(input), static_cast<const float*>(scale),                   \
+                static_cast<uint8_t*>(output), numel, output_dtype_code);                         \
+        }                                                                                         \
+    } while (0)
+
     if (input_dtype_code == 0) {
-        comfy::hip_backend::quantize_per_tensor_fp8_kernel<float><<<blocks, comfy::hip_backend::kThreads, 0, stream>>>(static_cast<const float*>(input), static_cast<const float*>(scale), static_cast<uint8_t*>(output), numel, output_dtype_code);
+        COMFY_LAUNCH_QUANT(float);
     } else if (input_dtype_code == 1) {
-        comfy::hip_backend::quantize_per_tensor_fp8_kernel<__half><<<blocks, comfy::hip_backend::kThreads, 0, stream>>>(static_cast<const __half*>(input), static_cast<const float*>(scale), static_cast<uint8_t*>(output), numel, output_dtype_code);
+        COMFY_LAUNCH_QUANT(__half);
     } else if (input_dtype_code == 2) {
-        comfy::hip_backend::quantize_per_tensor_fp8_kernel<__bf16><<<blocks, comfy::hip_backend::kThreads, 0, stream>>>(static_cast<const __bf16*>(input), static_cast<const float*>(scale), static_cast<uint8_t*>(output), numel, output_dtype_code);
+        COMFY_LAUNCH_QUANT(__bf16);
     } else {
         throw std::runtime_error("Unsupported input dtype for quantize_per_tensor_fp8");
     }
+#undef COMFY_LAUNCH_QUANT
 }
 
 void launch_dequantize_per_tensor_fp8_kernel(
@@ -99,16 +204,36 @@ void launch_dequantize_per_tensor_fp8_kernel(
         return;  // a zero-block launch is hipErrorInvalidConfiguration
     }
 
-    const int blocks = static_cast<int>((numel + comfy::hip_backend::kThreads - 1) / comfy::hip_backend::kThreads);
+    using namespace comfy::hip_backend;
+
+    const bool vec = vec_aligned(input) && vec_aligned(output);
+    const int64_t per_thread = vec ? kVecElems : 1;
+    const int blocks =
+        static_cast<int>((numel + per_thread * kThreads - 1) / (per_thread * kThreads));
+
+#define COMFY_LAUNCH_DEQUANT(T)                                                                   \
+    do {                                                                                          \
+        if (vec) {                                                                                \
+            dequantize_per_tensor_fp8_vec_kernel<T><<<blocks, kThreads, 0, stream>>>(             \
+                static_cast<const uint8_t*>(input), static_cast<const float*>(scale), output,     \
+                numel, input_dtype_code);                                                         \
+        } else {                                                                                  \
+            dequantize_per_tensor_fp8_kernel<T><<<blocks, kThreads, 0, stream>>>(                 \
+                static_cast<const uint8_t*>(input), static_cast<const float*>(scale), output,     \
+                numel, input_dtype_code);                                                         \
+        }                                                                                         \
+    } while (0)
+
     if (output_dtype_code == 0) {
-        comfy::hip_backend::dequantize_per_tensor_fp8_kernel<float><<<blocks, comfy::hip_backend::kThreads, 0, stream>>>(static_cast<const uint8_t*>(input), static_cast<const float*>(scale), output, numel, input_dtype_code);
+        COMFY_LAUNCH_DEQUANT(float);
     } else if (output_dtype_code == 1) {
-        comfy::hip_backend::dequantize_per_tensor_fp8_kernel<__half><<<blocks, comfy::hip_backend::kThreads, 0, stream>>>(static_cast<const uint8_t*>(input), static_cast<const float*>(scale), output, numel, input_dtype_code);
+        COMFY_LAUNCH_DEQUANT(__half);
     } else if (output_dtype_code == 2) {
-        comfy::hip_backend::dequantize_per_tensor_fp8_kernel<__bf16><<<blocks, comfy::hip_backend::kThreads, 0, stream>>>(static_cast<const uint8_t*>(input), static_cast<const float*>(scale), output, numel, input_dtype_code);
+        COMFY_LAUNCH_DEQUANT(__bf16);
     } else {
         throw std::runtime_error("Unsupported output dtype for dequantize_per_tensor_fp8");
     }
+#undef COMFY_LAUNCH_DEQUANT
 }
 
 } // extern "C"

--- a/comfy_kitchen/backends/hip/ops/stochastic_round_fp8.hip
+++ b/comfy_kitchen/backends/hip/ops/stochastic_round_fp8.hip
@@ -17,11 +17,12 @@ namespace comfy::hip_backend {
 
 constexpr int kMaxKernelThreads = 128;
 
-template<typename InputType>
-__global__ void stochastic_round_fp8_kernel(
-    uint8_t* rng_and_dst,
-    const InputType* src,
-    int64_t size,
+// Shared by the scalar and vectorized kernels so the two cannot drift onto
+// different rounding. output_dtype_code is uniform across a launch, so the
+// constants below hoist out of the vectorized body.
+__forceinline__ __device__ uint8_t stochastic_round_one(
+    float src_value,
+    uint8_t rng_byte,
     int output_dtype_code) {
 
     const bool e4m3 = output_dtype_code == 5;
@@ -33,14 +34,9 @@ __global__ void stochastic_round_fp8_kernel(
     const float subnormal_mantissa_scale = exp2f(-exponent_bias + 1 - mantissa_bits);
     const float subnormal_value_scale = exp2f(-exponent_bias + 1);
 
-    const int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
-    if (idx >= size) {
-        return;
-    }
-
     // Match the CUDA implementation: reduce the source value through FP16 before
     // applying stochastic mantissa rounding.
-    const float value = __half2float(__float2half(to_float(src[idx])));
+    const float value = __half2float(__float2half(src_value));
     const float abs_value = fabsf(value);
     const float sign = value < 0.0f ? -1.0f : (value > 0.0f ? 1.0f : 0.0f);
 
@@ -48,12 +44,10 @@ __global__ void stochastic_round_fp8_kernel(
     // has to leave here too: the fp8_clamp below would drop it for a finite bound
     // before pack_fp8 could encode it.
     if (fp8_is_nan(value)) {
-        rng_and_dst[idx] = pack_fp8(value, output_dtype_code);
-        return;
+        return pack_fp8(value, output_dtype_code);
     }
     if (abs_value == 0.0f) {
-        rng_and_dst[idx] = pack_fp8(0.0f, output_dtype_code);
-        return;
+        return pack_fp8(0.0f, output_dtype_code);
     }
 
     float exponent = floorf(log2f(abs_value)) + exponent_bias;
@@ -63,11 +57,76 @@ __global__ void stochastic_round_fp8_kernel(
 
     const float normal_mantissa = (abs_value / exponent_scale - 1.0f) * mantissa_levels;
     const float subnormal_mantissa = abs_value / subnormal_mantissa_scale;
-    const float random = static_cast<float>(rng_and_dst[idx]) * (1.0f / 256.0f);
+    const float random = static_cast<float>(rng_byte) * (1.0f / 256.0f);
     const float mantissa = floorf((normal ? normal_mantissa : subnormal_mantissa) + random) / mantissa_levels;
     const float rounded = sign * (normal ? exponent_scale * (1.0f + mantissa) : subnormal_value_scale * mantissa);
 
-    rng_and_dst[idx] = pack_fp8(fp8_clamp(rounded, -fp8_max, fp8_max), output_dtype_code);
+    return pack_fp8(fp8_clamp(rounded, -fp8_max, fp8_max), output_dtype_code);
+}
+
+template<typename InputType>
+__global__ void stochastic_round_fp8_kernel(
+    uint8_t* rng_and_dst,
+    const InputType* src,
+    int64_t size,
+    int output_dtype_code) {
+
+    const int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (idx >= size) {
+        return;
+    }
+    rng_and_dst[idx] =
+        stochastic_round_one(to_float(src[idx]), rng_and_dst[idx], output_dtype_code);
+}
+
+// Vectorized counterpart. The RNG bytes and the fp8 result share one buffer, so
+// the chunk is read into registers once and written back after the whole run.
+template<typename InputType>
+__global__ void stochastic_round_fp8_vec_kernel(
+    uint8_t* __restrict__ rng_and_dst,
+    const InputType* __restrict__ src,
+    int64_t size,
+    int output_dtype_code) {
+
+    const int64_t i0 = (static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x) * kVecElems;
+    if (i0 >= size) {
+        return;
+    }
+
+    if (i0 + kVecElems <= size) {
+        const VecChunk<InputType> in = *reinterpret_cast<const VecChunk<InputType>*>(src + i0);
+        VecChunk<uint8_t> rd = *reinterpret_cast<const VecChunk<uint8_t>*>(rng_and_dst + i0);
+        #pragma unroll
+        for (int i = 0; i < kVecElems; ++i) {
+            rd.v[i] = stochastic_round_one(to_float(in.v[i]), rd.v[i], output_dtype_code);
+        }
+        *reinterpret_cast<VecChunk<uint8_t>*>(rng_and_dst + i0) = rd;
+    } else {
+        for (int64_t i = i0; i < size; ++i) {
+            rng_and_dst[i] =
+                stochastic_round_one(to_float(src[i]), rng_and_dst[i], output_dtype_code);
+        }
+    }
+}
+
+// A template rather than a macro so the two launches stay type-checked.
+template <typename InputType>
+static void launch_sr(void* rng_and_output, const void* input, int64_t numel,
+                      int output_dtype_code, hipStream_t stream) {
+    const bool vec = vec_aligned(rng_and_output) && vec_aligned(input);
+    const int64_t per_thread = vec ? kVecElems : 1;
+    const int blocks = static_cast<int>((numel + per_thread * kMaxKernelThreads - 1) /
+                                        (per_thread * kMaxKernelThreads));
+
+    auto* dst = static_cast<uint8_t*>(rng_and_output);
+    const auto* src = static_cast<const InputType*>(input);
+    if (vec) {
+        stochastic_round_fp8_vec_kernel<InputType>
+            <<<blocks, kMaxKernelThreads, 0, stream>>>(dst, src, numel, output_dtype_code);
+    } else {
+        stochastic_round_fp8_kernel<InputType>
+            <<<blocks, kMaxKernelThreads, 0, stream>>>(dst, src, numel, output_dtype_code);
+    }
 }
 
 } // namespace comfy::hip_backend
@@ -91,30 +150,14 @@ void launch_stochastic_round_fp8_kernel(
         throw std::runtime_error("stochastic_round_fp8 requires uint8 RNG storage");
     }
 
-    const int blocks = static_cast<int>((numel + comfy::hip_backend::kMaxKernelThreads - 1) /
-                                        comfy::hip_backend::kMaxKernelThreads);
+    using namespace comfy::hip_backend;
 
     if (input_dtype_code == 0) {
-        comfy::hip_backend::stochastic_round_fp8_kernel<float>
-            <<<blocks, comfy::hip_backend::kMaxKernelThreads, 0, stream>>>(
-                static_cast<uint8_t*>(rng_and_output),
-                static_cast<const float*>(input),
-                numel,
-                output_dtype_code);
+        launch_sr<float>(rng_and_output, input, numel, output_dtype_code, stream);
     } else if (input_dtype_code == 1) {
-        comfy::hip_backend::stochastic_round_fp8_kernel<__half>
-            <<<blocks, comfy::hip_backend::kMaxKernelThreads, 0, stream>>>(
-                static_cast<uint8_t*>(rng_and_output),
-                static_cast<const __half*>(input),
-                numel,
-                output_dtype_code);
+        launch_sr<__half>(rng_and_output, input, numel, output_dtype_code, stream);
     } else if (input_dtype_code == 2) {
-        comfy::hip_backend::stochastic_round_fp8_kernel<__bf16>
-            <<<blocks, comfy::hip_backend::kMaxKernelThreads, 0, stream>>>(
-                static_cast<uint8_t*>(rng_and_output),
-                static_cast<const __bf16*>(input),
-                numel,
-                output_dtype_code);
+        launch_sr<__bf16>(rng_and_output, input, numel, output_dtype_code, stream);
     } else {
         throw std::runtime_error("Unsupported input dtype for stochastic_round_fp8");
     }

--- a/tests/test_hip_wmma.py
+++ b/tests/test_hip_wmma.py
@@ -1739,6 +1739,24 @@ def test_stochastic_rounding_fp8_edge_values_match_eager(dtype):
     assert torch.isnan(q.float()[~finite]).all()
 
 
+@pytest.mark.parametrize("out_dtype", [torch.float8_e4m3fn, torch.float8_e5m2])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("numel", [15, 16, 17, 1 << 20])
+def test_stochastic_rounding_fp8_vector_and_scalar_paths_agree(hip, dtype, numel, out_dtype):
+    """An offset view runs the scalar fallback, which must give the same bits as
+    the vectorized path. The sizes straddle kVecElems to cover the chunk tail, and
+    the two fp8 formats take different constants through the rounding."""
+    torch.manual_seed(numel)
+    x = torch.randn(numel, device=DEV, dtype=dtype) * 10
+    rng = torch.randint(0, 256, (numel,), dtype=torch.uint8, device=DEV)
+
+    aligned = hip.stochastic_rounding_fp8(x.clone(), rng.clone(), out_dtype)
+    offset = hip.stochastic_rounding_fp8(_offset_copy(x), _offset_copy(rng), out_dtype)
+
+    assert x.data_ptr() % 16 == 0 and rng.data_ptr() % 16 == 0
+    assert torch.equal(aligned.view(torch.uint8), offset.view(torch.uint8))
+
+
 # A zero-length dimension makes the grid zero-dimensional, which HIP rejects with
 # hipErrorInvalidConfiguration rather than treating as a no-op.
 @needs_wmma

--- a/tests/test_hip_wmma.py
+++ b/tests/test_hip_wmma.py
@@ -67,16 +67,24 @@ def hip():
     return hip_backend
 
 
-# Covers each tile path: GEMV (M <= 8), 64x64, 128x128 and 256x128 (K > N), plus
-# sizes that are not multiples of the macro tile.
+# Covers each tile path on 16-48 WGP parts: GEMV (M <= 8), skinny (M or N <= 64),
+# and 64x64/128x128 at both K depths including both deep-K warp grids. K=2064/4112
+# are multiples of 16 but not of BKB=128, to hit its K tail.
 GEMM_SHAPES = [
     (1, 256, 256),
     (8, 512, 256),
     (17, 256, 512),
+    (64, 512, 2064),
     (128, 512, 256),
+    (256, 48, 512),
+    (300, 300, 2064),
     (333, 1152, 1152),
     (512, 256, 1024),
+    (512, 512, 4112),
+    (1024, 512, 4112),
+    (1024, 1024, 4112),
     (1024, 2048, 512),
+    (2048, 2048, 4112),
 ]
 
 

--- a/tests/test_qdq.py
+++ b/tests/test_qdq.py
@@ -96,15 +96,69 @@ class TestQuantizePerTensorFP8:
         assert result.dtype == torch.float8_e4m3fn
 
 
+def _with_hip(backends: list[str], func_name: str) -> list[str]:
+    """get_capable_backends does not enumerate hip; these tests exist for its
+    vectorized/scalar split, so add it explicitly when it is present."""
+    hip_info = ck.list_backends().get("hip", {})
+    if hip_info.get("available") and func_name in hip_info.get("capabilities", []):
+        backends = [*backends, "hip"]
+    return backends
+
+
+class TestQuantizeFP8MisalignedView:
+    """A vectorized fast path gates on base-pointer alignment, so a storage-offset
+    view exercises the scalar fallback and the gate itself."""
+
+    @pytest.fixture
+    def capable_backends(self, device):
+        backends = _with_hip(get_capable_backends("quantize_per_tensor_fp8", device),
+                             "quantize_per_tensor_fp8")
+        if not backends:
+            pytest.skip(f"No backend supports quantize_per_tensor_fp8 on {device}")
+        return backends
+
+    @pytest.mark.parametrize("out_dtype", [torch.float8_e4m3fn, torch.float8_e5m2])
+    def test_quantize_fp8_misaligned_view(self, capable_backends, device, seed, out_dtype):
+        base = torch.randn(1 << 20, device=device, dtype=torch.float16)
+        scale = torch.tensor([1.0], device=device)
+
+        for backend_name in capable_backends:
+            with ck.use_backend(backend_name):
+                out_view = ck.quantize_per_tensor_fp8(base[1:], scale, out_dtype)
+                out_contig = ck.quantize_per_tensor_fp8(base[1:].clone(), scale, out_dtype)
+
+            assert torch.equal(out_view.view(torch.uint8), out_contig.view(torch.uint8))
+
+
 class TestDequantizePerTensorFP8:
     """FP8 dequantization tests."""
 
     @pytest.fixture
     def capable_backends(self, device):
-        backends = get_capable_backends("dequantize_per_tensor_fp8", device)
+        backends = _with_hip(
+            get_capable_backends("dequantize_per_tensor_fp8", device),
+            "dequantize_per_tensor_fp8",
+        )
         if not backends:
             pytest.skip(f"No backend supports dequantize_per_tensor_fp8 on {device}")
         return backends
+
+    @pytest.mark.parametrize("fp8_dtype", [torch.float8_e4m3fn, torch.float8_e5m2])
+    def test_dequantize_fp8_misaligned_view(self, capable_backends, device, seed, fp8_dtype):
+        """Counterpart of TestQuantizeFP8MisalignedView for the dequant kernel."""
+        x = torch.randn(1 << 20, device=device, dtype=torch.float16)
+        scale = torch.tensor([1.0], device=device)
+        with ck.use_backend("eager"):
+            x_fp8 = ck.quantize_per_tensor_fp8(x, scale, fp8_dtype)
+
+        for backend_name in capable_backends:
+            with ck.use_backend(backend_name):
+                dq_view = ck.dequantize_per_tensor_fp8(x_fp8[1:], scale, output_type=torch.float16)
+                dq_contig = ck.dequantize_per_tensor_fp8(
+                    x_fp8[1:].clone(), scale, output_type=torch.float16
+                )
+
+            assert torch.equal(dq_view.view(torch.uint16), dq_contig.view(torch.uint16))
 
     @pytest.mark.parametrize("m,k", [(1024, 2048)])
     @pytest.mark.parametrize("output_dtype", [torch.float16, torch.bfloat16])


### PR DESCRIPTION
This PR is a continuation of #94 by @crashingalexsan and carries two commits. The first cherry picks the author's commits with their permission, squashed into one commit that keeps their authorship, rebased onto current `main`. The second extends the same vectorization to `stochastic_round_fp8`, the one fp8 elementwise kernel #94 left scalar.

Performance-only change: no public API or numerics are changed, and all paths remain bit-identical.

## GEMM tile selection

Replaces the previous `M`/`N`/`K` threshold-based WMMA tile selection with a shared `launch_gemm_wmma()` in `gemm_wmma.h`, used by both fp8 and int8 launchers. Selection now considers grid coverage, K depth, and warp grid.

| shape | fp8 | int8 |
|---|---:|---:|
| 2048x128x2048 | 3.85x | 3.77x |
| 256x4096x4096 | 1.66x | 1.62x |
| 512x512x512 | 1.48x | 1.75x |
| 4096x2048x8192 | 1.23x | 1.24x |
| 4096x4096x4096 | 1.14x | 1.11x |
| overall (19 shapes) | 1.06x | 1.06x |

Shapes selecting the same config stay within +/- 4%. Outputs are bit-identical.

## Elementwise kernels

`per_tensor_fp8` now has a 16-elements/thread path using 16-byte loads/stores when both pointers are aligned, with the original scalar path retained for misaligned views.

At 64M elements:

- Vectorized: 290 GB/s
- Scalar: 148 GB/s
- Speedup: 1.96x
- Output: bit-identical

## Stochastic rounding

`stochastic_round_fp8` receives the same vectorized path, reaching 297 GB/s at 64M elements vs 142 GB/s previously.

| elements | scalar | vectorized | speedup |
|---|---:|---:|---:|
| 1M | 41.1 us | 34.8 us | 1.18x |
| 4M | 107.5 us | 81.3 us | 1.32x |
| 16M | 435.5 us | 231.5 us | 1.88x |
| 64M | 1886.1 us | 903.4 us | 2.09x |

The per-element logic is shared through `stochastic_round_one()` to guarantee identical rounding between paths. Vectorization helpers are shared through `fp8_utils.h`.

Scalar/vectorized paths were verified bit-identical across `float32`/`float16`/`bfloat16`, both `e4m3fn` and `e5m2`, multiple sizes, and edge cases including NaNs, infinities, +/- 0, +/- 448, 57344 and subnormals.

## RDNA coverage

- Run-verified: gfx1200
- Compile-verified: gfx1030, gfx1100, gfx1151, gfx1201
- Vectorized kernels use 128-bit loads/stores, spill nothing, and peak at 37 VGPRs.
- On gfx11, fp8 scratch usage drops from 1440 B -> 804 B per output dtype.
- The worst gfx11 spiller, the `256x128 BKB=64` tile, is removed.

## Testing

gfx1200:

- 472 passed, 16 failed, 4 skipped
- `main`: 416 passed, 16 failed, 4 skipped

The same 16 NVFP4 failures occur on both revisions and originate from comfy-kitchen's Triton backend on AMD, unrelated to this PR.

The 56 additional passing tests cover deep-K/skinny GEMMs and misaligned-view elementwise cases.
