### PR TITLE
HIP: vectorize rowwise INT8 quantization with 16-byte loads

### DIFF
--- a/comfy_kitchen/backends/hip/ops/quantize_int8.hip
+++ b/comfy_kitchen/backends/hip/ops/quantize_int8.hip
@@ -47,6 +47,56 @@ __global__ __launch_bounds__(256) void quantize_int8_rowwise_kernel(
     }
 }
 
+template <typename InputT>
+struct RowwiseVectorTraits {
+    static constexpr int kElements = sizeof(uint4) / sizeof(InputT);
+};
+
+template <typename InputT>
+__global__ __launch_bounds__(256) void quantize_int8_rowwise_vectorized_kernel(
+    const InputT* __restrict__ x, int8_t* __restrict__ q,
+    float* __restrict__ scales, int M, int K) {
+
+    constexpr int kElements = RowwiseVectorTraits<InputT>::kElements;
+    __shared__ float red[256];
+    const int row = blockIdx.x;
+    const int t = threadIdx.x;
+    const int chunks = K / kElements;
+    const int64_t row_offset = static_cast<int64_t>(row) * K;
+
+    float lmax = 0.0f;
+    for (int chunk_idx = t; chunk_idx < chunks; chunk_idx += 256) {
+        const uint4 raw = *reinterpret_cast<const uint4*>(
+            x + row_offset + static_cast<int64_t>(chunk_idx) * kElements);
+        const InputT* values = reinterpret_cast<const InputT*>(&raw);
+#pragma unroll
+        for (int i = 0; i < kElements; ++i) {
+            lmax = fmaxf(lmax, fabsf(load_row_value<InputT>(values[i])));
+        }
+    }
+
+    red[t] = lmax;
+    __syncthreads();
+    for (int s = 128; s > 0; s >>= 1) {
+        if (t < s) red[t] = fmaxf(red[t], red[t + s]);
+        __syncthreads();
+    }
+
+    const float scale = fmaxf(red[0] / kInt8Max, 1e-30f);
+    if (t == 0) scales[row] = scale;
+    const float inv = 1.0f / scale;
+
+    for (int chunk_idx = t; chunk_idx < chunks; chunk_idx += 256) {
+        const int64_t base = row_offset + static_cast<int64_t>(chunk_idx) * kElements;
+        const uint4 raw = *reinterpret_cast<const uint4*>(x + base);
+        const InputT* values = reinterpret_cast<const InputT*>(&raw);
+#pragma unroll
+        for (int i = 0; i < kElements; ++i) {
+            q[base + i] = quant_round(load_row_value<InputT>(values[i]), inv);
+        }
+    }
+}
+
 __global__ void absmax_kernel(const void* __restrict__ x, int in_code,
                               unsigned int* __restrict__ out, int64_t numel) {
     __shared__ float red[256];
@@ -238,8 +288,26 @@ extern "C" void launch_quantize_int8_rowwise_kernel(
     if (M == 0) {
         return;  // a zero-block launch is hipErrorInvalidConfiguration
     }
-    quantize_int8_rowwise_kernel<<<M, 256, 0, stream>>>(
-        x, in_code, static_cast<int8_t*>(q), static_cast<float*>(scales), M, K);
+    const bool vector_aligned = reinterpret_cast<uintptr_t>(x) % sizeof(uint4) == 0;
+    if (in_code == 0 && vector_aligned &&
+        K % RowwiseVectorTraits<float>::kElements == 0) {
+        quantize_int8_rowwise_vectorized_kernel<float><<<M, 256, 0, stream>>>(
+            static_cast<const float*>(x), static_cast<int8_t*>(q),
+            static_cast<float*>(scales), M, K);
+    } else if (in_code == 1 && vector_aligned &&
+               K % RowwiseVectorTraits<__half>::kElements == 0) {
+        quantize_int8_rowwise_vectorized_kernel<__half><<<M, 256, 0, stream>>>(
+            static_cast<const __half*>(x), static_cast<int8_t*>(q),
+            static_cast<float*>(scales), M, K);
+    } else if (in_code == 2 && vector_aligned &&
+               K % RowwiseVectorTraits<__bf16>::kElements == 0) {
+        quantize_int8_rowwise_vectorized_kernel<__bf16><<<M, 256, 0, stream>>>(
+            static_cast<const __bf16*>(x), static_cast<int8_t*>(q),
+            static_cast<float*>(scales), M, K);
+    } else {
+        quantize_int8_rowwise_kernel<<<M, 256, 0, stream>>>(
+            x, in_code, static_cast<int8_t*>(q), static_cast<float*>(scales), M, K);
+    }
 }
 
 // Fused ConvRot rotation + rowwise int8 quantize. act_code: 0 none, 1 gelu tanh,

--- a/tests/test_hip_wmma.py
+++ b/tests/test_hip_wmma.py
@@ -927,6 +927,21 @@ def test_quantize_int8_rowwise_matches_eager():
     assert (q.int() - qe.int()).abs().max().item() <= 1
 
 
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("k", [8, 9], ids=["vector-width", "ragged"])
+def test_quantize_int8_rowwise_offset_matches_aligned(dtype, k):
+    torch.manual_seed(k)
+    aligned = torch.randn(17, k, device=DEV, dtype=dtype)
+    offset = _offset_copy(aligned)
+
+    with ck.use_backend("hip"):
+        aligned_q, aligned_scale = ck.quantize_int8_rowwise(aligned)
+        offset_q, offset_scale = ck.quantize_int8_rowwise(offset)
+
+    assert torch.equal(offset_q, aligned_q)
+    assert torch.equal(offset_scale, aligned_scale)
+
+
 def test_quantize_int8_tensorwise_matches_eager():
     torch.manual_seed(0)
     x = torch.randn(64, 512, device=DEV, dtype=torch.bfloat16)


### PR DESCRIPTION
## Summary

Implements Change 2 proposed in #102:

- Load 16 bytes per thread with `uint4` for FP32, FP16, and BF16 inputs.
- Use the vectorized kernel only when row alignment and K permit it; otherwise
  keep the existing scalar fallback.
- Preserve the existing rounding, clamping, and scale behavior.

The vectorized path uses the portable HIP `uint4` type and has no architecture-specific guard, so it also applies to other supported HIP architectures. Performance was measured on gfx1151.

## Performance

Measured on AMD Radeon 8060S (gfx1151), ROCm 7.2, with aligned BF16 inputs:

| Shape (M x K) | Before | After | Speedup |
|---|---:|---:|---:|
| 4096 x 1024 | 0.0564 ms | 0.0269 ms | 2.09x |
| 8192 x 2048 | 0.4417 ms | 0.2196 ms | 2.01x |
| 4096 x 4096 | 0.4107 ms | 0.2268 ms | 1.81x |
| 18432 x 2048 | 0.9579 ms | 0.4999 ms | 1.92x |
| 512 x 14336 | 0.0996 ms | 0.0417 ms | 2.39x |
| 4096 x 14336 | 1.3498 ms | 0.8246 ms | 1.64x |

Geometric-mean speedup: **1.96x**.

For large BF16 shapes, one-read DRAM-equivalent bandwidth is about 214–229 GB/s, consistent with the 256 GB/s bandwidth of this gfx1151 system.

## Testing

```bash
CMAKE_BUILD_PARALLEL_LEVEL=16 python setup.py \
  build_ext --inplace --no-cuda --hip --hip-archs=gfx1151

pytest tests/test_qdq.py::TestQuantizeINT8 -q
pytest tests/test_hip_wmma.py -q
pytest tests/test_int8.py -q
```

- INT8 quantization: 4 passed
- HIP WMMA: 349 passed
- INT8: 62 passed, 39 skipped
- Vectorized and fallback outputs match bit-for-bit for FP32, FP16, and BF16,
  including aligned and offset-contiguous inputs.
