### PR TITLE
fix(eager): fallback int8 matmul on ROCm/HIP to prevent access violation on RDNA2

### DIFF
--- a/comfy_kitchen/backends/eager/quantization.py
+++ b/comfy_kitchen/backends/eager/quantization.py
@@ -750,7 +750,14 @@ def _int8_matmul_accumulate(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
     """Multiply INT8 matrices and return INT32 accumulators."""
     def fast_int8_mm(lhs: torch.Tensor, rhs: torch.Tensor) -> torch.Tensor:
         if getattr(torch.version, "hip", None):
-            return (lhs.to(torch.float32) @ rhs.to(torch.float32)).to(torch.int32)
+            k = lhs.size(1)
+            chunk_size = 512
+            if k <= chunk_size:
+                return (lhs.to(torch.float32) @ rhs.to(torch.float32)).to(torch.int32)
+            res = (lhs[:, :chunk_size].to(torch.float32) @ rhs[:chunk_size, :].to(torch.float32)).to(torch.int32)
+            for i in range(chunk_size, k, chunk_size):
+                res += (lhs[:, i:i+chunk_size].to(torch.float32) @ rhs[i:i+chunk_size, :].to(torch.float32)).to(torch.int32)
+            return res
         if hasattr(torch, "int8_mm"):
             return torch.int8_mm(lhs, rhs)
         return torch._int_mm(lhs, rhs)

--- a/comfy_kitchen/backends/eager/quantization.py
+++ b/comfy_kitchen/backends/eager/quantization.py
@@ -749,6 +749,8 @@ def _round_up(value: int, alignment: int) -> int:
 def _int8_matmul_accumulate(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
     """Multiply INT8 matrices and return INT32 accumulators."""
     def fast_int8_mm(lhs: torch.Tensor, rhs: torch.Tensor) -> torch.Tensor:
+        if getattr(torch.version, "hip", None):
+            return (lhs.to(torch.float32) @ rhs.to(torch.float32)).to(torch.int32)
         if hasattr(torch, "int8_mm"):
             return torch.int8_mm(lhs, rhs)
         return torch._int_mm(lhs, rhs)


### PR DESCRIPTION
### Summary

Fixes an access violation crash (`0xC0000005` in `torch_hip.dll` / `?_int_mm@cuda@at@@...`) when running INT8 quantized models (e.g. SeedVR2 / ConvRot / INT8 tensorwise) on AMD RDNA2 (e.g. RX 6700 XT / `gfx1031`) under ROCm on Windows.

### Root Cause

In PyTorch with ROCm/HIP on Windows, `torch._int_mm` attempts to dispatch to hardware matrix cores (WMMA / MFMA) in `torch_hip.dll`. On AMD RDNA2 architectures (`gfx1031`, `gfx1032`, etc.), these INT8 matrix cores are not present, resulting in an immediate native access violation (`0xC0000005`) during `_int8_matmul_accumulate`.

### Solution

In `fast_int8_mm`, check `getattr(torch.version, "hip", None)` and compute the INT8 matrix multiplication via GPU float matmul `(lhs.to(torch.float32) @ rhs.to(torch.float32)).to(torch.int32)`.

### Verification

Tested on:
- GPU: AMD Radeon RX 6700 XT (`gfx1031`, 12 GB VRAM)
- OS: Windows 11 Pro
- Stack: PyTorch 2.10.0+rocm7.14, ROCm 7.14
- Model: `seedvr2_3b_int8_convrot.safetensors`
- Result: Full 32-block transformer forward pass and sampling steps execute successfully on GPU with no crashes.
