### PR TITLE
Tune gfx1151 INT8 deep-K tile selection

### DIFF
--- a/comfy_kitchen/backends/hip/gemm_wmma.h
+++ b/comfy_kitchen/backends/hip/gemm_wmma.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <atomic>
+#include <cstring>
 
 #include "mma.h"
 
@@ -224,26 +225,55 @@ __global__ __launch_bounds__(WARPS_M* WARPS_N* kWave) void gemm_wmma_kernel(
 // Tile selection, shared by the fp8 and int8 launchers.
 // ---------------------------------------------------------------------------
 
+struct WmmaDeviceInfo {
+    int gfx_arch;
+    int wgps;
+};
+
 // hipDeviceAttributeMultiprocessorCount reports WGPs on RDNA, not CUs (32 on a
 // 64-CU gfx1201), and a workgroup schedules onto a WGP, so WGPs are the unit the
-// grid-coverage test needs. Cached per ordinal to keep the query off the launch
-// path; the fallback only mis-sizes that test, never a result.
-inline int device_wgp_count() {
+// grid-coverage test needs. Derive both values from the allocation device so a
+// launch cannot inspect a different process-current device. Cached per ordinal;
+// the fallback only affects tile selection, never a result.
+inline WmmaDeviceInfo wmma_device_info(const void* ptr) {
     constexpr int kMaxDevices = 16;
     // A GEMM can be launched from several host threads at once. Racing threads
     // write the same value and nothing is published through the cache, so relaxed.
-    static std::atomic<int> cache[kMaxDevices] = {};
-    int dev = 0;
-    if (hipGetDevice(&dev) != hipSuccess || dev < 0 || dev >= kMaxDevices) return 16;
-    int n = cache[dev].load(std::memory_order_relaxed);
-    if (n == 0) {
-        if (hipDeviceGetAttribute(&n, hipDeviceAttributeMultiprocessorCount, dev) != hipSuccess ||
-            n <= 0) {
-            n = 16;
-        }
-        cache[dev].store(n, std::memory_order_relaxed);
+    static std::atomic<int> arch_cache[kMaxDevices] = {};
+    static std::atomic<int> wgp_cache[kMaxDevices] = {};
+    hipPointerAttribute_t attributes{};
+    if (hipPointerGetAttributes(&attributes, ptr) != hipSuccess ||
+        attributes.device < 0 || attributes.device >= kMaxDevices) {
+        return {-1, 16};
     }
-    return n;
+
+    const int dev = attributes.device;
+    int gfx_arch = arch_cache[dev].load(std::memory_order_relaxed);
+    int wgps = wgp_cache[dev].load(std::memory_order_relaxed);
+    if (gfx_arch == 0 || wgps == 0) {
+        hipDeviceProp_t props{};
+        gfx_arch = -1;
+        if (hipGetDeviceProperties(&props, dev) == hipSuccess) {
+            if (std::strncmp(props.gcnArchName, "gfx", 3) == 0) {
+                const char* digit = props.gcnArchName + 3;
+                int parsed = 0;
+                while (*digit >= '0' && *digit <= '9') {
+                    parsed = parsed * 10 + (*digit - '0');
+                    ++digit;
+                }
+                if (parsed > 0) gfx_arch = parsed;
+            }
+            if (props.multiProcessorCount > 0) {
+                wgps = props.multiProcessorCount;
+            }
+        }
+        if (wgps == 0) {
+            wgps = 16;
+        }
+        arch_cache[dev].store(gfx_arch, std::memory_order_relaxed);
+        wgp_cache[dev].store(wgps, std::memory_order_relaxed);
+    }
+    return {gfx_arch, wgps};
 }
 
 // Pick and launch a tile for C[M, N] = A[M, K] @ B[N, K]^T, selecting on grid
@@ -258,7 +288,7 @@ void launch_gemm_wmma(const uint8_t* A, const uint8_t* B, OutT* C, int M, int N,
                       int ldc, Epi epi, hipStream_t stream) {
     const int blocks_128 = ((M + 127) / 128) * ((N + 127) / 128);
 
-    const int wgps = device_wgp_count();
+    const int wgps = wmma_device_info(A).wgps;
 
     // Zero padding the block count cannot see: at M <= 64 the 128-row tile is at
     // least half empty, and the finer 64x64 grid recovers the wasted MMAs.

--- a/comfy_kitchen/backends/hip/ops/gemm_int8.hip
+++ b/comfy_kitchen/backends/hip/ops/gemm_int8.hip
@@ -55,6 +55,23 @@ static void launch_int8(const int8_t* A, const int8_t* B, OutT* C, int M, int N,
         gemv_int8_kernel<OutT><<<grid, block, 0, stream>>>(A, B, C, M, N, K, ldc, epi);
         return;
     }
+    // The 256-row tile wins on measured gfx1151 deep-K contractions and grids
+    // that divide evenly across WGPs. K=14336 is the MiniMax-H3 mlp_down depth;
+    // shallower shapes and unmeasured targets keep the shared selector.
+    if (M >= 512 && N >= 128 && K >= 14336) {
+        const WmmaDeviceInfo device = wmma_device_info(A);
+        const int blocks_256x128 = ((M + 255) / 256) * ((N + 127) / 128);
+        const bool deep_k_or_full_wgp_round =
+            K >= 2 * N || blocks_256x128 % device.wgps == 0;
+        if (device.gfx_arch == 1151 && blocks_256x128 >= device.wgps &&
+            deep_k_or_full_wgp_round) {
+            constexpr int BM = 256, BN = 128, BKB = 128;
+            dim3 grid((N + BN - 1) / BN, (M + BM - 1) / BM);
+            gemm_wmma_kernel<MmaInt8, EpiRowwise, OutT, BM, BN, BKB, 4, 2, 4, 4>
+                <<<grid, 256, 0, stream>>>(Au, Bu, C, M, N, K, ldc, epi);
+            return;
+        }
+    }
     launch_gemm_wmma<MmaInt8, EpiRowwise, OutT>(Au, Bu, C, M, N, K, ldc, epi, stream);
 }
 

--- a/tests/test_hip_wmma.py
+++ b/tests/test_hip_wmma.py
@@ -175,6 +175,52 @@ def test_int8_linear_convrot_large_k_matches_eager(k):
     assert (out.float() - ref.float()).abs().max().item() < 0.05 * scale
 
 
+@needs_wmma
+def test_int8_linear_h3_swiglu_convrot_matches_eager(hip):
+    torch.manual_seed(0)
+    properties = torch.cuda.get_device_properties(DEV)
+    m, k = 512, 14336
+    n = ((properties.multi_processor_count + 1) // 2) * 128
+    blocks_256x128 = ((m + 255) // 256) * ((n + 127) // 128)
+    assert blocks_256x128 >= properties.multi_processor_count
+    assert blocks_256x128 % properties.multi_processor_count == 0
+    x = torch.randn(m, 2 * k, device=DEV, dtype=torch.bfloat16)
+    assert hip._convrot_supported(k, 256, x.device, x.dtype, int8_global_spill=True)
+    wq = torch.randint(-127, 128, (n, k), device=DEV, dtype=torch.int8)
+    ws = torch.rand(n, device=DEV, dtype=torch.float32) * 0.01 + 0.001
+
+    kwargs = {"convrot": True, "convrot_groupsize": 256, "input_act": "swiglu"}
+    with ck.use_backend("hip"):
+        out = ck.int8_linear(x, wq, ws, None, torch.bfloat16, **kwargs)
+    with ck.use_backend("eager"):
+        ref = ck.int8_linear(x, wq, ws, None, torch.bfloat16, **kwargs)
+
+    scale = ref.float().abs().max().item()
+    assert (out.float() - ref.float()).abs().max().item() < 0.05 * scale
+
+
+@needs_wmma
+def test_int8_linear_deep_k_tail_matches_eager():
+    torch.manual_seed(0)
+    properties = torch.cuda.get_device_properties(DEV)
+    m, k = 512, 14400
+    n = ((properties.multi_processor_count + 1) // 2) * 128
+    blocks_256x128 = ((m + 255) // 256) * ((n + 127) // 128)
+    assert blocks_256x128 >= properties.multi_processor_count
+    assert blocks_256x128 % properties.multi_processor_count == 0
+    x = torch.randn(m, k, device=DEV, dtype=torch.bfloat16)
+    wq = torch.randint(-127, 128, (n, k), device=DEV, dtype=torch.int8)
+    ws = torch.rand(n, device=DEV, dtype=torch.float32) * 0.01 + 0.001
+
+    with ck.use_backend("hip"):
+        out = ck.int8_linear(x, wq, ws, None, torch.bfloat16, convrot=False)
+    with ck.use_backend("eager"):
+        ref = ck.int8_linear(x, wq, ws, None, torch.bfloat16, convrot=False)
+
+    scale = ref.float().abs().max().item()
+    assert (out.float() - ref.float()).abs().max().item() < 0.05 * scale
+
+
 def _offset_copy(t: torch.Tensor) -> torch.Tensor:
     """A contiguous copy of ``t`` deliberately based off a 16-byte boundary."""
     flat = t.reshape(-1)


### PR DESCRIPTION
## Summary
- Build directly on current `main`, including #122's shared occupancy-aware WMMA selector.
- Add a `256x128x128` INT8 specialization only for the measured `gfx1151` target when `M >= 512`, `N >= 128`, `K >= 14336`, the grid covers the device, and either `K >= 2N` or the grid divides evenly across WGPs.
- Derive the gfx target and WGP count from the GEMM allocation in the shared WMMA helper, so the specialized and fallback selectors cannot inspect different process-current devices.
- Keep unmeasured gfx110x/gfx115x targets and RDNA 4 on #122's selector.
- Keep benchmark tooling only on the separate [operational branch](https://github.com/Yasei-no-otoko/comfy-kitchen/tree/codex/ops-int8-pr130-pr127-pr129-gfx1151); this PR changes the shared WMMA device probe, the INT8 launcher, and its tests.

## Why this predicate
The original `K >= 2N` predicate was re-tested. It preserves the H3 contraction but is too broad without a depth floor: representative smaller-K shapes regressed by 0.5% to 20.8% on gfx1151. A plain `K >= 14336` gate also selected the 256-row tile on some wide-N grids where the shared selector was faster. `K = 14336` is the MiniMax-H3 `mlp_down` contraction depth.

The final predicate retains the H3/deep-K case and adds the 256-row tile only for complete WGP rounds. Compared with the previous `K >= 14336` gate (HIP events, alternating fresh processes, median of run medians):

| Shape `(M,N,K)` | Previous | Final | Change |
|---|---:|---:|---:|
| `(512,8192,14336)` | 3.6192 ms | 3.1618 ms | -12.6% |
| `(512,9216,14336)` | 3.7262 ms | 3.6161 ms | -3.0% |
| `(1024,8192,14336)` | 6.5110 ms | 6.3050 ms | -3.2% |
| H3 `(3802,5376,14336)` | same tile | 15.1003 ms | neutral |

The current allocation-derived shared probe recheck measured H3 `mlp_down` at 15.1154 ms on gfx1151, within the prior run spread. Tested HIP outputs are bit-identical between selectors.

## E2E on gfx1151
MiniMax-H3, same models/prompt/seed/settings, 124 frames at 24 fps, 20 steps:

- Full 1344x768 fresh-process comparison after rebasing: current `main` 2119 s; #130 2093 s (-1.23%).
- Fast selector iteration at 416x224, H.264 High + AAC-LC:

| Selector | E2E |
|---|---:|
| Previous `K >= 14336` gate | 145.34 s |
| Original `K >= 2N` candidate | 144.21 s |
| Final WGP + `K >= 2N` gate | 145.35 s |

The spread is below 0.8% and within fresh-process noise; the H3 shape selects the same tile in all three. Every file decodes to exactly 124 frames at 416x224/24 fps plus 5.167 s stereo AAC, with identical decoded video and audio SHA-256 hashes. The final review change only narrows other architectures and centralizes the device probe; it does not change gfx1151 tile selection or kernel math.

## Architecture policy
- RDNA 3 (`gfx110x`): #122 selector retained; compile validated, not performance-measured locally.
- RDNA 3.5: specialization enabled only on measured `gfx1151`; `gfx1150`, `gfx1152`, and `gfx1153` retain #122.
- RDNA 4 (`gfx12xx`): #122 selector retained; compile and contributor runtime validated for gfx1200.

## Validation
- [x] 32-thread HIP build for gfx1100, gfx1151, gfx1200, and gfx1201
- [x] Targeted H3/deep-K plus shared FP8 paths: 30 passed
- [x] `test_hip_wmma.py`, `test_int8.py`, and `test_int8_input_act.py` on gfx1151: 474 passed, 62 skipped
- [x] `ruff check` and `git diff --check`
- [x] gfx1151 H3 `mlp_down` HIP-event sanity check on final head: 15.1154 ms