### PR TITLE
Round fused SwiGLU to the storage dtype before ConvRot.

### DIFF
--- a/comfy_kitchen/backends/cuda/ops/int8_linear.cu
+++ b/comfy_kitchen/backends/cuda/ops/int8_linear.cu
@@ -930,10 +930,15 @@ __device__ __forceinline__ float load_input_act(
     const InputType* __restrict__ x, int64_t in_row, int col, int K)
 {
     if constexpr (ACT == kActSwiGLU) {
-        // Matches torch silu(gate) * up.
+        // Match F.silu(gate) * up in the storage dtype. Leaving the product in
+        // fp32 changes the ConvRot row absmax versus the eager chain, which
+        // materializes silu and the multiply before quantization. One LSB of
+        // scale moves the whole INT8 row.
         const float gate = to_float(x[in_row + col]);
         const float up = to_float(x[in_row + K + col]);
-        return (gate / (1.0f + expf(-gate))) * up;
+        const float silu = gate / (1.0f + expf(-gate));
+        const float silu_r = to_float(from_float<InputType>(silu));
+        return to_float(from_float<InputType>(silu_r * up));
     } else {
         return apply_input_act<ACT>(to_float(x[in_row + col]));
     }

--- a/comfy_kitchen/backends/hip/hadamard.h
+++ b/comfy_kitchen/backends/hip/hadamard.h
@@ -18,6 +18,8 @@
 #include <hip/hip_fp16.h>
 #include <hip/hip_runtime.h>
 
+#include "rope_math.h"
+
 namespace comfy::hip_backend {
 
 // convrot_quant_kernel handles 256/G groups per pass and rotates in log4(G)
@@ -112,10 +114,20 @@ template <int ACT>
 __forceinline__ __device__ float load_input_act(
     const void* x, int64_t in_row, int col, int K, int code) {
     if constexpr (ACT == kActSwiGLU) {
-        // Matches torch silu(gate) * up.
+        // Match F.silu(gate) * up in the storage dtype. See the CUDA
+        // load_input_act comment: an fp32 product changes the row absmax.
         const float gate = load_in(x, in_row + col, code);
         const float up = load_in(x, in_row + K + col, code);
-        return (gate / (1.0f + expf(-gate))) * up;
+        const float silu = gate / (1.0f + expf(-gate));
+        if (code == 0) {
+            return silu * up;
+        }
+        if (code == 1) {
+            const float silu_r = round_fp16(silu);
+            return round_fp16(silu_r * up);
+        }
+        const float silu_r = round_bf16(silu);
+        return round_bf16(silu_r * up);
     } else {
         return apply_input_act<ACT>(load_in(x, in_row + col, code));
     }

--- a/tests/test_int8_input_act.py
+++ b/tests/test_int8_input_act.py
@@ -214,6 +214,12 @@ class TestSwiGLUInputAct:
         assert err_fused <= max(err_chain * 1.05, 1e-4), (
             f"fused ({err_fused:.6f}) less accurate than chain ({err_chain:.6f})"
         )
+        # Storage-dtype rounding must match gelu/silu-then-quantize, otherwise
+        # the row scale moves and every INT8 code on the row can change.
+        if dtype in (torch.float16, torch.bfloat16):
+            assert torch.equal(fused_q, chain_q), (
+                f"{dtype} fused INT8 codes differ from the eager chain"
+            )
         assert fused_q.shape == (m, k)
         assert fused_q.dtype == torch.int8
         assert fused_s.shape == (m, 1)
@@ -241,9 +247,12 @@ class TestSwiGLUInputAct:
             )
 
         assert got.shape == (m, n)
-        denom = ref.float().abs().max()
-        rel = ((got.float() - ref.float()).abs().max() / denom).item()
-        assert rel < 0.05, f"{backend}: rel={rel:.3e}"
+        if backend == "cuda" and device == "cuda":
+            assert torch.equal(got, ref), f"{backend}: fused output is not bit-exact"
+        else:
+            denom = ref.float().abs().max()
+            rel = ((got.float() - ref.float()).abs().max() / denom).item()
+            assert rel < 0.05, f"{backend}: rel={rel:.3e}"
 
     @pytest.mark.parametrize(
         "tag,shape,kwargs",


### PR DESCRIPTION

## Summary

`int8_linear(..., input_act="swiglu")` is supposed to equal `int8_linear(silu(gate)*up, ...)`.
The fused CUDA/HIP quantizer left `silu*up` in fp32, so ConvRot's per-row absmax
diverged from the eager chain (which materializes BF16/FP16). One LSB of scale
rewrites the whole INT8 row.

This PR rounds silu and the multiply to the storage dtype before the rotation.

## Accuracy

Kitchen unit shapes + MiniMax-H3 fc2 (`N=5376`, `K=14336`), isolated build of this patch,
`F.silu(gate)*up` then `int8_linear` vs fused:

| | bit-neq | max\|Δ\| |
|---|---|---|
| M=4096 | **0 / 22,020,096** | 0 |
| M=32700 (H3 1344×768 packed rows) | **0 / 175,795,200** | 0 |

Same H3 t2va, 50 NFE, seed=42, INT8+FA, **old fused kernel** (fp32 product) vs
unfused INT8 (eager SwiGLU then quantize):

| | video PSNR mean / min | audio PSNR |
|---|---|---|
| old vs unfused INT8 | **22.0 / 19.8** | 49.8 |

That is a different diffusion sample, not a slightly noisier tensor.
After this PR, fc2 is **bit-exact**, so that pair should be identical (**PSNR 99**).

## Speed (why keep the fuse)

H3 fc2, M=32700, RTX 4090 D, CUDA event, 50 DiT blocks/step:

|  | ms / block | 
|---|---|
| `silu*mul` + `int8_linear` | 16.44 |
| fused `input_act=swiglu` (this PR) | **12.47** | 
| delta | **−3.97** |

20 NFE exclusive 4090 D (SGLang, earlier run with the old fuse; wall-clock
should match because the extra rounding is register-only):

| | denoise | e2e | step |
|---|---|---|---|
| INT8+FA, no fuse | 276.1 s | 294.7 s | 13.80 s |
| + fused SwiGLU | 271.7 s | 290.3 s | 13.58 s |
| delta | **−4.4 s** | **−4.4 s** | **−0.22 s** |

## Test plan

```bash
pytest tests/test_int8_input_act.py -k swiglu
```

CUDA+bf16 `int8_linear(x, input_act="swiglu")` must `torch.equal` the eager chain.
FP16/BF16 fused INT8 codes must equal `quantize(silu(gate)*up)`.

## Files

- `comfy_kitchen/backends/cuda/ops/int8_linear.cu` — CUDA quantizer
- `comfy_kitchen/backends/hip/hadamard.h` — HIP mirror
- `tests/test_int8_input_act.py` — require bit-exact on the fused CUDA path
