### PR TITLE
HIP native BF16/INT8 attention and gfx12 INT8 inference stack for AMD ROCm

### DIFF
--- a/comfy_kitchen/__init__.py
+++ b/comfy_kitchen/__init__.py
@@ -51,6 +51,7 @@ else:
 __all__ = [
     # Normalization
     "adaln",
+    "rms_gated_residual",
     "rms_adaln",
     # Attention
     "PrequantizedInt8Attention",
@@ -62,6 +63,12 @@ __all__ = [
     "flash_attention_decode_is_available",
     "na2d",
     "na3d",
+    "hip_attention",
+    "hip_attention_is_supported",
+    "hip_int8_attention",
+    "hip_int8_attention_is_supported",
+    "hip_int8_attention_split",
+    "hip_int8_attention_split_is_supported",
     # Quantization / dequantization
     "quantize_per_tensor_fp8",
     "dequantize_per_tensor_fp8",
@@ -84,6 +91,14 @@ __all__ = [
     "dequantize_w4a8_int8_weight",
     "gemv_awq_w4a16",
     "int8_linear",
+    "int8_linear_gated_residual",
+    "int8_linear_modulated",
+    "int8_linear_rms_modulated",
+    "int8_linear_pair",
+    "int8_linear_pair_modulated",
+    "int8_linear_triple_modulated",
+    "int8_linear_pair_rms_modulated",
+    "int8_linear_swiglu_split",
     "w4a8_int8_linear",
     # Positional encoding
     "apply_rope",
@@ -124,6 +139,92 @@ __all__ = [
 # =============================================================================
 # Public API Functions
 # =============================================================================
+
+
+def _call_backend(name: str, kwargs: dict):
+    """Dispatch a thin public wrapper whose signature matches its backends."""
+    impl = registry.get_implementation(name, kwargs=kwargs)
+    return impl(**kwargs)
+
+
+def hip_attention_is_supported(
+    q: torch.Tensor, k: torch.Tensor, v: torch.Tensor
+) -> bool:
+    """Return whether the floating-point HIP kernel accepts this SDPA call."""
+    return (
+        bool(getattr(torch.version, "hip", None))
+        and registry.is_available("hip")
+        and _hip_backend.hip_attention_is_supported(q, k, v)
+    )
+
+
+def hip_int8_attention_is_supported(
+    q: torch.Tensor, k: torch.Tensor, v: torch.Tensor
+) -> bool:
+    """Return whether the quantized HIP kernel accepts this SDPA call."""
+    return (
+        bool(getattr(torch.version, "hip", None))
+        and registry.is_available("hip")
+        and _hip_backend.hip_int8_attention_is_supported(q, k, v)
+    )
+
+
+def hip_int8_attention_split_is_supported(
+    q: tuple[torch.Tensor, torch.Tensor],
+    k: tuple[torch.Tensor, torch.Tensor],
+    v: tuple[torch.Tensor, torch.Tensor],
+) -> bool:
+    """Whether two sequence segments can avoid a materialized concatenation."""
+    return (
+        bool(getattr(torch.version, "hip", None))
+        and registry.is_available("hip")
+        and _hip_backend.hip_int8_attention_split_is_supported(q, k, v)
+    )
+
+
+def hip_attention(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    scale: float | None = None,
+) -> torch.Tensor:
+    """Run FP16/BF16 HIP attention after a positive capability check."""
+    if not (
+        bool(getattr(torch.version, "hip", None)) and registry.is_available("hip")
+    ):
+        raise RuntimeError("HIP attention requires the HIP backend")
+    return _hip_backend.hip_attention(q, k, v, scale)
+
+
+def hip_int8_attention(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    scale: float | None = None,
+) -> torch.Tensor:
+    """Run HIP attention after a positive capability check.
+
+    Long calls use INT8; overhead-bound short calls retain BF16.
+    """
+    if not (
+        bool(getattr(torch.version, "hip", None)) and registry.is_available("hip")
+    ):
+        raise RuntimeError("INT8 HIP attention requires the HIP backend")
+    resolved_scale = float(scale if scale is not None else q.shape[-1] ** -0.5)
+    return _hip_backend.hip_int8_attention(q, k, v, resolved_scale)
+
+
+def hip_int8_attention_split(
+    q: tuple[torch.Tensor, torch.Tensor],
+    k: tuple[torch.Tensor, torch.Tensor],
+    v: tuple[torch.Tensor, torch.Tensor],
+    scale: float | None = None,
+) -> torch.Tensor:
+    """Run quantized HIP attention over two logical sequence segments."""
+    if not hip_int8_attention_split_is_supported(q, k, v):
+        raise ValueError("unsupported split INT8 HIP attention contract")
+    resolved_scale = float(scale if scale is not None else q[0].shape[-1] ** -0.5)
+    return _hip_backend.hip_int8_attention_split(q, k, v, resolved_scale)
 
 
 def na3d(
@@ -804,6 +905,17 @@ def mm_int8(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
     return _mm_int8(a, b)
 
 
+def rms_gated_residual(
+    activation: torch.Tensor,
+    norm_weight: torch.Tensor,
+    residual: torch.Tensor,
+    gate: torch.Tensor,
+    eps: float = 1.0e-5,
+) -> torch.Tensor:
+    """Compute exact RMSNorm followed by a visible gate product and residual add."""
+    return _call_backend("rms_gated_residual", locals())
+
+
 def int8_linear(
     x: torch.Tensor,
     weight: torch.Tensor,
@@ -847,6 +959,167 @@ def int8_linear(
     }
     impl = registry.get_implementation("int8_linear", kwargs=kwargs)
     return impl(**kwargs)
+
+
+def int8_linear_gated_residual(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    residual: torch.Tensor,
+    gate: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    out_dtype: torch.dtype | None = None,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+    input_act: str | None = None,
+    weight_tile_k: int = 0,
+    dual_m: bool = False,
+) -> torch.Tensor:
+    """INT8 linear with an exact BF16 gated-residual writeback."""
+    if out_dtype is None:
+        out_dtype = torch.bfloat16
+    return _call_backend("int8_linear_gated_residual", locals())
+
+
+def int8_linear_modulated(
+    x: torch.Tensor,
+    modulation_scale: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    out_dtype: torch.dtype | None = None,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+    weight_tiled_b: bool = False,
+    modulation_shift: torch.Tensor | None = None,
+    weight_tile_k: int = 0,
+) -> torch.Tensor:
+    """Batch-one affine modulation with fused INT8 quantization."""
+    if out_dtype is None:
+        out_dtype = torch.bfloat16
+    return _call_backend("int8_linear_modulated", locals())
+
+
+def int8_linear_rms_modulated(
+    x: torch.Tensor,
+    norm_weight: torch.Tensor,
+    norm_eps: float,
+    modulation_scale: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    out_dtype: torch.dtype | None = None,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+    weight_tiled_b: bool = False,
+) -> torch.Tensor:
+    """INT8 projection with RMSNorm and batch-one modulation in its producer."""
+    if out_dtype is None:
+        out_dtype = torch.bfloat16
+    return _call_backend("int8_linear_rms_modulated", locals())
+
+
+def int8_linear_pair(
+    x: torch.Tensor,
+    weight0: torch.Tensor,
+    weight1: torch.Tensor,
+    weight_scale0: torch.Tensor,
+    weight_scale1: torch.Tensor,
+    bias0: torch.Tensor | None = None,
+    bias1: torch.Tensor | None = None,
+    out_dtype: torch.dtype | None = None,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+    weight_tile_k: int = 0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Two equal-width INT8 linears sharing activation quantization when supported."""
+    if out_dtype is None:
+        out_dtype = torch.bfloat16
+    return _call_backend("int8_linear_pair", locals())
+
+
+def int8_linear_pair_modulated(
+    x: torch.Tensor,
+    modulation_scale: torch.Tensor,
+    weight0: torch.Tensor,
+    weight1: torch.Tensor,
+    weight_scale0: torch.Tensor,
+    weight_scale1: torch.Tensor,
+    bias0: torch.Tensor | None = None,
+    bias1: torch.Tensor | None = None,
+    out_dtype: torch.dtype | None = None,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+    modulation_shift: torch.Tensor | None = None,
+    weight_tile_k: int = 0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Two batch-one affine-modulated linears sharing INT8 quantization."""
+    if out_dtype is None:
+        out_dtype = torch.bfloat16
+    return _call_backend("int8_linear_pair_modulated", locals())
+
+
+def int8_linear_triple_modulated(
+    x: torch.Tensor,
+    modulation_scale: torch.Tensor,
+    weight0: torch.Tensor,
+    weight1: torch.Tensor,
+    weight2: torch.Tensor,
+    weight_scale0: torch.Tensor,
+    weight_scale1: torch.Tensor,
+    weight_scale2: torch.Tensor,
+    bias0: torch.Tensor | None = None,
+    bias1: torch.Tensor | None = None,
+    bias2: torch.Tensor | None = None,
+    out_dtype: torch.dtype | None = None,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+    modulation_shift: torch.Tensor | None = None,
+    weight_tile_k: int = 0,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Three affine-modulated INT8 linears sharing one activation quantization."""
+    if out_dtype is None:
+        out_dtype = torch.bfloat16
+    return _call_backend("int8_linear_triple_modulated", locals())
+
+
+def int8_linear_pair_rms_modulated(
+    x: torch.Tensor,
+    norm_weight: torch.Tensor,
+    norm_eps: float,
+    modulation_scale: torch.Tensor,
+    weight0: torch.Tensor,
+    weight1: torch.Tensor,
+    weight_scale0: torch.Tensor,
+    weight_scale1: torch.Tensor,
+    bias0: torch.Tensor | None = None,
+    bias1: torch.Tensor | None = None,
+    out_dtype: torch.dtype | None = None,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Paired INT8 projections sharing RMSNorm, modulation, and quantization."""
+    if out_dtype is None:
+        out_dtype = torch.bfloat16
+    return _call_backend("int8_linear_pair_rms_modulated", locals())
+
+
+def int8_linear_swiglu_split(
+    gate: torch.Tensor,
+    up: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    out_dtype: torch.dtype | None = None,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+    weight_tiled_b: bool = False,
+    weight_tile_k: int = 0,
+) -> torch.Tensor:
+    """INT8 down projection that may absorb split BF16 SwiGLU inputs."""
+    if out_dtype is None:
+        out_dtype = torch.bfloat16
+    return _call_backend("int8_linear_swiglu_split", locals())
 
 
 # =============================================================================

--- a/comfy_kitchen/backends/eager/__init__.py
+++ b/comfy_kitchen/backends/eager/__init__.py
@@ -1,5 +1,6 @@
 __all__ = [
     "adaln",
+    "rms_gated_residual",
     "na3d",
     "rms_adaln",
     "apply_rope",
@@ -47,6 +48,14 @@ __all__ = [
     "scaled_mm_svdquant_w4a4",
     "stochastic_rounding_fp8",
     "int8_linear",
+    "int8_linear_gated_residual",
+    "int8_linear_modulated",
+    "int8_linear_rms_modulated",
+    "int8_linear_pair",
+    "int8_linear_pair_modulated",
+    "int8_linear_triple_modulated",
+    "int8_linear_pair_rms_modulated",
+    "int8_linear_swiglu_split",
     "w4a8_int8_linear",
 ]
 
@@ -69,6 +78,7 @@ from .convrot_w4a4 import (
     quantize_convrot_w4a4_weight,
 )
 from .na import na3d
+from .residual import rms_gated_residual
 from .quantization import (
     dequantize_int8_convrot_weight,
     dequantize_int8_convrot_weight_dtype,
@@ -79,6 +89,14 @@ from .quantization import (
     dequantize_nvfp4,
     dequantize_per_tensor_fp8,
     int8_linear,
+    int8_linear_gated_residual,
+    int8_linear_modulated,
+    int8_linear_rms_modulated,
+    int8_linear_pair,
+    int8_linear_pair_modulated,
+    int8_linear_triple_modulated,
+    int8_linear_pair_rms_modulated,
+    int8_linear_swiglu_split,
     quantize_and_rotate_rowwise,
     quantize_int8_convrot_weight,
     quantize_int8_rowwise,
@@ -440,6 +458,16 @@ def _build_constraints() -> dict:
         },
         default_devices=all_devices,
     )
+    out["rms_gated_residual"] = FunctionConstraints(
+        params={
+            "activation": ParamConstraint(dtypes=standard_floats),
+            "norm_weight": ParamConstraint(dtypes=standard_floats),
+            "residual": ParamConstraint(dtypes=standard_floats),
+            "gate": ParamConstraint(dtypes=standard_floats),
+            "eps": ParamConstraint(dtypes=frozenset({float})),
+        },
+        default_devices=all_devices,
+    )
     out["quantize_int8_rowwise"] = FunctionConstraints(
         params={
             "x": ParamConstraint(dtypes=standard_floats),
@@ -524,6 +552,73 @@ def _build_constraints() -> dict:
         },
         default_devices=all_devices,
     )
+    float_param = ParamConstraint(dtypes=standard_floats)
+    int8_param = ParamConstraint(dtypes=frozenset({torch.int8}))
+    int_param = ParamConstraint(dtypes=frozenset({int}))
+    float_value = ParamConstraint(dtypes=frozenset({float}))
+    bool_param = ParamConstraint(dtypes=frozenset({bool}))
+    fusion_options = {
+        "out_dtype": float_param,
+        "convrot": bool_param,
+        "convrot_groupsize": int_param,
+    }
+
+    def fusion_constraints(params):
+        return FunctionConstraints(
+            params=params | fusion_options, default_devices=all_devices
+        )
+
+    def projections(count):
+        return {
+            name: constraint
+            for index in range(count)
+            for name, constraint in (
+                (f"weight{index}", int8_param),
+                (f"weight_scale{index}", float_param),
+                (f"bias{index}", float_param),
+            )
+        }
+
+    single = {
+        "x": float_param,
+        "weight": int8_param,
+        "weight_scale": float_param,
+        "bias": float_param,
+    }
+    modulation = {
+        "modulation_scale": float_param,
+        "modulation_shift": float_param,
+    }
+    tiled = {"weight_tiled_b": bool_param, "weight_tile_k": int_param}
+    out.update({
+        "int8_linear_gated_residual": fusion_constraints(single | {
+            "residual": float_param, "gate": float_param,
+            "weight_tile_k": int_param, "dual_m": bool_param,
+        }),
+        "int8_linear_modulated": fusion_constraints(single | modulation | tiled),
+        "int8_linear_rms_modulated": fusion_constraints(single | modulation | {
+            "norm_weight": float_param, "norm_eps": float_value,
+            "weight_tiled_b": bool_param,
+        }),
+        "int8_linear_pair": fusion_constraints({"x": float_param} | projections(2) | {
+            "weight_tile_k": int_param,
+        }),
+        "int8_linear_pair_modulated": fusion_constraints(
+            {"x": float_param} | projections(2) | modulation | {"weight_tile_k": int_param}
+        ),
+        "int8_linear_triple_modulated": fusion_constraints(
+            {"x": float_param} | projections(3) | modulation | {"weight_tile_k": int_param}
+        ),
+        "int8_linear_pair_rms_modulated": fusion_constraints(
+            {"x": float_param} | projections(2) | modulation | {
+                "norm_weight": float_param, "norm_eps": float_value,
+            }
+        ),
+        "int8_linear_swiglu_split": fusion_constraints({
+            "gate": float_param, "up": float_param, "weight": int8_param,
+            "weight_scale": float_param, "bias": float_param,
+        } | tiled),
+    })
 
     if hasattr(torch, "float8_e8m0fnu"):
         out["quantize_mxfp8"] = FunctionConstraints(

--- a/comfy_kitchen/backends/eager/quantization.py
+++ b/comfy_kitchen/backends/eager/quantization.py
@@ -1056,6 +1056,248 @@ def int8_linear(
     return result.reshape(*orig_shape[:-1], weight.shape[0])
 
 
+def int8_linear_gated_residual(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    residual: torch.Tensor,
+    gate: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    out_dtype: torch.dtype = torch.bfloat16,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+    input_act: str | None = None,
+    weight_tile_k: int = 0,
+    dual_m: bool = False,
+) -> torch.Tensor:
+    """Portable ``residual + gate * int8_linear(...)`` reference."""
+    del weight_tile_k, dual_m
+    projected = int8_linear(
+        x, weight, weight_scale, bias, out_dtype, convrot,
+        convrot_groupsize, input_act,
+    )
+    return torch.addcmul(residual, gate, projected)
+
+
+def _modulate_int8_input(
+    x: torch.Tensor,
+    scale: torch.Tensor,
+    shift: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Materialize the portable batch-one modulation contract once."""
+    k = x.shape[-1]
+    if scale.numel() != k:
+        raise ValueError(
+            f"modulation_scale must contain one batch-one row of {k} values, "
+            f"got {scale.numel()}"
+        )
+    shape = (1,) * (x.ndim - 1) + (k,)
+    factor = 1.0 + scale.reshape(shape)
+    if shift is None:
+        return x * factor
+    if shift.numel() != k:
+        raise ValueError(
+            f"modulation_shift must contain one batch-one row of {k} values, "
+            f"got {shift.numel()}"
+        )
+    return torch.addcmul(shift.reshape(shape), x, factor)
+
+
+def _int8_linear_group(x, projections, out_dtype, convrot, group_size):
+    return tuple(
+        int8_linear(
+            x, weight, scale, bias, out_dtype, convrot, group_size
+        )
+        for weight, scale, bias in projections
+    )
+
+
+def int8_linear_pair(
+    x: torch.Tensor,
+    weight0: torch.Tensor,
+    weight1: torch.Tensor,
+    weight_scale0: torch.Tensor,
+    weight_scale1: torch.Tensor,
+    bias0: torch.Tensor | None = None,
+    bias1: torch.Tensor | None = None,
+    out_dtype: torch.dtype = torch.bfloat16,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Portable reference for two equal-width INT8 projections."""
+    if weight0.shape != weight1.shape:
+        raise ValueError(
+            f"paired INT8 weights must have the same shape, got "
+            f"{tuple(weight0.shape)} and {tuple(weight1.shape)}"
+        )
+    return _int8_linear_group(
+        x,
+        ((weight0, weight_scale0, bias0), (weight1, weight_scale1, bias1)),
+        out_dtype,
+        convrot,
+        convrot_groupsize,
+    )
+
+
+def int8_linear_modulated(
+    x: torch.Tensor,
+    modulation_scale: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    out_dtype: torch.dtype = torch.bfloat16,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+    weight_tiled_b: bool = False,
+    modulation_shift: torch.Tensor | None = None,
+    weight_tile_k: int = 0,
+) -> torch.Tensor:
+    """Portable batch-one affine-modulation reference for an INT8 projection."""
+    if weight_tiled_b or weight_tile_k:
+        raise ValueError("The eager backend cannot consume WMMA-tiled weights")
+    return int8_linear(
+        _modulate_int8_input(x, modulation_scale, modulation_shift),
+        weight, weight_scale, bias, out_dtype,
+        convrot, convrot_groupsize,
+    )
+
+
+def int8_linear_rms_modulated(
+    x: torch.Tensor,
+    norm_weight: torch.Tensor,
+    norm_eps: float,
+    modulation_scale: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    out_dtype: torch.dtype = torch.bfloat16,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+    weight_tiled_b: bool = False,
+) -> torch.Tensor:
+    """Portable RMSNorm plus batch-one modulation reference."""
+    if weight_tiled_b:
+        raise ValueError("The eager backend cannot consume WMMA-tiled weights")
+    normalized = torch.nn.functional.rms_norm(
+        x, (x.shape[-1],), norm_weight, norm_eps
+    )
+    return int8_linear_modulated(
+        normalized, modulation_scale, weight, weight_scale, bias, out_dtype,
+        convrot, convrot_groupsize, weight_tiled_b,
+    )
+
+
+def int8_linear_pair_modulated(
+    x: torch.Tensor,
+    modulation_scale: torch.Tensor,
+    weight0: torch.Tensor,
+    weight1: torch.Tensor,
+    weight_scale0: torch.Tensor,
+    weight_scale1: torch.Tensor,
+    bias0: torch.Tensor | None = None,
+    bias1: torch.Tensor | None = None,
+    out_dtype: torch.dtype = torch.bfloat16,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+    modulation_shift: torch.Tensor | None = None,
+    weight_tile_k: int = 0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Portable batch-one affine-modulation reference for paired projections."""
+    if weight_tile_k:
+        raise ValueError("The eager backend cannot consume WMMA-tiled weights")
+    return int8_linear_pair(
+        _modulate_int8_input(x, modulation_scale, modulation_shift),
+        weight0, weight1, weight_scale0, weight_scale1,
+        bias0, bias1, out_dtype, convrot, convrot_groupsize,
+    )
+
+
+def int8_linear_triple_modulated(
+    x: torch.Tensor,
+    modulation_scale: torch.Tensor,
+    weight0: torch.Tensor,
+    weight1: torch.Tensor,
+    weight2: torch.Tensor,
+    weight_scale0: torch.Tensor,
+    weight_scale1: torch.Tensor,
+    weight_scale2: torch.Tensor,
+    bias0: torch.Tensor | None = None,
+    bias1: torch.Tensor | None = None,
+    bias2: torch.Tensor | None = None,
+    out_dtype: torch.dtype = torch.bfloat16,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+    modulation_shift: torch.Tensor | None = None,
+    weight_tile_k: int = 0,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Portable affine-modulation reference for three projections."""
+    if weight_tile_k:
+        raise ValueError("The eager backend cannot consume WMMA-tiled weights")
+    return _int8_linear_group(
+        _modulate_int8_input(x, modulation_scale, modulation_shift),
+        (
+            (weight0, weight_scale0, bias0),
+            (weight1, weight_scale1, bias1),
+            (weight2, weight_scale2, bias2),
+        ),
+        out_dtype,
+        convrot,
+        convrot_groupsize,
+    )
+
+
+def int8_linear_pair_rms_modulated(
+    x: torch.Tensor,
+    norm_weight: torch.Tensor,
+    norm_eps: float,
+    modulation_scale: torch.Tensor,
+    weight0: torch.Tensor,
+    weight1: torch.Tensor,
+    weight_scale0: torch.Tensor,
+    weight_scale1: torch.Tensor,
+    bias0: torch.Tensor | None = None,
+    bias1: torch.Tensor | None = None,
+    out_dtype: torch.dtype = torch.bfloat16,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Portable paired RMSNorm plus batch-one modulation reference."""
+    normalized = torch.nn.functional.rms_norm(
+        x, (x.shape[-1],), norm_weight, norm_eps
+    )
+    return int8_linear_pair_modulated(
+        normalized, modulation_scale, weight0, weight1,
+        weight_scale0, weight_scale1, bias0, bias1, out_dtype,
+        convrot, convrot_groupsize,
+    )
+
+
+def int8_linear_swiglu_split(
+    gate: torch.Tensor,
+    up: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    out_dtype: torch.dtype = torch.bfloat16,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+    weight_tiled_b: bool = False,
+) -> torch.Tensor:
+    """Portable reference for a down projection consuming split SwiGLU inputs."""
+    if weight_tiled_b:
+        raise ValueError("The eager backend cannot consume WMMA-tiled weights")
+    if gate.shape != up.shape:
+        raise ValueError(
+            f"split SwiGLU inputs must have the same shape, got "
+            f"{tuple(gate.shape)} and {tuple(up.shape)}"
+        )
+    activated = torch.nn.functional.silu(gate) * up
+    return int8_linear(
+        activated, weight, weight_scale, bias, out_dtype,
+        convrot, convrot_groupsize,
+    )
+
+
 # =============================================================================
 # torch.library Custom Op Definitions — INT8 Tensor-wise
 # =============================================================================
@@ -1233,3 +1475,43 @@ def _op_int8_linear_fake(x, weight, weight_scale, bias, output_dtype_code,
                          convrot=False, convrot_groupsize=256, input_act=None):
     out_dtype = DTYPE_CODE_TO_DTYPE[output_dtype_code]
     return torch.empty(*x.shape[:-1], weight.shape[0], dtype=out_dtype, device=x.device)
+
+
+@torch.library.custom_op("comfy_kitchen::int8_linear_tiled_b", mutates_args=())
+def _op_int8_linear_tiled_b(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    bias: torch.Tensor | None,
+    output_dtype_code: int,
+    convrot: bool,
+    convrot_groupsize: int,
+    tile_k: int,
+    dual_m: bool,
+) -> torch.Tensor:
+    """Internal dispatch for physically tiled TensorWise INT8 weights."""
+    out_dtype = DTYPE_CODE_TO_DTYPE[output_dtype_code]
+    kwargs = {
+        "x": x,
+        "weight": weight,
+        "weight_scale": weight_scale,
+        "bias": bias,
+        "out_dtype": out_dtype,
+        "convrot": convrot,
+        "convrot_groupsize": convrot_groupsize,
+        "tile_k": tile_k,
+        "dual_m": dual_m,
+    }
+    impl = registry.get_implementation("int8_linear_tiled_b", kwargs=kwargs)
+    return impl(**kwargs)
+
+
+@_op_int8_linear_tiled_b.register_fake
+def _op_int8_linear_tiled_b_fake(
+    x, weight, weight_scale, bias, output_dtype_code, convrot,
+    convrot_groupsize, tile_k, dual_m,
+):
+    out_dtype = DTYPE_CODE_TO_DTYPE[output_dtype_code]
+    return torch.empty(
+        *x.shape[:-1], weight.shape[0], dtype=out_dtype, device=x.device
+    )

--- a/comfy_kitchen/backends/eager/residual.py
+++ b/comfy_kitchen/backends/eager/residual.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+import torch
+import torch.nn.functional as F
+
+
+def rms_gated_residual(
+    activation: torch.Tensor,
+    norm_weight: torch.Tensor,
+    residual: torch.Tensor,
+    gate: torch.Tensor,
+    eps: float = 1.0e-5,
+) -> torch.Tensor:
+    """Reference RMSNorm followed by the visible gate product and residual add."""
+    normalized = F.rms_norm(
+        activation, (activation.shape[-1],), norm_weight, eps
+    )
+    return residual + gate * normalized

--- a/comfy_kitchen/backends/hip/CMakeLists.txt
+++ b/comfy_kitchen/backends/hip/CMakeLists.txt
@@ -155,10 +155,13 @@ set(HIP_SOURCES
     ops/per_tensor_fp8.hip
     ops/stochastic_round_fp8.hip
     ops/quantize_int8.hip
+    ops/attention_bf16.hip
+    ops/rms_gated_residual.hip
     ops/gemm_fp8.hip
     ops/gemm_int8.hip
     ops/convrot_w4a4.hip
     ops/adaln.hip
+    ops/rms_convrot_quant.hip
     ops/na3d.hip
     sage_attention/quant_qk_int8.hip
     sage_attention/quant_v_int8.hip
@@ -183,6 +186,12 @@ add_library(comfy_kitchen_hip_kernels OBJECT ${HIP_SOURCES})
 target_compile_options(comfy_kitchen_hip_kernels PRIVATE
     $<$<COMPILE_LANGUAGE:HIP>:-O3>
     $<$<COMPILE_LANGUAGE:HIP>:-ffast-math>
+)
+# The quantized attention specialization preserves ordered FP32 softmax and
+# normalization arithmetic; contraction or reassociation changes its BF16
+# output boundary even when aggregate cosine rounds to one.
+set_source_files_properties(sage_attention/int8_attn.hip PROPERTIES
+    COMPILE_OPTIONS "$<$<COMPILE_LANGUAGE:HIP>:-fno-fast-math>"
 )
 if(COMFY_ENABLE_LINEINFO OR CMAKE_BUILD_TYPE STREQUAL "Debug")
     target_compile_options(

--- a/comfy_kitchen/backends/hip/__init__.py
+++ b/comfy_kitchen/backends/hip/__init__.py
@@ -17,6 +17,7 @@ import functools
 import importlib.util
 import json
 import logging
+import math
 import os
 import pathlib
 import sys
@@ -47,6 +48,7 @@ __all__ = [
     "na3d",
     "rms_adaln",
     "gemv_awq_w4a16",
+    "rms_gated_residual",
     "quantize_svdquant_w4a4",
     "scaled_mm_svdquant_w4a4",
     "apply_rope",
@@ -65,9 +67,18 @@ __all__ = [
     "dequantize_w4a8_int8_weight",
     "has_wmma",
     "int8_linear",
+    "int8_linear_gated_residual",
+    "int8_linear_tiled_b",
     "int8_attention_is_available",
     "flash_attention_decode_is_available",
     "flash_decode",
+    "int8_linear_modulated",
+    "int8_linear_rms_modulated",
+    "int8_linear_pair",
+    "int8_linear_pair_modulated",
+    "int8_linear_triple_modulated",
+    "int8_linear_pair_rms_modulated",
+    "int8_linear_swiglu_split",
     "is_available",
     "sage_int8_attend",
     "sage_int8_quantize",
@@ -158,8 +169,14 @@ _ARCH_GROUPS = json.loads(
 _ARCH_ELEMENTWISE_ONLY = frozenset(_ARCH_GROUPS["elementwise_only"])
 _ARCH_WMMA_GFX11 = frozenset(_ARCH_GROUPS["wmma_gfx11"])
 _ARCH_WMMA_GFX12 = frozenset(_ARCH_GROUPS["wmma_gfx12"])
-_ARCH_WMMA = _ARCH_WMMA_GFX11 | _ARCH_WMMA_GFX12
+_ARCH_WMMA_NONDUPLICATED = _ARCH_WMMA_GFX12
+_ARCH_WMMA = _ARCH_WMMA_GFX11 | _ARCH_WMMA_NONDUPLICATED
 _ARCH_SUPPORTED = _ARCH_ELEMENTWISE_ONLY | _ARCH_WMMA
+
+
+def _has_nonduplicated_wmma(device: torch.device | int | None = None) -> bool:
+    """Whether WMMA operands use the gfx12 128-bit layout."""
+    return _gfx_arch(device) in _ARCH_WMMA_NONDUPLICATED
 
 # The GEMMs, and only the GEMMs, need matrix cores. Everything else is elementwise
 # or a scalar reduction and runs on any supported architecture. This set names the
@@ -168,6 +185,15 @@ _ARCH_SUPPORTED = _ARCH_ELEMENTWISE_ONLY | _ARCH_WMMA
 # which gates on has_wmma() itself rather than through the registry.
 _WMMA_ONLY_OPS = frozenset({
     "int8_linear",
+    "int8_linear_gated_residual",
+    "int8_linear_tiled_b",
+    "int8_linear_modulated",
+    "int8_linear_rms_modulated",
+    "int8_linear_pair",
+    "int8_linear_pair_modulated",
+    "int8_linear_triple_modulated",
+    "int8_linear_pair_rms_modulated",
+    "int8_linear_swiglu_split",
     "na3d",
     "convrot_w4a4_linear",
     "scaled_mm_svdquant_w4a4",
@@ -511,6 +537,7 @@ def dequantize_int8_convrot_weight_dtype(
 # Keyed by device and dtype: convrot_max_k() reports the LDS budget of whichever
 # device is current and FP32 rows consume twice the LDS of FP16/BF16 rows.
 _convrot_max_k: dict[tuple[int, torch.dtype], int] = {}
+_CONVROT_SPILL_WORKSPACE_BYTES = 32 << 20
 
 
 def _convrot_supported(
@@ -551,27 +578,171 @@ def _rotate_quant_int8(
     q = torch.empty((m, k), dtype=torch.int8, device=x2d.device)
     scales = torch.empty((m,), dtype=torch.float32, device=x2d.device)
     x_arg = _operand(x2d, x2d.device, "x2d")
-    spill_rotated = None
-    spill_partials = None
     # check_convrot_k queries the current device's LDS budget, so pin it to the
     # operand's device rather than trusting the caller thread's current device.
     with torch.cuda.device(x2d.device):
-        if group_size == 256 and _C.convrot_int8_needs_spill(m, k, DTYPE_TO_CODE[x2d.dtype]):
-            spill_rotated = torch.empty((m, k), dtype=x2d.dtype, device=x2d.device)
-            spill_partials = torch.empty((m, k // 256), dtype=torch.float32, device=x2d.device)
-        _C.quantize_int8_convrot(
-            _dl(x_arg),
-            _dl(q),
-            _dl(scales),
-            None if spill_rotated is None else _dl(spill_rotated),
-            None if spill_partials is None else _dl(spill_partials),
-            m,
-            k,
-            group_size,
-            _input_act_code(input_act),
-            _stream(x2d),
+        if group_size != 256 or not _C.convrot_int8_needs_spill(
+            m, k, DTYPE_TO_CODE[x2d.dtype]
+        ):
+            _C.quantize_int8_convrot(
+                _dl(x_arg), _dl(q), _dl(scales), None, None, m, k,
+                group_size, _input_act_code(input_act), _stream(x2d),
+            )
+            return q, scales
+
+        workspace_per_row = x_arg.element_size() * k + 4 * (k // 256)
+        row_cap = max(1, _CONVROT_SPILL_WORKSPACE_BYTES // workspace_per_row)
+        chunk_count = (m + row_cap - 1) // row_cap
+        # The native policy chooses the exact global implementation for wide
+        # chunks of at least 96 rows. Balance chunks so a short final slice does
+        # not switch to the otherwise-equivalent one-wave LDS schedule, whose
+        # activation rounding can differ at quantization boundaries.
+        chunk_count = min(chunk_count, max(1, m // 96))
+        chunk_rows = (m + chunk_count - 1) // chunk_count
+        spill_rotated = torch.empty(
+            (chunk_rows, k), dtype=x_arg.dtype, device=x2d.device
+        )
+        spill_partials = torch.empty(
+            (chunk_rows, k // 256), dtype=torch.float32, device=x2d.device
+        )
+        start = 0
+        for chunk in range(chunk_count):
+            rows = m // chunk_count + (chunk < m % chunk_count)
+            end = start + rows
+            _C.quantize_int8_convrot(
+                _dl(x_arg[start:end]),
+                _dl(q[start:end]),
+                _dl(scales[start:end]),
+                _dl(spill_rotated),
+                _dl(spill_partials),
+                rows,
+                k,
+                group_size,
+                _input_act_code(input_act),
+                _stream(x2d),
+            )
+            start = end
+    return q, scales
+
+
+def _rotate_quant_int8_tiled128(
+    x2d: torch.Tensor, group_size: int
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Emit INT8 directly as [M/128, K/128, 128, 128] tiles."""
+    m, k = x2d.shape
+    padded_m = (m + 127) // 128 * 128
+    q = torch.empty((padded_m, k), dtype=torch.int8, device=x2d.device)
+    scales = torch.empty((m,), dtype=torch.float32, device=x2d.device)
+    with torch.cuda.device(x2d.device):
+        _C.quantize_int8_convrot_tiled128(
+            _dl(x2d), _dl(q), _dl(scales), m, k, group_size, _stream(x2d)
         )
     return q, scales
+
+
+def _rotate_quant_int8_modulated(
+    x2d: torch.Tensor, modulation_scale: torch.Tensor, group_size: int
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Fold exact twice-rounded BF16 batch-one modulation into ConvRot."""
+    m, k = x2d.shape
+    q = torch.empty((m, k), dtype=torch.int8, device=x2d.device)
+    scales = torch.empty((m,), dtype=torch.float32, device=x2d.device)
+    with torch.cuda.device(x2d.device):
+        _C.quantize_int8_convrot_modulated(
+            _dl(x2d), _dl(modulation_scale), _dl(q), _dl(scales),
+            m, k, group_size, _stream(x2d),
+        )
+    return q, scales
+
+
+def _rotate_quant_int8_affine(
+    x2d: torch.Tensor,
+    modulation_scale: torch.Tensor,
+    modulation_shift: torch.Tensor,
+    group_size: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Fold exact BF16 shift-and-scale modulation into generic ConvRot."""
+    m, k = x2d.shape
+    q = torch.empty((m, k), dtype=torch.int8, device=x2d.device)
+    scales = torch.empty((m,), dtype=torch.float32, device=x2d.device)
+    with torch.cuda.device(x2d.device):
+        _C.quantize_int8_convrot_affine(
+            _dl(x2d), _dl(modulation_scale), _dl(modulation_shift),
+            _dl(q), _dl(scales), m, k, group_size, _stream(x2d),
+        )
+    return q, scales
+
+
+def _rotate_quant_int8_rms_modulated(
+    x2d: torch.Tensor,
+    norm_weight: torch.Tensor,
+    norm_eps: float,
+    modulation_scale: torch.Tensor,
+    group_size: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Fold exact BF16 RMSNorm and modulation into the ConvRot producer."""
+    m, k = x2d.shape
+    q = torch.empty((m, k), dtype=torch.int8, device=x2d.device)
+    scales = torch.empty((m,), dtype=torch.float32, device=x2d.device)
+    with torch.cuda.device(x2d.device):
+        _C.quantize_int8_convrot_rms_modulated_fused_stats(
+            _dl(x2d), _dl(norm_weight), _dl(modulation_scale),
+            _dl(q), _dl(scales), m, k, group_size, norm_eps, _stream(x2d),
+        )
+    return q, scales
+
+
+def _rotate_quant_int8_swiglu_split_tiled128(
+    gate2d: torch.Tensor, up2d: torch.Tensor, group_size: int
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Apply exact BF16 SwiGLU while emitting the down GEMM's tiled INT8 A."""
+    m, k = gate2d.shape
+    padded_m = (m + 127) // 128 * 128
+    q = torch.empty((padded_m, k), dtype=torch.int8, device=gate2d.device)
+    scales = torch.empty((m,), dtype=torch.float32, device=gate2d.device)
+    with torch.cuda.device(gate2d.device):
+        _C.quantize_int8_convrot_swiglu_split_tiled128(
+            _dl(gate2d), _dl(up2d), _dl(q), _dl(scales),
+            m, k, group_size, _stream(gate2d),
+        )
+    return q, scales
+
+
+def _use_tiled_a_down(
+    x2d: torch.Tensor,
+    m: int,
+    n: int,
+    k: int,
+    out_dtype: torch.dtype,
+    convrot_groupsize: int,
+    input_act: str | None,
+) -> bool:
+    """Whether the measured tiled-A down schedule is exact-applicable."""
+    return (
+        _has_nonduplicated_wmma(x2d.device)
+        and x2d.dtype == torch.bfloat16
+        and out_dtype == torch.bfloat16
+        and m >= 512
+        and n == 3840
+        and k == 10240
+        and convrot_groupsize == 256
+        and input_act is None
+    )
+
+
+def _tiled_b_supported(
+    x: torch.Tensor, m: int, n: int, k: int,
+    out_dtype: torch.dtype, tile_k: int,
+) -> bool:
+    return (
+        _has_nonduplicated_wmma(x.device)
+        and x.dtype == torch.bfloat16
+        and out_dtype == torch.bfloat16
+        and m >= 96
+        and n % 128 == 0
+        and tile_k in (64, 128)
+        and k % tile_k == 0
+    )
 
 
 def quantize_and_rotate_rowwise(
@@ -628,6 +799,10 @@ def int8_linear(
     convrot: bool = False,
     convrot_groupsize: int = 256,
     input_act: str | None = None,
+    _weight_tile_k: int = 0,
+    _dual_m: bool = False,
+    _residual: torch.Tensor | None = None,
+    _gate: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """INT8 linear with dynamic row-wise activation quantization, on WMMA."""
     # Rejected here so every route fails the same way, not just the fused one.
@@ -651,7 +826,44 @@ def int8_linear(
     m = x2d.shape[0]
     k = k_act
     n = weight.shape[0]
-
+    gated = _residual is not None or _gate is not None
+    if gated:
+        if _residual is None or _gate is None:
+            raise ValueError("residual and gate must be provided together")
+        expected = (*orig_shape[:-1], n)
+        if tuple(_residual.shape) != expected:
+            raise ValueError(
+                f"residual shape must be {expected}, got {tuple(_residual.shape)}"
+            )
+        if _gate.numel() != n:
+            raise ValueError(f"gate must contain N={n} elements")
+        native_gated = (
+            _weight_tile_k in (64, 128)
+            and input_act is None
+            and out_dtype == torch.bfloat16
+            and x.dtype == torch.bfloat16
+            and _residual.dtype == torch.bfloat16
+            and _gate.dtype == torch.bfloat16
+            and _residual.device == x.device
+            and _gate.device == x.device
+        )
+        if not native_gated:
+            projected = int8_linear(
+                x, weight, weight_scale, bias, out_dtype, convrot,
+                convrot_groupsize, input_act, _weight_tile_k, _dual_m,
+            )
+            return torch.addcmul(_residual, _gate, projected)
+    use_down_tiled_a = convrot and _use_tiled_a_down(
+        x2d, m, n, k, out_dtype, convrot_groupsize, input_act
+    )
+    if _weight_tile_k:
+        if (not _tiled_b_supported(x, m, n, k, out_dtype, _weight_tile_k)
+                or input_act is not None or use_down_tiled_a):
+            raise ValueError(
+                "tiled-B INT8 linear requires non-duplicated WMMA BF16, M>=96, "
+                "N divisible by 128, K divisible by tile_k, no input "
+                "activation, and no tiled-A producer"
+            )
     # The WMMA K-step and the small-M GEMV both read a row 16 bytes at a time.
     if k % 16 != 0:
         raise ValueError(f"int8_linear requires K divisible by 16, got {k}")
@@ -671,7 +883,10 @@ def int8_linear(
                 input_act=input_act,
             )
         # The only route that absorbs the activation; the rest apply it eagerly.
-        q, x_scale = _rotate_quant_int8(x2d, convrot_groupsize, input_act)
+        if use_down_tiled_a:
+            q, x_scale = _rotate_quant_int8_tiled128(x2d, convrot_groupsize)
+        else:
+            q, x_scale = _rotate_quant_int8(x2d, convrot_groupsize, input_act)
     else:
         x2d = _apply_input_act(x2d, input_act)
         q = torch.empty((m, k), dtype=torch.int8, device=x.device)
@@ -683,13 +898,847 @@ def int8_linear(
         bias = _bias_operand(bias, n, x.device)
 
     out = torch.empty((m, n), dtype=out_dtype, device=x.device)
-    _C.int8_gemm(
-        _dl(q), _dl(weight), _dl(out),
-        _dl(x_scale), _dl(weight_scale), 0 if weight_scale.numel() == 1 else 1,
-        None if bias is None else _dl(bias),
-        m, n, k, DTYPE_TO_CODE[out_dtype], _stream(x),
-    )
+    if gated:
+        residual2d = _residual.reshape(m, n).contiguous()
+        gate1d = _gate.reshape(n).contiguous()
+        _C.int8_gemm_b_tiled_gated_residual(
+            _dl(q), _dl(weight), _dl(out), _dl(x_scale), _dl(weight_scale),
+            0 if weight_scale.numel() == 1 else 1,
+            None if bias is None else _dl(bias), _dl(residual2d), _dl(gate1d),
+            m, n, k, _weight_tile_k, _dual_m, _stream(x),
+        )
+        return out.reshape(*orig_shape[:-1], n)
+    if _weight_tile_k:
+        gemm = _C.int8_gemm_b_tiled
+    elif use_down_tiled_a:
+        gemm = _C.int8_gemm_a_tiled128_down
+    else:
+        gemm = _C.int8_gemm
+    gemm_args = [
+        _dl(q), _dl(weight), _dl(out), _dl(x_scale), _dl(weight_scale),
+        0 if weight_scale.numel() == 1 else 1,
+        None if bias is None else _dl(bias), m, n, k,
+        DTYPE_TO_CODE[out_dtype],
+    ]
+    if _weight_tile_k:
+        gemm_args.extend((_weight_tile_k, _dual_m))
+    gemm_args.append(_stream(x))
+    gemm(*gemm_args)
     return out.reshape(*orig_shape[:-1], n)
+
+
+def int8_linear_gated_residual(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    residual: torch.Tensor,
+    gate: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    out_dtype: torch.dtype = torch.bfloat16,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+    input_act: str | None = None,
+    weight_tile_k: int = 0,
+    dual_m: bool = False,
+) -> torch.Tensor:
+    """INT8 linear followed by exact BF16 ``residual + gate * linear``."""
+    return int8_linear(
+        x, weight, weight_scale, bias, out_dtype, convrot,
+        convrot_groupsize, input_act, weight_tile_k, dual_m,
+        residual, gate,
+    )
+
+
+def int8_linear_tiled_b(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    out_dtype: torch.dtype = torch.bfloat16,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+    tile_k: int = 64,
+    dual_m: bool = True,
+) -> torch.Tensor:
+    """INT8 linear for a 128-by-``tile_k`` physically tiled weight."""
+    return int8_linear(
+        x, weight, weight_scale, bias, out_dtype, convrot,
+        convrot_groupsize, _weight_tile_k=tile_k, _dual_m=dual_m,
+    )
+
+
+def rms_gated_residual(
+    activation: torch.Tensor,
+    norm_weight: torch.Tensor,
+    residual: torch.Tensor,
+    gate: torch.Tensor,
+    eps: float = 1.0e-5,
+) -> torch.Tensor:
+    """Exact BF16 RMSNorm, gate multiplication, and residual add."""
+    use_fused = (
+        activation.dtype == torch.bfloat16
+        and norm_weight.dtype == torch.bfloat16
+        and residual.dtype == torch.bfloat16
+        and gate.dtype == torch.bfloat16
+        and activation.device == norm_weight.device == residual.device == gate.device
+        and activation.ndim == 3
+        and activation.shape[0] == 1
+        and activation.shape == residual.shape
+        and activation.shape[-1] > 0
+        and activation.shape[-1] % 4 == 0
+        and activation.shape[-1] <= _C.convrot_max_k(DTYPE_TO_CODE[activation.dtype])
+        and norm_weight.numel() == activation.shape[-1]
+        and gate.numel() == activation.shape[-1]
+    )
+    if not use_fused:
+        return _eager.rms_gated_residual(
+            activation, norm_weight, residual, gate, eps
+        )
+
+    shape = activation.shape
+    width = activation.shape[-1]
+    activation_2d = activation.reshape(-1, width).contiguous()
+    norm_weight_1d = norm_weight.reshape(-1).contiguous()
+    residual_2d = residual.reshape(-1, width).contiguous()
+    gate_1d = gate.reshape(-1).contiguous()
+    output = torch.empty_like(activation_2d)
+    _C.rms_gated_residual_bf16(
+        _dl(activation_2d), _dl(norm_weight_1d), _dl(residual_2d),
+        _dl(gate_1d), _dl(output), activation_2d.shape[0], width,
+        float(eps), _stream(activation),
+    )
+    return output.reshape(shape)
+
+
+def int8_linear_modulated(
+    x: torch.Tensor,
+    modulation_scale: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    out_dtype: torch.dtype = torch.bfloat16,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+    weight_tiled_b: bool = False,
+    modulation_shift: torch.Tensor | None = None,
+    weight_tile_k: int = 0,
+) -> torch.Tensor:
+    """INT8 projection with batch-one BF16 modulation in its ConvRot load."""
+    k = x.shape[-1]
+    if k != weight.shape[-1]:
+        raise ValueError(
+            f"Input and weight inner dimensions must match, got {k} and {weight.shape[-1]}"
+        )
+    if modulation_scale.numel() != k:
+        raise ValueError(
+            f"modulation_scale must contain one batch-one row of {k} values, "
+            f"got {modulation_scale.numel()}"
+        )
+
+    modulation_scale = modulation_scale.to(device=x.device).reshape(-1).contiguous()
+    if modulation_shift is not None:
+        if modulation_shift.numel() != k:
+            raise ValueError(
+                f"modulation_shift must contain one batch-one row of {k} values, "
+                f"got {modulation_shift.numel()}"
+            )
+        modulation_shift = (
+            modulation_shift.to(device=x.device).reshape(-1).contiguous()
+        )
+    orig_shape = x.shape
+    x2d = x.reshape(-1, k).contiguous()
+    m = x2d.shape[0]
+    n = weight.shape[0]
+    if weight_tiled_b and weight_tile_k:
+        raise ValueError("Only one tiled-B layout may be selected")
+    if weight_tile_k and not _tiled_b_supported(
+        x, m, n, k, out_dtype, weight_tile_k
+    ):
+        raise ValueError(
+            "tiled-B INT8 linear requires non-duplicated WMMA BF16, M>=96, "
+            "N divisible by 128, and K divisible by tile_k"
+        )
+    use_affine_fused = (
+        modulation_shift is not None
+        and x2d.dtype == torch.bfloat16
+        and modulation_scale.dtype == torch.bfloat16
+        and modulation_shift.dtype == torch.bfloat16
+        and out_dtype == torch.bfloat16
+        and convrot
+        and convrot_groupsize == 256
+        and not _C.convrot_int8_needs_spill(m, k, DTYPE_TO_CODE[x2d.dtype])
+    )
+    use_scale_fused = (
+        modulation_shift is None
+        and _has_nonduplicated_wmma(x.device)
+        and x2d.dtype == torch.bfloat16
+        and modulation_scale.dtype == torch.bfloat16
+        and out_dtype == torch.bfloat16
+        and convrot
+        and convrot_groupsize == 256
+        and k == 3840
+        and n == 11520
+    )
+    use_fused = use_affine_fused or use_scale_fused
+    if not use_fused:
+        if weight_tiled_b or weight_tile_k:
+            raise ValueError(
+                "WMMA-tiled weight is only valid for a fused modulation path"
+            )
+        scale_shape = (1,) * (x.ndim - 1) + (k,)
+        scale = modulation_scale.reshape(scale_shape)
+        if modulation_shift is None:
+            modulated = x * (1.0 + scale)
+        else:
+            modulated = torch.addcmul(
+                modulation_shift.reshape(scale_shape), x, 1.0 + scale
+            )
+        return int8_linear(
+            modulated, weight, weight_scale, bias, out_dtype,
+            convrot, convrot_groupsize,
+        )
+
+    weight = _aligned(weight.to(device=x.device).contiguous())
+    weight_scale = weight_scale.to(device=x.device, dtype=torch.float32).reshape(-1)
+    if weight_scale.numel() not in (1, n):
+        raise ValueError(
+            f"INT8 weight scale must be scalar or per-output-channel, got "
+            f"{tuple(weight_scale.shape)}"
+        )
+    if bias is not None:
+        bias = _bias_operand(bias, n, x.device)
+
+    if modulation_shift is None:
+        q, x_scale = _rotate_quant_int8_modulated(
+            x2d, modulation_scale, convrot_groupsize
+        )
+    else:
+        q, x_scale = _rotate_quant_int8_affine(
+            x2d, modulation_scale, modulation_shift, convrot_groupsize
+        )
+    out = torch.empty((m, n), dtype=out_dtype, device=x.device)
+    gemm_args = [
+        _dl(q), _dl(weight), _dl(out), _dl(x_scale), _dl(weight_scale),
+        0 if weight_scale.numel() == 1 else 1,
+        None if bias is None else _dl(bias),
+        m, n, k, DTYPE_TO_CODE[out_dtype],
+    ]
+    if weight_tile_k:
+        _C.int8_gemm_b_tiled(
+            *gemm_args, weight_tile_k, m >= 512, _stream(x)
+        )
+    elif weight_tiled_b:
+        _C.int8_gemm_b_tiled(*gemm_args, 64, True, _stream(x))
+    else:
+        _C.int8_gemm(*gemm_args, _stream(x))
+    return out.reshape(*orig_shape[:-1], n)
+
+
+def int8_linear_rms_modulated(
+    x: torch.Tensor,
+    norm_weight: torch.Tensor,
+    norm_eps: float,
+    modulation_scale: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    out_dtype: torch.dtype = torch.bfloat16,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+    weight_tiled_b: bool = False,
+) -> torch.Tensor:
+    """INT8 QKV projection with exact RMSNorm and modulation in ConvRot."""
+    k = x.shape[-1]
+    if k != weight.shape[-1]:
+        raise ValueError(
+            f"Input and weight inner dimensions must match, got {k} and {weight.shape[-1]}"
+        )
+    if norm_weight.numel() != k or modulation_scale.numel() != k:
+        raise ValueError(
+            f"norm_weight and modulation_scale must each contain {k} values"
+        )
+
+    norm_weight = norm_weight.to(device=x.device).reshape(-1).contiguous()
+    modulation_scale = modulation_scale.to(device=x.device).reshape(-1).contiguous()
+    orig_shape = x.shape
+    x2d = x.reshape(-1, k).contiguous()
+    m = x2d.shape[0]
+    n = weight.shape[0]
+    use_fused = (
+        _has_nonduplicated_wmma(x.device)
+        and x2d.dtype == torch.bfloat16
+        and norm_weight.dtype == torch.bfloat16
+        and modulation_scale.dtype == torch.bfloat16
+        and out_dtype == torch.bfloat16
+        and convrot
+        and convrot_groupsize == 256
+        and k == 3840
+        and n == 11520
+    )
+    if not use_fused:
+        if weight_tiled_b:
+            raise ValueError(
+                "WMMA-tiled QKV weight is only valid for its fused WMMA path"
+            )
+        normalized = torch.nn.functional.rms_norm(
+            x, (k,), norm_weight, norm_eps
+        )
+        return int8_linear_modulated(
+            normalized, modulation_scale, weight, weight_scale, bias,
+            out_dtype, convrot, convrot_groupsize, weight_tiled_b,
+        )
+
+    weight = _aligned(weight.to(device=x.device).contiguous())
+    weight_scale = weight_scale.to(
+        device=x.device, dtype=torch.float32
+    ).reshape(-1)
+    if weight_scale.numel() not in (1, n):
+        raise ValueError(
+            f"INT8 weight scale must be scalar or per-output-channel, got "
+            f"{tuple(weight_scale.shape)}"
+        )
+    if bias is not None:
+        bias = _bias_operand(bias, n, x.device)
+
+    q, x_scale = _rotate_quant_int8_rms_modulated(
+        x2d, norm_weight, norm_eps, modulation_scale, convrot_groupsize
+    )
+    out = torch.empty((m, n), dtype=out_dtype, device=x.device)
+    gemm_args = [
+        _dl(q), _dl(weight), _dl(out), _dl(x_scale), _dl(weight_scale),
+        0 if weight_scale.numel() == 1 else 1,
+        None if bias is None else _dl(bias),
+        m, n, k, DTYPE_TO_CODE[out_dtype],
+    ]
+    if weight_tiled_b:
+        _C.int8_gemm_b_tiled(*gemm_args, 64, True, _stream(x))
+    else:
+        _C.int8_gemm(*gemm_args, _stream(x))
+    return out.reshape(*orig_shape[:-1], n)
+
+
+def _int8_linear_pair_impl(
+    x: torch.Tensor,
+    weight0: torch.Tensor,
+    weight1: torch.Tensor,
+    weight_scale0: torch.Tensor,
+    weight_scale1: torch.Tensor,
+    bias0: torch.Tensor | None = None,
+    bias1: torch.Tensor | None = None,
+    out_dtype: torch.dtype = torch.bfloat16,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+    modulation_scale: torch.Tensor | None = None,
+    norm_weight: torch.Tensor | None = None,
+    norm_eps: float = 0.0,
+    weight_tile_k: int = 0,
+    modulation_shift: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Two INT8 linears sharing one row-wise activation quantization."""
+    if weight0.shape != weight1.shape or weight0.ndim != 2:
+        raise ValueError(
+            f"paired INT8 weights must have the same 2D shape, got "
+            f"{tuple(weight0.shape)} and {tuple(weight1.shape)}"
+        )
+    if x.shape[-1] != weight0.shape[-1]:
+        raise ValueError(
+            f"Input and weight inner dimensions must match, got {x.shape[-1]} "
+            f"and {weight0.shape[-1]}"
+        )
+    weight0 = _aligned(weight0.to(device=x.device).contiguous())
+    weight1 = _aligned(weight1.to(device=x.device).contiguous())
+    weight_scale0 = weight_scale0.to(device=x.device, dtype=torch.float32).reshape(-1)
+    weight_scale1 = weight_scale1.to(device=x.device, dtype=torch.float32).reshape(-1)
+    n, k = weight0.shape
+    for name, scale in (
+        ("weight_scale0", weight_scale0),
+        ("weight_scale1", weight_scale1),
+    ):
+        if scale.numel() not in (1, n):
+            raise ValueError(
+                f"{name} must be scalar or per-output-channel, got {tuple(scale.shape)}"
+            )
+
+    orig_shape = x.shape
+    x2d = x.reshape(-1, k).contiguous()
+    m = x2d.shape[0]
+    if k % 16 != 0:
+        raise ValueError(f"int8_linear_pair requires K divisible by 16, got {k}")
+    if weight_tile_k and not _tiled_b_supported(
+        x, m, n, k, out_dtype, weight_tile_k
+    ):
+        raise ValueError(
+            "tiled-B INT8 pair requires non-duplicated WMMA BF16, M>=96, "
+            "N divisible by 128, and K divisible by tile_k"
+        )
+
+    if convrot:
+        if convrot_groupsize not in (16, 64, 256):
+            raise ValueError(
+                f"ConvRot group size must be 16, 64 or 256, got {convrot_groupsize}"
+            )
+        if k % convrot_groupsize != 0:
+            raise ValueError(
+                f"ConvRot group size {convrot_groupsize} does not divide input features {k}"
+            )
+        if not _convrot_supported(k, convrot_groupsize, x.device, x.dtype):
+            return _eager.int8_linear_pair(
+                x, weight0, weight1, weight_scale0, weight_scale1,
+                bias0, bias1, out_dtype, convrot, convrot_groupsize,
+            )
+        if modulation_shift is not None:
+            if modulation_scale is None:
+                raise ValueError("Affine-modulated pair requires modulation_scale")
+            q, x_scale = _rotate_quant_int8_affine(
+                x2d, modulation_scale, modulation_shift,
+                convrot_groupsize,
+            )
+        elif norm_weight is not None:
+            if modulation_scale is None:
+                raise ValueError("RMS-modulated pair requires modulation_scale")
+            q, x_scale = _rotate_quant_int8_rms_modulated(
+                x2d, norm_weight, norm_eps, modulation_scale,
+                convrot_groupsize,
+            )
+        elif modulation_scale is None:
+            q, x_scale = _rotate_quant_int8(x2d, convrot_groupsize)
+        else:
+            q, x_scale = _rotate_quant_int8_modulated(
+                x2d, modulation_scale, convrot_groupsize
+            )
+    else:
+        q = torch.empty((m, k), dtype=torch.int8, device=x.device)
+        x_scale = torch.empty((m,), dtype=torch.float32, device=x.device)
+        _C.quantize_int8_rowwise(
+            _dl(x2d), _dl(q), _dl(x_scale), m, k, _stream(x)
+        )
+
+    x_scale = x_scale.reshape(-1).contiguous()
+    if bias0 is not None:
+        bias0 = _bias_operand(bias0, n, x.device)
+    if bias1 is not None:
+        bias1 = _bias_operand(bias1, n, x.device)
+
+    # Equal-width projections can share each activation tile while retaining a
+    # single accumulator set per thread.  The 512-thread workgroup wins once it
+    # has enough output tiles and N is not narrower than K; smaller or narrow-N
+    # calls keep the two mature single-GEMM launches.  The dimensional rule is
+    # shared across all callers, while the device gate limits the default to the
+    # architecture on which this schedule has been measured.
+    output_tiles = ((m + 127) // 128) * ((n + 127) // 128)
+    use_paired_gemm = (
+        not weight_tile_k
+        and _has_nonduplicated_wmma(x.device)
+        and out_dtype == torch.bfloat16
+        and m >= 96
+        and n >= k
+        and k % 64 == 0
+        and output_tiles >= 96
+    )
+    if use_paired_gemm:
+        out0 = torch.empty((m, n), dtype=out_dtype, device=x.device)
+        out1 = torch.empty_like(out0)
+        _C.int8_gemm_pair(
+            _dl(q), _dl(weight0), _dl(weight1), _dl(out0), _dl(out1),
+            _dl(x_scale), _dl(weight_scale0),
+            0 if weight_scale0.numel() == 1 else 1,
+            _dl(weight_scale1), 0 if weight_scale1.numel() == 1 else 1,
+            None if bias0 is None else _dl(bias0),
+            None if bias1 is None else _dl(bias1),
+            m, n, k, DTYPE_TO_CODE[out_dtype], _stream(x),
+        )
+        return (
+            out0.reshape(*orig_shape[:-1], n),
+            out1.reshape(*orig_shape[:-1], n),
+        )
+
+    outputs = []
+    for weight, weight_scale, bias in (
+        (weight0, weight_scale0, bias0),
+        (weight1, weight_scale1, bias1),
+    ):
+        out = torch.empty((m, n), dtype=out_dtype, device=x.device)
+        gemm = _C.int8_gemm_b_tiled if weight_tile_k else _C.int8_gemm
+        gemm_args = [
+            _dl(q), _dl(weight), _dl(out), _dl(x_scale), _dl(weight_scale),
+            0 if weight_scale.numel() == 1 else 1,
+            None if bias is None else _dl(bias), m, n, k,
+            DTYPE_TO_CODE[out_dtype],
+        ]
+        if weight_tile_k:
+            gemm_args.extend((weight_tile_k, m >= 512))
+        gemm_args.append(_stream(x))
+        gemm(*gemm_args)
+        outputs.append(out.reshape(*orig_shape[:-1], n))
+    return outputs[0], outputs[1]
+
+
+def int8_linear_pair(
+    x: torch.Tensor,
+    weight0: torch.Tensor,
+    weight1: torch.Tensor,
+    weight_scale0: torch.Tensor,
+    weight_scale1: torch.Tensor,
+    bias0: torch.Tensor | None = None,
+    bias1: torch.Tensor | None = None,
+    out_dtype: torch.dtype = torch.bfloat16,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+    weight_tile_k: int = 0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    return _int8_linear_pair_impl(
+        x, weight0, weight1, weight_scale0, weight_scale1,
+        bias0, bias1, out_dtype, convrot, convrot_groupsize,
+        weight_tile_k=weight_tile_k,
+    )
+
+
+def int8_linear_pair_modulated(
+    x: torch.Tensor,
+    modulation_scale: torch.Tensor,
+    weight0: torch.Tensor,
+    weight1: torch.Tensor,
+    weight_scale0: torch.Tensor,
+    weight_scale1: torch.Tensor,
+    bias0: torch.Tensor | None = None,
+    bias1: torch.Tensor | None = None,
+    out_dtype: torch.dtype = torch.bfloat16,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+    modulation_shift: torch.Tensor | None = None,
+    weight_tile_k: int = 0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Paired INT8 projection sharing exact modulated quantization."""
+    k = x.shape[-1]
+    if modulation_scale.numel() != k:
+        raise ValueError(
+            f"modulation_scale must contain one batch-one row of {k} values, "
+            f"got {modulation_scale.numel()}"
+        )
+    modulation_scale = modulation_scale.to(device=x.device).reshape(-1).contiguous()
+    if modulation_shift is not None:
+        if modulation_shift.numel() != k:
+            raise ValueError(
+                f"modulation_shift must contain one batch-one row of {k} values, "
+                f"got {modulation_shift.numel()}"
+            )
+        modulation_shift = (
+            modulation_shift.to(device=x.device).reshape(-1).contiguous()
+        )
+    m = x.numel() // k
+    use_affine_fused = (
+        modulation_shift is not None
+        and x.dtype == torch.bfloat16
+        and modulation_scale.dtype == torch.bfloat16
+        and modulation_shift.dtype == torch.bfloat16
+        and out_dtype == torch.bfloat16
+        and convrot
+        and convrot_groupsize == 256
+        and not _C.convrot_int8_needs_spill(m, k, DTYPE_TO_CODE[x.dtype])
+    )
+    use_scale_fused = (
+        modulation_shift is None
+        and _has_nonduplicated_wmma(x.device)
+        and x.dtype == torch.bfloat16
+        and modulation_scale.dtype == torch.bfloat16
+        and out_dtype == torch.bfloat16
+        and convrot
+        and convrot_groupsize == 256
+        and m >= 96
+        and tuple(weight0.shape) == (10240, 3840)
+        and tuple(weight1.shape) == (10240, 3840)
+    )
+    use_fused = use_affine_fused or use_scale_fused
+    if not use_fused:
+        scale_shape = (1,) * (x.ndim - 1) + (k,)
+        scale = modulation_scale.reshape(scale_shape)
+        if modulation_shift is None:
+            modulated = x * (1.0 + scale)
+        else:
+            modulated = torch.addcmul(
+                modulation_shift.reshape(scale_shape), x, 1.0 + scale
+            )
+        return int8_linear_pair(
+            modulated, weight0, weight1, weight_scale0, weight_scale1,
+            bias0, bias1, out_dtype, convrot, convrot_groupsize,
+            weight_tile_k,
+        )
+    return _int8_linear_pair_impl(
+        x, weight0, weight1, weight_scale0, weight_scale1,
+        bias0, bias1, out_dtype, convrot, convrot_groupsize,
+        modulation_scale, weight_tile_k=weight_tile_k,
+        modulation_shift=modulation_shift,
+    )
+
+
+def int8_linear_triple_modulated(
+    x: torch.Tensor,
+    modulation_scale: torch.Tensor,
+    weight0: torch.Tensor,
+    weight1: torch.Tensor,
+    weight2: torch.Tensor,
+    weight_scale0: torch.Tensor,
+    weight_scale1: torch.Tensor,
+    weight_scale2: torch.Tensor,
+    bias0: torch.Tensor | None = None,
+    bias1: torch.Tensor | None = None,
+    bias2: torch.Tensor | None = None,
+    out_dtype: torch.dtype = torch.bfloat16,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+    modulation_shift: torch.Tensor | None = None,
+    weight_tile_k: int = 0,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Three projections sharing one exact affine ConvRot quantization."""
+    weights = (weight0, weight1, weight2)
+    weight_scales = (weight_scale0, weight_scale1, weight_scale2)
+    biases = (bias0, bias1, bias2)
+    if any(weight.ndim != 2 or weight.shape != weight0.shape for weight in weights):
+        raise ValueError(
+            "triple INT8 weights must have the same 2D shape, got "
+            + ", ".join(str(tuple(weight.shape)) for weight in weights)
+        )
+
+    n, k = weight0.shape
+    if x.shape[-1] != k:
+        raise ValueError(
+            f"Input and weight inner dimensions must match, got {x.shape[-1]} and {k}"
+        )
+    if modulation_scale.numel() != k:
+        raise ValueError(
+            f"modulation_scale must contain one batch-one row of {k} values, "
+            f"got {modulation_scale.numel()}"
+        )
+    if modulation_shift is not None and modulation_shift.numel() != k:
+        raise ValueError(
+            f"modulation_shift must contain one batch-one row of {k} values, "
+            f"got {modulation_shift.numel()}"
+        )
+
+    modulation_scale = (
+        modulation_scale.to(device=x.device).reshape(-1).contiguous()
+    )
+    if modulation_shift is not None:
+        modulation_shift = (
+            modulation_shift.to(device=x.device).reshape(-1).contiguous()
+        )
+    orig_shape = x.shape
+    x2d = x.reshape(-1, k).contiguous()
+    m = x2d.shape[0]
+
+    use_fused = (
+        modulation_shift is not None
+        and x2d.dtype == torch.bfloat16
+        and modulation_scale.dtype == torch.bfloat16
+        and modulation_shift.dtype == torch.bfloat16
+        and out_dtype == torch.bfloat16
+        and convrot
+        and convrot_groupsize == 256
+        and not _C.convrot_int8_needs_spill(m, k, DTYPE_TO_CODE[x2d.dtype])
+    )
+    if not use_fused:
+        if weight_tile_k:
+            raise ValueError(
+                "WMMA-tiled weights require fused affine triple quantization"
+            )
+        return _eager.int8_linear_triple_modulated(
+            x, modulation_scale, weight0, weight1, weight2,
+            weight_scale0, weight_scale1, weight_scale2,
+            bias0, bias1, bias2, out_dtype, convrot, convrot_groupsize,
+            modulation_shift,
+        )
+
+    if weight_tile_k and not _tiled_b_supported(
+        x, m, n, k, out_dtype, weight_tile_k
+    ):
+        raise ValueError(
+            "tiled-B INT8 triple requires non-duplicated WMMA BF16, M>=96, "
+            "N divisible by 128, and K divisible by tile_k"
+        )
+
+    prepared_weights = tuple(
+        _aligned(weight.to(device=x.device).contiguous()) for weight in weights
+    )
+    prepared_scales = tuple(
+        scale.to(device=x.device, dtype=torch.float32).reshape(-1)
+        for scale in weight_scales
+    )
+    for index, scale in enumerate(prepared_scales):
+        if scale.numel() not in (1, n):
+            raise ValueError(
+                f"weight_scale{index} must be scalar or per-output-channel, "
+                f"got {tuple(scale.shape)}"
+            )
+    prepared_biases = tuple(
+        None if bias is None else _bias_operand(bias, n, x.device)
+        for bias in biases
+    )
+
+    q, x_scale = _rotate_quant_int8_affine(
+        x2d, modulation_scale, modulation_shift, convrot_groupsize
+    )
+    outputs = []
+    for weight, weight_scale, bias in zip(
+        prepared_weights, prepared_scales, prepared_biases, strict=True
+    ):
+        output = torch.empty((m, n), dtype=out_dtype, device=x.device)
+        gemm_args = [
+            _dl(q), _dl(weight), _dl(output), _dl(x_scale), _dl(weight_scale),
+            0 if weight_scale.numel() == 1 else 1,
+            None if bias is None else _dl(bias), m, n, k,
+            DTYPE_TO_CODE[out_dtype],
+        ]
+        if weight_tile_k:
+            _C.int8_gemm_b_tiled(
+                *gemm_args, weight_tile_k, m >= 512, _stream(x)
+            )
+        else:
+            _C.int8_gemm(*gemm_args, _stream(x))
+        outputs.append(output.reshape(*orig_shape[:-1], n))
+    return outputs[0], outputs[1], outputs[2]
+
+
+def int8_linear_pair_rms_modulated(
+    x: torch.Tensor,
+    norm_weight: torch.Tensor,
+    norm_eps: float,
+    modulation_scale: torch.Tensor,
+    weight0: torch.Tensor,
+    weight1: torch.Tensor,
+    weight_scale0: torch.Tensor,
+    weight_scale1: torch.Tensor,
+    bias0: torch.Tensor | None = None,
+    bias1: torch.Tensor | None = None,
+    out_dtype: torch.dtype = torch.bfloat16,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Paired projections sharing exact fused RMS/modulation quantization."""
+    k = x.shape[-1]
+    if norm_weight.numel() != k or modulation_scale.numel() != k:
+        raise ValueError(
+            f"norm_weight and modulation_scale must each contain {k} values"
+        )
+    norm_weight = norm_weight.to(device=x.device).reshape(-1).contiguous()
+    modulation_scale = modulation_scale.to(device=x.device).reshape(-1).contiguous()
+    m = x.numel() // k
+    use_fused = (
+        _has_nonduplicated_wmma(x.device)
+        and x.dtype == torch.bfloat16
+        and norm_weight.dtype == torch.bfloat16
+        and modulation_scale.dtype == torch.bfloat16
+        and out_dtype == torch.bfloat16
+        and convrot
+        and convrot_groupsize == 256
+        and m >= 96
+        and tuple(weight0.shape) == (10240, 3840)
+        and tuple(weight1.shape) == (10240, 3840)
+    )
+    if not use_fused:
+        normalized = torch.nn.functional.rms_norm(
+            x, (k,), norm_weight, norm_eps
+        )
+        return int8_linear_pair_modulated(
+            normalized, modulation_scale, weight0, weight1,
+            weight_scale0, weight_scale1, bias0, bias1, out_dtype,
+            convrot, convrot_groupsize,
+        )
+    return _int8_linear_pair_impl(
+        x, weight0, weight1, weight_scale0, weight_scale1,
+        bias0, bias1, out_dtype, convrot, convrot_groupsize,
+        modulation_scale, norm_weight, norm_eps,
+    )
+
+
+def int8_linear_swiglu_split(
+    gate: torch.Tensor,
+    up: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    out_dtype: torch.dtype = torch.bfloat16,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+    weight_tiled_b: bool = False,
+    weight_tile_k: int = 0,
+) -> torch.Tensor:
+    """Down projection with exact split-BF16 SwiGLU folded into ConvRot."""
+    if gate.shape != up.shape:
+        raise ValueError(
+            f"split SwiGLU inputs must have the same shape, got "
+            f"{tuple(gate.shape)} and {tuple(up.shape)}"
+        )
+    if gate.device != up.device:
+        raise ValueError(
+            f"split SwiGLU inputs must share a device, got {gate.device} and {up.device}"
+        )
+    if weight.ndim != 2 or gate.shape[-1] != weight.shape[-1]:
+        raise ValueError(
+            f"Input and weight inner dimensions must match, got "
+            f"{gate.shape[-1]} and {weight.shape[-1] if weight.ndim == 2 else tuple(weight.shape)}"
+        )
+
+    orig_shape = gate.shape
+    k = orig_shape[-1]
+    m = gate.numel() // k
+    n = weight.shape[0]
+    use_split_tiled = (
+        _has_nonduplicated_wmma(gate.device)
+        and gate.dtype == torch.bfloat16
+        and up.dtype == torch.bfloat16
+        and out_dtype == torch.bfloat16
+        and convrot
+        and convrot_groupsize == 256
+        and m >= 512
+        and n == 3840
+        and k == 10240
+    )
+    if not use_split_tiled:
+        if weight_tiled_b and not weight_tile_k:
+            raise ValueError(
+                "a generic WMMA-tiled down weight requires its physical K tile"
+            )
+        activated = torch.nn.functional.silu(gate) * up
+        return int8_linear(
+            activated, weight, weight_scale, bias, out_dtype,
+            convrot, convrot_groupsize, _weight_tile_k=weight_tile_k,
+            _dual_m=m >= 512,
+        )
+
+    if weight_tiled_b and weight_tile_k not in (0, 128):
+        raise ValueError("the fused tiled-A/B down path requires a 128-byte K tile")
+
+    weight = _aligned(weight.to(device=gate.device).contiguous())
+    weight_scale = weight_scale.to(
+        device=gate.device, dtype=torch.float32
+    ).reshape(-1)
+    if weight_scale.numel() not in (1, n):
+        raise ValueError(
+            f"INT8 weight scale must be scalar or per-output-channel, got "
+            f"{tuple(weight_scale.shape)}"
+        )
+    if bias is not None:
+        bias = _bias_operand(bias, n, gate.device)
+
+    gate2d = gate.reshape(m, k).contiguous()
+    up2d = up.reshape(m, k).contiguous()
+    q, x_scale = _rotate_quant_int8_swiglu_split_tiled128(
+        gate2d, up2d, convrot_groupsize
+    )
+    output = torch.empty((m, n), dtype=out_dtype, device=gate.device)
+    gemm = (
+        _C.int8_gemm_a_tiled128_b_tiled128_down
+        if weight_tiled_b
+        else _C.int8_gemm_a_tiled128_down
+    )
+    gemm(
+        _dl(q), _dl(weight), _dl(output),
+        _dl(x_scale), _dl(weight_scale),
+        0 if weight_scale.numel() == 1 else 1,
+        None if bias is None else _dl(bias),
+        m, n, k, DTYPE_TO_CODE[out_dtype], _stream(gate2d),
+    )
+    return output.reshape(*orig_shape[:-1], n)
 
 
 # ---------------------------------------------------------------------------
@@ -1374,6 +2423,189 @@ def na3d(
     return out
 
 
+def _attention_device_is_supported(tensor: torch.Tensor) -> bool:
+    return bool(tensor.is_cuda and _has_nonduplicated_wmma(tensor.device))
+
+
+def _attention_inputs_are_supported(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+) -> bool:
+    if not _attention_device_is_supported(q):
+        return False
+    if q.ndim != 4 or k.ndim != 4 or v.ndim != 4:
+        return False
+    q_shape, k_shape, v_shape = q.shape, k.shape, v.shape
+    dtype = q.dtype
+    if not (
+        dtype == k.dtype == v.dtype
+        and dtype in (torch.float16, torch.bfloat16)
+        and q.device == k.device == v.device
+        and q_shape[0] == k_shape[0] == v_shape[0] > 0
+        and q_shape[1] == k_shape[1] == v_shape[1] > 0
+        and q_shape[2] > 0
+        and k_shape[2] == v_shape[2] > 0
+        and q_shape[3] == k_shape[3] == v_shape[3] == 128
+        and q.stride(3) == k.stride(3) == v.stride(3) == 1
+        and q.stride(2) % 8 == k.stride(2) % 8 == v.stride(2) % 8 == 0
+        and q.data_ptr() % 16 == k.data_ptr() % 16 == v.data_ptr() % 16 == 0
+    ):
+        return False
+    long = q_shape[0] == 1 and q_shape[2] >= 1024
+    if dtype != torch.bfloat16 or q_shape[2] != k_shape[2]:
+        return long
+    # The batch-one native schedule wins once there are at least 128 queries. The
+    # compact native schedule covers many independent <=16-query batches. Both
+    # predicates are dimensional and come from paired production-shape gates.
+    batch_one_short = q_shape[0] == 1 and 128 <= q_shape[2] < 1024
+    batched_short = (
+        q_shape[0] > 1
+        and q_shape[2] <= 16
+        and q_shape[0] * q_shape[1] >= 1024
+    )
+    return long or batch_one_short or batched_short
+
+
+def hip_attention_is_supported(
+    q: torch.Tensor, k: torch.Tensor, v: torch.Tensor
+) -> bool:
+    if not _attention_inputs_are_supported(q, k, v):
+        return False
+    return q.dtype is torch.bfloat16
+
+
+def hip_int8_attention_is_supported(
+    q: torch.Tensor, k: torch.Tensor, v: torch.Tensor
+) -> bool:
+    if not _attention_inputs_are_supported(q, k, v):
+        return False
+    # Short and multi-batch INT8 calls reuse the BF16 HIP route.
+    if q.shape[0] > 1 or q.shape[2] < 1024:
+        return hip_attention_is_supported(q, k, v)
+    return True
+
+
+def hip_int8_attention_split_is_supported(
+    q: tuple[torch.Tensor, torch.Tensor],
+    k: tuple[torch.Tensor, torch.Tensor],
+    v: tuple[torch.Tensor, torch.Tensor],
+) -> bool:
+    if not all(isinstance(parts, tuple) and len(parts) == 2 for parts in (q, k, v)):
+        return False
+    tensors = (*q, *k, *v)
+    first = q[0]
+    if not _attention_device_is_supported(first):
+        return False
+    if any(
+        tensor.ndim != 4
+        or tensor.dtype != first.dtype
+        or tensor.dtype not in (torch.float16, torch.bfloat16)
+        or tensor.device != first.device
+        or tensor.shape[0] != 1
+        or tensor.shape[1] != first.shape[1]
+        or tensor.shape[2] <= 0
+        or tensor.shape[3] != 128
+        or tensor.stride(3) != 1
+        for tensor in tensors
+    ):
+        return False
+    return (
+        first.shape[1] > 0
+        and q[0].shape[2] + q[1].shape[2] >= 1024
+        and k[0].shape[2] == v[0].shape[2]
+        and k[1].shape[2] == v[1].shape[2]
+    )
+
+
+def hip_attention(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    scale: float | None = None,
+) -> torch.Tensor:
+    """HIP BF16 attention for supported unmasked D=128 calls.
+
+    Compact multi-batch and long batch-one calls use the native HIP schedule.
+    There is no Triton/Gluon runtime dependency.
+    """
+    if q.dtype is not torch.bfloat16:
+        raise RuntimeError("HIP native attention is BF16")
+    output = torch.empty_strided(q.shape, q.stride(), device=q.device, dtype=q.dtype)
+    resolved_scale = float(scale if scale is not None else 1.0 / math.sqrt(q.shape[3]))
+    _C.bf16_sdpa_hip(
+        _dl(q), _dl(k), _dl(v), _dl(output), resolved_scale, _stream(q)
+    )
+    return output
+
+
+def _int8_attention_workspace(reference: torch.Tensor, q_len: int, kv_len: int):
+    heads = int(reference.shape[1])
+    padded_q = -(-q_len // 128) * 128
+    padded_k = -(-kv_len // 64) * 64
+    tiles = padded_k // 64
+    tensor = functools.partial(torch.empty, device=reference.device)
+    return (
+        tensor((1, heads, q_len, 128), dtype=torch.int8),
+        tensor((1, heads, padded_k, 128), dtype=torch.int8),
+        tensor((1, heads, tiles, 128, 64), dtype=torch.int8),
+        tensor((heads, padded_q), dtype=torch.float32),
+        tensor((heads, padded_k // 16), dtype=torch.float32),
+        tensor((heads, tiles, 128), dtype=torch.float32),
+        tensor((1, heads), dtype=torch.int32),
+    )
+
+
+def hip_int8_attention(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    scale: float,
+) -> torch.Tensor:
+    """Run INT8 attention, retaining BF16 for overhead-bound short calls."""
+    # Capability is checked by the public caller; any supported sub-1024 or
+    # multi-batch contract is one of the measured BF16 short routes.
+    if q.shape[0] > 1 or q.shape[2] < 1024:
+        return hip_attention(q, k, v, scale)
+    q_len = int(q.shape[2])
+    kv_len = int(k.shape[2])
+    output = torch.empty_strided(q.shape, q.stride(), device=q.device, dtype=q.dtype)
+    workspaces = _int8_attention_workspace(q, q_len, kv_len)
+    _C.hip_int8_attention(
+        _dl(q),
+        _dl(k),
+        _dl(v),
+        _dl(output),
+        *(_dl(tensor) for tensor in workspaces),
+        float(scale),
+        _stream(q),
+    )
+    return output
+
+
+def hip_int8_attention_split(
+    q: tuple[torch.Tensor, torch.Tensor],
+    k: tuple[torch.Tensor, torch.Tensor],
+    v: tuple[torch.Tensor, torch.Tensor],
+    scale: float,
+) -> torch.Tensor:
+    """INT8 attention from two logical sequence segments without BF16 cats."""
+    q0, q1 = q
+    k0, k1 = k
+    v0, v1 = v
+    q_len = int(q0.shape[2] + q1.shape[2])
+    kv_len = int(k0.shape[2] + k1.shape[2])
+    heads = int(q0.shape[1])
+    output = torch.empty((1, heads, q_len, 128), device=q0.device, dtype=q0.dtype)
+    workspaces = _int8_attention_workspace(q0, q_len, kv_len)
+    _C.hip_int8_attention_split(
+        _dl(q0), _dl(q1), _dl(k0), _dl(k1), _dl(v0), _dl(v1),
+        _dl(output), *(_dl(tensor) for tensor in workspaces),
+        float(scale), _stream(q0),
+    )
+    return output
+
+
 def _adaln_impl(kernel, x, scale, shift, eps) -> torch.Tensor:
     """``kernel`` is _C.adaln (LayerNorm) or _C.rms_adaln (RMSNorm)."""
     from comfy_kitchen.backends._modulation import adaln_prep_modulation
@@ -1737,6 +2969,26 @@ def _build_constraints(has_wmma: bool = True) -> dict:
                 return ValidationResult.fail("q", "grid dims exceed HIP limits")
         return ValidationResult.ok()
 
+    bf16_param = ParamConstraint(dtypes=frozenset({torch.bfloat16}))
+    out_param = ParamConstraint(dtypes=out_floats)
+    int8_2d = ParamConstraint(
+        dtypes=frozenset({torch.int8}), shape_rules=(ExactDims(2),)
+    )
+    int_param = ParamConstraint(dtypes=frozenset({int}))
+    bool_param = ParamConstraint(dtypes=frozenset({bool}))
+    divisible_bf16 = ParamConstraint(
+        dtypes=frozenset({torch.bfloat16}), shape_rules=(DivisibleBy(-1, 16),)
+    )
+    divisible_float = ParamConstraint(
+        dtypes=floats, shape_rules=(DivisibleBy(-1, 16),)
+    )
+
+    def fusion(params):
+        return FunctionConstraints(params=params, default_devices=dev)
+
+    def projection_weights(count):
+        return {f"weight{index}": int8_2d for index in range(count)}
+
     constraints = {
         # fp32 has no 16-bit matrix path, so it goes to triton/eager.
         "na3d": FunctionConstraints(
@@ -1816,6 +3068,69 @@ def _build_constraints(has_wmma: bool = True) -> dict:
             },
             default_devices=dev,
         ),
+        "int8_linear_gated_residual": fusion({
+            "x": divisible_bf16, "weight": int8_2d,
+            "residual": bf16_param, "gate": bf16_param,
+            "out_dtype": bf16_param, "weight_tile_k": int_param,
+            "dual_m": bool_param,
+        }),
+        "int8_linear_tiled_b": FunctionConstraints(
+            params={
+                "x": ParamConstraint(
+                    dtypes=frozenset({torch.bfloat16}),
+                    shape_rules=(DivisibleBy(-1, 16),),
+                ),
+                "weight": ParamConstraint(
+                    dtypes=frozenset({torch.int8}), shape_rules=(ExactDims(2),)
+                ),
+                "out_dtype": ParamConstraint(dtypes=frozenset({torch.bfloat16})),
+                "convrot": ParamConstraint(dtypes=frozenset({bool})),
+                "convrot_groupsize": ParamConstraint(dtypes=frozenset({int})),
+                "tile_k": ParamConstraint(dtypes=frozenset({int})),
+                "dual_m": ParamConstraint(dtypes=frozenset({bool})),
+            },
+            default_devices=dev,
+        ),
+        "rms_gated_residual": fusion({
+            "activation": bf16_param, "norm_weight": bf16_param,
+            "residual": bf16_param, "gate": bf16_param,
+            "eps": ParamConstraint(dtypes=frozenset({float})),
+        }),
+        "int8_linear_modulated": fusion({
+            "x": divisible_bf16, "modulation_scale": bf16_param,
+            "modulation_shift": bf16_param, "weight": int8_2d,
+            "out_dtype": out_param, "weight_tiled_b": bool_param,
+            "weight_tile_k": int_param,
+        }),
+        "int8_linear_rms_modulated": fusion({
+            "x": divisible_bf16, "norm_weight": bf16_param,
+            "modulation_scale": bf16_param, "weight": int8_2d,
+            "out_dtype": out_param, "weight_tiled_b": bool_param,
+        }),
+        "int8_linear_pair": fusion(
+            {"x": divisible_float, "out_dtype": out_param,
+             "weight_tile_k": int_param} | projection_weights(2)
+        ),
+        "int8_linear_pair_modulated": fusion(
+            {"x": divisible_bf16, "modulation_scale": bf16_param,
+             "modulation_shift": bf16_param, "out_dtype": out_param,
+             "weight_tile_k": int_param} | projection_weights(2)
+        ),
+        "int8_linear_triple_modulated": fusion(
+            {"x": divisible_bf16, "modulation_scale": bf16_param,
+             "modulation_shift": bf16_param, "out_dtype": out_param,
+             "weight_tile_k": int_param} | projection_weights(3)
+        ),
+        "int8_linear_pair_rms_modulated": fusion(
+            {"x": divisible_bf16, "norm_weight": bf16_param,
+             "modulation_scale": bf16_param, "out_dtype": out_param}
+            | projection_weights(2)
+        ),
+        "int8_linear_swiglu_split": fusion({
+            "gate": divisible_bf16, "up": divisible_bf16,
+            "weight": int8_2d, "out_dtype": out_param,
+            "weight_tiled_b": bool_param, "weight_tile_k": int_param,
+        }),
         "quantize_w4a8_int8_weight": FunctionConstraints(
             params={
                 "weight": ParamConstraint(dtypes=floats, shape_rules=(ExactDims(2),)),

--- a/comfy_kitchen/backends/hip/__init__.py
+++ b/comfy_kitchen/backends/hip/__init__.py
@@ -2472,13 +2472,6 @@ def hip_attention_is_supported(
 ) -> bool:
     if not _attention_inputs_are_supported(q, k, v):
         return False
-    if (
-        _has_nonduplicated_wmma(q.device)
-        and q.shape[0] == 1
-        and q.shape[2] >= 1024
-        and q.shape[3] == 128
-    ):
-        return False
     return q.dtype is torch.bfloat16
 
 
@@ -2538,7 +2531,11 @@ def hip_attention(
     """
     if q.dtype is not torch.bfloat16:
         raise RuntimeError("HIP native attention is BF16")
-    output = torch.empty_strided(q.shape, q.stride(), device=q.device, dtype=q.dtype)
+    output = torch.empty(
+        (q.shape[0], q.shape[2], q.shape[1], q.shape[3]),
+        device=q.device,
+        dtype=q.dtype,
+    ).movedim(1, 2)
     resolved_scale = float(scale if scale is not None else 1.0 / math.sqrt(q.shape[3]))
     _C.bf16_sdpa_hip(
         _dl(q), _dl(k), _dl(v), _dl(output), resolved_scale, _stream(q)
@@ -2551,30 +2548,15 @@ def _int8_attention_workspace(reference: torch.Tensor, q_len: int, kv_len: int):
     padded_q = -(-q_len // 128) * 128
     padded_k = -(-kv_len // 64) * 64
     tiles = padded_k // 64
-    specs = (
-        ((1, heads, q_len, 128), torch.int8, 1),
-        ((1, heads, padded_k, 128), torch.int8, 1),
-        ((1, heads, tiles, 128, 64), torch.int8, 1),
-        ((heads, padded_q), torch.float32, 4),
-        ((heads, padded_k // 16), torch.float32, 4),
-        ((heads, tiles, 128), torch.float32, 4),
-        ((1, heads), torch.int32, 4),
-    )
-    offsets = []
-    total_bytes = 0
-    for shape, _dtype, item_size in specs:
-        total_bytes = -(-total_bytes // item_size) * item_size
-        offsets.append(total_bytes)
-        total_bytes += math.prod(shape) * item_size
-
-    # A single short-lived allocation avoids seven allocator/VBAR interactions
-    # per attention call without retaining a private VRAM cache.
-    storage = torch.empty(total_bytes, dtype=torch.uint8, device=reference.device)
-    return tuple(
-        storage[offset : offset + math.prod(shape) * dtype_size]
-        .view(dtype)
-        .view(shape)
-        for (shape, dtype, dtype_size), offset in zip(specs, offsets)
+    tensor = functools.partial(torch.empty, device=reference.device)
+    return (
+        tensor((1, heads, q_len, 128), dtype=torch.int8),
+        tensor((1, heads, padded_k, 128), dtype=torch.int8),
+        tensor((1, heads, tiles, 128, 64), dtype=torch.int8),
+        tensor((heads, padded_q), dtype=torch.float32),
+        tensor((heads, padded_k // 16), dtype=torch.float32),
+        tensor((heads, tiles, 128), dtype=torch.float32),
+        tensor((1, heads), dtype=torch.int32),
     )
 
 

--- a/comfy_kitchen/backends/hip/__init__.py
+++ b/comfy_kitchen/backends/hip/__init__.py
@@ -2472,6 +2472,13 @@ def hip_attention_is_supported(
 ) -> bool:
     if not _attention_inputs_are_supported(q, k, v):
         return False
+    if (
+        _has_nonduplicated_wmma(q.device)
+        and q.shape[0] == 1
+        and q.shape[2] >= 1024
+        and q.shape[3] == 128
+    ):
+        return False
     return q.dtype is torch.bfloat16
 
 
@@ -2544,15 +2551,30 @@ def _int8_attention_workspace(reference: torch.Tensor, q_len: int, kv_len: int):
     padded_q = -(-q_len // 128) * 128
     padded_k = -(-kv_len // 64) * 64
     tiles = padded_k // 64
-    tensor = functools.partial(torch.empty, device=reference.device)
-    return (
-        tensor((1, heads, q_len, 128), dtype=torch.int8),
-        tensor((1, heads, padded_k, 128), dtype=torch.int8),
-        tensor((1, heads, tiles, 128, 64), dtype=torch.int8),
-        tensor((heads, padded_q), dtype=torch.float32),
-        tensor((heads, padded_k // 16), dtype=torch.float32),
-        tensor((heads, tiles, 128), dtype=torch.float32),
-        tensor((1, heads), dtype=torch.int32),
+    specs = (
+        ((1, heads, q_len, 128), torch.int8, 1),
+        ((1, heads, padded_k, 128), torch.int8, 1),
+        ((1, heads, tiles, 128, 64), torch.int8, 1),
+        ((heads, padded_q), torch.float32, 4),
+        ((heads, padded_k // 16), torch.float32, 4),
+        ((heads, tiles, 128), torch.float32, 4),
+        ((1, heads), torch.int32, 4),
+    )
+    offsets = []
+    total_bytes = 0
+    for shape, _dtype, item_size in specs:
+        total_bytes = -(-total_bytes // item_size) * item_size
+        offsets.append(total_bytes)
+        total_bytes += math.prod(shape) * item_size
+
+    # A single short-lived allocation avoids seven allocator/VBAR interactions
+    # per attention call without retaining a private VRAM cache.
+    storage = torch.empty(total_bytes, dtype=torch.uint8, device=reference.device)
+    return tuple(
+        storage[offset : offset + math.prod(shape) * dtype_size]
+        .view(dtype)
+        .view(shape)
+        for (shape, dtype, dtype_size), offset in zip(specs, offsets)
     )
 
 

--- a/comfy_kitchen/backends/hip/dlpack_bindings.cpp
+++ b/comfy_kitchen/backends/hip/dlpack_bindings.cpp
@@ -1917,7 +1917,7 @@ void bf16_sdpa_hip(
     const int kv_len = static_cast<int>(k.shape(2));
     if (batch <= 0 || q_heads <= 0 || kv_heads <= 0 || q_heads % kv_heads != 0 ||
         q_len <= 0 || kv_len <= 0 ||
-        (head_dim != 64 && head_dim != 80 && head_dim != 128) ||
+        (head_dim != 128) ||
         k.shape(0) != q.shape(0) || k.shape(3) != q.shape(3) ||
         v.shape(0) != q.shape(0) || v.shape(1) != k.shape(1) ||
         v.shape(2) != k.shape(2) || v.shape(3) != q.shape(3) ||

--- a/comfy_kitchen/backends/hip/dlpack_bindings.cpp
+++ b/comfy_kitchen/backends/hip/dlpack_bindings.cpp
@@ -10,6 +10,7 @@
 #include <nanobind/nanobind.h>
 #include <nanobind/ndarray.h>
 #include <nanobind/stl/optional.h>
+#include <nanobind/stl/string.h>
 
 #include "launchers.h"
 
@@ -51,6 +52,21 @@ void launch_convrot_w4a4_gemm_kernel(const void*, const void*, void*, const void
 void launch_quantize_int8_rowwise_kernel(const void*, int, void*, void*, int, int, hipStream_t);
 void launch_quantize_int8_convrot_kernel(const void*, int, void*, void*, void*, void*, int, int,
                                          int, int, hipStream_t);
+void launch_quantize_int8_convrot_tiled128_kernel(const void*, int, void*, void*, int, int, int,
+                                                  hipStream_t);
+void launch_quantize_int8_convrot_swiglu_split_tiled128_kernel(
+    const void*, const void*, void*, void*, int, int, int, hipStream_t);
+void launch_quantize_int8_convrot_modulated_kernel(
+    const void*, const void*, void*, void*, int, int, int, hipStream_t);
+void launch_quantize_int8_convrot_affine_kernel(
+    const void*, const void*, const void*, void*, void*, int, int, int,
+    hipStream_t);
+void launch_quantize_int8_convrot_rms_modulated_kernel(
+    const void*, const void*, const void*, const void*, void*, void*,
+    int, int, int, hipStream_t);
+void launch_quantize_int8_convrot_rms_modulated_fused_stats_kernel(
+    const void*, const void*, const void*, void*, void*, int, int, int,
+    float, hipStream_t);
 void launch_quantize_int8_tensorwise_kernel(const void*, int, void*, void*, void*, int64_t,
                                             hipStream_t);
 void launch_dequantize_int8_simple_kernel(const void*, const void*, void*, int64_t, int64_t, int,
@@ -67,7 +83,6 @@ void launch_quantize_w4a8_convrot_kernel(const void*, const void*, void*, void*,
 int w4a8_requant_max_k_kernel();
 void launch_na3d_kernel(const void*, const void*, const void*, void*, int, int, int, int, int, int,
                         int, int, int, int, int, int, float, int, hipStream_t);
-
 void launch_sage_quant_qk_int8(const void*, void*, void*, const void*, void*, void*, void*, int,
                                int, int, int, int, int, int, int, int64_t, int64_t, int64_t,
                                int64_t, int64_t, int64_t, int, int, hipStream_t);
@@ -339,6 +354,257 @@ void int8_gemm(nb::ndarray<> a, nb::ndarray<> b, nb::ndarray<> c, nb::ndarray<> 
     check_hip_launch();
 }
 
+void int8_gemm_b_tiled(
+    nb::ndarray<> a, nb::ndarray<> b, nb::ndarray<> c,
+    nb::ndarray<> scale_a, nb::ndarray<> scale_b, int scale_b_stride,
+    OptArray bias, int M, int N, int K, int out_code, int tile_k,
+    bool dual_m, uintptr_t stream_ptr) {
+    constexpr const char* kFn = "int8_gemm_b_tiled";
+    if (scale_b_stride != 0 && scale_b_stride != 1) {
+        throw std::runtime_error(std::string(kFn) +
+                                 ": scale_b_stride must be 0 or 1");
+    }
+    require_nonneg(M, kFn, "M");
+    require_nonneg(N, kFn, "N");
+    require_nonneg(K, kFn, "K");
+    if (M != 0 && (M < 96 || N % 128 != 0 ||
+                   (tile_k != 64 && tile_k != 128) || K % tile_k != 0)) {
+        throw std::runtime_error(
+            std::string(kFn) +
+            ": requires M>=96, N divisible by 128, K divisible by "
+            "tile_k, and tile_k in {64,128}");
+    }
+    require_dtype(a, 4, 4, kFn, "a");
+    require_dtype(b, 4, 4, kFn, "b");
+    require_dtype(c, 0, 2, kFn, "c");
+    require_out_matches(c, out_code, kFn);
+    require_len(a, static_cast<int64_t>(M) * K, kFn, "a");
+    require_len(b, static_cast<int64_t>(N) * K, kFn, "b");
+    require_len(c, static_cast<int64_t>(M) * N, kFn, "c");
+    require_scale_len(scale_a, static_cast<size_t>(M), kFn, "scale_a");
+    require_scale_len(scale_b,
+                      scale_b_stride == 1 ? static_cast<size_t>(N) : 1,
+                      kFn, "scale_b");
+    require_bias(bias, N, kFn);
+
+    launch_int8_gemm_b_tiled_kernel(
+        a.data(), b.data(), c.data(), scale_a.data(), scale_b.data(),
+        scale_b_stride, opt_data(bias), opt_code(bias), M, N, K, N,
+        out_code, tile_k, dual_m,
+        reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+void int8_gemm_b_tiled_gated_residual(
+    nb::ndarray<> a, nb::ndarray<> b, nb::ndarray<> c,
+    nb::ndarray<> scale_a, nb::ndarray<> scale_b, int scale_b_stride,
+    OptArray bias, nb::ndarray<> residual, nb::ndarray<> gate,
+    int M, int N, int K, int tile_k, bool dual_m, uintptr_t stream_ptr) {
+    constexpr const char* kFn = "int8_gemm_b_tiled_gated_residual";
+    if (scale_b_stride != 0 && scale_b_stride != 1) {
+        throw std::runtime_error(std::string(kFn) +
+                                 ": scale_b_stride must be 0 or 1");
+    }
+    require_nonneg(M, kFn, "M");
+    require_nonneg(N, kFn, "N");
+    require_nonneg(K, kFn, "K");
+    if (M != 0 && (M < 96 || N % 128 != 0 ||
+                   (tile_k != 64 && tile_k != 128) || K % tile_k != 0)) {
+        throw std::runtime_error(
+            std::string(kFn) +
+            ": requires M>=96, N divisible by 128, K divisible by "
+            "tile_k, and tile_k in {64,128}");
+    }
+    require_dtype(a, 4, 4, kFn, "a");
+    require_dtype(b, 4, 4, kFn, "b");
+    require_dtype(c, 2, 2, kFn, "c");
+    require_dtype(residual, 2, 2, kFn, "residual");
+    require_dtype(gate, 2, 2, kFn, "gate");
+    require_len(a, static_cast<int64_t>(M) * K, kFn, "a");
+    require_len(b, static_cast<int64_t>(N) * K, kFn, "b");
+    require_len(c, static_cast<int64_t>(M) * N, kFn, "c");
+    require_len(residual, static_cast<int64_t>(M) * N, kFn, "residual");
+    require_len(gate, N, kFn, "gate");
+    require_scale_len(scale_a, static_cast<size_t>(M), kFn, "scale_a");
+    require_scale_len(scale_b,
+                      scale_b_stride == 1 ? static_cast<size_t>(N) : 1,
+                      kFn, "scale_b");
+    require_bias(bias, N, kFn);
+    if (residual.ndim() != 2 || residual.shape(0) != static_cast<size_t>(M) ||
+        residual.shape(1) != static_cast<size_t>(N) ||
+        residual.stride(0) != N || residual.stride(1) != 1 ||
+        gate.ndim() != 1 || gate.shape(0) != static_cast<size_t>(N) ||
+        gate.stride(0) != 1) {
+        throw std::runtime_error(
+            std::string(kFn) +
+            ": residual must be packed [M,N] and gate packed [N]");
+    }
+
+    launch_int8_gemm_b_tiled_gated_residual_kernel(
+        a.data(), b.data(), c.data(), scale_a.data(), scale_b.data(),
+        scale_b_stride, opt_data(bias), opt_code(bias), residual.data(),
+        gate.data(), M, N, K, N, tile_k, dual_m,
+        reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+void int8_gemm_pair(
+    nb::ndarray<> a, nb::ndarray<> b0, nb::ndarray<> b1,
+    nb::ndarray<> c0, nb::ndarray<> c1, nb::ndarray<> scale_a,
+    nb::ndarray<> scale_b0, int scale_b_stride0,
+    nb::ndarray<> scale_b1, int scale_b_stride1,
+    OptArray bias0, OptArray bias1, int M, int N, int K,
+    int out_code, uintptr_t stream_ptr) {
+    constexpr const char* kFn = "int8_gemm_pair";
+    if ((scale_b_stride0 != 0 && scale_b_stride0 != 1) ||
+        (scale_b_stride1 != 0 && scale_b_stride1 != 1)) {
+        throw std::runtime_error(
+            std::string(kFn) + ": scale strides must be 0 or 1");
+    }
+    require_nonneg(M, kFn, "M");
+    require_nonneg(N, kFn, "N");
+    require_nonneg(K, kFn, "K");
+    if (M != 0 && (M < 96 || N < 96 || K == 0 || K % 64 != 0)) {
+        throw std::runtime_error(
+            std::string(kFn) +
+            ": requires M,N>=96 and positive K divisible by 64");
+    }
+    require_dtype(a, 4, 4, kFn, "a");
+    require_dtype(b0, 4, 4, kFn, "b0");
+    require_dtype(b1, 4, 4, kFn, "b1");
+    require_dtype(c0, 0, 2, kFn, "c0");
+    require_dtype(c1, 0, 2, kFn, "c1");
+    require_out_matches(c0, out_code, kFn);
+    require_out_matches(c1, out_code, kFn);
+    require_len(a, static_cast<int64_t>(M) * K, kFn, "a");
+    require_len(b0, static_cast<int64_t>(N) * K, kFn, "b0");
+    require_len(b1, static_cast<int64_t>(N) * K, kFn, "b1");
+    require_len(c0, static_cast<int64_t>(M) * N, kFn, "c0");
+    require_len(c1, static_cast<int64_t>(M) * N, kFn, "c1");
+    require_scale_len(scale_a, static_cast<size_t>(M), kFn, "scale_a");
+    require_scale_len(
+        scale_b0, scale_b_stride0 == 1 ? static_cast<size_t>(N) : 1,
+        kFn, "scale_b0");
+    require_scale_len(
+        scale_b1, scale_b_stride1 == 1 ? static_cast<size_t>(N) : 1,
+        kFn, "scale_b1");
+    require_bias(bias0, N, kFn);
+    require_bias(bias1, N, kFn);
+
+    launch_int8_gemm_pair_kernel(
+        a.data(), b0.data(), b1.data(), c0.data(), c1.data(),
+        scale_a.data(), scale_b0.data(), scale_b_stride0,
+        scale_b1.data(), scale_b_stride1,
+        opt_data(bias0), opt_code(bias0), opt_data(bias1), opt_code(bias1),
+        M, N, K, N /*ldc*/, out_code,
+        reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+void rms_gated_residual_bf16(
+    nb::ndarray<> activation, nb::ndarray<> norm_weight,
+    nb::ndarray<> residual, nb::ndarray<> gate, nb::ndarray<> output,
+    int rows, int width, float eps, uintptr_t stream_ptr) {
+    constexpr const char* kFn = "rms_gated_residual_bf16";
+    require_nonneg(rows, kFn, "rows");
+    if (width <= 0 || width % 4 != 0) {
+        throw std::runtime_error(
+            std::string(kFn) + ": width must be positive and divisible by 4");
+    }
+    require_dtype(activation, 2, 2, kFn, "activation");
+    require_dtype(norm_weight, 2, 2, kFn, "norm_weight");
+    require_dtype(residual, 2, 2, kFn, "residual");
+    require_dtype(gate, 2, 2, kFn, "gate");
+    require_dtype(output, 2, 2, kFn, "output");
+    const int64_t numel = static_cast<int64_t>(rows) * width;
+    require_len(activation, numel, kFn, "activation");
+    require_len(norm_weight, width, kFn, "norm_weight");
+    require_len(residual, numel, kFn, "residual");
+    require_len(gate, width, kFn, "gate");
+    require_len(output, numel, kFn, "output");
+
+    launch_rms_gated_residual_bf16_kernel(
+        activation.data(), norm_weight.data(), residual.data(), gate.data(),
+        output.data(), rows, width, eps,
+        reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+void int8_gemm_a_tiled128_down(
+    nb::ndarray<> a, nb::ndarray<> b, nb::ndarray<> c,
+    nb::ndarray<> scale_a, nb::ndarray<> scale_b, int scale_b_stride,
+    OptArray bias, int M, int N, int K, int out_code, uintptr_t stream_ptr) {
+    constexpr const char* kFn = "int8_gemm_a_tiled128_down";
+    if (scale_b_stride != 0 && scale_b_stride != 1) {
+        throw std::runtime_error(std::string(kFn) +
+                                 ": scale_b_stride must be 0 or 1");
+    }
+    require_nonneg(M, kFn, "M");
+    require_nonneg(N, kFn, "N");
+    require_nonneg(K, kFn, "K");
+    if (N <= 0 || K <= 0 || N % 128 != 0 || K % 128 != 0) {
+        throw std::runtime_error(
+            std::string(kFn) +
+            ": requires positive N and K divisible by 128");
+    }
+    require_dtype(a, 4, 4, kFn, "a");
+    require_dtype(b, 4, 4, kFn, "b");
+    require_dtype(c, 0, 2, kFn, "c");
+    require_out_matches(c, out_code, kFn);
+    const int64_t padded_m = (static_cast<int64_t>(M) + 127) / 128 * 128;
+    require_len(a, padded_m * K, kFn, "a");
+    require_len(b, static_cast<int64_t>(N) * K, kFn, "b");
+    require_len(c, static_cast<int64_t>(M) * N, kFn, "c");
+    require_scale_len(scale_a, static_cast<size_t>(M), kFn, "scale_a");
+    require_scale_len(scale_b, scale_b_stride == 1 ? static_cast<size_t>(N) : 1,
+                      kFn, "scale_b");
+    require_bias(bias, N, kFn);
+
+    launch_int8_gemm_a_tiled128_down_kernel(
+        a.data(), b.data(), c.data(), scale_a.data(), scale_b.data(),
+        scale_b_stride, opt_data(bias), opt_code(bias), M, N, K, N,
+        out_code, reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+void int8_gemm_a_tiled128_b_tiled128_down(
+    nb::ndarray<> a, nb::ndarray<> b, nb::ndarray<> c,
+    nb::ndarray<> scale_a, nb::ndarray<> scale_b, int scale_b_stride,
+    OptArray bias, int M, int N, int K, int out_code, uintptr_t stream_ptr) {
+    constexpr const char* kFn = "int8_gemm_a_tiled128_b_tiled128_down";
+    if (scale_b_stride != 0 && scale_b_stride != 1) {
+        throw std::runtime_error(std::string(kFn) +
+                                 ": scale_b_stride must be 0 or 1");
+    }
+    require_nonneg(M, kFn, "M");
+    require_nonneg(N, kFn, "N");
+    require_nonneg(K, kFn, "K");
+    if (N <= 0 || K <= 0 || N % 128 != 0 || K % 128 != 0) {
+        throw std::runtime_error(
+            std::string(kFn) +
+            ": requires positive N and K divisible by 128");
+    }
+    require_dtype(a, 4, 4, kFn, "a");
+    require_dtype(b, 4, 4, kFn, "b");
+    require_dtype(c, 0, 2, kFn, "c");
+    require_out_matches(c, out_code, kFn);
+    const int64_t padded_m = (static_cast<int64_t>(M) + 127) / 128 * 128;
+    require_len(a, padded_m * K, kFn, "a");
+    require_len(b, static_cast<int64_t>(N) * K, kFn, "b");
+    require_len(c, static_cast<int64_t>(M) * N, kFn, "c");
+    require_scale_len(scale_a, static_cast<size_t>(M), kFn, "scale_a");
+    require_scale_len(scale_b,
+                      scale_b_stride == 1 ? static_cast<size_t>(N) : 1,
+                      kFn, "scale_b");
+    require_bias(bias, N, kFn);
+
+    launch_int8_gemm_a_tiled128_b_tiled128_down_kernel(
+        a.data(), b.data(), c.data(), scale_a.data(), scale_b.data(),
+        scale_b_stride, opt_data(bias), opt_code(bias), M, N, K, N,
+        out_code, reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
 void convrot_w4a4_gemm(nb::ndarray<> a, nb::ndarray<> b, nb::ndarray<> c, nb::ndarray<> x_scale,
                        nb::ndarray<> w_scale, OptArray bias, int M, int N, int K, int out_code,
                        uintptr_t stream_ptr) {
@@ -438,6 +704,148 @@ void quantize_int8_convrot(nb::ndarray<> x, nb::ndarray<> q, nb::ndarray<> scale
                                         scales.data(), spill_rotated_ptr, spill_partials_ptr, M, K,
                                         group_size, act_code,
                                         reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+void quantize_int8_convrot_tiled128(
+    nb::ndarray<> x, nb::ndarray<> q, nb::ndarray<> scales,
+    int M, int K, int group_size, uintptr_t stream_ptr) {
+    constexpr const char* kFn = "quantize_int8_convrot_tiled128";
+    require_nonneg(M, kFn, "M");
+    require_convrot_group(K, group_size, kFn);
+    require_dtype(x, 2, 2, kFn, "x");
+    require_dtype(q, 4, 4, kFn, "q");
+    require_len(x, static_cast<int64_t>(M) * K, kFn, "x");
+    const int64_t padded_m = (static_cast<int64_t>(M) + 127) / 128 * 128;
+    require_len(q, padded_m * K, kFn, "q");
+    require_scale_len(scales, static_cast<size_t>(M), kFn, "scales");
+
+    launch_quantize_int8_convrot_tiled128_kernel(
+        x.data(), map_dtype_to_code(x.dtype()), q.data(), scales.data(),
+        M, K, group_size, reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+void quantize_int8_convrot_swiglu_split_tiled128(
+    nb::ndarray<> gate, nb::ndarray<> up, nb::ndarray<> q,
+    nb::ndarray<> scales, int M, int K, int group_size,
+    uintptr_t stream_ptr) {
+    constexpr const char* kFn =
+        "quantize_int8_convrot_swiglu_split_tiled128";
+    require_nonneg(M, kFn, "M");
+    require_convrot_group(K, group_size, kFn);
+    require_dtype(gate, 2, 2, kFn, "gate");
+    require_dtype(up, 2, 2, kFn, "up");
+    require_dtype(q, 4, 4, kFn, "q");
+    require_len(gate, static_cast<int64_t>(M) * K, kFn, "gate");
+    require_len(up, static_cast<int64_t>(M) * K, kFn, "up");
+    const int64_t padded_m =
+        (static_cast<int64_t>(M) + 127) / 128 * 128;
+    require_len(q, padded_m * K, kFn, "q");
+    require_scale_len(scales, static_cast<size_t>(M), kFn, "scales");
+
+    launch_quantize_int8_convrot_swiglu_split_tiled128_kernel(
+        gate.data(), up.data(), q.data(), scales.data(), M, K, group_size,
+        reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+void quantize_int8_convrot_modulated(
+    nb::ndarray<> x, nb::ndarray<> modulation_scale, nb::ndarray<> q,
+    nb::ndarray<> scales, int M, int K, int group_size,
+    uintptr_t stream_ptr) {
+    constexpr const char* kFn = "quantize_int8_convrot_modulated";
+    require_nonneg(M, kFn, "M");
+    require_convrot_group(K, group_size, kFn);
+    require_dtype(x, 2, 2, kFn, "x");
+    require_dtype(modulation_scale, 2, 2, kFn, "modulation_scale");
+    require_dtype(q, 4, 4, kFn, "q");
+    require_len(x, static_cast<int64_t>(M) * K, kFn, "x");
+    require_len(modulation_scale, static_cast<int64_t>(K), kFn,
+                "modulation_scale");
+    require_len(q, static_cast<int64_t>(M) * K, kFn, "q");
+    require_scale_len(scales, static_cast<size_t>(M), kFn, "scales");
+
+    launch_quantize_int8_convrot_modulated_kernel(
+        x.data(), modulation_scale.data(), q.data(), scales.data(),
+        M, K, group_size, reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+void quantize_int8_convrot_affine(
+    nb::ndarray<> x, nb::ndarray<> modulation_scale,
+    nb::ndarray<> modulation_shift, nb::ndarray<> q,
+    nb::ndarray<> scales, int M, int K, int group_size,
+    uintptr_t stream_ptr) {
+    constexpr const char* kFn = "quantize_int8_convrot_affine";
+    require_nonneg(M, kFn, "M");
+    require_convrot_group(K, group_size, kFn);
+    require_dtype(x, 2, 2, kFn, "x");
+    require_dtype(modulation_scale, 2, 2, kFn, "modulation_scale");
+    require_dtype(modulation_shift, 2, 2, kFn, "modulation_shift");
+    require_dtype(q, 4, 4, kFn, "q");
+    require_len(x, static_cast<int64_t>(M) * K, kFn, "x");
+    require_len(modulation_scale, static_cast<int64_t>(K), kFn,
+                "modulation_scale");
+    require_len(modulation_shift, static_cast<int64_t>(K), kFn,
+                "modulation_shift");
+    require_len(q, static_cast<int64_t>(M) * K, kFn, "q");
+    require_scale_len(scales, static_cast<size_t>(M), kFn, "scales");
+
+    launch_quantize_int8_convrot_affine_kernel(
+        x.data(), modulation_scale.data(), modulation_shift.data(),
+        q.data(), scales.data(), M, K, group_size,
+        reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+void quantize_int8_convrot_rms_modulated(
+    nb::ndarray<> x, nb::ndarray<> norm_weight, nb::ndarray<> rstd,
+    nb::ndarray<> modulation_scale, nb::ndarray<> q, nb::ndarray<> scales,
+    int M, int K, int group_size, uintptr_t stream_ptr) {
+    constexpr const char* kFn = "quantize_int8_convrot_rms_modulated";
+    require_nonneg(M, kFn, "M");
+    require_convrot_group(K, group_size, kFn);
+    require_dtype(x, 2, 2, kFn, "x");
+    require_dtype(norm_weight, 2, 2, kFn, "norm_weight");
+    require_dtype(rstd, 0, 0, kFn, "rstd");
+    require_dtype(modulation_scale, 2, 2, kFn, "modulation_scale");
+    require_dtype(q, 4, 4, kFn, "q");
+    require_len(x, static_cast<int64_t>(M) * K, kFn, "x");
+    require_len(norm_weight, K, kFn, "norm_weight");
+    require_len(rstd, M, kFn, "rstd");
+    require_len(modulation_scale, K, kFn, "modulation_scale");
+    require_len(q, static_cast<int64_t>(M) * K, kFn, "q");
+    require_scale_len(scales, static_cast<size_t>(M), kFn, "scales");
+
+    launch_quantize_int8_convrot_rms_modulated_kernel(
+        x.data(), norm_weight.data(), rstd.data(), modulation_scale.data(),
+        q.data(), scales.data(), M, K, group_size,
+        reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+void quantize_int8_convrot_rms_modulated_fused_stats(
+    nb::ndarray<> x, nb::ndarray<> norm_weight,
+    nb::ndarray<> modulation_scale, nb::ndarray<> q, nb::ndarray<> scales,
+    int M, int K, int group_size, float eps, uintptr_t stream_ptr) {
+    constexpr const char* kFn =
+        "quantize_int8_convrot_rms_modulated_fused_stats";
+    require_nonneg(M, kFn, "M");
+    require_convrot_group(K, group_size, kFn);
+    require_dtype(x, 2, 2, kFn, "x");
+    require_dtype(norm_weight, 2, 2, kFn, "norm_weight");
+    require_dtype(modulation_scale, 2, 2, kFn, "modulation_scale");
+    require_dtype(q, 4, 4, kFn, "q");
+    require_len(x, static_cast<int64_t>(M) * K, kFn, "x");
+    require_len(norm_weight, K, kFn, "norm_weight");
+    require_len(modulation_scale, K, kFn, "modulation_scale");
+    require_len(q, static_cast<int64_t>(M) * K, kFn, "q");
+    require_scale_len(scales, static_cast<size_t>(M), kFn, "scales");
+    launch_quantize_int8_convrot_rms_modulated_fused_stats_kernel(
+        x.data(), norm_weight.data(), modulation_scale.data(), q.data(),
+        scales.data(), M, K, group_size, eps,
+        reinterpret_cast<hipStream_t>(stream_ptr));
     check_hip_launch();
 }
 
@@ -1366,7 +1774,6 @@ void sage_sdpa_prequantized(nb::ndarray<> q_int8, nb::ndarray<> k_int8, nb::ndar
                 reinterpret_cast<hipStream_t>(stream_ptr), kFn);
 }
 
-
 // BF16 decode attention. Every extent below is derived from the operands rather
 // than taken from the caller, and the kernel indexes with the strides passed
 // here, so a mismatch is an out-of-bounds device access. Mirrors the checks in
@@ -1494,6 +1901,283 @@ void flash_attention_decode(nb::ndarray<> q, nb::ndarray<> k, nb::ndarray<> v,
     check_hip_launch();
 }
 
+
+void bf16_sdpa_hip(
+    nb::ndarray<> q, nb::ndarray<> k, nb::ndarray<> v, nb::ndarray<> output,
+    float sm_scale, uintptr_t stream_ptr) {
+    constexpr const char* kFn = "bf16_sdpa_hip";
+    if (q.ndim() != 4 || k.ndim() != 4 || v.ndim() != 4 || output.ndim() != 4) {
+        throw std::runtime_error(std::string(kFn) + ": q, k, v and output must be 4D");
+    }
+    const int batch = static_cast<int>(q.shape(0));
+    const int q_heads = static_cast<int>(q.shape(1));
+    const int q_len = static_cast<int>(q.shape(2));
+    const int head_dim = static_cast<int>(q.shape(3));
+    const int kv_heads = static_cast<int>(k.shape(1));
+    const int kv_len = static_cast<int>(k.shape(2));
+    if (batch <= 0 || q_heads <= 0 || kv_heads <= 0 || q_heads % kv_heads != 0 ||
+        q_len <= 0 || kv_len <= 0 ||
+        (head_dim != 64 && head_dim != 80 && head_dim != 128) ||
+        k.shape(0) != q.shape(0) || k.shape(3) != q.shape(3) ||
+        v.shape(0) != q.shape(0) || v.shape(1) != k.shape(1) ||
+        v.shape(2) != k.shape(2) || v.shape(3) != q.shape(3) ||
+        output.shape(0) != q.shape(0) || output.shape(1) != q.shape(1) ||
+        output.shape(2) != q.shape(2) || output.shape(3) != q.shape(3)) {
+        throw std::runtime_error(
+            std::string(kFn) +
+            ": incompatible BF16 [B,H,N,D] tensors or unsupported head dimension");
+    }
+    require_dtype(q, 2, 2, kFn, "q");
+    require_dtype(k, 2, 2, kFn, "k");
+    require_dtype(v, 2, 2, kFn, "v");
+    require_dtype(output, 2, 2, kFn, "output");
+    auto require_supported_layout = [&](const nb::ndarray<>& tensor, const char* name) {
+        if (tensor.stride(3) != 1 || tensor.stride(2) % 8 != 0) {
+            throw std::runtime_error(
+                std::string(kFn) + ": " + name +
+                " must have a contiguous head dimension and 16-byte-aligned rows");
+        }
+        if (reinterpret_cast<uintptr_t>(tensor.data()) % 16 != 0) {
+            throw std::runtime_error(
+                std::string(kFn) + ": " + name + " must be 16-byte aligned");
+        }
+    };
+    require_supported_layout(q, "q");
+    require_supported_layout(k, "k");
+    require_supported_layout(v, "v");
+    require_supported_layout(output, "output");
+
+    launch_bf16_sdpa_hip(
+        q.data(), k.data(), v.data(), output.data(), batch, q_heads, kv_heads,
+        q_len, kv_len, head_dim,
+        q.stride(0), q.stride(1), q.stride(2),
+        k.stride(0), k.stride(1), k.stride(2),
+        v.stride(0), v.stride(1), v.stride(2),
+        output.stride(0), output.stride(1), output.stride(2), sm_scale,
+        reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+void hip_int8_attention(
+    nb::ndarray<> q, nb::ndarray<> k, nb::ndarray<> v, nb::ndarray<> output,
+    nb::ndarray<> q_int8, nb::ndarray<> k_int8, nb::ndarray<> v_int8,
+    nb::ndarray<> q_descale, nb::ndarray<> k_descale, nb::ndarray<> v_descale,
+    nb::ndarray<> anchor_indices, float sm_scale, uintptr_t stream_ptr) {
+    constexpr const char* kFn = "hip_int8_attention";
+    if (q.ndim() != 4 || k.ndim() != 4 || v.ndim() != 4 ||
+        q.shape(0) != 1 || q.shape(1) == 0 || q.shape(3) != 128 ||
+        k.shape(0) != 1 || k.shape(1) != q.shape(1) || k.shape(3) != 128 ||
+        v.shape(0) != 1 || v.shape(1) != q.shape(1) || v.shape(3) != 128 ||
+        k.shape(2) != v.shape(2)) {
+        throw std::runtime_error(
+            std::string(kFn) +
+            ": q must be [1, H, Q, 128] and k/v matching [1, H, K, 128]");
+    }
+    const int heads = static_cast<int>(q.shape(1));
+    const int q_len = static_cast<int>(q.shape(2));
+    const int kv_len = static_cast<int>(k.shape(2));
+    if (q_len <= 0 || kv_len <= 0) {
+        throw std::runtime_error(std::string(kFn) + ": Q and K/V lengths must be positive");
+    }
+    require_dtype(q, 1, 2, kFn, "q");
+    require_dtype(k, 1, 2, kFn, "k");
+    require_dtype(v, 1, 2, kFn, "v");
+    const int input_dtype_code = map_dtype_to_code(q.dtype());
+    if (map_dtype_to_code(k.dtype()) != input_dtype_code ||
+        map_dtype_to_code(v.dtype()) != input_dtype_code) {
+        throw std::runtime_error(std::string(kFn) + ": q, k, and v dtypes must match");
+    }
+    if (q.stride(3) != 1 || k.stride(3) != 1 || v.stride(3) != 1) {
+        throw std::runtime_error(std::string(kFn) + ": the head dimension must be contiguous");
+    }
+    const int padded_k = ((kv_len + 63) / 64) * 64;
+    const int padded_q = ((q_len + 127) / 128) * 128;
+    const int tiles = padded_k / 64;
+    const auto stream = reinterpret_cast<hipStream_t>(stream_ptr);
+
+    if (output.ndim() != 4 || output.shape(0) != 1 ||
+        output.shape(1) != static_cast<size_t>(heads) ||
+        output.shape(2) != static_cast<size_t>(q_len) || output.shape(3) != 128 ||
+        q_int8.ndim() != 4 || q_int8.shape(0) != 1 ||
+        q_int8.shape(1) != static_cast<size_t>(heads) ||
+        q_int8.shape(2) != static_cast<size_t>(q_len) || q_int8.shape(3) != 128 ||
+        k_int8.ndim() != 4 || k_int8.shape(0) != 1 ||
+        k_int8.shape(1) != static_cast<size_t>(heads) ||
+        k_int8.shape(2) != static_cast<size_t>(padded_k) || k_int8.shape(3) != 128 ||
+        v_int8.ndim() != 5 || v_int8.shape(0) != 1 ||
+        v_int8.shape(1) != static_cast<size_t>(heads) ||
+        v_int8.shape(2) != static_cast<size_t>(tiles) || v_int8.shape(3) != 128 ||
+        v_int8.shape(4) != 64) {
+        throw std::runtime_error(std::string(kFn) + ": incompatible packed workspace shapes");
+    }
+    require_dtype(output, 1, 2, kFn, "output");
+    if (map_dtype_to_code(output.dtype()) != input_dtype_code) {
+        throw std::runtime_error(std::string(kFn) + ": output dtype must match q");
+    }
+    require_dtype(q_int8, 4, 4, kFn, "q_int8");
+    require_dtype(k_int8, 4, 4, kFn, "k_int8");
+    require_dtype(v_int8, 4, 4, kFn, "v_int8");
+    require_scale_len(q_descale, static_cast<size_t>(heads) * padded_q,
+                      kFn, "q_descale");
+    require_scale_len(k_descale, static_cast<size_t>(heads) * (padded_k / 16),
+                      kFn, "k_descale");
+    require_scale_len(v_descale, static_cast<size_t>(heads) * tiles * 128,
+                      kFn, "v_descale");
+    if (output.stride(3) != 1) {
+        throw std::runtime_error(
+            std::string(kFn) + ": output head dimension must be contiguous");
+    }
+    require_packed_contiguous(q_int8, kFn, "q_int8");
+    require_packed_contiguous(k_int8, kFn, "k_int8");
+    require_packed_contiguous(v_int8, kFn, "v_int8");
+    require_packed_contiguous(q_descale, kFn, "q_descale");
+    require_packed_contiguous(k_descale, kFn, "k_descale");
+    require_packed_contiguous(v_descale, kFn, "v_descale");
+    if (anchor_indices.dtype().bits != 32 ||
+        anchor_indices.size() < static_cast<size_t>(heads)) {
+        throw std::runtime_error(
+            std::string(kFn) + ": anchor_indices must contain H int32s");
+    }
+
+    // Keeping all three producers and the consumer on this stream preserves
+    // the one-call API without host synchronization.
+    launch_gfx12_qk_quant(
+        q.data(), q_int8.data(), q_descale.data(),
+        k.data(), k_int8.data(), k_descale.data(), anchor_indices.data(),
+        heads, q_len, kv_len, padded_q, padded_k,
+        q.stride(0), q.stride(1), q.stride(2),
+        k.stride(0), k.stride(1), k.stride(2), input_dtype_code, stream);
+    launch_gfx12_tile_channel_v_quant(
+        v.data(), v_int8.data(), v_descale.data(), heads, kv_len, tiles,
+        v.stride(1), v.stride(2), input_dtype_code, stream);
+    launch_gfx12_int8_attention(
+        q_int8.data(), k_int8.data(), v_int8.data(), output.data(),
+        q_descale.data(), k_descale.data(), v_descale.data(), heads, q_len,
+        kv_len, padded_q, padded_k, padded_k / 16,
+        output.stride(1), output.stride(2),
+        sm_scale, input_dtype_code, stream);
+    check_hip_launch();
+}
+
+void hip_int8_attention_split(
+    nb::ndarray<> q0, nb::ndarray<> q1,
+    nb::ndarray<> k0, nb::ndarray<> k1,
+    nb::ndarray<> v0, nb::ndarray<> v1,
+    nb::ndarray<> output, nb::ndarray<> q_int8, nb::ndarray<> k_int8,
+    nb::ndarray<> v_int8, nb::ndarray<> q_descale, nb::ndarray<> k_descale,
+    nb::ndarray<> v_descale, nb::ndarray<> anchor_indices,
+    float sm_scale, uintptr_t stream_ptr) {
+    constexpr const char* kFn = "hip_int8_attention_split";
+    const nb::ndarray<>* inputs[] = {&q0, &q1, &k0, &k1, &v0, &v1};
+    const char* names[] = {"q0", "q1", "k0", "k1", "v0", "v1"};
+    if (q0.ndim() != 4 || q0.shape(0) != 1 || q0.shape(1) == 0 ||
+        q0.shape(2) == 0 || q0.shape(3) != 128) {
+        throw std::runtime_error(
+            std::string(kFn) + ": q0 must be non-empty [1, H, Q0, 128]");
+    }
+    const int heads = static_cast<int>(q0.shape(1));
+    const int input_dtype_code = map_dtype_to_code(q0.dtype());
+    for (int index = 0; index < 6; ++index) {
+        const auto& tensor = *inputs[index];
+        if (tensor.ndim() != 4 || tensor.shape(0) != 1 ||
+            tensor.shape(1) != static_cast<size_t>(heads) || tensor.shape(2) == 0 ||
+            tensor.shape(3) != 128 || tensor.stride(3) != 1) {
+            throw std::runtime_error(
+                std::string(kFn) + ": " + names[index] +
+                " must be non-empty [1, H, N, 128] with contiguous head dimension");
+        }
+        require_dtype(tensor, 1, 2, kFn, names[index]);
+        if (map_dtype_to_code(tensor.dtype()) != input_dtype_code) {
+            throw std::runtime_error(
+                std::string(kFn) + ": all input dtypes must match q0");
+        }
+        if (reinterpret_cast<uintptr_t>(tensor.data()) % 16 != 0 ||
+            (tensor.stride(1) * 2) % 16 != 0 ||
+            (tensor.stride(2) * 2) % 16 != 0) {
+            throw std::runtime_error(
+                std::string(kFn) + ": " + names[index] +
+                " rows and heads must be 16-byte aligned");
+        }
+    }
+    if (k0.shape(2) != v0.shape(2) || k1.shape(2) != v1.shape(2)) {
+        throw std::runtime_error(
+            std::string(kFn) + ": corresponding K/V segment lengths must match");
+    }
+
+    const int q0_len = static_cast<int>(q0.shape(2));
+    const int q1_len = static_cast<int>(q1.shape(2));
+    const int k0_len = static_cast<int>(k0.shape(2));
+    const int k1_len = static_cast<int>(k1.shape(2));
+    const int q_len = q0_len + q1_len;
+    const int kv_len = k0_len + k1_len;
+    const int padded_q = ((q_len + 127) / 128) * 128;
+    const int padded_k = ((kv_len + 63) / 64) * 64;
+    const int tiles = padded_k / 64;
+
+    if (output.ndim() != 4 || output.shape(0) != 1 ||
+        output.shape(1) != static_cast<size_t>(heads) ||
+        output.shape(2) != static_cast<size_t>(q_len) || output.shape(3) != 128 ||
+        q_int8.ndim() != 4 || q_int8.shape(0) != 1 ||
+        q_int8.shape(1) != static_cast<size_t>(heads) ||
+        q_int8.shape(2) != static_cast<size_t>(q_len) || q_int8.shape(3) != 128 ||
+        k_int8.ndim() != 4 || k_int8.shape(0) != 1 ||
+        k_int8.shape(1) != static_cast<size_t>(heads) ||
+        k_int8.shape(2) != static_cast<size_t>(padded_k) || k_int8.shape(3) != 128 ||
+        v_int8.ndim() != 5 || v_int8.shape(0) != 1 ||
+        v_int8.shape(1) != static_cast<size_t>(heads) ||
+        v_int8.shape(2) != static_cast<size_t>(tiles) || v_int8.shape(3) != 128 ||
+        v_int8.shape(4) != 64) {
+        throw std::runtime_error(std::string(kFn) + ": incompatible output/workspace shapes");
+    }
+    require_dtype(output, 1, 2, kFn, "output");
+    if (map_dtype_to_code(output.dtype()) != input_dtype_code) {
+        throw std::runtime_error(std::string(kFn) + ": output dtype must match q0");
+    }
+    require_dtype(q_int8, 4, 4, kFn, "q_int8");
+    require_dtype(k_int8, 4, 4, kFn, "k_int8");
+    require_dtype(v_int8, 4, 4, kFn, "v_int8");
+    require_scale_len(q_descale, static_cast<size_t>(heads) * padded_q,
+                      kFn, "q_descale");
+    require_scale_len(k_descale, static_cast<size_t>(heads) * (padded_k / 16),
+                      kFn, "k_descale");
+    require_scale_len(v_descale, static_cast<size_t>(heads) * tiles * 128,
+                      kFn, "v_descale");
+    if (output.stride(3) != 1) {
+        throw std::runtime_error(
+            std::string(kFn) + ": output head dimension must be contiguous");
+    }
+    require_packed_contiguous(q_int8, kFn, "q_int8");
+    require_packed_contiguous(k_int8, kFn, "k_int8");
+    require_packed_contiguous(v_int8, kFn, "v_int8");
+    require_packed_contiguous(q_descale, kFn, "q_descale");
+    require_packed_contiguous(k_descale, kFn, "k_descale");
+    require_packed_contiguous(v_descale, kFn, "v_descale");
+    if (anchor_indices.dtype().bits != 32 ||
+        anchor_indices.size() < static_cast<size_t>(heads)) {
+        throw std::runtime_error(
+            std::string(kFn) + ": anchor_indices must contain H int32s");
+    }
+
+    const auto stream = reinterpret_cast<hipStream_t>(stream_ptr);
+    launch_gfx12_qk_quant_split(
+        q0.data(), q1.data(), q_int8.data(), q_descale.data(),
+        k0.data(), k1.data(), k_int8.data(), k_descale.data(),
+        anchor_indices.data(), heads, q0_len, q1_len, k0_len, k1_len,
+        padded_q, padded_k, q0.stride(1), q0.stride(2),
+        q1.stride(1), q1.stride(2), k0.stride(1), k0.stride(2),
+        k1.stride(1), k1.stride(2), input_dtype_code, stream);
+    launch_gfx12_tile_channel_v_quant_split(
+        v0.data(), v1.data(), v_int8.data(), v_descale.data(), heads,
+        k0_len, k1_len, tiles, v0.stride(1), v0.stride(2),
+        v1.stride(1), v1.stride(2), input_dtype_code, stream);
+    launch_gfx12_int8_attention(
+        q_int8.data(), k_int8.data(), v_int8.data(), output.data(),
+        q_descale.data(), k_descale.data(), v_descale.data(), heads, q_len,
+        kv_len, padded_q, padded_k, padded_k / 16,
+        output.stride(1), output.stride(2), sm_scale, input_dtype_code, stream);
+    check_hip_launch();
+}
+
 NB_MODULE(_C, m) {
     m.doc() = "ComfyKitchen HIP backend native operations (RDNA2-RDNA4, WMMA on gfx11/gfx12)";
     m.def("quantize_per_tensor_fp8", &quantize_per_tensor_fp8);
@@ -1501,9 +2185,30 @@ NB_MODULE(_C, m) {
     m.def("stochastic_round_fp8", &stochastic_round_fp8);
     m.def("scaled_mm_fp8", &scaled_mm_fp8);
     m.def("int8_gemm", &int8_gemm);
+    m.def("int8_gemm_b_tiled", &int8_gemm_b_tiled);
+    m.def("int8_gemm_b_tiled_gated_residual",
+          &int8_gemm_b_tiled_gated_residual);
+    m.def("int8_gemm_pair", &int8_gemm_pair);
+    m.def("rms_gated_residual_bf16", &rms_gated_residual_bf16);
+    m.def("int8_gemm_a_tiled128_down", &int8_gemm_a_tiled128_down);
+    m.def("int8_gemm_a_tiled128_b_tiled128_down",
+          &int8_gemm_a_tiled128_b_tiled128_down);
     m.def("convrot_w4a4_gemm", &convrot_w4a4_gemm);
     m.def("quantize_int8_rowwise", &quantize_int8_rowwise);
-    m.def("quantize_int8_convrot", &quantize_int8_convrot);
+    m.def("quantize_int8_convrot", &quantize_int8_convrot,
+          nb::arg("x"), nb::arg("q"), nb::arg("scales"),
+          nb::arg("spill_rotated").none(), nb::arg("spill_partials").none(),
+          nb::arg("M"), nb::arg("K"), nb::arg("group_size"),
+          nb::arg("act_code"), nb::arg("stream_ptr"));
+    m.def("quantize_int8_convrot_tiled128", &quantize_int8_convrot_tiled128);
+    m.def("quantize_int8_convrot_swiglu_split_tiled128",
+          &quantize_int8_convrot_swiglu_split_tiled128);
+    m.def("quantize_int8_convrot_modulated", &quantize_int8_convrot_modulated);
+    m.def("quantize_int8_convrot_affine", &quantize_int8_convrot_affine);
+    m.def("quantize_int8_convrot_rms_modulated",
+          &quantize_int8_convrot_rms_modulated);
+    m.def("quantize_int8_convrot_rms_modulated_fused_stats",
+          &quantize_int8_convrot_rms_modulated_fused_stats);
     m.def("quantize_int8_tensorwise", &quantize_int8_tensorwise);
     m.def("dequantize_int8_simple", &dequantize_int8_simple);
     m.def("dequantize_int8_convrot_weight", &dequantize_int8_convrot_weight);
@@ -1534,6 +2239,20 @@ NB_MODULE(_C, m) {
           nb::arg("v_int8"), nb::arg("o"), nb::arg("q_scale"), nb::arg("k_scale"),
           nb::arg("v_scale"), nb::arg("cta_k"), nb::arg("sm_scale"),
           nb::arg("output_dtype_code"), nb::arg("stream_ptr"), nb::arg("attn_mask") = nb::none());
+    m.def("bf16_sdpa_hip", &bf16_sdpa_hip,
+          nb::arg("q"), nb::arg("k"), nb::arg("v"), nb::arg("output"),
+          nb::arg("sm_scale"), nb::arg("stream_ptr"));
+    m.def("hip_int8_attention", &hip_int8_attention,
+          nb::arg("q"), nb::arg("k"), nb::arg("v"), nb::arg("output"),
+          nb::arg("q_int8"), nb::arg("k_int8"), nb::arg("v_int8"),
+          nb::arg("q_descale"), nb::arg("k_descale"), nb::arg("v_descale"),
+          nb::arg("anchor_indices"), nb::arg("sm_scale"), nb::arg("stream_ptr"));
+    m.def("hip_int8_attention_split", &hip_int8_attention_split,
+          nb::arg("q0"), nb::arg("q1"), nb::arg("k0"), nb::arg("k1"),
+          nb::arg("v0"), nb::arg("v1"), nb::arg("output"),
+          nb::arg("q_int8"), nb::arg("k_int8"), nb::arg("v_int8"),
+          nb::arg("q_descale"), nb::arg("k_descale"), nb::arg("v_descale"),
+          nb::arg("anchor_indices"), nb::arg("sm_scale"), nb::arg("stream_ptr"));
     m.def("adaln", &adaln);
     m.def("rms_adaln", &rms_adaln);
     m.def("apply_rope", &apply_rope);

--- a/comfy_kitchen/backends/hip/epilogue.h
+++ b/comfy_kitchen/backends/hip/epilogue.h
@@ -67,4 +67,49 @@ struct EpiRowwise {
     }
 };
 
+// out = residual + gate[col] * bf16(linear)
+//
+// The explicit BF16 conversion is observable: ComfyUI materializes the INT8
+// linear output before torch.addcmul consumes it.  Keeping that rounding point
+// makes this a traffic/dispatch fusion rather than a numerical approximation.
+struct EpiRowwiseGatedResidual {
+    const float* scale_a;
+    const float* scale_b;
+    int scale_b_stride;
+    const void* bias;
+    int bias_code;
+    const __bf16* residual;
+    const __bf16* gate;
+    int residual_stride;
+
+    __forceinline__ __device__ void init() {}
+
+    __forceinline__ __device__ float operator()(int row, int col, float acc) const {
+        #pragma clang fp contract(off)
+        #pragma clang fp reassociate(off)
+        float linear = acc * scale_a[row];
+        linear *= scale_b[col * scale_b_stride];
+        if (bias) linear += load_scalar(bias, bias_code, col);
+        const __bf16 rounded = static_cast<__bf16>(linear);
+        return fmaf(
+            static_cast<float>(gate[col]), static_cast<float>(rounded),
+            static_cast<float>(residual[static_cast<int64_t>(row) * residual_stride + col]));
+    }
+};
+
+// Pair-only specialization for the bias-free ConvRot FeedForward projections.
+// Keeping the same left-to-right scale expression preserves EpiRowwise's BF16
+// result while removing the runtime bias pointer/dtype branches from every
+// unrolled output element.
+struct EpiRowwiseNoBias {
+    const float* scale_a;
+    const float* scale_b;
+
+    __forceinline__ __device__ void init() {}
+
+    __forceinline__ __device__ float operator()(int row, int col, float acc) const {
+        return acc * scale_a[row] * scale_b[col];
+    }
+};
+
 }  // namespace comfy::hip_backend

--- a/comfy_kitchen/backends/hip/gemm_wmma.h
+++ b/comfy_kitchen/backends/hip/gemm_wmma.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <atomic>
+#include <type_traits>
 
 #include "mma.h"
 
@@ -35,7 +36,7 @@ constexpr int kLdsPad = 8;
 // kbytes is the source row length in bytes (K for 8-bit types, K/2 for int4) and
 // is a multiple of 16, so a 16-byte chunk starting inside a row also ends inside
 // it. Out-of-range rows and the K tail are zero-filled.
-template <int ROWS, int BKB, int THREADS>
+template <int ROWS, int BKB, int THREADS, bool COALESCED_STAGING = false>
 struct TileStager {
     static constexpr int kChunksPerRow = BKB / 16;
     static constexpr int kChunks = ROWS * kChunksPerRow;
@@ -48,19 +49,52 @@ struct TileStager {
 
     uint4 regs[kPerThread];
 
+    template <bool ASSUME_ROWS_FULL = false, bool ASSUME_K_FULL = false>
     __forceinline__ __device__ void load(const uint8_t* __restrict__ src, int row0, int rows_total,
                                          int kbyte0, int kbytes) {
         const int tid = threadIdx.x;
         #pragma unroll
         for (int i = 0; i < kPerThread; ++i) {
-            const int c = tid * kPerThread + i;
+            // A thread-strided assignment makes every load instruction cover
+            // consecutive 16-byte chunks across a wave. Keep the original
+            // thread-major order as the control until exact-shape profiling
+            // promotes this layout.
+            const int c = COALESCED_STAGING ? tid + i * THREADS
+                                             : tid * kPerThread + i;
             const int grow = row0 + c / kChunksPerRow;
             const int gk = kbyte0 + (c % kChunksPerRow) * 16;
 
-            regs[i] = (grow < rows_total && gk < kbytes)
-                          ? *reinterpret_cast<const uint4*>(
-                                src + static_cast<int64_t>(grow) * kbytes + gk)
-                          : make_uint4(0, 0, 0, 0);
+            if constexpr (ASSUME_ROWS_FULL && ASSUME_K_FULL) {
+                const uint8_t* const p =
+                    src + static_cast<int64_t>(grow) * kbytes + gk;
+                regs[i] = *reinterpret_cast<const uint4*>(p);
+            } else {
+                const bool valid_row = ASSUME_ROWS_FULL || grow < rows_total;
+                const bool valid_k = ASSUME_K_FULL || gk < kbytes;
+                if (valid_row && valid_k) {
+                    const uint8_t* const p =
+                        src + static_cast<int64_t>(grow) * kbytes + gk;
+                    regs[i] = *reinterpret_cast<const uint4*>(p);
+                } else {
+                    regs[i] = make_uint4(0, 0, 0, 0);
+                }
+            }
+        }
+    }
+
+    // Load one physically contiguous [ROWS, BKB] activation tile. The caller
+    // supplies A as [M_tile, K_tile, ROWS, BKB], so the wave-coalesced chunk
+    // assignment becomes a dense global-memory span instead of touching four
+    // K-strided rows per wave instruction.
+    __forceinline__ __device__ void load_contiguous(
+        const uint8_t* __restrict__ tile) {
+        const int tid = threadIdx.x;
+        #pragma unroll
+        for (int i = 0; i < kPerThread; ++i) {
+            const int c = COALESCED_STAGING ? tid + i * THREADS
+                                             : tid * kPerThread + i;
+            const uint8_t* const p = tile + static_cast<int64_t>(c) * 16;
+            regs[i] = *reinterpret_cast<const uint4*>(p);
         }
     }
 
@@ -68,7 +102,8 @@ struct TileStager {
         const int tid = threadIdx.x;
         #pragma unroll
         for (int i = 0; i < kPerThread; ++i) {
-            const int c = tid * kPerThread + i;
+            const int c = COALESCED_STAGING ? tid + i * THREADS
+                                             : tid * kPerThread + i;
             uint8_t* dst = lds + (c / kChunksPerRow) * kStride + (c % kChunksPerRow) * 16;
             // 8-byte stores: kLdsPad breaks 16-byte LDS alignment.
             *reinterpret_cast<uint2*>(dst) = make_uint2(regs[i].x, regs[i].y);
@@ -79,7 +114,10 @@ struct TileStager {
 
 // Epi is a functor: float operator()(int row, int col, float acc) const.
 template <typename Mma, typename Epi, typename OutT,
-          int BM, int BN, int BKB, int WARPS_M, int WARPS_N, int TM, int TN>
+          int BM, int BN, int BKB, int WARPS_M, int WARPS_N, int TM, int TN,
+          bool COALESCED_STAGING = false, bool TILED_A = false,
+          bool VOPD_CROSS_E = false, bool ASSUME_NK_FULL = false,
+          bool TILED_B = false>
 __global__ __launch_bounds__(WARPS_M* WARPS_N* kWave) void gemm_wmma_kernel(
     const uint8_t* __restrict__ A, const uint8_t* __restrict__ B, OutT* __restrict__ C,
     int M, int N, int kbytes, int ldc, Epi epi) {
@@ -135,11 +173,22 @@ __global__ __launch_bounds__(WARPS_M* WARPS_N* kWave) void gemm_wmma_kernel(
 
     const int row = frag_row(lane);
 
-    TileStager<BM, BKB, kThreads> sa;
-    TileStager<BN, BKB, kThreads> sb;
+    TileStager<BM, BKB, kThreads, COALESCED_STAGING> sa;
+    TileStager<BN, BKB, kThreads, COALESCED_STAGING> sb;
 
-    sa.load(A, m0, M, 0, kbytes);
-    sb.load(B, n0, N, 0, kbytes);
+    if constexpr (TILED_A) {
+        const int64_t tile = static_cast<int64_t>(bm) * (kbytes / BKB);
+        sa.load_contiguous(A + tile * BM * BKB);
+    } else {
+        sa.template load<false, ASSUME_NK_FULL>(A, m0, M, 0, kbytes);
+    }
+    if constexpr (TILED_B) {
+        const int64_t tile = static_cast<int64_t>(bn) * (kbytes / BKB);
+        sb.load_contiguous(B + tile * BN * BKB);
+    } else {
+        sb.template load<ASSUME_NK_FULL, ASSUME_NK_FULL>(
+            B, n0, N, 0, kbytes);
+    }
     sa.store(As);
     sb.store(Bs);
     __syncthreads();
@@ -150,8 +199,23 @@ __global__ __launch_bounds__(WARPS_M* WARPS_N* kWave) void gemm_wmma_kernel(
 
         // Prefetch the next tile's global reads ahead of the current tile's math.
         if (has_next) {
-            sa.load(A, m0, M, knext, kbytes);
-            sb.load(B, n0, N, knext, kbytes);
+            if constexpr (TILED_A) {
+                const int64_t tile =
+                    static_cast<int64_t>(bm) * (kbytes / BKB) + knext / BKB;
+                sa.load_contiguous(A + tile * BM * BKB);
+            } else {
+                sa.template load<false, ASSUME_NK_FULL>(
+                    A, m0, M, knext, kbytes);
+            }
+            if constexpr (TILED_B) {
+                const int64_t tile =
+                    static_cast<int64_t>(bn) * (kbytes / BKB)
+                    + knext / BKB;
+                sb.load_contiguous(B + tile * BN * BKB);
+            } else {
+                sb.template load<ASSUME_NK_FULL, ASSUME_NK_FULL>(
+                    B, n0, N, knext, kbytes);
+            }
         }
 
         // Register-level pipeline over K-steps: the LDS reads for step kk+1 are
@@ -203,18 +267,654 @@ __global__ __launch_bounds__(WARPS_M* WARPS_N* kWave) void gemm_wmma_kernel(
     // Row-major writeback: the TN column tiles of one accumulator row cover
     // TN*16 consecutive columns, keeping the stores of an iteration contiguous.
     const int col_lane = acc_col(lane);
-    #pragma unroll
-    for (int i = 0; i < TM; ++i) {
+    if constexpr (VOPD_CROSS_E) {
+        // Adjacent accumulator elements occupy different gfx12 VGPR banks.
+        // Keep two independent row epilogues adjacent in the instruction graph
+        // so the backend can form legal VOPD mul/FMA pairs. Each expression and
+        // output location retain the control path's exact order.
+        #pragma clang fp reassociate(off)
         #pragma unroll
-        for (int e = 0; e < 8; ++e) {
-            const int r = m0 + wm * (TM * 16) + i * 16 + acc_row(lane, e);
-            if (r >= M) continue;
-            OutT* crow = C + static_cast<int64_t>(r) * ldc;
+        for (int i = 0; i < TM; ++i) {
             #pragma unroll
-            for (int j = 0; j < TN; ++j) {
-                const int col = n0 + wn * (TN * 16) + j * 16 + col_lane;
-                if (col >= N) continue;
-                crow[col] = static_cast<OutT>(epi(r, col, Mma::get(acc[i][j], e)));
+            for (int e = 0; e < 8; e += 2) {
+                const int r0 =
+                    m0 + wm * (TM * 16) + i * 16 + acc_row(lane, e);
+                const int r1 =
+                    m0 + wm * (TM * 16) + i * 16 + acc_row(lane, e + 1);
+                const bool valid0 = r0 < M;
+                const bool valid1 = r1 < M;
+                if (!valid0 && !valid1) continue;
+                #pragma unroll
+                for (int j = 0; j < TN; ++j) {
+                    const int col =
+                        n0 + wn * (TN * 16) + j * 16 + col_lane;
+                    if constexpr (!ASSUME_NK_FULL) {
+                        if (col >= N) continue;
+                    }
+                    if (valid0) {
+                        OutT* const crow0 =
+                            C + static_cast<int64_t>(r0) * ldc;
+                        crow0[col] = static_cast<OutT>(
+                            epi(r0, col, Mma::get(acc[i][j], e)));
+                    }
+                    if (valid1) {
+                        OutT* const crow1 =
+                            C + static_cast<int64_t>(r1) * ldc;
+                        crow1[col] = static_cast<OutT>(
+                            epi(r1, col, Mma::get(acc[i][j], e + 1)));
+                    }
+                }
+            }
+        }
+    } else {
+        #pragma unroll
+        for (int i = 0; i < TM; ++i) {
+            #pragma unroll
+            for (int e = 0; e < 8; ++e) {
+                const int r =
+                    m0 + wm * (TM * 16) + i * 16 + acc_row(lane, e);
+                if (r >= M) continue;
+                OutT* crow = C + static_cast<int64_t>(r) * ldc;
+                #pragma unroll
+                for (int j = 0; j < TN; ++j) {
+                    const int col =
+                        n0 + wn * (TN * 16) + j * 16 + col_lane;
+                    if constexpr (!ASSUME_NK_FULL) {
+                        if (col >= N) continue;
+                    }
+                    crow[col] = static_cast<OutT>(
+                        epi(r, col, Mma::get(acc[i][j], e)));
+                }
+            }
+        }
+    }
+}
+
+// Two equal-width projections over the same activation tile. Half of the
+// workgroup computes each projection, so each thread retains the same single
+// accumulator set as gemm_wmma_kernel while both halves share every global/LDS
+// load of A. The two outputs remain independent and keep the single-GEMM MMA and
+// epilogue order exactly.
+template <typename Mma, typename Epi, typename OutT,
+          int BM, int BN, int BKB, int WARPS_M, int WARPS_N, int TM, int TN,
+          bool TILED_B = false>
+__global__ __launch_bounds__(2 * WARPS_M * WARPS_N * kWave)
+void gemm_wmma_pair_kernel(
+    const uint8_t* __restrict__ A,
+    const uint8_t* __restrict__ B0,
+    const uint8_t* __restrict__ B1,
+    OutT* __restrict__ C0,
+    OutT* __restrict__ C1,
+    int M, int N, int kbytes, int ldc, Epi epi0, Epi epi1) {
+
+    constexpr int kProjectionWarps = WARPS_M * WARPS_N;
+    constexpr int kThreads = 2 * kProjectionWarps * kWave;
+    constexpr int kStride = BKB + kLdsPad;
+    constexpr int kStepBytes = Mma::kStepBytes;
+    constexpr int kSteps = BKB / kStepBytes;
+
+    static_assert(BM == WARPS_M * TM * 16,
+                  "the M warp grid must tile BM exactly");
+    static_assert(BN == WARPS_N * TN * 16,
+                  "the N warp grid must tile BN exactly");
+    static_assert(BKB % kStepBytes == 0,
+                  "BKB must be a whole number of MMA K-steps");
+
+    __shared__ __align__(16) uint8_t As[BM * kStride];
+    __shared__ __align__(16) uint8_t Bs[2][BN * kStride];
+
+    const int tid = threadIdx.x;
+    const int lane = tid % kWave;
+    const int warp = tid / kWave;
+    const int projection = warp / kProjectionWarps;
+    const int projection_warp = warp - projection * kProjectionWarps;
+    const int wm = projection_warp / WARPS_N;
+    const int wn = projection_warp % WARPS_N;
+
+    constexpr int kGroupM = 4;
+    const int blocks_n = gridDim.x;
+    const int blocks_m = gridDim.y;
+    const int bid = blockIdx.y * blocks_n + blockIdx.x;
+    const int per_group = kGroupM * blocks_n;
+    const int group = bid / per_group;
+    const int idx_in_group = bid - group * per_group;
+    const int group_rows = min(kGroupM, blocks_m - group * kGroupM);
+    const int bm = group * kGroupM + idx_in_group % group_rows;
+    const int bn = idx_in_group / group_rows;
+
+    const int m0 = bm * BM;
+    const int n0 = bn * BN;
+
+    typename Mma::Acc acc[TM][TN];
+    #pragma unroll
+    for (int i = 0; i < TM; ++i)
+        #pragma unroll
+        for (int j = 0; j < TN; ++j) acc[i][j] = Mma::zero();
+
+    const int row = frag_row(lane);
+    TileStager<BM, BKB, kThreads> sa;
+    TileStager<BN, BKB, kThreads> sb0;
+    TileStager<BN, BKB, kThreads> sb1;
+
+    sa.load(A, m0, M, 0, kbytes);
+    if constexpr (TILED_B) {
+        const int64_t tile = static_cast<int64_t>(bn) * (kbytes / BKB);
+        sb0.load_contiguous(B0 + tile * BN * BKB);
+        sb1.load_contiguous(B1 + tile * BN * BKB);
+    } else {
+        sb0.load(B0, n0, N, 0, kbytes);
+        sb1.load(B1, n0, N, 0, kbytes);
+    }
+    sa.store(As);
+    sb0.store(Bs[0]);
+    sb1.store(Bs[1]);
+    __syncthreads();
+
+    for (int kb0 = 0; kb0 < kbytes; kb0 += BKB) {
+        const int knext = kb0 + BKB;
+        const bool has_next = knext < kbytes;
+        if (has_next) {
+            sa.load(A, m0, M, knext, kbytes);
+            if constexpr (TILED_B) {
+                const int64_t tile =
+                    static_cast<int64_t>(bn) * (kbytes / BKB)
+                    + knext / BKB;
+                sb0.load_contiguous(B0 + tile * BN * BKB);
+                sb1.load_contiguous(B1 + tile * BN * BKB);
+            } else {
+                sb0.load(B0, n0, N, knext, kbytes);
+                sb1.load(B1, n0, N, knext, kbytes);
+            }
+        }
+
+        typename Mma::Frag af[2][TM];
+        typename Mma::Frag bf[2][TN];
+        #pragma unroll
+        for (int i = 0; i < TM; ++i)
+            af[0][i] = Mma::load(
+                As, wm * (TM * 16) + i * 16 + row, 0, kStride, lane);
+        #pragma unroll
+        for (int j = 0; j < TN; ++j)
+            bf[0][j] = Mma::load(
+                Bs[projection], wn * (TN * 16) + j * 16 + row,
+                0, kStride, lane);
+
+        #pragma unroll
+        for (int kk = 0; kk < kSteps; ++kk) {
+            const int cur = kk & 1;
+            const int nxt = cur ^ 1;
+            if (kk + 1 < kSteps) {
+                const int kbyte = (kk + 1) * kStepBytes;
+                #pragma unroll
+                for (int i = 0; i < TM; ++i)
+                    af[nxt][i] = Mma::load(
+                        As, wm * (TM * 16) + i * 16 + row,
+                        kbyte, kStride, lane);
+                #pragma unroll
+                for (int j = 0; j < TN; ++j)
+                    bf[nxt][j] = Mma::load(
+                        Bs[projection], wn * (TN * 16) + j * 16 + row,
+                        kbyte, kStride, lane);
+            }
+
+            #pragma unroll
+            for (int i = 0; i < TM; ++i)
+                #pragma unroll
+                for (int j = 0; j < TN; ++j)
+                    acc[i][j] = Mma::mma(
+                        af[cur][i], bf[cur][j], acc[i][j]);
+        }
+
+        if (has_next) {
+            __syncthreads();
+            sa.store(As);
+            sb0.store(Bs[0]);
+            sb1.store(Bs[1]);
+            __syncthreads();
+        }
+    }
+
+    constexpr bool kCacheRowwiseEpilogue =
+        std::is_same_v<Epi, EpiRowwiseNoBias> ||
+        std::is_same_v<Epi, EpiRowwise>;
+    float* scale_a_lds = nullptr;
+    float* scale_b_lds = nullptr;
+    float* bias_lds = nullptr;
+    if constexpr (kCacheRowwiseEpilogue) {
+        // The matrix loop is finished, so its A/B tiles can hold the much
+        // smaller epilogue operands. Synchronize before overwriting them, then
+        // load each unique row/channel scale and optional bias once per
+        // workgroup instead of once per unrolled accumulator element.
+        __syncthreads();
+        scale_a_lds = reinterpret_cast<float*>(As);
+        scale_b_lds = reinterpret_cast<float*>(&Bs[0][0]);
+        bias_lds = scale_b_lds + 2 * BN;
+        if (tid < BM) {
+            const int r = m0 + tid;
+            scale_a_lds[tid] = r < M ? epi0.scale_a[r] : 0.0f;
+        }
+        if (tid < BN) {
+            const int col = n0 + tid;
+            if (col < N) {
+                if constexpr (std::is_same_v<Epi, EpiRowwiseNoBias>) {
+                    scale_b_lds[tid] = epi0.scale_b[col];
+                } else {
+                    scale_b_lds[tid] =
+                        epi0.scale_b[col * epi0.scale_b_stride];
+                    bias_lds[tid] = epi0.bias
+                        ? load_scalar(epi0.bias, epi0.bias_code, col)
+                        : 0.0f;
+                }
+            } else {
+                scale_b_lds[tid] = 0.0f;
+                if constexpr (std::is_same_v<Epi, EpiRowwise>) {
+                    bias_lds[tid] = 0.0f;
+                }
+            }
+        } else if (tid < 2 * BN) {
+            const int local_col = tid - BN;
+            const int col = n0 + local_col;
+            if (col < N) {
+                if constexpr (std::is_same_v<Epi, EpiRowwiseNoBias>) {
+                    scale_b_lds[BN + local_col] = epi1.scale_b[col];
+                } else {
+                    scale_b_lds[BN + local_col] =
+                        epi1.scale_b[col * epi1.scale_b_stride];
+                    bias_lds[BN + local_col] = epi1.bias
+                        ? load_scalar(epi1.bias, epi1.bias_code, col)
+                        : 0.0f;
+                }
+            } else {
+                scale_b_lds[BN + local_col] = 0.0f;
+                if constexpr (std::is_same_v<Epi, EpiRowwise>) {
+                    bias_lds[BN + local_col] = 0.0f;
+                }
+            }
+        }
+        __syncthreads();
+    }
+
+    Epi epi = projection == 0 ? epi0 : epi1;
+    OutT* C = projection == 0 ? C0 : C1;
+    epi.init();
+    const int col_lane = acc_col(lane);
+    if constexpr (kCacheRowwiseEpilogue) {
+        // The accepted pair is row-major at writeback. Load its activation
+        // scale once for the four adjacent column fragments instead of letting
+        // the generic functor reload it for every fully unrolled output.
+        #pragma clang fp reassociate(off)
+        #pragma unroll
+        for (int i = 0; i < TM; ++i) {
+            #pragma unroll
+            for (int e = 0; e < 8; ++e) {
+                const int r =
+                    m0 + wm * (TM * 16) + i * 16 + acc_row(lane, e);
+                if (r >= M) continue;
+                OutT* crow = C + static_cast<int64_t>(r) * ldc;
+                const int local_row =
+                    wm * (TM * 16) + i * 16 + acc_row(lane, e);
+                const float row_scale = scale_a_lds[local_row];
+                #pragma unroll
+                for (int j = 0; j < TN; ++j) {
+                    const int col =
+                        n0 + wn * (TN * 16) + j * 16 + col_lane;
+                    if (col >= N) continue;
+                    const int local_col =
+                        wn * (TN * 16) + j * 16 + col_lane;
+                    float value = Mma::get(acc[i][j], e) * row_scale;
+                    value *= scale_b_lds[projection * BN + local_col];
+                    if constexpr (std::is_same_v<Epi, EpiRowwise>) {
+                        if (epi.bias) {
+                            value +=
+                                bias_lds[projection * BN + local_col];
+                        }
+                    }
+                    crow[col] = static_cast<OutT>(value);
+                }
+            }
+        }
+    } else {
+        #pragma unroll
+        for (int i = 0; i < TM; ++i) {
+            #pragma unroll
+            for (int e = 0; e < 8; ++e) {
+                const int r =
+                    m0 + wm * (TM * 16) + i * 16 + acc_row(lane, e);
+                if (r >= M) continue;
+                OutT* crow = C + static_cast<int64_t>(r) * ldc;
+                #pragma unroll
+                for (int j = 0; j < TN; ++j) {
+                    const int col =
+                        n0 + wn * (TN * 16) + j * 16 + col_lane;
+                    if (col >= N) continue;
+                    crow[col] = static_cast<OutT>(
+                        epi(r, col, Mma::get(acc[i][j], e)));
+                }
+            }
+        }
+    }
+}
+
+// Two adjacent M tiles over one weight tile. Half of the workgroup computes
+// each M tile, so every thread keeps the same accumulator shape and arithmetic
+// order as gemm_wmma_kernel while both halves share each global/LDS B stage.
+// gemm_wmma_pair_kernel shares A across two projections; this kernel instead
+// shares B across two row tiles.
+template <typename Mma, typename Epi, typename OutT,
+          int BM, int BN, int BKB, int WARPS_M, int WARPS_N, int TM, int TN,
+          bool VOPD_CROSS_E = false, bool TILED_B = false>
+__global__ __launch_bounds__(2 * WARPS_M * WARPS_N * kWave)
+void gemm_wmma_dual_m_kernel(
+    const uint8_t* __restrict__ A,
+    const uint8_t* __restrict__ B,
+    OutT* __restrict__ C,
+    int M, int N, int kbytes, int ldc, Epi epi) {
+
+    constexpr int kTileWarps = WARPS_M * WARPS_N;
+    constexpr int kThreads = 2 * kTileWarps * kWave;
+    constexpr int kStride = BKB + kLdsPad;
+    constexpr int kStepBytes = Mma::kStepBytes;
+    constexpr int kSteps = BKB / kStepBytes;
+
+    static_assert(BM == WARPS_M * TM * 16,
+                  "the M warp grid must tile BM exactly");
+    static_assert(BN == WARPS_N * TN * 16,
+                  "the N warp grid must tile BN exactly");
+    static_assert(BKB % kStepBytes == 0,
+                  "BKB must be a whole number of MMA K-steps");
+
+    __shared__ __align__(16) uint8_t As[2][BM * kStride];
+    __shared__ __align__(16) uint8_t Bs[BN * kStride];
+
+    const int tid = threadIdx.x;
+    const int lane = tid % kWave;
+    const int warp = tid / kWave;
+    const int mtile = warp / kTileWarps;
+    const int tile_warp = warp - mtile * kTileWarps;
+    const int wm = tile_warp / WARPS_N;
+    const int wn = tile_warp % WARPS_N;
+
+    // Each block covers two adjacent M tiles. Group two such blocks so the
+    // traversal retains the production kernel's four-M-tile B locality.
+    constexpr int kGroupM = 2;
+    const int blocks_n = gridDim.x;
+    const int blocks_m = gridDim.y;
+    const int bid = blockIdx.y * blocks_n + blockIdx.x;
+    const int per_group = kGroupM * blocks_n;
+    const int group = bid / per_group;
+    const int idx_in_group = bid - group * per_group;
+    const int group_rows = min(kGroupM, blocks_m - group * kGroupM);
+    const int bm_pair = group * kGroupM + idx_in_group % group_rows;
+    const int bn = idx_in_group / group_rows;
+
+    const int m0_pair = bm_pair * (2 * BM);
+    const int m0 = m0_pair + mtile * BM;
+    const int n0 = bn * BN;
+
+    typename Mma::Acc acc[TM][TN];
+    #pragma unroll
+    for (int i = 0; i < TM; ++i)
+        #pragma unroll
+        for (int j = 0; j < TN; ++j) acc[i][j] = Mma::zero();
+
+    const int row = frag_row(lane);
+    TileStager<BM, BKB, kThreads> sa0;
+    TileStager<BM, BKB, kThreads> sa1;
+    TileStager<BN, BKB, kThreads> sb;
+
+    sa0.load(A, m0_pair, M, 0, kbytes);
+    sa1.load(A, m0_pair + BM, M, 0, kbytes);
+    if constexpr (TILED_B) {
+        const int64_t tile = static_cast<int64_t>(bn) * (kbytes / BKB);
+        sb.load_contiguous(B + tile * BN * BKB);
+    } else {
+        sb.load(B, n0, N, 0, kbytes);
+    }
+    sa0.store(As[0]);
+    sa1.store(As[1]);
+    sb.store(Bs);
+    __syncthreads();
+
+    for (int kb0 = 0; kb0 < kbytes; kb0 += BKB) {
+        const int knext = kb0 + BKB;
+        const bool has_next = knext < kbytes;
+        if (has_next) {
+            sa0.load(A, m0_pair, M, knext, kbytes);
+            sa1.load(A, m0_pair + BM, M, knext, kbytes);
+            if constexpr (TILED_B) {
+                const int64_t tile =
+                    static_cast<int64_t>(bn) * (kbytes / BKB)
+                    + knext / BKB;
+                sb.load_contiguous(B + tile * BN * BKB);
+            } else {
+                sb.load(B, n0, N, knext, kbytes);
+            }
+        }
+
+        typename Mma::Frag af[2][TM];
+        typename Mma::Frag bf[2][TN];
+        #pragma unroll
+        for (int i = 0; i < TM; ++i)
+            af[0][i] = Mma::load(
+                As[mtile], wm * (TM * 16) + i * 16 + row,
+                0, kStride, lane);
+        #pragma unroll
+        for (int j = 0; j < TN; ++j)
+            bf[0][j] = Mma::load(
+                Bs, wn * (TN * 16) + j * 16 + row,
+                0, kStride, lane);
+
+        #pragma unroll
+        for (int kk = 0; kk < kSteps; ++kk) {
+            const int cur = kk & 1;
+            const int nxt = cur ^ 1;
+            if (kk + 1 < kSteps) {
+                const int kbyte = (kk + 1) * kStepBytes;
+                #pragma unroll
+                for (int i = 0; i < TM; ++i)
+                    af[nxt][i] = Mma::load(
+                        As[mtile], wm * (TM * 16) + i * 16 + row,
+                        kbyte, kStride, lane);
+                #pragma unroll
+                for (int j = 0; j < TN; ++j)
+                    bf[nxt][j] = Mma::load(
+                        Bs, wn * (TN * 16) + j * 16 + row,
+                        kbyte, kStride, lane);
+            }
+
+            #pragma unroll
+            for (int i = 0; i < TM; ++i)
+                #pragma unroll
+                for (int j = 0; j < TN; ++j)
+                    acc[i][j] = Mma::mma(
+                        af[cur][i], bf[cur][j], acc[i][j]);
+        }
+
+        if (has_next) {
+            __syncthreads();
+            sa0.store(As[0]);
+            sa1.store(As[1]);
+            sb.store(Bs);
+            __syncthreads();
+        }
+    }
+
+    epi.init();
+    const int col_lane = acc_col(lane);
+    if constexpr (std::is_same_v<Epi, EpiRowwiseNoBias>) {
+        #pragma clang fp reassociate(off)
+        // Cache the four channel scales owned by this lane directly in VGPRs.
+        // This avoids both the generic functor's fully-unrolled reloads and an
+        // LDS round trip/barrier after the matrix loop.
+        float col_scale[TN];
+        #pragma unroll
+        for (int j = 0; j < TN; ++j) {
+            const int col = n0 + wn * (TN * 16) + j * 16 + col_lane;
+            col_scale[j] = col < N ? epi.scale_b[col] : 0.0f;
+        }
+        #pragma unroll
+        for (int i = 0; i < TM; ++i) {
+            #pragma unroll
+            for (int e = 0; e < 8; ++e) {
+                const int r =
+                    m0 + wm * (TM * 16) + i * 16 + acc_row(lane, e);
+                if (r >= M) continue;
+                OutT* const crow = C + static_cast<int64_t>(r) * ldc;
+                const float row_scale = epi.scale_a[r];
+                #pragma unroll
+                for (int j = 0; j < TN; ++j) {
+                    const int col =
+                        n0 + wn * (TN * 16) + j * 16 + col_lane;
+                    if (col >= N) continue;
+                    float value = Mma::get(acc[i][j], e) * row_scale;
+                    value *= col_scale[j];
+                    crow[col] = static_cast<OutT>(value);
+                }
+            }
+        }
+    } else if constexpr (std::is_same_v<Epi, EpiRowwise>) {
+        #pragma clang fp contract(off)
+        #pragma clang fp reassociate(off)
+        // Bias-bearing checkpoints otherwise reload the same channel scale and
+        // bias for every accumulator element. Each lane owns TN columns, so
+        // retain those operands across all of its output rows just as the
+        // bias-free specialization does.
+        float col_scale[TN];
+        float col_bias[TN];
+        #pragma unroll
+        for (int j = 0; j < TN; ++j) {
+            const int col = n0 + wn * (TN * 16) + j * 16 + col_lane;
+            if (col < N) {
+                col_scale[j] = epi.scale_b[col * epi.scale_b_stride];
+                col_bias[j] = epi.bias
+                    ? load_scalar(epi.bias, epi.bias_code, col) : 0.0f;
+            } else {
+                col_scale[j] = 0.0f;
+                col_bias[j] = 0.0f;
+            }
+        }
+        #pragma unroll
+        for (int i = 0; i < TM; ++i) {
+            #pragma unroll
+            for (int e = 0; e < 8; ++e) {
+                const int r =
+                    m0 + wm * (TM * 16) + i * 16 + acc_row(lane, e);
+                if (r >= M) continue;
+                OutT* const crow = C + static_cast<int64_t>(r) * ldc;
+                const float row_scale = epi.scale_a[r];
+                #pragma unroll
+                for (int j = 0; j < TN; ++j) {
+                    const int col =
+                        n0 + wn * (TN * 16) + j * 16 + col_lane;
+                    if (col >= N) continue;
+                    float value = Mma::get(acc[i][j], e) * row_scale;
+                    value *= col_scale[j];
+                    value += col_bias[j];
+                    crow[col] = static_cast<OutT>(value);
+                }
+            }
+        }
+    } else if constexpr (std::is_same_v<Epi, EpiRowwiseGatedResidual>) {
+        #pragma clang fp contract(off)
+        #pragma clang fp reassociate(off)
+        // This is the same cached rowwise linear epilogue above, followed by
+        // the visible BF16 materialization and addcmul arithmetic.  Gate is a
+        // row-broadcast vector, so each lane retains its TN values while the
+        // residual is read once at the final output location.
+        float col_scale[TN];
+        float col_bias[TN];
+        float col_gate[TN];
+        #pragma unroll
+        for (int j = 0; j < TN; ++j) {
+            const int col = n0 + wn * (TN * 16) + j * 16 + col_lane;
+            if (col < N) {
+                col_scale[j] = epi.scale_b[col * epi.scale_b_stride];
+                col_bias[j] = epi.bias
+                    ? load_scalar(epi.bias, epi.bias_code, col) : 0.0f;
+                col_gate[j] = static_cast<float>(epi.gate[col]);
+            } else {
+                col_scale[j] = 0.0f;
+                col_bias[j] = 0.0f;
+                col_gate[j] = 0.0f;
+            }
+        }
+        #pragma unroll
+        for (int i = 0; i < TM; ++i) {
+            #pragma unroll
+            for (int e = 0; e < 8; ++e) {
+                const int r =
+                    m0 + wm * (TM * 16) + i * 16 + acc_row(lane, e);
+                if (r >= M) continue;
+                OutT* const crow = C + static_cast<int64_t>(r) * ldc;
+                const __bf16* const residual_row =
+                    epi.residual + static_cast<int64_t>(r) * epi.residual_stride;
+                const float row_scale = epi.scale_a[r];
+                #pragma unroll
+                for (int j = 0; j < TN; ++j) {
+                    const int col =
+                        n0 + wn * (TN * 16) + j * 16 + col_lane;
+                    if (col >= N) continue;
+                    float linear = Mma::get(acc[i][j], e) * row_scale;
+                    linear *= col_scale[j];
+                    linear += col_bias[j];
+                    const __bf16 rounded = static_cast<__bf16>(linear);
+                    const float value = fmaf(
+                        col_gate[j], static_cast<float>(rounded),
+                        static_cast<float>(residual_row[col]));
+                    crow[col] = static_cast<OutT>(value);
+                }
+            }
+        }
+    } else if constexpr (VOPD_CROSS_E) {
+        #pragma clang fp reassociate(off)
+        #pragma unroll
+        for (int i = 0; i < TM; ++i) {
+            #pragma unroll
+            for (int e = 0; e < 8; e += 2) {
+                const int r0 =
+                    m0 + wm * (TM * 16) + i * 16 + acc_row(lane, e);
+                const int r1 =
+                    m0 + wm * (TM * 16) + i * 16 + acc_row(lane, e + 1);
+                const bool valid0 = r0 < M;
+                const bool valid1 = r1 < M;
+                if (!valid0 && !valid1) continue;
+                #pragma unroll
+                for (int j = 0; j < TN; ++j) {
+                    const int col =
+                        n0 + wn * (TN * 16) + j * 16 + col_lane;
+                    if (col >= N) continue;
+                    if (valid0) {
+                        OutT* const crow0 =
+                            C + static_cast<int64_t>(r0) * ldc;
+                        crow0[col] = static_cast<OutT>(
+                            epi(r0, col, Mma::get(acc[i][j], e)));
+                    }
+                    if (valid1) {
+                        OutT* const crow1 =
+                            C + static_cast<int64_t>(r1) * ldc;
+                        crow1[col] = static_cast<OutT>(
+                            epi(r1, col, Mma::get(acc[i][j], e + 1)));
+                    }
+                }
+            }
+        }
+    } else {
+        #pragma unroll
+        for (int i = 0; i < TM; ++i) {
+            #pragma unroll
+            for (int e = 0; e < 8; ++e) {
+                const int r =
+                    m0 + wm * (TM * 16) + i * 16 + acc_row(lane, e);
+                if (r >= M) continue;
+                OutT* crow = C + static_cast<int64_t>(r) * ldc;
+                #pragma unroll
+                for (int j = 0; j < TN; ++j) {
+                    const int col =
+                        n0 + wn * (TN * 16) + j * 16 + col_lane;
+                    if (col >= N) continue;
+                    crow[col] = static_cast<OutT>(
+                        epi(r, col, Mma::get(acc[i][j], e)));
+                }
             }
         }
     }

--- a/comfy_kitchen/backends/hip/hadamard.h
+++ b/comfy_kitchen/backends/hip/hadamard.h
@@ -13,6 +13,7 @@
 // even index), which is the layout the iu4 A-fragment consumes directly.
 #pragma once
 
+#include <cstring>
 #include <stdexcept>
 #include <string>
 #include <type_traits>
@@ -20,7 +21,38 @@
 #include <hip/hip_fp16.h>
 #include <hip/hip_runtime.h>
 
+#include "rope_math.h"
+#include "swiglu_bf16.h"
+
 namespace comfy::hip_backend {
+
+typedef __bf16 convrot_bf16x2 __attribute__((ext_vector_type(2)));
+typedef __bf16 convrot_bf16x4 __attribute__((ext_vector_type(4)));
+
+extern "C" __device__ float __ocml_rsqrt_f32(float);
+
+__forceinline__ __device__ float ieee_div_f32(
+    float numerator, float denominator) {
+    bool denominator_scale = false;
+    bool scale = false;
+    const float scaled_denominator = __builtin_amdgcn_div_scalef(
+        numerator, denominator, false, &denominator_scale);
+    const float scaled_numerator = __builtin_amdgcn_div_scalef(
+        numerator, denominator, true, &scale);
+    float reciprocal = __builtin_amdgcn_rcpf(scaled_denominator);
+    const float reciprocal_error =
+        fmaf(-scaled_denominator, reciprocal, 1.0f);
+    reciprocal = fmaf(reciprocal_error, reciprocal, reciprocal);
+    float quotient = scaled_numerator * reciprocal;
+    float remainder =
+        fmaf(-scaled_denominator, quotient, scaled_numerator);
+    quotient = fmaf(remainder, reciprocal, quotient);
+    remainder = fmaf(-scaled_denominator, quotient, scaled_numerator);
+    quotient = __builtin_amdgcn_div_fmasf(
+        remainder, reciprocal, quotient, scale);
+    return __builtin_amdgcn_div_fixupf(
+        quotient, denominator, numerator);
+}
 
 // convrot_quant_kernel handles 256/G groups per pass and rotates in log4(G)
 // stages, so a G outside this set either divides to a zero-width pass or is not
@@ -132,6 +164,14 @@ inline int convrot_pick_fused_block_threads(int M, int K, int in_dtype) {
     }
     static constexpr int kFallbackBlocks[] = {768, 640, 512, 64};
     for (int block_threads : kFallbackBlocks) {
+        // Once a wide row can only fit the one-wave schedule, each workgroup
+        // serializes dozens of G=256 rotations. The cooperative
+        // two-pass path is the scalable fallback for these long inference
+        // rows; retain one-wave LDS for short-M calls where its launch and
+        // workspace savings still matter.
+        if (block_threads == 64 && M >= 96 && K >= 12288) {
+            continue;
+        }
         if (block_threads < preferred && convrot_fused_lds_fits(K, block_threads, in_dtype)) {
             return block_threads;
         }
@@ -374,7 +414,23 @@ __forceinline__ __device__ float finite_absmax_for_quant(float abs_max) {
     return abs_max;
 }
 
-constexpr int kConvrotGlobalGroupsPerBlock = 8;
+// Match ``torch.addcmul(shift, x, 1 + scale)`` when all operands and the
+// materialized result are BF16.  The add that forms the scale factor is a
+// separate PyTorch operation, while addcmul evaluates the multiply-add in
+// FP32 before rounding its output once to BF16.
+__forceinline__ __device__ float load_affine_modulated_bf16(
+    const void* __restrict__ x, const void* __restrict__ modulation_scale,
+    const void* __restrict__ modulation_shift, int64_t index, int column) {
+    const float factor = round_bf16(
+        1.0f + static_cast<float>(
+            static_cast<const __bf16*>(modulation_scale)[column]));
+    const float value = static_cast<float>(static_cast<const __bf16*>(x)[index]);
+    const float shift = static_cast<float>(
+        static_cast<const __bf16*>(modulation_shift)[column]);
+    return round_bf16(fmaf(value, factor, shift));
+}
+
+constexpr int kConvrotGlobalGroupsPerBlock = 4;
 constexpr int kConvrotGlobalBlockThreads = kConvrotGlobalGroupsPerBlock * 64;
 constexpr size_t kConvrotGlobalSmemBytes =
     static_cast<size_t>(kConvrotGlobalGroupsPerBlock) * 2 * kConvRotGroup256 * sizeof(float);
@@ -518,10 +574,15 @@ void launch_convrot_quant_global_managed(
 
 // Fused single-kernel path: FHT in LDS, vectorized loads, warp-shuffle absmax.
 // One block per row; the rotated row stays in shared memory as RowT.
-template <typename RowT, int BLOCK_THREADS, int ACT>
+template <typename RowT, int BLOCK_THREADS, int ACT, bool AFFINE_MODULATE = false>
 __global__ __launch_bounds__(BLOCK_THREADS) void convrot_quant_fused_kernel(
     const void* __restrict__ x, int in_dtype, int8_t* __restrict__ qout,
-    float* __restrict__ scaleout, int M, int K) {
+    float* __restrict__ scaleout, int M, int K,
+    const void* __restrict__ modulation_scale = nullptr,
+    const void* __restrict__ modulation_shift = nullptr) {
+
+    static_assert(!AFFINE_MODULATE || std::is_same_v<RowT, __bf16>);
+    static_assert(!AFFINE_MODULATE || ACT == kActNone);
 
     constexpr int kGroupThreads = 64;
     constexpr int kGroupsInFlight = BLOCK_THREADS / kGroupThreads;
@@ -560,7 +621,20 @@ __global__ __launch_bounds__(BLOCK_THREADS) void convrot_quant_fused_kernel(
         float xv2 = 0.0f;
         float xv3 = 0.0f;
         if (active) {
-            if constexpr (ACT == kActNone) {
+            if constexpr (AFFINE_MODULATE) {
+                xv0 = load_affine_modulated_bf16(
+                    x, modulation_scale, modulation_shift,
+                    in_row_offset + col, col);
+                xv1 = load_affine_modulated_bf16(
+                    x, modulation_scale, modulation_shift,
+                    in_row_offset + col + 1, col + 1);
+                xv2 = load_affine_modulated_bf16(
+                    x, modulation_scale, modulation_shift,
+                    in_row_offset + col + 2, col + 2);
+                xv3 = load_affine_modulated_bf16(
+                    x, modulation_scale, modulation_shift,
+                    in_row_offset + col + 3, col + 3);
+            } else if constexpr (ACT == kActNone) {
                 if (in_dtype == 2) {
                     load_input_act4_bf16(x, in_row_offset, col, xv0, xv1, xv2, xv3);
                 } else {
@@ -612,22 +686,26 @@ __global__ __launch_bounds__(BLOCK_THREADS) void convrot_quant_fused_kernel(
     }
 }
 
-template <typename RowT, int ACT, int BLOCK_THREADS>
+template <typename RowT, int ACT, int BLOCK_THREADS, bool AFFINE_MODULATE = false>
 inline bool launch_convrot_quant_fused_impl(
     const void* x, int in_dtype, int8_t* qout, float* scaleout, int M, int K,
-    hipStream_t stream) {
+    hipStream_t stream, const void* modulation_scale = nullptr,
+    const void* modulation_shift = nullptr) {
     const int groups_in_flight = BLOCK_THREADS / 64;
     const size_t shmem =
         static_cast<size_t>(K) * sizeof(RowT) +
         static_cast<size_t>(groups_in_flight) * 2 * kConvRotGroup256 * sizeof(float);
-    auto kernel = convrot_quant_fused_kernel<RowT, BLOCK_THREADS, ACT>;
+    auto kernel = convrot_quant_fused_kernel<
+        RowT, BLOCK_THREADS, ACT, AFFINE_MODULATE>;
     const hipError_t attr_err = hipFuncSetAttribute(
         reinterpret_cast<const void*>(kernel), hipFuncAttributeMaxDynamicSharedMemorySize,
         static_cast<int>(shmem));
     if (attr_err != hipSuccess) {
         return false;
     }
-    kernel<<<M, BLOCK_THREADS, shmem, stream>>>(x, in_dtype, qout, scaleout, M, K);
+    kernel<<<M, BLOCK_THREADS, shmem, stream>>>(
+        x, in_dtype, qout, scaleout, M, K,
+        modulation_scale, modulation_shift);
     return hipGetLastError() == hipSuccess;
 }
 
@@ -648,6 +726,53 @@ struct LaunchConvrotQuantFusedForBlock {
             x, in_dtype, qout, scaleout, M, K, stream);
     }
 };
+
+template <int BLOCK_THREADS>
+inline bool launch_convrot_quant_affine_fused_impl(
+    const void* x, const void* modulation_scale,
+    const void* modulation_shift, int8_t* qout, float* scaleout,
+    int M, int K, hipStream_t stream) {
+    return launch_convrot_quant_fused_impl<
+        __bf16, kActNone, BLOCK_THREADS, true>(
+            x, 2, qout, scaleout, M, K, stream,
+            modulation_scale, modulation_shift);
+}
+
+struct LaunchConvrotQuantAffineForBlock {
+    const void* x;
+    const void* modulation_scale;
+    const void* modulation_shift;
+    int8_t* qout;
+    float* scaleout;
+    int M;
+    int K;
+    hipStream_t stream;
+    bool* launched;
+
+    template <int BLOCK_THREADS>
+    void operator()() const {
+        *launched = launch_convrot_quant_affine_fused_impl<BLOCK_THREADS>(
+            x, modulation_scale, modulation_shift, qout, scaleout,
+            M, K, stream);
+    }
+};
+
+inline bool launch_convrot_quant_affine_bf16(
+    const void* x, const void* modulation_scale,
+    const void* modulation_shift, int8_t* qout, float* scaleout,
+    int M, int K, hipStream_t stream) {
+    const int block_threads = convrot_pick_fused_block_threads(M, K, /*bf16*/ 2);
+    if (block_threads == 0) {
+        return false;
+    }
+    bool launched = false;
+    dispatch_convrot_fused_block_threads(
+        block_threads,
+        LaunchConvrotQuantAffineForBlock{
+            x, modulation_scale, modulation_shift, qout, scaleout,
+            M, K, stream, &launched});
+    return launched;
+}
 
 template <int ACT>
 struct LaunchConvrotQuantFusedForRow {
@@ -757,6 +882,561 @@ __global__ __launch_bounds__(BLOCK_THREADS) void convrot_quant_kernel(
             q = q < -127 ? -127 : (q > 127 ? 127 : q);
             qout[static_cast<int64_t>(row) * K + j] = static_cast<int8_t>(q);
         }
+    }
+}
+
+// Wide-row ConvRot-256: four groups per pass. Wave32 shuffles cover the first
+// two radix-4 stages; the rest use ping-pong LDS (512 threads, two values each,
+// two barriers). Bank-aligned FP32 LDS. Not an arch-specific WMMA path; keep
+// separate from convrot_quant_kernel for other shapes and devices.
+template <int ACT, bool TILED_QOUT = false, bool SPLIT_SWIGLU = false,
+          bool MODULATE = false, bool PACK_QUANT = false,
+          bool RMSNORM = false, bool FUSED_RMS_STATS = false,
+          bool PACKED_ELEMENT_SCHEDULE = false>
+__global__ __launch_bounds__(512) void convrot_quant_512x2_bf16_kernel(
+    const void* __restrict__ x, const void* __restrict__ auxiliary, int in_dtype,
+    int8_t* __restrict__ qout, float* __restrict__ scaleout,
+    int M, int K, const void* __restrict__ norm_weight = nullptr,
+    const float* __restrict__ rstd = nullptr, float rms_eps = 0.0f) {
+
+    static_assert(!SPLIT_SWIGLU || ACT == kActSwiGLU);
+    static_assert(!MODULATE || ACT == kActNone);
+    static_assert(!MODULATE || !SPLIT_SWIGLU);
+    static_assert(!RMSNORM || MODULATE);
+    static_assert(!FUSED_RMS_STATS || RMSNORM);
+    static_assert(!PACKED_ELEMENT_SCHEDULE ||
+                  ((ACT == kActSwiGLU && TILED_QOUT && SPLIT_SWIGLU &&
+                    PACK_QUANT && !MODULATE && !RMSNORM) ||
+                   (ACT == kActNone && !TILED_QOUT && !SPLIT_SWIGLU &&
+                    MODULATE && PACK_QUANT)));
+
+    constexpr int kThreads = 512;
+    constexpr int kGroup = 256;
+    constexpr int kGroupsPerThread = 2;
+    constexpr int kGroupsPerSlot = kThreads / kGroup;
+    constexpr int kGroupsPerPass = kGroupsPerSlot * kGroupsPerThread;
+    const float h4[4][4] = {
+        {1, 1, 1, -1},
+        {1, 1, -1, 1},
+        {1, -1, 1, 1},
+        {-1, 1, 1, 1},
+    };
+
+    __shared__ float stage[2][kThreads * kGroupsPerThread];
+    __shared__ float wave_max[kThreads / 32];
+    extern __shared__ unsigned char rowbuf_raw[];
+    __bf16* rowbuf = reinterpret_cast<__bf16*>(rowbuf_raw);
+
+    const int row = blockIdx.x;
+    const int t = threadIdx.x;
+    const int lane = t & 31;
+    const int wave = t >> 5;
+    const int local_group = t / kGroup;
+    const int element = t % kGroup;
+    const int group_count = K / kGroup;
+    // Tile-major INT8 output is [M_tile, K_tile, row_in_tile, K_in_tile].
+    // This removes the hot down GEMM's K-strided activation loads.
+    const int64_t qout_row_base = TILED_QOUT
+        ? static_cast<int64_t>(row >> 7) * K * 128 + (row & 127) * 128
+        : static_cast<int64_t>(row) * K;
+    constexpr int kInputWidth =
+        ACT == kActSwiGLU && !SPLIT_SWIGLU ? 2 : 1;
+    const int64_t input_row = static_cast<int64_t>(row) * K * kInputWidth;
+    const float norm = rsqrtf(static_cast<float>(kGroup));
+
+    float row_rstd = 0.0f;
+    if constexpr (RMSNORM) {
+        if constexpr (FUSED_RMS_STATS) {
+            #pragma clang fp reassociate(off)
+            #pragma clang fp contract(on)
+            #pragma clang fp reciprocal(off)
+            // Match PyTorch's vectorized K=3840 RMSNorm statistics exactly.
+            // Only the first eight waves participate, reproducing its 32x8
+            // workgroup and four-BF16 vector ownership.  The same loads also
+            // seed the existing BF16 row buffer for the ConvRot pass.
+            float sum_sq = 0.0f;
+            if (t < 256) {
+                const auto* input_vectors =
+                    reinterpret_cast<const convrot_bf16x4*>(
+                        static_cast<const __bf16*>(x) + input_row);
+                auto* row_vectors =
+                    reinterpret_cast<convrot_bf16x4*>(rowbuf);
+                #pragma unroll
+                for (int vector = t; vector < 3840 / 4; vector += 256) {
+                    const convrot_bf16x4 values = input_vectors[vector];
+                    row_vectors[vector] = values;
+                    #pragma unroll
+                    for (int element4 = 0; element4 < 4; ++element4) {
+                        const float value =
+                            static_cast<float>(values[element4]);
+                        sum_sq += value * value;
+                    }
+                }
+                #pragma unroll
+                for (int offset = 16; offset > 0; offset >>= 1) {
+                    sum_sq += __shfl_down(sum_sq, offset, 32);
+                }
+            }
+
+            #pragma unroll
+            for (int offset = 4; offset > 0; offset >>= 1) {
+                if (lane == 0 && wave < 8 && wave >= offset &&
+                    wave < 2 * offset) {
+                    wave_max[wave - offset] = sum_sq;
+                }
+                __syncthreads();
+                if (lane == 0 && wave < offset) {
+                    sum_sq += wave_max[wave];
+                }
+                __syncthreads();
+            }
+            if (t == 0) {
+                const float mean_square =
+                    ieee_div_f32(sum_sq, static_cast<float>(K));
+                wave_max[0] = __ocml_rsqrt_f32(mean_square + rms_eps);
+            }
+            __syncthreads();
+            row_rstd = wave_max[0];
+        } else {
+            row_rstd = rstd[row];
+        }
+    }
+    float local_max = 0.0f;
+    if constexpr (PACKED_ELEMENT_SCHEDULE) {
+        // Eight ConvRot-256 groups per pass: radix 0 is register-local, 1/2
+        // stay in-wave, only radix 3 uses LDS. Same 8-KiB ping-pong stage
+        // as the four-group schedule (one visibility + one reuse barrier).
+        constexpr int kPackedElements = 4;
+        constexpr int kPackedThreadsPerGroup = kGroup / kPackedElements;
+        constexpr int kPackedGroupsPerPass = kThreads / kPackedThreadsPerGroup;
+        float* packed_stage = &stage[0][0];
+        const int packed_local_group = t / kPackedThreadsPerGroup;
+        const int packed_thread = t % kPackedThreadsPerGroup;
+        const int element_base = packed_thread * kPackedElements;
+
+        for (int group_base = 0; group_base < group_count;
+             group_base += kPackedGroupsPerPass) {
+            const int group = group_base + packed_local_group;
+            const bool active = group < group_count;
+            float transformed[kPackedElements] = {0.0f, 0.0f, 0.0f, 0.0f};
+            if (active) {
+                const int64_t index = input_row + group * kGroup + element_base;
+                float input[kPackedElements];
+                if constexpr (SPLIT_SWIGLU) {
+                    const convrot_bf16x4 gates =
+                        *reinterpret_cast<const convrot_bf16x4*>(
+                            static_cast<const __bf16*>(x) + index);
+                    const convrot_bf16x4 ups =
+                        *reinterpret_cast<const convrot_bf16x4*>(
+                            static_cast<const __bf16*>(auxiliary) + index);
+                    #pragma unroll
+                    for (int element4 = 0; element4 < kPackedElements; ++element4) {
+                        input[element4] = static_cast<float>(
+                            swiglu_bf16_value(gates[element4], ups[element4]));
+                    }
+                } else {
+                    const int column = group * kGroup + element_base;
+                    const convrot_bf16x4 values =
+                        *reinterpret_cast<const convrot_bf16x4*>(
+                            (FUSED_RMS_STATS ? rowbuf : static_cast<const __bf16*>(x) + input_row)
+                            + column);
+                    const convrot_bf16x4 weights =
+                        *reinterpret_cast<const convrot_bf16x4*>(
+                            static_cast<const __bf16*>(norm_weight) + column);
+                    const convrot_bf16x4 modulation =
+                        *reinterpret_cast<const convrot_bf16x4*>(
+                            static_cast<const __bf16*>(auxiliary) + column);
+                    #pragma unroll
+                    for (int element4 = 0; element4 < kPackedElements; ++element4) {
+                        const float factor = round_bf16(
+                            1.0f + static_cast<float>(modulation[element4]));
+                        float normalized =
+                            row_rstd * static_cast<float>(values[element4]);
+                        asm volatile("" : "+v"(normalized));
+                        normalized *= static_cast<float>(weights[element4]);
+                        normalized = round_bf16(normalized);
+                        input[element4] = round_bf16(normalized * factor);
+                    }
+                }
+                #pragma unroll
+                for (int digit = 0; digit < 4; ++digit) {
+                    transformed[digit] =
+                        h4[digit][0] * input[0] + h4[digit][1] * input[1] +
+                        h4[digit][2] * input[2] + h4[digit][3] * input[3];
+                }
+            }
+
+            // Radix 1: four adjacent physical threads own the four inputs.
+            const int digit1 = packed_thread & 3;
+            const int base1 = lane - digit1;
+            #pragma unroll
+            for (int element4 = 0; element4 < kPackedElements; ++element4) {
+                const float v0 = __shfl(transformed[element4], base1, 32);
+                const float v1 = __shfl(transformed[element4], base1 + 1, 32);
+                const float v2 = __shfl(transformed[element4], base1 + 2, 32);
+                const float v3 = __shfl(transformed[element4], base1 + 3, 32);
+                transformed[element4] =
+                    h4[digit1][0] * v0 + h4[digit1][1] * v1 +
+                    h4[digit1][2] * v2 + h4[digit1][3] * v3;
+            }
+
+            // Radix 2: the four source threads are still in one wave.
+            const int digit2 = (packed_thread >> 2) & 3;
+            const int base2 = lane - digit2 * 4;
+            #pragma unroll
+            for (int element4 = 0; element4 < kPackedElements; ++element4) {
+                const float v0 = __shfl(transformed[element4], base2, 32);
+                const float v1 = __shfl(transformed[element4], base2 + 4, 32);
+                const float v2 = __shfl(transformed[element4], base2 + 8, 32);
+                const float v3 = __shfl(transformed[element4], base2 + 12, 32);
+                transformed[element4] =
+                    h4[digit2][0] * v0 + h4[digit2][1] * v1 +
+                    h4[digit2][2] * v2 + h4[digit2][3] * v3;
+                packed_stage[packed_local_group * kGroup + element_base + element4] =
+                    transformed[element4];
+            }
+            __syncthreads();
+
+            // Radix 3 crosses the two waves assigned to this group.
+            const int digit3 = (packed_thread >> 4) & 3;
+            const int base3 = packed_local_group * kGroup + element_base - digit3 * 64;
+            #pragma unroll
+            for (int element4 = 0; element4 < kPackedElements; ++element4) {
+                const float v0 = packed_stage[base3 + element4];
+                const float v1 = packed_stage[base3 + 64 + element4];
+                const float v2 = packed_stage[base3 + 128 + element4];
+                const float v3 = packed_stage[base3 + 192 + element4];
+                transformed[element4] =
+                    h4[digit3][0] * v0 + h4[digit3][1] * v1 +
+                    h4[digit3][2] * v2 + h4[digit3][3] * v3;
+                if (active) {
+                    const __bf16 stored =
+                        static_cast<__bf16>(transformed[element4] * norm);
+                    rowbuf[static_cast<int64_t>(group) * kGroup + element_base + element4] =
+                        stored;
+                    local_max = fmaxf(
+                        local_max, fabsf(static_cast<float>(stored)));
+                }
+            }
+            if (group_base + kPackedGroupsPerPass < group_count) {
+                __syncthreads();
+            }
+        }
+    } else {
+    for (int group_base = 0; group_base < group_count;
+         group_base += kGroupsPerPass) {
+        float transformed[kGroupsPerThread];
+        bool active[kGroupsPerThread];
+
+        #pragma unroll
+        for (int slot = 0; slot < kGroupsPerThread; ++slot) {
+            const int group =
+                group_base + local_group + slot * kGroupsPerSlot;
+            active[slot] = group < group_count;
+            if (!active[slot]) {
+                transformed[slot] = 0.0f;
+            } else if constexpr (SPLIT_SWIGLU) {
+                const int64_t index =
+                    input_row + group * kGroup + element;
+                transformed[slot] = static_cast<float>(
+                    swiglu_bf16_value(
+                        static_cast<const __bf16*>(x)[index],
+                        static_cast<const __bf16*>(auxiliary)[index]));
+            } else if constexpr (MODULATE) {
+                const int column = group * kGroup + element;
+                const int64_t index = input_row + column;
+                // Match `x * (1 + scale)` as two BF16 elementwise kernels:
+                // round the add before the multiply, then round the product
+                // before the first ConvRot butterfly consumes it.
+                // `__bf16` casts carry excess precision under -ffast-math and
+                // clang otherwise contracts both observable rounding points
+                // into the final conversion.  Use the bitwise helper shared
+                // with fused RoPE so the add and multiply each materialize
+                // PyTorch's BF16 result without an intermediate tensor.
+                const float factor = round_bf16(
+                    1.0f + static_cast<float>(
+                        static_cast<const __bf16*>(auxiliary)[column]));
+                if constexpr (RMSNORM) {
+                    // Match PyTorch's BF16 RMSNorm materialization exactly:
+                    // gamma * (rstd * x), all in FP32, then one BF16 rounding.
+                    // The empty vector-asm boundary prevents Kitchen's global
+                    // -ffast-math from reassociating the two FP32 multiplies.
+                    float normalized =
+                        row_rstd * static_cast<float>(
+                            FUSED_RMS_STATS
+                                ? rowbuf[column]
+                                : static_cast<const __bf16*>(x)[index]);
+                    asm volatile("" : "+v"(normalized));
+                    normalized *= static_cast<float>(
+                        static_cast<const __bf16*>(norm_weight)[column]);
+                    normalized = round_bf16(normalized);
+                    transformed[slot] = round_bf16(normalized * factor);
+                } else {
+                    transformed[slot] = round_bf16(
+                        static_cast<float>(
+                            static_cast<const __bf16*>(x)[index]) * factor);
+                }
+            } else {
+                transformed[slot] = load_input_act<ACT>(
+                    x, input_row, group * kGroup + element, K, in_dtype);
+            }
+        }
+
+        // Radix stages 0 and 1 never leave their aligned 16-lane subgroup.
+        #pragma unroll
+        for (int radix_stage = 0; radix_stage < 2; ++radix_stage) {
+            const int stride = 1 << (2 * radix_stage);
+            const int digit = (element / stride) & 3;
+            const int base = (element & 15) - digit * stride;
+            #pragma unroll
+            for (int slot = 0; slot < kGroupsPerThread; ++slot) {
+                const float v0 = __shfl(transformed[slot], base, 16);
+                const float v1 = __shfl(transformed[slot], base + stride, 16);
+                const float v2 = __shfl(transformed[slot], base + 2 * stride, 16);
+                const float v3 = __shfl(transformed[slot], base + 3 * stride, 16);
+                transformed[slot] =
+                    h4[digit][0] * v0 + h4[digit][1] * v1 +
+                    h4[digit][2] * v2 + h4[digit][3] * v3;
+            }
+        }
+
+        #pragma unroll
+        for (int slot = 0; slot < kGroupsPerThread; ++slot) {
+            stage[0][t + slot * kThreads] = transformed[slot];
+        }
+        __syncthreads();
+
+        // Radix stage 2 reads FP32 LDS and publishes stage 3's input.  Each
+        // wave accesses one contiguous 32-float span per operand, so no two
+        // lanes address the same 4-byte bank.
+        {
+            constexpr int stride = 16;
+            const int digit = (element / stride) & 3;
+            #pragma unroll
+            for (int slot = 0; slot < kGroupsPerThread; ++slot) {
+                const int group_offset =
+                    (local_group + slot * kGroupsPerSlot) * kGroup;
+                const int base = group_offset + element - digit * stride;
+                const float v0 = stage[0][base];
+                const float v1 = stage[0][base + stride];
+                const float v2 = stage[0][base + 2 * stride];
+                const float v3 = stage[0][base + 3 * stride];
+                transformed[slot] =
+                    h4[digit][0] * v0 + h4[digit][1] * v1 +
+                    h4[digit][2] * v2 + h4[digit][3] * v3;
+                stage[1][t + slot * kThreads] = transformed[slot];
+            }
+        }
+        __syncthreads();
+
+        // Final radix stage only reads stage[1].  The next pass starts by
+        // writing stage[0], so no end-of-pass barrier is needed.
+        {
+            constexpr int stride = 64;
+            const int digit = (element / stride) & 3;
+            #pragma unroll
+            for (int slot = 0; slot < kGroupsPerThread; ++slot) {
+                const int group_offset =
+                    (local_group + slot * kGroupsPerSlot) * kGroup;
+                const int base = group_offset + element - digit * stride;
+                const float v0 = stage[1][base];
+                const float v1 = stage[1][base + stride];
+                const float v2 = stage[1][base + 2 * stride];
+                const float v3 = stage[1][base + 3 * stride];
+                transformed[slot] =
+                    h4[digit][0] * v0 + h4[digit][1] * v1 +
+                    h4[digit][2] * v2 + h4[digit][3] * v3;
+            }
+        }
+
+        #pragma unroll
+        for (int slot = 0; slot < kGroupsPerThread; ++slot) {
+            const int group =
+                group_base + local_group + slot * kGroupsPerSlot;
+            if (active[slot]) {
+                const __bf16 stored =
+                    static_cast<__bf16>(transformed[slot] * norm);
+                rowbuf[static_cast<int64_t>(group) * kGroup + element] = stored;
+                local_max = fmaxf(local_max, fabsf(static_cast<float>(stored)));
+            }
+        }
+    }
+    }
+
+    // Register/wave reduction replaces the stock 256-float LDS reduction and
+    // its eight workgroup barriers with two workgroup barriers total.
+    #pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1) {
+        local_max = fmaxf(local_max, __shfl_down(local_max, offset, 32));
+    }
+    if (lane == 0) wave_max[wave] = local_max;
+    __syncthreads();
+    if (wave == 0) {
+        float value = lane < kThreads / 32 ? wave_max[lane] : 0.0f;
+        #pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1) {
+            value = fmaxf(value, __shfl_down(value, offset, 32));
+        }
+        if (lane == 0) wave_max[0] = value;
+    }
+    __syncthreads();
+
+    const float row_max = fmaxf(wave_max[0], 1.0e-10f);
+    const float scale = row_max / 127.0f;
+    const float inverse_scale = 127.0f / row_max;
+    if (t == 0) scaleout[row] = scale;
+
+    if constexpr (PACK_QUANT) {
+        // One aligned dword LDS read covers two adjacent BF16
+        // values, avoiding the two-lanes-per-bank mapping of scalar BF16 reads.
+        // Even logical columns are also physically adjacent in the tiled128
+        // layout, so one aligned 16-bit store preserves both output layouts.
+        for (int pair = t; pair < K / 2; pair += kThreads) {
+            const int column = 2 * pair;
+            const convrot_bf16x2 values =
+                *reinterpret_cast<const convrot_bf16x2*>(rowbuf + column);
+            int q0 = static_cast<int>(
+                rintf(static_cast<float>(values[0]) * inverse_scale));
+            int q1 = static_cast<int>(
+                rintf(static_cast<float>(values[1]) * inverse_scale));
+            q0 = q0 < -127 ? -127 : (q0 > 127 ? 127 : q0);
+            q1 = q1 < -127 ? -127 : (q1 > 127 ? 127 : q1);
+            const int64_t qindex = TILED_QOUT
+                ? qout_row_base + static_cast<int64_t>(column >> 7) * 16384 +
+                      (column & 127)
+                : qout_row_base + column;
+            const uint16_t packed =
+                static_cast<uint8_t>(static_cast<int8_t>(q0)) |
+                (static_cast<uint16_t>(
+                     static_cast<uint8_t>(static_cast<int8_t>(q1))) << 8);
+            *reinterpret_cast<uint16_t*>(qout + qindex) = packed;
+        }
+    } else {
+        for (int column = t; column < K; column += kThreads) {
+            int quantized = static_cast<int>(
+                rintf(static_cast<float>(rowbuf[column]) * inverse_scale));
+            quantized = quantized < -127 ? -127 : (quantized > 127 ? 127 : quantized);
+            const int64_t qindex = TILED_QOUT
+                ? qout_row_base + static_cast<int64_t>(column >> 7) * 16384 +
+                      (column & 127)
+                : qout_row_base + column;
+            qout[qindex] = static_cast<int8_t>(quantized);
+        }
+    }
+}
+
+inline bool convrot_wave32_512_supported() {
+    int device = 0;
+    hipDeviceProp_t properties{};
+    return hipGetDevice(&device) == hipSuccess &&
+        hipGetDeviceProperties(&properties, device) == hipSuccess &&
+        properties.warpSize == 32 && properties.maxThreadsPerBlock >= 512;
+}
+
+inline bool convrot_512x2_supported(int K) {
+    if (!convrot_wave32_512_supported()) {
+        return false;
+    }
+    int device = 0;
+    int lds_bytes = 0;
+    if (hipGetDevice(&device) != hipSuccess ||
+        hipDeviceGetAttribute(
+            &lds_bytes, hipDeviceAttributeMaxSharedMemoryPerBlock, device) !=
+            hipSuccess) {
+        return false;
+    }
+    constexpr size_t kStaticBytes =
+        (2 * 512 * 2 + 512 / 32) * sizeof(float);
+    return static_cast<size_t>(K) * sizeof(__bf16) + kStaticBytes <=
+        static_cast<size_t>(lds_bytes);
+}
+
+inline bool use_convrot_packed_quant() {
+    return convrot_wave32_512_supported();
+}
+
+inline bool use_convrot_packed_elements() {
+    return convrot_wave32_512_supported();
+}
+
+template <int ACT>
+inline void launch_convrot_quant_512x2_bf16(
+    const void* x, int in_dtype, int8_t* qout, float* scaleout,
+    int M, int K, hipStream_t stream) {
+    if (use_convrot_packed_quant()) {
+        convrot_quant_512x2_bf16_kernel<ACT, false, false, false, true>
+            <<<M, 512, static_cast<size_t>(K) * sizeof(__bf16), stream>>>(
+                x, nullptr, in_dtype, qout, scaleout, M, K);
+    } else {
+        convrot_quant_512x2_bf16_kernel<ACT>
+            <<<M, 512, static_cast<size_t>(K) * sizeof(__bf16), stream>>>(
+                x, nullptr, in_dtype, qout, scaleout, M, K);
+    }
+}
+
+inline void launch_convrot_quant_512x2_bf16_tiled128(
+    const void* x, int in_dtype, int8_t* qout, float* scaleout,
+    int M, int K, hipStream_t stream) {
+    if (use_convrot_packed_quant()) {
+        convrot_quant_512x2_bf16_kernel<kActNone, true, false, false, true>
+            <<<M, 512, static_cast<size_t>(K) * sizeof(__bf16), stream>>>(
+                x, nullptr, in_dtype, qout, scaleout, M, K);
+    } else {
+        convrot_quant_512x2_bf16_kernel<kActNone, true>
+            <<<M, 512, static_cast<size_t>(K) * sizeof(__bf16), stream>>>(
+                x, nullptr, in_dtype, qout, scaleout, M, K);
+    }
+}
+
+inline void launch_convrot_quant_512x2_bf16_swiglu_split_tiled128(
+    const void* gate, const void* up, int8_t* qout, float* scaleout,
+    int M, int K, hipStream_t stream) {
+    if (use_convrot_packed_elements()) {
+        convrot_quant_512x2_bf16_kernel<
+            kActSwiGLU, true, true, false, true, false, false, true>
+            <<<M, 512, static_cast<size_t>(K) * sizeof(__bf16), stream>>>(
+                gate, up, 2, qout, scaleout, M, K);
+    } else if (use_convrot_packed_quant()) {
+        convrot_quant_512x2_bf16_kernel<kActSwiGLU, true, true, false, true>
+            <<<M, 512, static_cast<size_t>(K) * sizeof(__bf16), stream>>>(
+                gate, up, 2, qout, scaleout, M, K);
+    } else {
+        convrot_quant_512x2_bf16_kernel<kActSwiGLU, true, true>
+            <<<M, 512, static_cast<size_t>(K) * sizeof(__bf16), stream>>>(
+                gate, up, 2, qout, scaleout, M, K);
+    }
+}
+
+inline void launch_convrot_quant_512x2_bf16_modulated(
+    const void* x, const void* modulation_scale,
+    int8_t* qout, float* scaleout, int M, int K, hipStream_t stream) {
+    if (use_convrot_packed_quant()) {
+        convrot_quant_512x2_bf16_kernel<kActNone, false, false, true, true>
+            <<<M, 512, static_cast<size_t>(K) * sizeof(__bf16), stream>>>(
+                x, modulation_scale, 2, qout, scaleout, M, K);
+    } else {
+        convrot_quant_512x2_bf16_kernel<kActNone, false, false, true>
+            <<<M, 512, static_cast<size_t>(K) * sizeof(__bf16), stream>>>(
+                x, modulation_scale, 2, qout, scaleout, M, K);
+    }
+}
+
+inline void launch_convrot_quant_512x2_bf16_rms_modulated(
+    const void* x, const void* norm_weight, const float* rstd,
+    const void* modulation_scale, int8_t* qout, float* scaleout,
+    int M, int K, hipStream_t stream) {
+    if (use_convrot_packed_quant()) {
+        convrot_quant_512x2_bf16_kernel<
+            kActNone, false, false, true, true, true>
+            <<<M, 512, static_cast<size_t>(K) * sizeof(__bf16), stream>>>(
+                x, modulation_scale, 2, qout, scaleout, M, K,
+                norm_weight, rstd);
+    } else {
+        convrot_quant_512x2_bf16_kernel<
+            kActNone, false, false, true, false, true>
+            <<<M, 512, static_cast<size_t>(K) * sizeof(__bf16), stream>>>(
+                x, modulation_scale, 2, qout, scaleout, M, K,
+                norm_weight, rstd);
     }
 }
 

--- a/comfy_kitchen/backends/hip/launchers.h
+++ b/comfy_kitchen/backends/hip/launchers.h
@@ -13,6 +13,16 @@
 
 extern "C" {
 
+// Native unmasked BF16 attention. This dimensional entry accepts B>1 and GQA.
+void launch_bf16_sdpa_hip(
+    const void* q, const void* k, const void* v, void* output,
+    int batch, int q_heads, int kv_heads, int q_len, int kv_len, int head_dim,
+    int64_t q_stride_b, int64_t q_stride_h, int64_t q_stride_n,
+    int64_t k_stride_b, int64_t k_stride_h, int64_t k_stride_n,
+    int64_t v_stride_b, int64_t v_stride_h, int64_t v_stride_n,
+    int64_t o_stride_b, int64_t o_stride_h, int64_t o_stride_n,
+    float sm_scale, hipStream_t stream);
+
 // Fused 3D neighborhood attention over contiguous (B, T, H, W, NH, HD) tensors.
 // dtype_code is a DTYPE_TO_CODE value: 1 float16, 2 bfloat16. See ops/na3d.hip.
 void launch_na3d_kernel(const void* q, const void* k, const void* v, void* out, int batch,
@@ -31,12 +41,97 @@ void launch_flash_decode(const void* q, const void* k, const void* v, const int*
                          int64_t k_batch_stride, int64_t k_row_stride, int64_t k_head_stride,
                          hipStream_t stream);
 
+// Quantized D=128 attention. Q uses a per-row scale, K a per-16-row scale,
+// and V is [head, tile64, D, 64].
+void launch_gfx12_int8_attention(
+    const void* q, const void* k, const void* v, void* o,
+    const void* q_descale, const void* k_descale, const void* v_descale,
+    int num_heads, int qo_len, int kv_len, int padded_q, int padded_k,
+    int k_groups_per_head,
+    int64_t output_stride_h, int64_t output_stride_n,
+    float sm_scale, int output_dtype_code, hipStream_t stream);
+void launch_gfx12_tile_channel_v_quant(
+    const void* v, void* output, void* descale, int num_heads,
+    int n_ctx, int tiles,
+    int64_t stride_h, int64_t stride_n, int input_dtype_code,
+    hipStream_t stream);
+void launch_gfx12_tile_channel_v_quant_split(
+    const void* v0, const void* v1, void* output, void* descale,
+    int num_heads, int v0_len, int v1_len, int tiles,
+    int64_t v0_stride_h, int64_t v0_stride_n,
+    int64_t v1_stride_h, int64_t v1_stride_n, int input_dtype_code,
+    hipStream_t stream);
+void launch_gfx12_qk_quant(
+    const void* q, void* q_int8, void* q_scale,
+    const void* k, void* k_int8, void* k_scale, void* anchor_indices,
+    int num_heads, int q_len, int kv_len, int padded_q, int padded_k,
+    int64_t q_stride_b, int64_t q_stride_h, int64_t q_stride_n,
+    int64_t k_stride_b, int64_t k_stride_h, int64_t k_stride_n,
+    int input_dtype_code, hipStream_t stream);
+void launch_gfx12_qk_quant_split(
+    const void* q0, const void* q1, void* q_int8, void* q_scale,
+    const void* k0, const void* k1, void* k_int8, void* k_scale,
+    void* anchor_indices, int num_heads, int q0_len, int q1_len,
+    int k0_len, int k1_len, int padded_q, int padded_k,
+    int64_t q0_stride_h, int64_t q0_stride_n,
+    int64_t q1_stride_h, int64_t q1_stride_n,
+    int64_t k0_stride_h, int64_t k0_stride_n,
+    int64_t k1_stride_h, int64_t k1_stride_n, int input_dtype_code,
+    hipStream_t stream);
+
 // ldc is c's row stride, so a caller writing an N-column slice of a wider output
 // passes that output's width; a whole GEMM passes N.
 void launch_int8_gemm_kernel(const void* a, const void* b, void* c, const void* scale_a,
                              const void* scale_b, int scale_b_stride, const void* bias,
                              int bias_code, int M, int N, int K, int ldc, int out_code,
                              hipStream_t stream);
+
+// B is physically [N / 128, K / tile_k, 128, tile_k]. The private entry is
+// generic over divisible M/N/K so exact-shape gates can select single- or
+// dual-M ownership without reintroducing row-stride partition camping.
+void launch_int8_gemm_b_tiled_kernel(
+    const void* a, const void* b, void* c, const void* scale_a,
+    const void* scale_b, int scale_b_stride, const void* bias,
+    int bias_code, int M, int N, int K, int ldc, int out_code,
+    int tile_k, bool dual_m, hipStream_t stream);
+
+// Same tiled-B GEMM with an exact BF16 materialization followed by
+// residual + gate * linear in the writeback epilogue. Gate is broadcast over M.
+void launch_int8_gemm_b_tiled_gated_residual_kernel(
+    const void* a, const void* b, void* c, const void* scale_a,
+    const void* scale_b, int scale_b_stride, const void* bias,
+    int bias_code, const void* residual, const void* gate,
+    int M, int N, int K, int ldc, int tile_k, bool dual_m,
+    hipStream_t stream);
+
+// Two equal-width row-major GEMMs sharing activation staging.
+void launch_int8_gemm_pair_kernel(
+    const void* a, const void* b0, const void* b1, void* c0, void* c1,
+    const void* scale_a, const void* scale_b0, int scale_b_stride0,
+    const void* scale_b1, int scale_b_stride1, const void* bias0,
+    int bias_code0, const void* bias1, int bias_code1, int M, int N, int K,
+    int ldc, int out_code, hipStream_t stream);
+
+// A is physically [M_tile, K_tile, 128, 128]; B remains row-major.
+void launch_int8_gemm_a_tiled128_down_kernel(
+    const void* a, const void* b, void* c, const void* scale_a,
+    const void* scale_b, int scale_b_stride, const void* bias,
+    int bias_code, int M, int N, int K, int ldc, int out_code,
+    hipStream_t stream);
+
+// A is physically [M_tile, K_tile, 128, 128] and B is physically
+// [N / 128, K / 128, 128, 128].
+void launch_int8_gemm_a_tiled128_b_tiled128_down_kernel(
+    const void* a, const void* b, void* c, const void* scale_a,
+    const void* scale_b, int scale_b_stride, const void* bias,
+    int bias_code, int M, int N, int K, int ldc, int out_code,
+    hipStream_t stream);
+
+// Exact BF16 RMSNorm followed by gate multiplication and residual add.
+void launch_rms_gated_residual_bf16_kernel(
+    const void* activation, const void* norm_weight, const void* residual,
+    const void* gate, void* output, int rows, int width, float eps,
+    hipStream_t stream);
 
 // scale_code is a DTYPE_TO_CODE value: 0 float32, 5 e4m3 (passed as raw bytes).
 // codebook is 16 floats, or null for the uniform levels.

--- a/comfy_kitchen/backends/hip/mma.h
+++ b/comfy_kitchen/backends/hip/mma.h
@@ -1,17 +1,18 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
-// WMMA policies for RDNA3 (gfx11) and RDNA4 (gfx12), wave32.
+// WMMA policies for duplicated 256-bit operands (gfx11.0/11.5) and
+// non-duplicated 128-bit operands (gfx12), wave32.
 //
 // A policy holds the operand fragment type, the bytes of a K-row one MMA consumes
 // (kStepBytes), the LDS read, and the MMA. The tile kernels stay byte-addressed;
 // only the policy changes per architecture.
 //
 // Operand layout differs:
-//   gfx12: K is split across the half-waves. A lane holds 8 bytes at byte offset
+//   128b:  K is split across the half-waves. A lane holds 8 bytes at byte offset
 //          8 * (lane / 16) of its row. Every type is a v2i, which is what lets one
 //          kernel serve fp8, iu8 and iu4.
-//   gfx11: no K split. A lane holds the whole K-step of its row and both
+//   256b:  no K split. A lane holds the whole K-step of its row and both
 //          half-waves hold the same data (rocWMMA calls it input duplication),
 //          which reading at row = lane % 16 with no half-wave offset gives for
 //          free. Fragment width is the K-step: 16B iu8, 8B iu4, 32B bf16 for fp8.
@@ -380,10 +381,10 @@ struct MmaInt8 {
     using Frag = v2i;
     static constexpr int kStepBytes = 16;
     static __forceinline__ __device__ Frag load(const void*, int, int, int, int) { return Frag{}; }
-    static __forceinline__ __device__ Acc zero() { return Acc{0, 0, 0, 0, 0, 0, 0, 0}; }
     static __forceinline__ __device__ Frag load_aligned(const void*, int, int, int, int) {
         return Frag{};
     }
+    static __forceinline__ __device__ Acc zero() { return Acc{0, 0, 0, 0, 0, 0, 0, 0}; }
     static __forceinline__ __device__ Acc mma(Frag, Frag, Acc c) { COMFY_MMA_STUB_BODY }
     static __forceinline__ __device__ Acc mma_ua(Frag, Frag, Acc c) { COMFY_MMA_STUB_BODY }
     static __forceinline__ __device__ Acc mma_ub(Frag, Frag, Acc c) { COMFY_MMA_STUB_BODY }

--- a/comfy_kitchen/backends/hip/ops/attention_bf16.hip
+++ b/comfy_kitchen/backends/hip/ops/attention_bf16.hip
@@ -67,7 +67,7 @@ __forceinline__ __device__ void store_bf16_acc(
 }
 
 template <int HD, int BLOCK_M, int BLOCK_N, bool DIRECT_GLOBAL, bool NO_KV_TAIL = false,
-          bool GLOBAL_TRANSPOSE_V = false, int SCORE_SPLITS = 1>
+          bool GLOBAL_TRANSPOSE_V = false>
 __global__ __launch_bounds__(BLOCK_M * 2)
 void bf16_attention_kernel(
     const __bf16* __restrict__ q, const __bf16* __restrict__ k,
@@ -82,7 +82,6 @@ void bf16_attention_kernel(
     using Shape = Bf16AttentionShape<HD, BLOCK_M, BLOCK_N>;
     constexpr int DT = Shape::kDimTiles;
     constexpr int KT = Shape::kKeyTiles;
-    static_assert(DT % SCORE_SPLITS == 0);
 
     __shared__ __align__(16) __bf16 staged_k[
         DIRECT_GLOBAL ? 1 : 2 * BLOCK_N * Shape::kKStride];
@@ -228,13 +227,10 @@ void bf16_attention_kernel(
         const __bf16* const current_v = staged_v +
             (tile & 1) * HD * Shape::kVStride;
 
-        MmaBf16::Acc score_split[KT][SCORE_SPLITS];
+        MmaBf16::Acc score[KT];
 #pragma unroll
         for (int kt = 0; kt < KT; ++kt) {
-#pragma unroll
-            for (int split = 0; split < SCORE_SPLITS; ++split) {
-                score_split[kt][split] = MmaBf16::zero();
-            }
+            score[kt] = MmaBf16::zero();
         }
 #pragma unroll
         for (int dt = 0; dt < DT; ++dt) {
@@ -253,21 +249,7 @@ void bf16_attention_kernel(
                         current_k + (kt * 16 + frag_row(lane)) * Shape::kKStride + dt * 16,
                         lane);
                 }
-                score_split[kt][dt % SCORE_SPLITS] = MmaBf16::mma(
-                    k_fragment, q_fragment[dt], score_split[kt][dt % SCORE_SPLITS]);
-            }
-        }
-
-        MmaBf16::Acc score[KT];
-#pragma unroll
-        for (int kt = 0; kt < KT; ++kt) {
-            score[kt] = score_split[kt][0];
-#pragma unroll
-            for (int split = 1; split < SCORE_SPLITS; ++split) {
-#pragma unroll
-                for (int e = 0; e < 8; ++e) {
-                    score[kt][e] += score_split[kt][split][e];
-                }
+                score[kt] = MmaBf16::mma(k_fragment, q_fragment[dt], score[kt]);
             }
         }
 
@@ -416,7 +398,7 @@ void bf16_attention_kernel(
 }
 
 template <int HD, int BLOCK_M, int BLOCK_N, bool DIRECT_GLOBAL, bool NO_KV_TAIL = false,
-          bool GLOBAL_TRANSPOSE_V = false, int SCORE_SPLITS = 1>
+          bool GLOBAL_TRANSPOSE_V = false>
 void launch_bf16_attention_shape(
     const void* q, const void* k, const void* v, void* output,
     int batch, int q_heads, int kv_heads, int q_len, int kv_len,
@@ -427,7 +409,7 @@ void launch_bf16_attention_shape(
     float sm_scale, hipStream_t stream) {
     const dim3 grid((q_len + BLOCK_M - 1) / BLOCK_M, q_heads, batch);
     bf16_attention_kernel<HD, BLOCK_M, BLOCK_N, DIRECT_GLOBAL, NO_KV_TAIL,
-                          GLOBAL_TRANSPOSE_V, SCORE_SPLITS>
+                          GLOBAL_TRANSPOSE_V>
         <<<grid, Bf16AttentionShape<HD, BLOCK_M, BLOCK_N>::kThreads, 0, stream>>>(
             static_cast<const __bf16*>(q), static_cast<const __bf16*>(k),
             static_cast<const __bf16*>(v), static_cast<__bf16*>(output),
@@ -459,7 +441,7 @@ void dispatch_bf16_attention(
             q_stride_b, q_stride_h, q_stride_n, k_stride_b, k_stride_h,
             k_stride_n, v_stride_b, v_stride_h, v_stride_n, o_stride_b,
             o_stride_h, o_stride_n, sm_scale, stream);
-    } else if constexpr (HD == 128) {
+    } else {
         if (kv_len % 48 == 0) {
             launch_bf16_attention_shape<HD, 192, 48, false, true, true>(
                 q, k, v, output, batch, q_heads, kv_heads, q_len, kv_len,
@@ -468,20 +450,6 @@ void dispatch_bf16_attention(
                 o_stride_h, o_stride_n, sm_scale, stream);
         } else {
             launch_bf16_attention_shape<HD, 192, 48, false, false, true>(
-                q, k, v, output, batch, q_heads, kv_heads, q_len, kv_len,
-                q_stride_b, q_stride_h, q_stride_n, k_stride_b, k_stride_h,
-                k_stride_n, v_stride_b, v_stride_h, v_stride_n, o_stride_b,
-                o_stride_h, o_stride_n, sm_scale, stream);
-        }
-    } else {
-        if (kv_len % 32 == 0) {
-            launch_bf16_attention_shape<HD, 320, 32, false, true>(
-                q, k, v, output, batch, q_heads, kv_heads, q_len, kv_len,
-                q_stride_b, q_stride_h, q_stride_n, k_stride_b, k_stride_h,
-                k_stride_n, v_stride_b, v_stride_h, v_stride_n, o_stride_b,
-                o_stride_h, o_stride_n, sm_scale, stream);
-        } else {
-            launch_bf16_attention_shape<HD, 320, 32, false>(
                 q, k, v, output, batch, q_heads, kv_heads, q_len, kv_len,
                 q_stride_b, q_stride_h, q_stride_n, k_stride_b, k_stride_h,
                 k_stride_n, v_stride_b, v_stride_h, v_stride_n, o_stride_b,
@@ -515,12 +483,10 @@ extern "C" void launch_bf16_sdpa_hip(
         sm_scale, stream)
 
     switch (head_dim) {
-        case 64: COMFY_BF16_ATTN_CASE(64); break;
-        case 80: COMFY_BF16_ATTN_CASE(80); break;
         case 128: COMFY_BF16_ATTN_CASE(128); break;
         default:
             throw std::runtime_error(
-                "BF16 HIP attention supports head dimensions 64, 80, and 128, got " +
+                "BF16 HIP attention supports head dimension 128, got " +
                 std::to_string(head_dim));
     }
 #undef COMFY_BF16_ATTN_CASE

--- a/comfy_kitchen/backends/hip/ops/attention_bf16.hip
+++ b/comfy_kitchen/backends/hip/ops/attention_bf16.hip
@@ -1,0 +1,344 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Forward-only, unmasked BF16 scaled dot-product attention for RDNA wave32
+// matrix cores. The score and output products are both transposed:
+//
+//   S^T = K @ Q^T,  O^T = V^T @ P^T.
+//
+// One query column therefore stays on a lane through the online softmax, and
+// the BF16 probability fragment flows directly into the second WMMA. K and a
+// transposed V tile are shared by every 16-query wave in the workgroup.
+
+#include <hip/hip_runtime.h>
+
+#include <cfloat>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+
+#include "../mma.h"
+
+namespace comfy::hip_backend {
+namespace {
+
+constexpr float kAttentionLog2e = 1.4426950408889634f;
+
+template <int HD, int BLOCK_M, int BLOCK_N>
+struct Bf16AttentionShape {
+    static_assert(HD % 16 == 0);
+    static_assert(BLOCK_M % 16 == 0);
+    static_assert(BLOCK_N % 16 == 0);
+    static constexpr int kWaves = BLOCK_M / 16;
+    static constexpr int kThreads = kWaves * 32;
+    static constexpr int kDimTiles = HD / 16;
+    static constexpr int kKeyTiles = BLOCK_N / 16;
+    static constexpr int kKStride = HD + 8;
+    static constexpr int kVStride = BLOCK_N + 8;
+};
+
+template <typename T>
+__forceinline__ __device__ T half_wave_swap(T value) {
+    return __shfl_xor(value, 16, 32);
+}
+
+__forceinline__ __device__ float sum8_balanced(const v8f& value) {
+    const float sum01 = value[0] + value[1];
+    const float sum23 = value[2] + value[3];
+    const float sum45 = value[4] + value[5];
+    const float sum67 = value[6] + value[7];
+    return (sum01 + sum23) + (sum45 + sum67);
+}
+
+__forceinline__ __device__ void store_bf16_acc(
+    __bf16* __restrict__ row, int d_base, const v8f& value, int lane) {
+#if defined(COMFY_MMA_GFX12)
+    __attribute__((aligned(16))) __bf16 packed[8];
+#pragma unroll
+    for (int e = 0; e < 8; ++e) packed[e] = static_cast<__bf16>(value[e]);
+    *reinterpret_cast<uint4*>(row + d_base + 8 * (lane / 16)) =
+        *reinterpret_cast<const uint4*>(packed);
+#else
+#pragma unroll
+    for (int e = 0; e < 8; ++e) {
+        row[d_base + acc_row(lane, e)] = static_cast<__bf16>(value[e]);
+    }
+#endif
+}
+
+template <int HD, int BLOCK_M, int BLOCK_N, bool DIRECT_GLOBAL>
+__global__ __launch_bounds__(BLOCK_M * 2)
+void bf16_attention_kernel(
+    const __bf16* __restrict__ q, const __bf16* __restrict__ k,
+    const __bf16* __restrict__ v, __bf16* __restrict__ output,
+    int q_heads, int kv_heads, int q_len, int kv_len,
+    int64_t q_stride_b, int64_t q_stride_h, int64_t q_stride_n,
+    int64_t k_stride_b, int64_t k_stride_h, int64_t k_stride_n,
+    int64_t v_stride_b, int64_t v_stride_h, int64_t v_stride_n,
+    int64_t o_stride_b, int64_t o_stride_h, int64_t o_stride_n,
+    float sm_scale) {
+
+    using Shape = Bf16AttentionShape<HD, BLOCK_M, BLOCK_N>;
+    constexpr int DT = Shape::kDimTiles;
+    constexpr int KT = Shape::kKeyTiles;
+
+    __shared__ __align__(16) __bf16 staged_k[
+        DIRECT_GLOBAL ? 1 : BLOCK_N * Shape::kKStride];
+    __shared__ __align__(16) __bf16 staged_v[
+        DIRECT_GLOBAL ? 1 : HD * Shape::kVStride];
+
+    const int tid = threadIdx.x;
+    const int lane = tid & 31;
+    const int wave = tid >> 5;
+    const int head = blockIdx.y;
+    const int batch_index = blockIdx.z;
+    const int kv_head = head / (q_heads / kv_heads);
+    const int query_block = blockIdx.x * BLOCK_M;
+    const int query_row = query_block + wave * 16 + frag_row(lane);
+    const int query_column = query_block + wave * 16 + acc_col(lane);
+
+    const __bf16* const q_head =
+        q + static_cast<int64_t>(batch_index) * q_stride_b +
+        static_cast<int64_t>(head) * q_stride_h;
+    const __bf16* const k_head =
+        k + static_cast<int64_t>(batch_index) * k_stride_b +
+        static_cast<int64_t>(kv_head) * k_stride_h;
+    const __bf16* const v_head =
+        v + static_cast<int64_t>(batch_index) * v_stride_b +
+        static_cast<int64_t>(kv_head) * v_stride_h;
+    __bf16* const o_head =
+        output + static_cast<int64_t>(batch_index) * o_stride_b +
+        static_cast<int64_t>(head) * o_stride_h;
+
+    MmaBf16::Frag q_fragment[DT];
+    const int safe_query_row = query_row < q_len ? query_row : q_len - 1;
+#pragma unroll
+    for (int dt = 0; dt < DT; ++dt) {
+        q_fragment[dt] = load_frag_16bit<MmaBf16>(
+            q_head + static_cast<int64_t>(safe_query_row) * q_stride_n + dt * 16,
+            lane);
+    }
+
+    MmaBf16::Acc output_acc[DT];
+#pragma unroll
+    for (int dt = 0; dt < DT; ++dt) output_acc[dt] = MmaBf16::zero();
+
+    float row_max = -FLT_MAX;
+    float row_sum = 1.0f;
+    const float score_scale = sm_scale * kAttentionLog2e;
+    const int key_tiles = (kv_len + BLOCK_N - 1) / BLOCK_N;
+
+    for (int tile = 0; tile < key_tiles; ++tile) {
+        const int key0 = tile * BLOCK_N;
+        if constexpr (!DIRECT_GLOBAL) {
+            if (tile != 0) __syncthreads();
+            for (int index = tid; index < BLOCK_N * HD; index += Shape::kThreads) {
+                const int key_in_tile = index / HD;
+                const int d = index - key_in_tile * HD;
+                const int key_index = key0 + key_in_tile;
+                __bf16 k_value = static_cast<__bf16>(0.0f);
+                __bf16 v_value = static_cast<__bf16>(0.0f);
+                if (key_index < kv_len) {
+                    k_value = k_head[static_cast<int64_t>(key_index) * k_stride_n + d];
+                    v_value = v_head[static_cast<int64_t>(key_index) * v_stride_n + d];
+                }
+                staged_k[key_in_tile * Shape::kKStride + d] = k_value;
+                staged_v[d * Shape::kVStride + key_in_tile] = v_value;
+            }
+            __syncthreads();
+        }
+
+        MmaBf16::Acc score[KT];
+#pragma unroll
+        for (int kt = 0; kt < KT; ++kt) score[kt] = MmaBf16::zero();
+#pragma unroll
+        for (int dt = 0; dt < DT; ++dt) {
+#pragma unroll
+            for (int kt = 0; kt < KT; ++kt) {
+                MmaBf16::Frag k_fragment{};
+                if constexpr (DIRECT_GLOBAL) {
+                    const int key_index = key0 + kt * 16 + frag_row(lane);
+                    if (key_index < kv_len) {
+                        k_fragment = load_frag_16bit<MmaBf16>(
+                            k_head + static_cast<int64_t>(key_index) * k_stride_n + dt * 16,
+                            lane);
+                    }
+                } else {
+                    k_fragment = load_frag_16bit<MmaBf16>(
+                        staged_k + (kt * 16 + frag_row(lane)) * Shape::kKStride + dt * 16,
+                        lane);
+                }
+                score[kt] = MmaBf16::mma(k_fragment, q_fragment[dt], score[kt]);
+            }
+        }
+
+        float local_max = -FLT_MAX;
+#pragma unroll
+        for (int kt = 0; kt < KT; ++kt) {
+#pragma unroll
+            for (int e = 0; e < 8; ++e) {
+                float value = score[kt][e] * score_scale;
+                const int key_index = key0 + kt * 16 + acc_row(lane, e);
+                if (key_index >= kv_len) value = -FLT_MAX;
+                score[kt][e] = value;
+                local_max = fmaxf(local_max, value);
+            }
+        }
+        const float tile_max = fmaxf(local_max, half_wave_swap(local_max));
+        const float next_max = fmaxf(row_max, tile_max);
+        const float alpha = __builtin_amdgcn_exp2f(row_max - next_max);
+        row_max = next_max;
+        row_sum *= alpha;
+#pragma unroll
+        for (int dt = 0; dt < DT; ++dt) {
+#pragma unroll
+            for (int e = 0; e < 8; ++e) output_acc[dt][e] *= alpha;
+        }
+
+        MmaBf16::Frag probability[KT];
+        float tile_sum = 0.0f;
+#pragma unroll
+        for (int kt = 0; kt < KT; ++kt) {
+            v8f p;
+#pragma unroll
+            for (int e = 0; e < 8; ++e) {
+                p[e] = __builtin_amdgcn_exp2f(score[kt][e] - next_max);
+                probability[kt][e] = static_cast<__bf16>(p[e]);
+            }
+            tile_sum += sum8_balanced(p);
+        }
+        row_sum += tile_sum;
+
+#pragma unroll
+        for (int dt = 0; dt < DT; ++dt) {
+#pragma unroll
+            for (int kt = 0; kt < KT; ++kt) {
+                MmaBf16::Frag v_fragment{};
+                if constexpr (DIRECT_GLOBAL) {
+                    const int d = dt * 16 + frag_row(lane);
+#pragma unroll
+                    for (int i = 0; i < MmaBf16::kFragElems; ++i) {
+                        const int key_index =
+                            key0 + kt * 16 + MmaBf16::frag_base(lane) + i;
+                        if (key_index < kv_len) {
+                            v_fragment[i] = v_head[
+                                static_cast<int64_t>(key_index) * v_stride_n + d];
+                        }
+                    }
+                } else {
+                    v_fragment = load_frag_16bit<MmaBf16>(
+                        staged_v + (dt * 16 + frag_row(lane)) * Shape::kVStride + kt * 16,
+                        lane);
+                }
+                output_acc[dt] = MmaBf16::mma(
+                    v_fragment, probability[kt], output_acc[dt]);
+            }
+        }
+    }
+
+    row_sum += half_wave_swap(row_sum);
+    if (query_column < q_len) {
+        const float reciprocal = 1.0f / row_sum;
+        __bf16* const row = o_head + static_cast<int64_t>(query_column) * o_stride_n;
+#pragma unroll
+        for (int dt = 0; dt < DT; ++dt) {
+            v8f normalized;
+#pragma unroll
+            for (int e = 0; e < 8; ++e) normalized[e] = output_acc[dt][e] * reciprocal;
+            store_bf16_acc(row, dt * 16, normalized, lane);
+        }
+    }
+}
+
+template <int HD, int BLOCK_M, int BLOCK_N, bool DIRECT_GLOBAL>
+void launch_bf16_attention_shape(
+    const void* q, const void* k, const void* v, void* output,
+    int batch, int q_heads, int kv_heads, int q_len, int kv_len,
+    int64_t q_stride_b, int64_t q_stride_h, int64_t q_stride_n,
+    int64_t k_stride_b, int64_t k_stride_h, int64_t k_stride_n,
+    int64_t v_stride_b, int64_t v_stride_h, int64_t v_stride_n,
+    int64_t o_stride_b, int64_t o_stride_h, int64_t o_stride_n,
+    float sm_scale, hipStream_t stream) {
+    const dim3 grid((q_len + BLOCK_M - 1) / BLOCK_M, q_heads, batch);
+    bf16_attention_kernel<HD, BLOCK_M, BLOCK_N, DIRECT_GLOBAL>
+        <<<grid, Bf16AttentionShape<HD, BLOCK_M, BLOCK_N>::kThreads, 0, stream>>>(
+            static_cast<const __bf16*>(q), static_cast<const __bf16*>(k),
+            static_cast<const __bf16*>(v), static_cast<__bf16*>(output),
+            q_heads, kv_heads, q_len, kv_len,
+            q_stride_b, q_stride_h, q_stride_n,
+            k_stride_b, k_stride_h, k_stride_n,
+            v_stride_b, v_stride_h, v_stride_n,
+            o_stride_b, o_stride_h, o_stride_n, sm_scale);
+}
+
+template <int HD>
+void dispatch_bf16_attention(
+    const void* q, const void* k, const void* v, void* output,
+    int batch, int q_heads, int kv_heads, int q_len, int kv_len,
+    int64_t q_stride_b, int64_t q_stride_h, int64_t q_stride_n,
+    int64_t k_stride_b, int64_t k_stride_h, int64_t k_stride_n,
+    int64_t v_stride_b, int64_t v_stride_h, int64_t v_stride_n,
+    int64_t o_stride_b, int64_t o_stride_h, int64_t o_stride_n,
+    float sm_scale, hipStream_t stream) {
+    if (q_len <= 16 && kv_len <= 16) {
+        launch_bf16_attention_shape<HD, 16, 16, true>(
+            q, k, v, output, batch, q_heads, kv_heads, q_len, kv_len,
+            q_stride_b, q_stride_h, q_stride_n, k_stride_b, k_stride_h,
+            k_stride_n, v_stride_b, v_stride_h, v_stride_n, o_stride_b,
+            o_stride_h, o_stride_n, sm_scale, stream);
+    } else if (q_len <= 256) {
+        launch_bf16_attention_shape<HD, 32, 32, true>(
+            q, k, v, output, batch, q_heads, kv_heads, q_len, kv_len,
+            q_stride_b, q_stride_h, q_stride_n, k_stride_b, k_stride_h,
+            k_stride_n, v_stride_b, v_stride_h, v_stride_n, o_stride_b,
+            o_stride_h, o_stride_n, sm_scale, stream);
+    } else {
+        launch_bf16_attention_shape<HD, 64, 32, false>(
+            q, k, v, output, batch, q_heads, kv_heads, q_len, kv_len,
+            q_stride_b, q_stride_h, q_stride_n, k_stride_b, k_stride_h,
+            k_stride_n, v_stride_b, v_stride_h, v_stride_n, o_stride_b,
+            o_stride_h, o_stride_n, sm_scale, stream);
+    }
+}
+
+}  // namespace
+}  // namespace comfy::hip_backend
+
+extern "C" void launch_bf16_sdpa_hip(
+    const void* q, const void* k, const void* v, void* output,
+    int batch, int q_heads, int kv_heads, int q_len, int kv_len, int head_dim,
+    int64_t q_stride_b, int64_t q_stride_h, int64_t q_stride_n,
+    int64_t k_stride_b, int64_t k_stride_h, int64_t k_stride_n,
+    int64_t v_stride_b, int64_t v_stride_h, int64_t v_stride_n,
+    int64_t o_stride_b, int64_t o_stride_h, int64_t o_stride_n,
+    float sm_scale, hipStream_t stream) {
+    using namespace comfy::hip_backend;
+    if (batch <= 0 || q_heads <= 0 || kv_heads <= 0 || q_len <= 0 || kv_len <= 0 ||
+        q_heads % kv_heads != 0) {
+        throw std::runtime_error("BF16 HIP attention received invalid extents");
+    }
+
+#define COMFY_BF16_ATTN_CASE(HD)                                                        \
+    dispatch_bf16_attention<HD>(                                                       \
+        q, k, v, output, batch, q_heads, kv_heads, q_len, kv_len,                     \
+        q_stride_b, q_stride_h, q_stride_n, k_stride_b, k_stride_h, k_stride_n,       \
+        v_stride_b, v_stride_h, v_stride_n, o_stride_b, o_stride_h, o_stride_n,       \
+        sm_scale, stream)
+
+    switch (head_dim) {
+        case 64: COMFY_BF16_ATTN_CASE(64); break;
+        case 80: COMFY_BF16_ATTN_CASE(80); break;
+        case 128: COMFY_BF16_ATTN_CASE(128); break;
+        default:
+            throw std::runtime_error(
+                "BF16 HIP attention supports head dimensions 64, 80, and 128, got " +
+                std::to_string(head_dim));
+    }
+#undef COMFY_BF16_ATTN_CASE
+
+    const hipError_t error = hipGetLastError();
+    if (error != hipSuccess) {
+        throw std::runtime_error(
+            std::string("BF16 HIP attention launch failed: ") + hipGetErrorString(error));
+    }
+}

--- a/comfy_kitchen/backends/hip/ops/attention_bf16.hip
+++ b/comfy_kitchen/backends/hip/ops/attention_bf16.hip
@@ -33,8 +33,8 @@ struct Bf16AttentionShape {
     static constexpr int kThreads = kWaves * 32;
     static constexpr int kDimTiles = HD / 16;
     static constexpr int kKeyTiles = BLOCK_N / 16;
-    static constexpr int kKStride = HD + 8;
-    static constexpr int kVStride = BLOCK_N + 8;
+    static constexpr int kKStride = HD + 4;
+    static constexpr int kVStride = BLOCK_N + 4;
 };
 
 template <typename T>
@@ -66,7 +66,8 @@ __forceinline__ __device__ void store_bf16_acc(
 #endif
 }
 
-template <int HD, int BLOCK_M, int BLOCK_N, bool DIRECT_GLOBAL>
+template <int HD, int BLOCK_M, int BLOCK_N, bool DIRECT_GLOBAL, bool NO_KV_TAIL = false,
+          bool GLOBAL_TRANSPOSE_V = false, int SCORE_SPLITS = 1>
 __global__ __launch_bounds__(BLOCK_M * 2)
 void bf16_attention_kernel(
     const __bf16* __restrict__ q, const __bf16* __restrict__ k,
@@ -81,11 +82,12 @@ void bf16_attention_kernel(
     using Shape = Bf16AttentionShape<HD, BLOCK_M, BLOCK_N>;
     constexpr int DT = Shape::kDimTiles;
     constexpr int KT = Shape::kKeyTiles;
+    static_assert(DT % SCORE_SPLITS == 0);
 
     __shared__ __align__(16) __bf16 staged_k[
-        DIRECT_GLOBAL ? 1 : BLOCK_N * Shape::kKStride];
+        DIRECT_GLOBAL ? 1 : 2 * BLOCK_N * Shape::kKStride];
     __shared__ __align__(16) __bf16 staged_v[
-        DIRECT_GLOBAL ? 1 : HD * Shape::kVStride];
+        DIRECT_GLOBAL || GLOBAL_TRANSPOSE_V ? 1 : 2 * HD * Shape::kVStride];
 
     const int tid = threadIdx.x;
     const int lane = tid & 31;
@@ -126,31 +128,114 @@ void bf16_attention_kernel(
     float row_max = -FLT_MAX;
     float row_sum = 1.0f;
     const float score_scale = sm_scale * kAttentionLog2e;
-    const int key_tiles = (kv_len + BLOCK_N - 1) / BLOCK_N;
+    const int key_tiles = NO_KV_TAIL
+        ? kv_len / BLOCK_N
+        : (kv_len + BLOCK_N - 1) / BLOCK_N;
+
+    constexpr int kPackElems = 8;
+    constexpr int kPacksPerRow = HD / kPackElems;
+    constexpr int kPacksPerTile = BLOCK_N * kPacksPerRow;
+    constexpr int kKStageItems = GLOBAL_TRANSPOSE_V
+        ? (kPacksPerTile + Shape::kThreads - 1) / Shape::kThreads
+        : 1;
+    static_assert(DIRECT_GLOBAL || GLOBAL_TRANSPOSE_V ||
+                  kPacksPerTile <= Shape::kThreads);
+    const int pack = tid;
+    const int key_in_tile = pack / kPacksPerRow;
+    const int pack_d =
+        (pack - key_in_tile * kPacksPerRow) * kPackElems;
+    if constexpr (!DIRECT_GLOBAL) {
+        if constexpr (GLOBAL_TRANSPOSE_V) {
+#pragma unroll
+            for (int item = 0; item < kKStageItems; ++item) {
+                const int item_pack = tid + item * Shape::kThreads;
+                if (item_pack >= kPacksPerTile) continue;
+                const int item_key = item_pack / kPacksPerRow;
+                const int item_d =
+                    (item_pack - item_key * kPacksPerRow) * kPackElems;
+                v8bf k_value{};
+                if constexpr (NO_KV_TAIL) {
+                    k_value = *reinterpret_cast<const v8bf*>(
+                        k_head + static_cast<int64_t>(item_key) * k_stride_n + item_d);
+                } else if (item_key < kv_len) {
+                    k_value = *reinterpret_cast<const v8bf*>(
+                        k_head + static_cast<int64_t>(item_key) * k_stride_n + item_d);
+                }
+                *reinterpret_cast<v8bf*>(
+                    staged_k + item_key * Shape::kKStride + item_d) = k_value;
+            }
+        } else if (pack < kPacksPerTile) {
+            v8bf k_value{};
+            v8bf v_value{};
+            if constexpr (NO_KV_TAIL) {
+                k_value = *reinterpret_cast<const v8bf*>(
+                    k_head + static_cast<int64_t>(key_in_tile) * k_stride_n + pack_d);
+                v_value = *reinterpret_cast<const v8bf*>(
+                    v_head + static_cast<int64_t>(key_in_tile) * v_stride_n + pack_d);
+            } else if (key_in_tile < kv_len) {
+                k_value = *reinterpret_cast<const v8bf*>(
+                    k_head + static_cast<int64_t>(key_in_tile) * k_stride_n + pack_d);
+                v_value = *reinterpret_cast<const v8bf*>(
+                    v_head + static_cast<int64_t>(key_in_tile) * v_stride_n + pack_d);
+            }
+            *reinterpret_cast<v8bf*>(
+                staged_k + key_in_tile * Shape::kKStride + pack_d) = k_value;
+#pragma unroll
+            for (int e = 0; e < kPackElems; ++e) {
+                staged_v[(pack_d + e) * Shape::kVStride + key_in_tile] = v_value[e];
+            }
+        }
+        __syncthreads();
+    }
 
     for (int tile = 0; tile < key_tiles; ++tile) {
         const int key0 = tile * BLOCK_N;
+        const bool has_next_tile = tile + 1 < key_tiles;
+        const int next_key_index = key0 + BLOCK_N + key_in_tile;
+        const int next_buffer = (tile + 1) & 1;
+        v8bf next_k[kKStageItems]{};
         if constexpr (!DIRECT_GLOBAL) {
-            if (tile != 0) __syncthreads();
-            for (int index = tid; index < BLOCK_N * HD; index += Shape::kThreads) {
-                const int key_in_tile = index / HD;
-                const int d = index - key_in_tile * HD;
-                const int key_index = key0 + key_in_tile;
-                __bf16 k_value = static_cast<__bf16>(0.0f);
-                __bf16 v_value = static_cast<__bf16>(0.0f);
-                if (key_index < kv_len) {
-                    k_value = k_head[static_cast<int64_t>(key_index) * k_stride_n + d];
-                    v_value = v_head[static_cast<int64_t>(key_index) * v_stride_n + d];
+            if constexpr (GLOBAL_TRANSPOSE_V) {
+#pragma unroll
+                for (int item = 0; item < kKStageItems; ++item) {
+                    const int item_pack = tid + item * Shape::kThreads;
+                    if (!has_next_tile || item_pack >= kPacksPerTile) continue;
+                    const int item_key = item_pack / kPacksPerRow;
+                    const int item_d =
+                        (item_pack - item_key * kPacksPerRow) * kPackElems;
+                    const int next_key = key0 + BLOCK_N + item_key;
+                    if constexpr (NO_KV_TAIL) {
+                        next_k[item] = *reinterpret_cast<const v8bf*>(
+                            k_head + static_cast<int64_t>(next_key) * k_stride_n + item_d);
+                    } else if (next_key < kv_len) {
+                        next_k[item] = *reinterpret_cast<const v8bf*>(
+                            k_head + static_cast<int64_t>(next_key) * k_stride_n + item_d);
+                    }
                 }
-                staged_k[key_in_tile * Shape::kKStride + d] = k_value;
-                staged_v[d * Shape::kVStride + key_in_tile] = v_value;
+            } else if (has_next_tile && pack < kPacksPerTile) {
+                if constexpr (NO_KV_TAIL) {
+                    next_k[0] = *reinterpret_cast<const v8bf*>(
+                        k_head + static_cast<int64_t>(next_key_index) * k_stride_n + pack_d);
+                } else if (next_key_index < kv_len) {
+                    next_k[0] = *reinterpret_cast<const v8bf*>(
+                        k_head + static_cast<int64_t>(next_key_index) * k_stride_n + pack_d);
+                }
             }
-            __syncthreads();
         }
 
-        MmaBf16::Acc score[KT];
+        const __bf16* const current_k = staged_k +
+            (tile & 1) * BLOCK_N * Shape::kKStride;
+        const __bf16* const current_v = staged_v +
+            (tile & 1) * HD * Shape::kVStride;
+
+        MmaBf16::Acc score_split[KT][SCORE_SPLITS];
 #pragma unroll
-        for (int kt = 0; kt < KT; ++kt) score[kt] = MmaBf16::zero();
+        for (int kt = 0; kt < KT; ++kt) {
+#pragma unroll
+            for (int split = 0; split < SCORE_SPLITS; ++split) {
+                score_split[kt][split] = MmaBf16::zero();
+            }
+        }
 #pragma unroll
         for (int dt = 0; dt < DT; ++dt) {
 #pragma unroll
@@ -165,10 +250,57 @@ void bf16_attention_kernel(
                     }
                 } else {
                     k_fragment = load_frag_16bit<MmaBf16>(
-                        staged_k + (kt * 16 + frag_row(lane)) * Shape::kKStride + dt * 16,
+                        current_k + (kt * 16 + frag_row(lane)) * Shape::kKStride + dt * 16,
                         lane);
                 }
-                score[kt] = MmaBf16::mma(k_fragment, q_fragment[dt], score[kt]);
+                score_split[kt][dt % SCORE_SPLITS] = MmaBf16::mma(
+                    k_fragment, q_fragment[dt], score_split[kt][dt % SCORE_SPLITS]);
+            }
+        }
+
+        MmaBf16::Acc score[KT];
+#pragma unroll
+        for (int kt = 0; kt < KT; ++kt) {
+            score[kt] = score_split[kt][0];
+#pragma unroll
+            for (int split = 1; split < SCORE_SPLITS; ++split) {
+#pragma unroll
+                for (int e = 0; e < 8; ++e) {
+                    score[kt][e] += score_split[kt][split][e];
+                }
+            }
+        }
+
+        if constexpr (!DIRECT_GLOBAL) {
+            if constexpr (GLOBAL_TRANSPOSE_V) {
+#pragma unroll
+                for (int item = 0; item < kKStageItems; ++item) {
+                    const int item_pack = tid + item * Shape::kThreads;
+                    if (!has_next_tile || item_pack >= kPacksPerTile) continue;
+                    const int item_key = item_pack / kPacksPerRow;
+                    const int item_d =
+                        (item_pack - item_key * kPacksPerRow) * kPackElems;
+                    *reinterpret_cast<v8bf*>(
+                        staged_k + next_buffer * BLOCK_N * Shape::kKStride +
+                        item_key * Shape::kKStride + item_d) = next_k[item];
+                }
+            } else if (has_next_tile && pack < kPacksPerTile) {
+                *reinterpret_cast<v8bf*>(
+                    staged_k + next_buffer * BLOCK_N * Shape::kKStride +
+                    key_in_tile * Shape::kKStride + pack_d) = next_k[0];
+            }
+        }
+
+        v8bf next_v{};
+        if constexpr (!DIRECT_GLOBAL && !GLOBAL_TRANSPOSE_V) {
+            if (has_next_tile && pack < kPacksPerTile) {
+                if constexpr (NO_KV_TAIL) {
+                    next_v = *reinterpret_cast<const v8bf*>(
+                        v_head + static_cast<int64_t>(next_key_index) * v_stride_n + pack_d);
+                } else if (next_key_index < kv_len) {
+                    next_v = *reinterpret_cast<const v8bf*>(
+                        v_head + static_cast<int64_t>(next_key_index) * v_stride_n + pack_d);
+                }
             }
         }
 
@@ -179,7 +311,9 @@ void bf16_attention_kernel(
             for (int e = 0; e < 8; ++e) {
                 float value = score[kt][e] * score_scale;
                 const int key_index = key0 + kt * 16 + acc_row(lane, e);
-                if (key_index >= kv_len) value = -FLT_MAX;
+                if constexpr (!NO_KV_TAIL) {
+                    if (key_index >= kv_len) value = -FLT_MAX;
+                }
                 score[kt][e] = value;
                 local_max = fmaxf(local_max, value);
             }
@@ -195,26 +329,52 @@ void bf16_attention_kernel(
             for (int e = 0; e < 8; ++e) output_acc[dt][e] *= alpha;
         }
 
-        MmaBf16::Frag probability[KT];
+        if constexpr (!DIRECT_GLOBAL && !GLOBAL_TRANSPOSE_V) {
+            if (has_next_tile && pack < kPacksPerTile) {
+#pragma unroll
+                for (int e = 0; e < kPackElems; ++e) {
+                    staged_v[next_buffer * HD * Shape::kVStride +
+                             (pack_d + e) * Shape::kVStride + key_in_tile] = next_v[e];
+                }
+            }
+        }
+
         float tile_sum = 0.0f;
 #pragma unroll
         for (int kt = 0; kt < KT; ++kt) {
+            MmaBf16::Frag probability;
             v8f p;
 #pragma unroll
             for (int e = 0; e < 8; ++e) {
                 p[e] = __builtin_amdgcn_exp2f(score[kt][e] - next_max);
-                probability[kt][e] = static_cast<__bf16>(p[e]);
+                probability[e] = static_cast<__bf16>(p[e]);
             }
             tile_sum += sum8_balanced(p);
-        }
-        row_sum += tile_sum;
-
 #pragma unroll
-        for (int dt = 0; dt < DT; ++dt) {
-#pragma unroll
-            for (int kt = 0; kt < KT; ++kt) {
+            for (int dt = 0; dt < DT; ++dt) {
                 MmaBf16::Frag v_fragment{};
-                if constexpr (DIRECT_GLOBAL) {
+                if constexpr (GLOBAL_TRANSPOSE_V) {
+                    const int tile_key = key0 + kt * 16;
+                    if (tile_key + 16 <= kv_len) {
+                        const int source_key = ((lane >> 4) << 3) + (lane & 7);
+                        const int source_half = (lane >> 3) & 1;
+                        const v8bf* const source = reinterpret_cast<const v8bf*>(
+                            v_head + static_cast<int64_t>(tile_key + source_key) * v_stride_n +
+                            dt * 16 + source_half * 8);
+                        v_fragment = __builtin_amdgcn_global_load_tr_b128_v8bf16(
+                            const_cast<v8bf*>(source));
+                    } else if (tile_key < kv_len) {
+                        const int d = dt * 16 + frag_row(lane);
+#pragma unroll
+                        for (int i = 0; i < MmaBf16::kFragElems; ++i) {
+                            const int key_index = tile_key + MmaBf16::frag_base(lane) + i;
+                            if (key_index < kv_len) {
+                                v_fragment[i] = v_head[
+                                    static_cast<int64_t>(key_index) * v_stride_n + d];
+                            }
+                        }
+                    }
+                } else if constexpr (DIRECT_GLOBAL) {
                     const int d = dt * 16 + frag_row(lane);
 #pragma unroll
                     for (int i = 0; i < MmaBf16::kFragElems; ++i) {
@@ -227,12 +387,17 @@ void bf16_attention_kernel(
                     }
                 } else {
                     v_fragment = load_frag_16bit<MmaBf16>(
-                        staged_v + (dt * 16 + frag_row(lane)) * Shape::kVStride + kt * 16,
+                        current_v + (dt * 16 + frag_row(lane)) * Shape::kVStride + kt * 16,
                         lane);
                 }
                 output_acc[dt] = MmaBf16::mma(
-                    v_fragment, probability[kt], output_acc[dt]);
+                    v_fragment, probability, output_acc[dt]);
             }
+        }
+        row_sum += tile_sum;
+
+        if constexpr (!DIRECT_GLOBAL) {
+            if (has_next_tile) __syncthreads();
         }
     }
 
@@ -250,7 +415,8 @@ void bf16_attention_kernel(
     }
 }
 
-template <int HD, int BLOCK_M, int BLOCK_N, bool DIRECT_GLOBAL>
+template <int HD, int BLOCK_M, int BLOCK_N, bool DIRECT_GLOBAL, bool NO_KV_TAIL = false,
+          bool GLOBAL_TRANSPOSE_V = false, int SCORE_SPLITS = 1>
 void launch_bf16_attention_shape(
     const void* q, const void* k, const void* v, void* output,
     int batch, int q_heads, int kv_heads, int q_len, int kv_len,
@@ -260,7 +426,8 @@ void launch_bf16_attention_shape(
     int64_t o_stride_b, int64_t o_stride_h, int64_t o_stride_n,
     float sm_scale, hipStream_t stream) {
     const dim3 grid((q_len + BLOCK_M - 1) / BLOCK_M, q_heads, batch);
-    bf16_attention_kernel<HD, BLOCK_M, BLOCK_N, DIRECT_GLOBAL>
+    bf16_attention_kernel<HD, BLOCK_M, BLOCK_N, DIRECT_GLOBAL, NO_KV_TAIL,
+                          GLOBAL_TRANSPOSE_V, SCORE_SPLITS>
         <<<grid, Bf16AttentionShape<HD, BLOCK_M, BLOCK_N>::kThreads, 0, stream>>>(
             static_cast<const __bf16*>(q), static_cast<const __bf16*>(k),
             static_cast<const __bf16*>(v), static_cast<__bf16*>(output),
@@ -292,12 +459,34 @@ void dispatch_bf16_attention(
             q_stride_b, q_stride_h, q_stride_n, k_stride_b, k_stride_h,
             k_stride_n, v_stride_b, v_stride_h, v_stride_n, o_stride_b,
             o_stride_h, o_stride_n, sm_scale, stream);
+    } else if constexpr (HD == 128) {
+        if (kv_len % 48 == 0) {
+            launch_bf16_attention_shape<HD, 192, 48, false, true, true>(
+                q, k, v, output, batch, q_heads, kv_heads, q_len, kv_len,
+                q_stride_b, q_stride_h, q_stride_n, k_stride_b, k_stride_h,
+                k_stride_n, v_stride_b, v_stride_h, v_stride_n, o_stride_b,
+                o_stride_h, o_stride_n, sm_scale, stream);
+        } else {
+            launch_bf16_attention_shape<HD, 192, 48, false, false, true>(
+                q, k, v, output, batch, q_heads, kv_heads, q_len, kv_len,
+                q_stride_b, q_stride_h, q_stride_n, k_stride_b, k_stride_h,
+                k_stride_n, v_stride_b, v_stride_h, v_stride_n, o_stride_b,
+                o_stride_h, o_stride_n, sm_scale, stream);
+        }
     } else {
-        launch_bf16_attention_shape<HD, 64, 32, false>(
-            q, k, v, output, batch, q_heads, kv_heads, q_len, kv_len,
-            q_stride_b, q_stride_h, q_stride_n, k_stride_b, k_stride_h,
-            k_stride_n, v_stride_b, v_stride_h, v_stride_n, o_stride_b,
-            o_stride_h, o_stride_n, sm_scale, stream);
+        if (kv_len % 32 == 0) {
+            launch_bf16_attention_shape<HD, 320, 32, false, true>(
+                q, k, v, output, batch, q_heads, kv_heads, q_len, kv_len,
+                q_stride_b, q_stride_h, q_stride_n, k_stride_b, k_stride_h,
+                k_stride_n, v_stride_b, v_stride_h, v_stride_n, o_stride_b,
+                o_stride_h, o_stride_n, sm_scale, stream);
+        } else {
+            launch_bf16_attention_shape<HD, 320, 32, false>(
+                q, k, v, output, batch, q_heads, kv_heads, q_len, kv_len,
+                q_stride_b, q_stride_h, q_stride_n, k_stride_b, k_stride_h,
+                k_stride_n, v_stride_b, v_stride_h, v_stride_n, o_stride_b,
+                o_stride_h, o_stride_n, sm_scale, stream);
+        }
     }
 }
 

--- a/comfy_kitchen/backends/hip/ops/gemm_int8.hip
+++ b/comfy_kitchen/backends/hip/ops/gemm_int8.hip
@@ -74,7 +74,20 @@ static void launch_int8(const int8_t* A, const int8_t* B, OutT* C, int M, int N,
     }
     const bool tuned = use_nonduplicated_int8_schedule();
     if (M >= 96 && N >= 96) {
-        if (tuned && M >= 512 && K == 3840 &&
+        if (tuned && M >= 512 && K == 3840 && N == 10240) {
+            constexpr int BM = 128, BN = 128, BKB = 64;
+            dim3 grid((N + BN - 1) / BN, (M + 2 * BM - 1) / (2 * BM));
+            if (epi.bias == nullptr && epi.scale_b_stride == 1) {
+                EpiRowwiseNoBias no_bias{epi.scale_a, epi.scale_b};
+                gemm_wmma_dual_m_kernel<MmaInt8, EpiRowwiseNoBias, OutT,
+                                        BM, BN, BKB, 4, 2, 2, 4, true>
+                    <<<grid, 512, 0, stream>>>(Au, Bu, C, M, N, K, ldc, no_bias);
+            } else {
+                gemm_wmma_dual_m_kernel<MmaInt8, EpiRowwise, OutT,
+                                        BM, BN, BKB, 4, 2, 2, 4, true>
+                    <<<grid, 512, 0, stream>>>(Au, Bu, C, M, N, K, ldc, epi);
+            }
+        } else if (tuned && M >= 512 && K == 3840 &&
             (N == 3840 || N == 11520)) {
             // Reuse each staged B tile across two adjacent M tiles for the
             // measured square and packed-QKV projection families.
@@ -92,12 +105,10 @@ static void launch_int8(const int8_t* A, const int8_t* B, OutT* C, int M, int N,
                     <<<grid, 512, 0, stream>>>(Au, Bu, C, M, N, K, ldc, epi);
             }
         } else if (tuned && M >= 512 && N >= 128 && K > N) {
-            // Deep-K projections benefit from a 256-row tile, a 128-byte K
-            // stage, and cooperative global-to-register-to-LDS staging.
-            constexpr int BM = 256, BN = 128, BKB = 128;
+            constexpr int BM = 128, BN = 128, BKB = 64;
             dim3 grid((N + BN - 1) / BN, (M + BM - 1) / BM);
             gemm_wmma_kernel<MmaInt8, EpiRowwise, OutT, BM, BN, BKB,
-                             4, 2, 4, 4, true>
+                             4, 2, 2, 4, true>
                 <<<grid, 256, 0, stream>>>(Au, Bu, C, M, N, K, ldc, epi);
         } else if (tuned) {
             // Non-duplicated WMMA operands favor the lower-LDS stage.
@@ -290,7 +301,7 @@ static void launch_int8_pair(
     if (use_nonduplicated_int8_schedule() &&
         epi0.bias == nullptr && epi1.bias == nullptr &&
         epi0.scale_b_stride == 1 && epi1.scale_b_stride == 1) {
-        constexpr int BKB = 64;
+        constexpr int BKB = 128;
         EpiRowwiseNoBias no_bias0{epi0.scale_a, epi0.scale_b};
         EpiRowwiseNoBias no_bias1{epi1.scale_a, epi1.scale_b};
         gemm_wmma_pair_kernel<MmaInt8, EpiRowwiseNoBias, OutT,
@@ -298,7 +309,7 @@ static void launch_int8_pair(
             <<<grid, 512, 0, stream>>>(
                 A, B0, B1, C0, C1, M, N, K, ldc, no_bias0, no_bias1);
     } else {
-        constexpr int BKB = 64;
+        constexpr int BKB = 128;
         gemm_wmma_pair_kernel<MmaInt8, EpiRowwise, OutT,
                               BM, BN, BKB, 4, 2, 2, 4>
             <<<grid, 512, 0, stream>>>(
@@ -349,20 +360,20 @@ extern "C" void launch_int8_gemm_pair_kernel(
     }
 }
 
-template <typename OutT>
+template <typename OutT, typename Epi>
 static void launch_int8_tiled_a_down(
     const uint8_t* A, const uint8_t* B, OutT* C,
-    int M, int N, int K, int ldc, comfy::hip_backend::EpiRowwise epi,
+    int M, int N, int K, int ldc, Epi epi,
     bool tiled_b, hipStream_t stream) {
     using namespace comfy::hip_backend;
     constexpr int BM = 128, BN = 128, BKB = 128;
     dim3 grid((N + BN - 1) / BN, (M + BM - 1) / BM);
     if (tiled_b) {
-        gemm_wmma_kernel<MmaInt8, EpiRowwise, OutT, BM, BN, BKB,
-                         4, 2, 2, 4, true, true, false, false, true>
+        gemm_wmma_kernel<MmaInt8, Epi, OutT, BM, BN, BKB,
+                         4, 2, 2, 4, false, true, false, false, true>
             <<<grid, 256, 0, stream>>>(A, B, C, M, N, K, ldc, epi);
     } else {
-        gemm_wmma_kernel<MmaInt8, EpiRowwise, OutT, BM, BN, BKB,
+        gemm_wmma_kernel<MmaInt8, Epi, OutT, BM, BN, BKB,
                          4, 2, 2, 4, true, true>
             <<<grid, 256, 0, stream>>>(A, B, C, M, N, K, ldc, epi);
     }
@@ -387,8 +398,14 @@ extern "C" void launch_int8_gemm_a_tiled128_down_kernel(
     const uint8_t* A = static_cast<const uint8_t*>(a);
     const uint8_t* B = static_cast<const uint8_t*>(b);
     if (out_code == kBF16) {
-        launch_int8_tiled_a_down(
-            A, B, static_cast<__bf16*>(c), M, N, K, ldc, epi, false, stream);
+        if (epi.bias == nullptr && epi.scale_b_stride == 1) {
+            EpiRowwiseNoBias no_bias{epi.scale_a, epi.scale_b};
+            launch_int8_tiled_a_down(
+                A, B, static_cast<__bf16*>(c), M, N, K, ldc, no_bias, false, stream);
+        } else {
+            launch_int8_tiled_a_down(
+                A, B, static_cast<__bf16*>(c), M, N, K, ldc, epi, false, stream);
+        }
     } else if (out_code == kF16) {
         launch_int8_tiled_a_down(
             A, B, static_cast<__half*>(c), M, N, K, ldc, epi, false, stream);
@@ -420,8 +437,14 @@ extern "C" void launch_int8_gemm_a_tiled128_b_tiled128_down_kernel(
     const uint8_t* A = static_cast<const uint8_t*>(a);
     const uint8_t* B = static_cast<const uint8_t*>(b);
     if (out_code == kBF16) {
-        launch_int8_tiled_a_down(
-            A, B, static_cast<__bf16*>(c), M, N, K, ldc, epi, true, stream);
+        if (epi.bias == nullptr && epi.scale_b_stride == 1) {
+            EpiRowwiseNoBias no_bias{epi.scale_a, epi.scale_b};
+            launch_int8_tiled_a_down(
+                A, B, static_cast<__bf16*>(c), M, N, K, ldc, no_bias, true, stream);
+        } else {
+            launch_int8_tiled_a_down(
+                A, B, static_cast<__bf16*>(c), M, N, K, ldc, epi, true, stream);
+        }
     } else if (out_code == kF16) {
         launch_int8_tiled_a_down(
             A, B, static_cast<__half*>(c), M, N, K, ldc, epi, true, stream);

--- a/comfy_kitchen/backends/hip/ops/gemm_int8.hip
+++ b/comfy_kitchen/backends/hip/ops/gemm_int8.hip
@@ -118,10 +118,11 @@ static void launch_int8(const int8_t* A, const int8_t* B, OutT* C, int M, int N,
                              4, 2, 2, 4>
                 <<<grid, 256, 0, stream>>>(Au, Bu, C, M, N, K, ldc, epi);
         } else {
-            // gfx11 and other WMMA targets: occupancy-aware tile selection
-            // from upstream #122.
-            launch_gemm_wmma<MmaInt8, EpiRowwise, OutT>(
-                Au, Bu, C, M, N, K, ldc, epi, stream);
+            // Portable starting geometry for other WMMA targets.
+            constexpr int BM = 128, BN = 128, BKB = 128;
+            dim3 grid((N + BN - 1) / BN, (M + BM - 1) / BM);
+            gemm_wmma_kernel<MmaInt8, EpiRowwise, OutT, BM, BN, BKB, 4, 2, 2, 4>
+                <<<grid, 256, 0, stream>>>(Au, Bu, C, M, N, K, ldc, epi);
         }
     } else {
         constexpr int BM = 64, BN = 64, BKB = 64;

--- a/comfy_kitchen/backends/hip/ops/gemm_int8.hip
+++ b/comfy_kitchen/backends/hip/ops/gemm_int8.hip
@@ -3,6 +3,7 @@
 //
 // INT8 GEMM on WMMA (v_wmma_i32_16x16x16_iu8), gfx11 and gfx12. See mma.h.
 // C[M, N] = (A[M, K] @ B[N, K]^T) * scale_a[row] * scale_b[col] + bias
+#include <cstring>
 #include <stdexcept>
 #include <string>
 
@@ -11,6 +12,22 @@
 #include "../launchers.h"
 
 namespace comfy::hip_backend {
+
+inline bool use_nonduplicated_int8_schedule() {
+    // The launch contract stays dimensional. Only the hardware choice is
+    // architecture-specific, and it remains private to this translation unit.
+    static const bool selected = [] {
+        int device = 0;
+        hipDeviceProp_t properties{};
+        if (hipGetDevice(&device) == hipSuccess &&
+            hipGetDeviceProperties(&properties, device) == hipSuccess &&
+            std::strncmp(properties.gcnArchName, "gfx12", 5) == 0) {
+            return true;
+        }
+        return false;
+    }();
+    return selected;
+}
 
 // Small-M path: reduce K across the wave, one wave per output column.
 template <typename OutT>
@@ -55,7 +72,52 @@ static void launch_int8(const int8_t* A, const int8_t* B, OutT* C, int M, int N,
         gemv_int8_kernel<OutT><<<grid, block, 0, stream>>>(A, B, C, M, N, K, ldc, epi);
         return;
     }
-    launch_gemm_wmma<MmaInt8, EpiRowwise, OutT>(Au, Bu, C, M, N, K, ldc, epi, stream);
+    const bool tuned = use_nonduplicated_int8_schedule();
+    if (M >= 96 && N >= 96) {
+        if (tuned && M >= 512 && K == 3840 &&
+            (N == 3840 || N == 11520)) {
+            // Reuse each staged B tile across two adjacent M tiles for the
+            // measured square and packed-QKV projection families.
+            constexpr int BM = 128, BN = 128, BKB = 64;
+            dim3 grid((N + BN - 1) / BN, (M + 2 * BM - 1) / (2 * BM));
+            if (epi.bias == nullptr && epi.scale_b_stride == 1) {
+                EpiRowwiseNoBias no_bias{epi.scale_a, epi.scale_b};
+                gemm_wmma_dual_m_kernel<MmaInt8, EpiRowwiseNoBias, OutT,
+                                        BM, BN, BKB, 4, 2, 2, 4, true>
+                    <<<grid, 512, 0, stream>>>(
+                        Au, Bu, C, M, N, K, ldc, no_bias);
+            } else {
+                gemm_wmma_dual_m_kernel<MmaInt8, EpiRowwise, OutT,
+                                        BM, BN, BKB, 4, 2, 2, 4, true>
+                    <<<grid, 512, 0, stream>>>(Au, Bu, C, M, N, K, ldc, epi);
+            }
+        } else if (tuned && M >= 512 && N >= 128 && K > N) {
+            // Deep-K projections benefit from a 256-row tile, a 128-byte K
+            // stage, and cooperative global-to-register-to-LDS staging.
+            constexpr int BM = 256, BN = 128, BKB = 128;
+            dim3 grid((N + BN - 1) / BN, (M + BM - 1) / BM);
+            gemm_wmma_kernel<MmaInt8, EpiRowwise, OutT, BM, BN, BKB,
+                             4, 2, 4, 4, true>
+                <<<grid, 256, 0, stream>>>(Au, Bu, C, M, N, K, ldc, epi);
+        } else if (tuned) {
+            // Non-duplicated WMMA operands favor the lower-LDS stage.
+            constexpr int BM = 128, BN = 128, BKB = 64;
+            dim3 grid((N + BN - 1) / BN, (M + BM - 1) / BM);
+            gemm_wmma_kernel<MmaInt8, EpiRowwise, OutT, BM, BN, BKB,
+                             4, 2, 2, 4>
+                <<<grid, 256, 0, stream>>>(Au, Bu, C, M, N, K, ldc, epi);
+        } else {
+            // gfx11 and other WMMA targets: occupancy-aware tile selection
+            // from upstream #122.
+            launch_gemm_wmma<MmaInt8, EpiRowwise, OutT>(
+                Au, Bu, C, M, N, K, ldc, epi, stream);
+        }
+    } else {
+        constexpr int BM = 64, BN = 64, BKB = 64;
+        dim3 grid((N + BN - 1) / BN, (M + BM - 1) / BM);
+        gemm_wmma_kernel<MmaInt8, EpiRowwise, OutT, BM, BN, BKB, 2, 2, 2, 2>
+            <<<grid, 128, 0, stream>>>(Au, Bu, C, M, N, K, ldc, epi);
+    }
 }
 
 }  // namespace comfy::hip_backend
@@ -98,5 +160,276 @@ extern "C" void launch_int8_gemm_kernel(
         launch_int8<float>(A, B, static_cast<float*>(c), M, N, K, ldc, epi, stream);
     } else {
         throw std::runtime_error("int8_gemm: unsupported output dtype");
+    }
+}
+
+template <typename OutT, int BKB, bool DUAL_M, typename Epi>
+static void launch_int8_b_tiled(
+    const uint8_t* A, const uint8_t* B, OutT* C,
+    int M, int N, int K, int ldc, Epi epi,
+    hipStream_t stream) {
+    using namespace comfy::hip_backend;
+    constexpr int BM = 128, BN = 128;
+    if constexpr (DUAL_M) {
+        dim3 grid((N + BN - 1) / BN, (M + 2 * BM - 1) / (2 * BM));
+        gemm_wmma_dual_m_kernel<MmaInt8, Epi, OutT,
+                                BM, BN, BKB, 4, 2, 2, 4,
+                                false, true>
+            <<<grid, 512, 0, stream>>>(A, B, C, M, N, K, ldc, epi);
+    } else {
+        dim3 grid((N + BN - 1) / BN, (M + BM - 1) / BM);
+        gemm_wmma_kernel<MmaInt8, Epi, OutT,
+                         BM, BN, BKB, 4, 2, 2, 4,
+                         true, false, false, true, true>
+            <<<grid, 256, 0, stream>>>(A, B, C, M, N, K, ldc, epi);
+    }
+}
+
+extern "C" void launch_int8_gemm_b_tiled_kernel(
+    const void* a, const void* b, void* c,
+    const void* scale_a, const void* scale_b, int scale_b_stride,
+    const void* bias, int bias_code, int M, int N, int K, int ldc,
+    int out_code, int tile_k, bool dual_m, hipStream_t stream) {
+    using namespace comfy::hip_backend;
+    if (M == 0 || N == 0) return;
+    if (M < 96 || N % 128 != 0 ||
+        (tile_k != 64 && tile_k != 128) || K % tile_k != 0 || ldc < N) {
+        throw std::runtime_error(
+            "int8_gemm_b_tiled: requires M>=96, N divisible by 128, "
+            "K divisible by tile_k, tile_k in {64,128}, and ldc>=N");
+    }
+    EpiRowwise epi{
+        static_cast<const float*>(scale_a), static_cast<const float*>(scale_b),
+        scale_b_stride, bias, bias_code};
+    const uint8_t* A = static_cast<const uint8_t*>(a);
+    const uint8_t* B = static_cast<const uint8_t*>(b);
+
+#define LAUNCH_TILED(OUT_T, EPI_ARG)                                            \
+    do {                                                                        \
+        if (tile_k == 64) {                                                     \
+            if (dual_m) launch_int8_b_tiled<OUT_T, 64, true>(                   \
+                A, B, static_cast<OUT_T*>(c), M, N, K, ldc, EPI_ARG, stream);   \
+            else launch_int8_b_tiled<OUT_T, 64, false>(                         \
+                A, B, static_cast<OUT_T*>(c), M, N, K, ldc, EPI_ARG, stream);   \
+        } else {                                                                \
+            if (dual_m) launch_int8_b_tiled<OUT_T, 128, true>(                  \
+                A, B, static_cast<OUT_T*>(c), M, N, K, ldc, EPI_ARG, stream);   \
+            else launch_int8_b_tiled<OUT_T, 128, false>(                        \
+                A, B, static_cast<OUT_T*>(c), M, N, K, ldc, EPI_ARG, stream);   \
+        }                                                                       \
+    } while (false)
+
+    if (epi.bias == nullptr && epi.scale_b_stride == 1) {
+        EpiRowwiseNoBias no_bias{epi.scale_a, epi.scale_b};
+        if (out_code == kBF16) {
+            LAUNCH_TILED(__bf16, no_bias);
+        } else if (out_code == kF16) {
+            LAUNCH_TILED(__half, no_bias);
+        } else if (out_code == kF32) {
+            LAUNCH_TILED(float, no_bias);
+        } else {
+            throw std::runtime_error("int8_gemm_b_tiled: unsupported output dtype");
+        }
+    } else if (out_code == kBF16) {
+        LAUNCH_TILED(__bf16, epi);
+    } else if (out_code == kF16) {
+        LAUNCH_TILED(__half, epi);
+    } else if (out_code == kF32) {
+        LAUNCH_TILED(float, epi);
+    } else {
+        throw std::runtime_error("int8_gemm_b_tiled: unsupported output dtype");
+    }
+#undef LAUNCH_TILED
+}
+
+extern "C" void launch_int8_gemm_b_tiled_gated_residual_kernel(
+    const void* a, const void* b, void* c,
+    const void* scale_a, const void* scale_b, int scale_b_stride,
+    const void* bias, int bias_code, const void* residual, const void* gate,
+    int M, int N, int K, int ldc, int tile_k, bool dual_m,
+    hipStream_t stream) {
+    using namespace comfy::hip_backend;
+    if (M == 0 || N == 0) return;
+    if (M < 96 || N % 128 != 0 ||
+        (tile_k != 64 && tile_k != 128) || K % tile_k != 0 || ldc < N) {
+        throw std::runtime_error(
+            "int8_gemm_b_tiled_gated_residual: requires M>=96, N divisible "
+            "by 128, K divisible by tile_k, tile_k in {64,128}, and ldc>=N");
+    }
+    EpiRowwiseGatedResidual epi{
+        static_cast<const float*>(scale_a), static_cast<const float*>(scale_b),
+        scale_b_stride, bias, bias_code,
+        static_cast<const __bf16*>(residual), static_cast<const __bf16*>(gate),
+        ldc};
+    const uint8_t* A = static_cast<const uint8_t*>(a);
+    const uint8_t* B = static_cast<const uint8_t*>(b);
+
+#define LAUNCH_TILED_GATED(TILE_K, DUAL_M)                                     \
+    launch_int8_b_tiled<__bf16, TILE_K, DUAL_M>(                              \
+        A, B, static_cast<__bf16*>(c), M, N, K, ldc, epi, stream)
+
+    if (tile_k == 64) {
+        if (dual_m) LAUNCH_TILED_GATED(64, true);
+        else LAUNCH_TILED_GATED(64, false);
+    } else {
+        if (dual_m) LAUNCH_TILED_GATED(128, true);
+        else LAUNCH_TILED_GATED(128, false);
+    }
+#undef LAUNCH_TILED_GATED
+}
+
+template <typename OutT>
+static void launch_int8_pair(
+    const uint8_t* A, const uint8_t* B0, const uint8_t* B1,
+    OutT* C0, OutT* C1, int M, int N, int K, int ldc,
+    comfy::hip_backend::EpiRowwise epi0,
+    comfy::hip_backend::EpiRowwise epi1, hipStream_t stream) {
+    using namespace comfy::hip_backend;
+    constexpr int BM = 128, BN = 128;
+    dim3 grid((N + BN - 1) / BN, (M + BM - 1) / BM);
+    if (use_nonduplicated_int8_schedule() &&
+        epi0.bias == nullptr && epi1.bias == nullptr &&
+        epi0.scale_b_stride == 1 && epi1.scale_b_stride == 1) {
+        constexpr int BKB = 64;
+        EpiRowwiseNoBias no_bias0{epi0.scale_a, epi0.scale_b};
+        EpiRowwiseNoBias no_bias1{epi1.scale_a, epi1.scale_b};
+        gemm_wmma_pair_kernel<MmaInt8, EpiRowwiseNoBias, OutT,
+                              BM, BN, BKB, 4, 2, 2, 4>
+            <<<grid, 512, 0, stream>>>(
+                A, B0, B1, C0, C1, M, N, K, ldc, no_bias0, no_bias1);
+    } else {
+        constexpr int BKB = 64;
+        gemm_wmma_pair_kernel<MmaInt8, EpiRowwise, OutT,
+                              BM, BN, BKB, 4, 2, 2, 4>
+            <<<grid, 512, 0, stream>>>(
+                A, B0, B1, C0, C1, M, N, K, ldc, epi0, epi1);
+    }
+}
+
+extern "C" void launch_int8_gemm_pair_kernel(
+    const void* a, const void* b0, const void* b1, void* c0, void* c1,
+    const void* scale_a, const void* scale_b0, int scale_b_stride0,
+    const void* scale_b1, int scale_b_stride1, const void* bias0,
+    int bias_code0, const void* bias1, int bias_code1, int M, int N, int K,
+    int ldc, int out_code, hipStream_t stream) {
+
+    using namespace comfy::hip_backend;
+    if (M == 0) return;
+    if (M < 96 || N < 96 || K <= 0 || K % 64 != 0 || ldc < N) {
+        throw std::runtime_error(
+            "int8_gemm_pair: requires M,N>=96, positive K divisible by 64, and ldc>=N");
+    }
+
+    EpiRowwise epi0{
+        static_cast<const float*>(scale_a),
+        static_cast<const float*>(scale_b0), scale_b_stride0,
+        bias0, bias_code0};
+    EpiRowwise epi1{
+        static_cast<const float*>(scale_a),
+        static_cast<const float*>(scale_b1), scale_b_stride1,
+        bias1, bias_code1};
+    const uint8_t* A = static_cast<const uint8_t*>(a);
+    const uint8_t* B0 = static_cast<const uint8_t*>(b0);
+    const uint8_t* B1 = static_cast<const uint8_t*>(b1);
+
+    if (out_code == kBF16) {
+        launch_int8_pair(
+            A, B0, B1, static_cast<__bf16*>(c0), static_cast<__bf16*>(c1),
+            M, N, K, ldc, epi0, epi1, stream);
+    } else if (out_code == kF16) {
+        launch_int8_pair(
+            A, B0, B1, static_cast<__half*>(c0), static_cast<__half*>(c1),
+            M, N, K, ldc, epi0, epi1, stream);
+    } else if (out_code == kF32) {
+        launch_int8_pair(
+            A, B0, B1, static_cast<float*>(c0), static_cast<float*>(c1),
+            M, N, K, ldc, epi0, epi1, stream);
+    } else {
+        throw std::runtime_error("int8_gemm_pair: unsupported output dtype");
+    }
+}
+
+template <typename OutT>
+static void launch_int8_tiled_a_down(
+    const uint8_t* A, const uint8_t* B, OutT* C,
+    int M, int N, int K, int ldc, comfy::hip_backend::EpiRowwise epi,
+    bool tiled_b, hipStream_t stream) {
+    using namespace comfy::hip_backend;
+    constexpr int BM = 128, BN = 128, BKB = 128;
+    dim3 grid((N + BN - 1) / BN, (M + BM - 1) / BM);
+    if (tiled_b) {
+        gemm_wmma_kernel<MmaInt8, EpiRowwise, OutT, BM, BN, BKB,
+                         4, 2, 2, 4, true, true, false, false, true>
+            <<<grid, 256, 0, stream>>>(A, B, C, M, N, K, ldc, epi);
+    } else {
+        gemm_wmma_kernel<MmaInt8, EpiRowwise, OutT, BM, BN, BKB,
+                         4, 2, 2, 4, true, true>
+            <<<grid, 256, 0, stream>>>(A, B, C, M, N, K, ldc, epi);
+    }
+}
+
+extern "C" void launch_int8_gemm_a_tiled128_down_kernel(
+    const void* a, const void* b, void* c,
+    const void* scale_a, const void* scale_b, int scale_b_stride,
+    const void* bias, int bias_code,
+    int M, int N, int K, int ldc, int out_code, hipStream_t stream) {
+
+    using namespace comfy::hip_backend;
+    if (M == 0) return;
+    if (N <= 0 || K <= 0 || N % 128 != 0 || K % 128 != 0 || ldc < N) {
+        throw std::runtime_error(
+            "int8_gemm_a_tiled128_down: requires positive N/K divisible by "
+            "128 and ldc>=N");
+    }
+    EpiRowwise epi{
+        static_cast<const float*>(scale_a), static_cast<const float*>(scale_b),
+        scale_b_stride, bias, bias_code};
+    const uint8_t* A = static_cast<const uint8_t*>(a);
+    const uint8_t* B = static_cast<const uint8_t*>(b);
+    if (out_code == kBF16) {
+        launch_int8_tiled_a_down(
+            A, B, static_cast<__bf16*>(c), M, N, K, ldc, epi, false, stream);
+    } else if (out_code == kF16) {
+        launch_int8_tiled_a_down(
+            A, B, static_cast<__half*>(c), M, N, K, ldc, epi, false, stream);
+    } else if (out_code == kF32) {
+        launch_int8_tiled_a_down(
+            A, B, static_cast<float*>(c), M, N, K, ldc, epi, false, stream);
+    } else {
+        throw std::runtime_error(
+            "int8_gemm_a_tiled128_down: unsupported output dtype");
+    }
+}
+
+extern "C" void launch_int8_gemm_a_tiled128_b_tiled128_down_kernel(
+    const void* a, const void* b, void* c,
+    const void* scale_a, const void* scale_b, int scale_b_stride,
+    const void* bias, int bias_code,
+    int M, int N, int K, int ldc, int out_code, hipStream_t stream) {
+
+    using namespace comfy::hip_backend;
+    if (M == 0) return;
+    if (N <= 0 || K <= 0 || N % 128 != 0 || K % 128 != 0 || ldc < N) {
+        throw std::runtime_error(
+            "int8_gemm_a_tiled128_b_tiled128_down: requires positive N/K "
+            "divisible by 128 and ldc>=N");
+    }
+    EpiRowwise epi{
+        static_cast<const float*>(scale_a), static_cast<const float*>(scale_b),
+        scale_b_stride, bias, bias_code};
+    const uint8_t* A = static_cast<const uint8_t*>(a);
+    const uint8_t* B = static_cast<const uint8_t*>(b);
+    if (out_code == kBF16) {
+        launch_int8_tiled_a_down(
+            A, B, static_cast<__bf16*>(c), M, N, K, ldc, epi, true, stream);
+    } else if (out_code == kF16) {
+        launch_int8_tiled_a_down(
+            A, B, static_cast<__half*>(c), M, N, K, ldc, epi, true, stream);
+    } else if (out_code == kF32) {
+        launch_int8_tiled_a_down(
+            A, B, static_cast<float*>(c), M, N, K, ldc, epi, true, stream);
+    } else {
+        throw std::runtime_error(
+            "int8_gemm_a_tiled128_b_tiled128_down: unsupported output dtype");
     }
 }

--- a/comfy_kitchen/backends/hip/ops/quantize_int8.hip
+++ b/comfy_kitchen/backends/hip/ops/quantize_int8.hip
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // INT8 quantization kernels for the WMMA int8 GEMM.
+#include <cstring>
 #include <stdexcept>
 
 #include "../hadamard.h"
@@ -9,6 +10,25 @@
 namespace comfy::hip_backend {
 
 constexpr float kInt8Max = 127.0f;
+
+inline bool use_convrot_512x2_bf16(int in_code, int K, int group_size) {
+    if (in_code != 2 || group_size != 256) {
+        return false;
+    }
+
+    // The packed-element schedule is exact and faster at these two measured
+    // widths. K=3072, 5120, 5376, and 6144 are slower and do not preserve the
+    // generic producer's rounding, so they retain that path.
+    if (K != 3840 && K != 10240) {
+        return false;
+    }
+
+    // Portable wave32 RDNA schedule: requires a 512-thread workgroup and
+    // enough LDS, but no arch-specific instruction or layout. Validated on
+    // gfx12; other supported devices retain the same exact fallback when
+    // these launch capabilities are absent.
+    return convrot_512x2_supported(K);
+}
 
 __forceinline__ __device__ int8_t quant_round(float v, float inv) {
     // rintf is round-half-to-even, matching torch.round.
@@ -211,15 +231,8 @@ void launch_convrot_quant_global_managed(
     dispatch_convrot_row_type(
         in_dtype,
         LaunchConvrotQuantGlobalManaged<ACT>{
-            x,
-            in_dtype,
-            qout,
-            scaleout,
-            M,
-            K,
-            stream,
-            spill_rotated,
-            spill_partials});
+            x, in_dtype, qout, scaleout, M, K, stream,
+            spill_rotated, spill_partials});
 }
 
 template void launch_convrot_quant_global_managed<kActNone>(
@@ -255,22 +268,147 @@ extern "C" void launch_quantize_int8_convrot_kernel(
     if (M == 0) {
         return;  // a zero-block launch is hipErrorInvalidConfiguration
     }
+    const bool schedule_512x2 =
+        use_convrot_512x2_bf16(in_code, K, group_size);
     if (act_code == kActGeluTanh) {
-        launch_convrot_quant<false, kActGeluTanh>(
-            x, in_code, static_cast<int8_t*>(q), static_cast<float*>(scales),
-            M, K, group_size, stream, spill_rotated, spill_partials);
+        if (schedule_512x2) {
+            launch_convrot_quant_512x2_bf16<kActGeluTanh>(
+                x, in_code, static_cast<int8_t*>(q), static_cast<float*>(scales),
+                M, K, stream);
+        } else {
+            launch_convrot_quant<false, kActGeluTanh>(
+                x, in_code, static_cast<int8_t*>(q), static_cast<float*>(scales),
+                M, K, group_size, stream, spill_rotated, spill_partials);
+        }
     } else if (act_code == kActSwiGLU) {
-        launch_convrot_quant<false, kActSwiGLU>(
-            x, in_code, static_cast<int8_t*>(q), static_cast<float*>(scales),
-            M, K, group_size, stream, spill_rotated, spill_partials);
+        if (schedule_512x2) {
+            launch_convrot_quant_512x2_bf16<kActSwiGLU>(
+                x, in_code, static_cast<int8_t*>(q), static_cast<float*>(scales),
+                M, K, stream);
+        } else {
+            launch_convrot_quant<false, kActSwiGLU>(
+                x, in_code, static_cast<int8_t*>(q), static_cast<float*>(scales),
+                M, K, group_size, stream, spill_rotated, spill_partials);
+        }
     } else {
-        launch_convrot_quant<false, kActNone>(
-            x, in_code, static_cast<int8_t*>(q), static_cast<float*>(scales),
-            M, K, group_size, stream, spill_rotated, spill_partials);
+        if (schedule_512x2) {
+            launch_convrot_quant_512x2_bf16<kActNone>(
+                x, in_code, static_cast<int8_t*>(q), static_cast<float*>(scales),
+                M, K, stream);
+        } else {
+            launch_convrot_quant<false, kActNone>(
+                x, in_code, static_cast<int8_t*>(q), static_cast<float*>(scales),
+                M, K, group_size, stream, spill_rotated, spill_partials);
+        }
     }
 }
 
-// Returns 1 when INT8 G=256 must use the global spill path for (M, K, in_dtype).
+// Exact producer for the tiled-A projection schedule. Quantized
+// bytes are written directly as [M_tile, K_tile, 128, 128]; no row-major INT8
+// intermediate or layout-conversion kernel is materialized.
+extern "C" void launch_quantize_int8_convrot_tiled128_kernel(
+    const void* x, int in_code, void* q, void* scales,
+    int M, int K, int group_size, hipStream_t stream) {
+
+    using namespace comfy::hip_backend;
+    if (in_code != 2 || K <= 0 || K % 128 != 0 || group_size != 256 ||
+        !convrot_512x2_supported(K)) {
+        throw std::runtime_error(
+            "convrot tiled128: requires BF16, K divisible by 128, "
+            "group_size=256, and sufficient wave32/LDS capacity");
+    }
+    check_convrot_k(K, group_size, in_code);
+    if (M == 0) return;
+    launch_convrot_quant_512x2_bf16_tiled128(
+        x, in_code, static_cast<int8_t*>(q), static_cast<float*>(scales),
+        M, K, stream);
+}
+
+// Consume separate BF16 gate/up projections,
+// reproduce the exact standalone SwiGLU rounding contract, and emit the same
+// tile-major INT8 activation expected by the accepted down GEMM.
+extern "C" void launch_quantize_int8_convrot_swiglu_split_tiled128_kernel(
+    const void* gate, const void* up, void* q, void* scales,
+    int M, int K, int group_size, hipStream_t stream) {
+
+    using namespace comfy::hip_backend;
+    if (K <= 0 || K % 128 != 0 || group_size != 256 ||
+        !convrot_512x2_supported(K)) {
+        throw std::runtime_error(
+            "convrot split swiglu tiled128: requires K divisible by 128, "
+            "group_size=256, and sufficient wave32/LDS capacity");
+    }
+    check_convrot_k(K, group_size, 2);
+    if (M == 0) return;
+    launch_convrot_quant_512x2_bf16_swiglu_split_tiled128(
+        gate, up, static_cast<int8_t*>(q), static_cast<float*>(scales),
+        M, K, stream);
+}
+
+// Fold exact batch-one BF16 scale modulation into the row-major ConvRot
+// producer.
+extern "C" void launch_quantize_int8_convrot_modulated_kernel(
+    const void* x, const void* modulation_scale, void* q, void* scales,
+    int M, int K, int group_size, hipStream_t stream) {
+
+    using namespace comfy::hip_backend;
+    if (K <= 0 || group_size != 256 || !convrot_512x2_supported(K)) {
+        throw std::runtime_error(
+            "convrot modulated: requires positive K, group_size=256, and "
+            "sufficient wave32/LDS capacity");
+    }
+    check_convrot_k(K, group_size, 2);
+    if (M == 0) return;
+    launch_convrot_quant_512x2_bf16_modulated(
+        x, modulation_scale, static_cast<int8_t*>(q),
+        static_cast<float*>(scales), M, K, stream);
+}
+
+// Fold a materialized BF16 affine modulation into the generic fused
+// ConvRot producer.  The schedule is selected from dimensions and LDS
+// capacity, so the path applies to any compatible hidden width.
+extern "C" void launch_quantize_int8_convrot_affine_kernel(
+    const void* x, const void* modulation_scale,
+    const void* modulation_shift, void* q, void* scales,
+    int M, int K, int group_size, hipStream_t stream) {
+
+    using namespace comfy::hip_backend;
+    if (group_size != 256) {
+        throw std::runtime_error(
+            "convrot affine: requires group_size=256");
+    }
+    check_convrot_k(K, group_size, 2, /*int8_quant=*/true);
+    if (M == 0) return;
+    if (!launch_convrot_quant_affine_bf16(
+            x, modulation_scale, modulation_shift,
+            static_cast<int8_t*>(q), static_cast<float*>(scales),
+            M, K, stream)) {
+        throw std::runtime_error(
+            "convrot affine: row does not fit the fused LDS schedule");
+    }
+}
+
+extern "C" void launch_quantize_int8_convrot_rms_modulated_kernel(
+    const void* x, const void* norm_weight, const void* rstd,
+    const void* modulation_scale, void* q, void* scales,
+    int M, int K, int group_size, hipStream_t stream) {
+
+    using namespace comfy::hip_backend;
+    if (K != 3840 || group_size != 256) {
+        throw std::runtime_error(
+            "convrot rms modulated: requires BF16 K=3840 and group_size=256");
+    }
+    check_convrot_k(K, group_size, 2);
+    if (M == 0) return;
+    launch_convrot_quant_512x2_bf16_rms_modulated(
+        x, norm_weight, static_cast<const float*>(rstd), modulation_scale,
+        static_cast<int8_t*>(q), static_cast<float*>(scales), M, K, stream);
+}
+
+// Returns 1 when INT8 G=256 must use the generic global-spill path for
+// this device. The specialized live shapes fit in LDS on capable wave32 RDNA
+// devices, so they do not allocate a workspace; generic and ultra-wide shapes
+// retain the generic capacity predicate.
 extern "C" int convrot_int8_needs_spill_host(int M, int K, int in_code) {
     using namespace comfy::hip_backend;
     return convrot_int8_needs_spill_buffers(M, K, in_code) ? 1 : 0;

--- a/comfy_kitchen/backends/hip/ops/rms_convrot_quant.hip
+++ b/comfy_kitchen/backends/hip/ops/rms_convrot_quant.hip
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Exact BF16 RMSNorm + BF16 modulation + ConvRot + INT8
+// rowwise quantization. The RMS statistic explicitly requests IEEE division
+// and OCML rsqrt while retaining the accepted fast-math ConvRot schedule.
+#include <stdexcept>
+
+#include "../hadamard.h"
+
+extern "C" void launch_quantize_int8_convrot_rms_modulated_fused_stats_kernel(
+    const void* x, const void* norm_weight, const void* modulation_scale,
+    void* q, void* scales, int M, int K, int group_size, float eps,
+    hipStream_t stream) {
+
+    using namespace comfy::hip_backend;
+    if (K != 3840 || group_size != 256) {
+        throw std::runtime_error(
+            "convrot fused rms modulated: requires BF16 K=3840 and group_size=256");
+    }
+    check_convrot_k(K, group_size, 2);
+    if (M == 0) return;
+
+    if (use_convrot_packed_elements()) {
+        convrot_quant_512x2_bf16_kernel<
+            kActNone, false, false, true, true, true, true, true>
+            <<<M, 512, static_cast<size_t>(K) * sizeof(__bf16), stream>>>(
+                x, modulation_scale, 2, static_cast<int8_t*>(q),
+                static_cast<float*>(scales), M, K, norm_weight, nullptr, eps);
+    } else if (use_convrot_packed_quant()) {
+        convrot_quant_512x2_bf16_kernel<
+            kActNone, false, false, true, true, true, true>
+            <<<M, 512, static_cast<size_t>(K) * sizeof(__bf16), stream>>>(
+                x, modulation_scale, 2, static_cast<int8_t*>(q),
+                static_cast<float*>(scales), M, K, norm_weight, nullptr, eps);
+    } else {
+        convrot_quant_512x2_bf16_kernel<
+            kActNone, false, false, true, false, true, true>
+            <<<M, 512, static_cast<size_t>(K) * sizeof(__bf16), stream>>>(
+                x, modulation_scale, 2, static_cast<int8_t*>(q),
+                static_cast<float*>(scales), M, K, norm_weight, nullptr, eps);
+    }
+}

--- a/comfy_kitchen/backends/hip/ops/rms_gated_residual.hip
+++ b/comfy_kitchen/backends/hip/ops/rms_gated_residual.hip
@@ -1,0 +1,183 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Exact BF16 RMSNorm followed by the separately rounded BF16 gate product and
+// residual add. One workgroup owns one row.
+#include <cstdint>
+#include <stdexcept>
+
+#include <hip/hip_bfloat16.h>
+#include <hip/hip_fp16.h>
+#include <hip/hip_runtime.h>
+
+#include "../rope_math.h"
+
+namespace comfy::hip_backend {
+
+typedef __bf16 RmsResidualBf16x4 __attribute__((ext_vector_type(4)));
+
+extern "C" __device__ float __ocml_rsqrt_f32(float);
+
+__forceinline__ __device__ float rms_residual_ieee_div_f32(
+    float numerator, float denominator) {
+    bool denominator_scale = false;
+    bool scale = false;
+    const float scaled_denominator = __builtin_amdgcn_div_scalef(
+        numerator, denominator, false, &denominator_scale);
+    const float scaled_numerator = __builtin_amdgcn_div_scalef(
+        numerator, denominator, true, &scale);
+    float reciprocal = __builtin_amdgcn_rcpf(scaled_denominator);
+    const float reciprocal_error =
+        fmaf(-scaled_denominator, reciprocal, 1.0f);
+    reciprocal = fmaf(reciprocal_error, reciprocal, reciprocal);
+    float quotient = scaled_numerator * reciprocal;
+    float remainder =
+        fmaf(-scaled_denominator, quotient, scaled_numerator);
+    quotient = fmaf(remainder, reciprocal, quotient);
+    remainder = fmaf(-scaled_denominator, quotient, scaled_numerator);
+    quotient = __builtin_amdgcn_div_fmasf(
+        remainder, reciprocal, quotient, scale);
+    return __builtin_amdgcn_div_fixupf(
+        quotient, denominator, numerator);
+}
+
+__forceinline__ __device__ __bf16 rms_gated_residual_value(
+    __bf16 raw, __bf16 norm_weight, float rstd,
+    __bf16 residual, __bf16 gate) {
+    // PyTorch RMSNorm materializes gamma * (rstd * x) in BF16. Preserve the
+    // two FP32 multiplies and the single visible BF16 rounding point.
+    float normalized = rstd * static_cast<float>(raw);
+    asm volatile("" : "+v"(normalized));
+    normalized *= static_cast<float>(norm_weight);
+    normalized = round_bf16(normalized);
+
+    // The eager block exit is two more BF16 kernels: gate * normalized, then
+    // residual + product. Each therefore has its own BF16 rounding point.
+    const float product = round_bf16(
+        normalized * static_cast<float>(gate));
+    return static_cast<__bf16>(round_bf16(
+        static_cast<float>(residual) + product));
+}
+
+template <int STATIC_WIDTH = 0>
+__global__ __launch_bounds__(256) void rms_gated_residual_bf16_kernel(
+    const __bf16* __restrict__ activation,
+    const __bf16* __restrict__ norm_weight,
+    const __bf16* __restrict__ residual,
+    const __bf16* __restrict__ gate,
+    __bf16* __restrict__ output, int width,
+    float eps) {
+
+    const int kWidth = STATIC_WIDTH ? STATIC_WIDTH : width;
+    const int kVectors = kWidth / 4;
+    __shared__ float wave_sums[8];
+    extern __shared__ __bf16 row[];
+
+    const int thread = threadIdx.x;
+    const int lane = thread & 31;
+    const int wave = thread >> 5;
+    const int row_index = blockIdx.x;
+    const int64_t row_offset = static_cast<int64_t>(row_index) * kWidth;
+
+    const auto* input_vectors =
+        reinterpret_cast<const RmsResidualBf16x4*>(activation + row_offset);
+    auto* row_vectors = reinterpret_cast<RmsResidualBf16x4*>(row);
+
+    float rstd;
+    {
+    #pragma clang fp reassociate(off)
+    #pragma clang fp contract(on)
+    #pragma clang fp reciprocal(off)
+    float sum_sq = 0.0f;
+    for (int vector = thread; vector < kVectors; vector += 256) {
+        const RmsResidualBf16x4 values = input_vectors[vector];
+        row_vectors[vector] = values;
+        #pragma unroll
+        for (int element = 0; element < 4; ++element) {
+            const float value = static_cast<float>(values[element]);
+            sum_sq += value * value;
+        }
+    }
+
+    #pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1) {
+        sum_sq += __shfl_down(sum_sq, offset, 32);
+    }
+
+    // Match PyTorch's eight-wave pairwise compute_stats() merge order.
+    #pragma unroll
+    for (int offset = 4; offset > 0; offset >>= 1) {
+        if (lane == 0 && wave >= offset && wave < 2 * offset) {
+            wave_sums[wave - offset] = sum_sq;
+        }
+        __syncthreads();
+        if (lane == 0 && wave < offset) {
+            sum_sq += wave_sums[wave];
+        }
+        __syncthreads();
+    }
+
+    if (thread == 0) {
+        const float mean_square = rms_residual_ieee_div_f32(
+            sum_sq, static_cast<float>(kWidth));
+        wave_sums[0] = __ocml_rsqrt_f32(mean_square + eps);
+    }
+    __syncthreads();
+    rstd = wave_sums[0];
+    }
+
+    const auto* weight_vectors =
+        reinterpret_cast<const RmsResidualBf16x4*>(norm_weight);
+    const auto* residual_vectors =
+        reinterpret_cast<const RmsResidualBf16x4*>(residual + row_offset);
+    const auto* gate_vectors =
+        reinterpret_cast<const RmsResidualBf16x4*>(gate);
+    auto* output_vectors =
+        reinterpret_cast<RmsResidualBf16x4*>(output + row_offset);
+
+    for (int vector = thread; vector < kVectors; vector += 256) {
+        const RmsResidualBf16x4 raw_values = row_vectors[vector];
+        const RmsResidualBf16x4 weight_values = weight_vectors[vector];
+        const RmsResidualBf16x4 residual_values = residual_vectors[vector];
+        const RmsResidualBf16x4 gate_values = gate_vectors[vector];
+        RmsResidualBf16x4 result;
+        #pragma unroll
+        for (int element = 0; element < 4; ++element) {
+            result[element] = rms_gated_residual_value(
+                raw_values[element], weight_values[element], rstd,
+                residual_values[element], gate_values[element]);
+        }
+        output_vectors[vector] = result;
+    }
+}
+
+}  // namespace comfy::hip_backend
+
+extern "C" void launch_rms_gated_residual_bf16_kernel(
+    const void* activation, const void* norm_weight, const void* residual,
+    const void* gate, void* output, int rows, int width, float eps,
+    hipStream_t stream) {
+
+    using namespace comfy::hip_backend;
+    if (rows < 0 || width <= 0 || width % 4 != 0) {
+        throw std::runtime_error(
+            "rms_gated_residual_bf16: requires non-negative rows and positive "
+            "width divisible by 4");
+    }
+    if (rows == 0) return;
+    const size_t shared_bytes = static_cast<size_t>(width) * sizeof(__bf16);
+#define CK_LAUNCH_RMS_GATED(STATIC_WIDTH)                                      \
+    rms_gated_residual_bf16_kernel<STATIC_WIDTH>                               \
+        <<<rows, 256, shared_bytes, stream>>>(                                  \
+            static_cast<const __bf16*>(activation),                            \
+            static_cast<const __bf16*>(norm_weight),                           \
+            static_cast<const __bf16*>(residual),                              \
+            static_cast<const __bf16*>(gate), static_cast<__bf16*>(output),    \
+            width, eps)
+    if (width == 3840) {
+        CK_LAUNCH_RMS_GATED(3840);
+    } else {
+        CK_LAUNCH_RMS_GATED(0);
+    }
+#undef CK_LAUNCH_RMS_GATED
+}

--- a/comfy_kitchen/backends/hip/ops/rms_rope.hip
+++ b/comfy_kitchen/backends/hip/ops/rms_rope.hip
@@ -127,6 +127,190 @@ __global__ __launch_bounds__(kRmsRopeThreads) void rms_rope_kernel(
     }
 }
 
+// On wave32 RDNA, a 128-wide head fits one wave that reproduces the 64-thread
+// kernel's reduction tree while several independent
+// rows share a workgroup. This removes all workgroup barriers and reduction LDS.
+__device__ __forceinline__ float rms_rope_ordered_fmac(float accumulator, float value) {
+    asm volatile("v_fmac_f32_e32 %0, %1, %1" : "+v"(accumulator) : "v"(value));
+    return accumulator;
+}
+
+__device__ __forceinline__ float rms_rope_ordered_add(float lhs, float rhs) {
+    float result;
+    asm volatile("v_add_f32_e32 %0, %1, %2" : "=v"(result) : "v"(lhs), "v"(rhs));
+    return result;
+}
+
+// Specialize the common BF16 Q/K, FP32-frequency, BF16-scale, interleaved
+// contract so uniform runtime type branches disappear from the hot loop.
+template <bool STATIC_BF16_TYPES>
+__device__ __forceinline__ float rms_rope_load_x(
+    const void* ptr, int64_t index, int code) {
+    if constexpr (STATIC_BF16_TYPES) {
+        return static_cast<float>(static_cast<const __bf16*>(ptr)[index]);
+    }
+    return load_in(ptr, index, code);
+}
+
+template <bool STATIC_BF16_TYPES>
+__device__ __forceinline__ float rms_rope_load_freq(
+    const void* ptr, int64_t index, int code) {
+    if constexpr (STATIC_BF16_TYPES) {
+        return static_cast<const float*>(ptr)[index];
+    }
+    return load_in(ptr, index, code);
+}
+
+template <bool STATIC_BF16_TYPES>
+__device__ __forceinline__ float rms_rope_load_scale(
+    const void* ptr, int64_t index, int code) {
+    if constexpr (STATIC_BF16_TYPES) {
+        return static_cast<float>(static_cast<const __bf16*>(ptr)[index]);
+    }
+    return load_in(ptr, index, code);
+}
+
+template <typename T, int ROWS_PER_BLOCK, bool STATIC_BF16_TYPES = false>
+__global__ __launch_bounds__(ROWS_PER_BLOCK * 32) void rms_rope_wave32_128_kernel(
+    const void* __restrict__ q, const void* __restrict__ k,
+    const void* __restrict__ freqs, const void* __restrict__ q_scale,
+    const void* __restrict__ k_scale, T* __restrict__ q_out, T* __restrict__ k_out,
+    int64_t rows, int64_t dim1, int64_t dim2, int rot_dim,
+    int64_t fb, int64_t fd1, int64_t fd2,
+    int64_t sx_b, int64_t sx_d1, int64_t sx_d2, int64_t sx_d,
+    int64_t so_b, int64_t so_d1, int64_t so_d2, int64_t so_d,
+    int64_t sf_b, int64_t sf_d1, int64_t sf_d2, int64_t sf_d, int64_t sf_rot,
+    int64_t sf_pair,
+    int x_code, int f_code, int s_code, float epsilon, bool split_half) {
+
+    constexpr int kHeadDim = 128;
+    const int lane = threadIdx.x & 31;
+    const int wave = threadIdx.x >> 5;
+    const int64_t row = static_cast<int64_t>(blockIdx.x) * ROWS_PER_BLOCK + wave;
+    if (row >= rows) return;
+
+    const int64_t d2 = row % dim2;
+    const int64_t d1 = (row / dim2) % dim1;
+    const int64_t b = row / (dim2 * dim1);
+    const int64_t xoff = b * sx_b + d1 * sx_d1 + d2 * sx_d2;
+    const int64_t ooff = b * so_b + d1 * so_d1 + d2 * so_d2;
+    const bool has_k = k != nullptr;
+
+    // Match the original 64-thread reduction association exactly. Each old
+    // thread first sums d and d+64; its s=32 partner owns d+32 and d+96.
+    const int dims[4] = {lane, lane + 64, lane + 32, lane + 96};
+    float sq_q_lo = 0.0f;
+    float sq_q_hi = 0.0f;
+    float sq_k_lo = 0.0f;
+    float sq_k_hi = 0.0f;
+    #pragma unroll
+    for (int i = 0; i < 2; ++i) {
+        const float qv = rms_rope_load_x<STATIC_BF16_TYPES>(
+            q, xoff + static_cast<int64_t>(dims[i]) * sx_d, x_code);
+        sq_q_lo = rms_rope_ordered_fmac(sq_q_lo, qv);
+        if (has_k) {
+            const float kv = rms_rope_load_x<STATIC_BF16_TYPES>(
+                k, xoff + static_cast<int64_t>(dims[i]) * sx_d, x_code);
+            sq_k_lo = rms_rope_ordered_fmac(sq_k_lo, kv);
+        }
+    }
+    #pragma unroll
+    for (int i = 2; i < 4; ++i) {
+        const float qv = rms_rope_load_x<STATIC_BF16_TYPES>(
+            q, xoff + static_cast<int64_t>(dims[i]) * sx_d, x_code);
+        sq_q_hi = rms_rope_ordered_fmac(sq_q_hi, qv);
+        if (has_k) {
+            const float kv = rms_rope_load_x<STATIC_BF16_TYPES>(
+                k, xoff + static_cast<int64_t>(dims[i]) * sx_d, x_code);
+            sq_k_hi = rms_rope_ordered_fmac(sq_k_hi, kv);
+        }
+    }
+
+    float sq_q = rms_rope_ordered_add(sq_q_lo, sq_q_hi);
+    float sq_k = rms_rope_ordered_add(sq_k_lo, sq_k_hi);
+    #pragma unroll
+    for (int off = 16; off > 0; off >>= 1) {
+        sq_q = rms_rope_ordered_add(sq_q, __shfl_xor(sq_q, off, 32));
+        sq_k = rms_rope_ordered_add(sq_k, __shfl_xor(sq_k, off, 32));
+    }
+    // Only lane zero's butterfly association is identical to red_[qk][0] in
+    // the reference down-tree. Broadcast that result so compiler scheduling of
+    // the other lanes cannot create rare one-ULP normalization differences.
+    sq_q = __shfl(sq_q, 0, 32);
+    sq_k = __shfl(sq_k, 0, 32);
+
+    const float rrms_q = rsqrtf(sq_q * (1.0f / kHeadDim) + epsilon);
+    const float rrms_k = has_k ? rsqrtf(sq_k * (1.0f / kHeadDim) + epsilon) : 0.0f;
+    const int64_t foff_row = (fb == 1 ? 0 : b) * sf_b +
+                             (fd1 == 1 ? 0 : d1) * sf_d1 +
+                             (fd2 == 1 ? 0 : d2) * sf_d2;
+
+    const int n_pairs = rot_dim / 2;
+    for (int p = lane; p < n_pairs; p += 32) {
+        const int64_t ia = STATIC_BF16_TYPES ? 2 * p : (split_half ? p : 2 * p);
+        const int64_t ib = STATIC_BF16_TYPES ? 2 * p + 1
+                                               : (split_half ? p + n_pairs : 2 * p + 1);
+        const int64_t ia_in = xoff + ia * sx_d;
+        const int64_t ib_in = xoff + ib * sx_d;
+        const int64_t ia_out = ooff + ia * so_d;
+        const int64_t ib_out = ooff + ib * so_d;
+        const int64_t foff = foff_row + static_cast<int64_t>(p) * sf_d;
+        const float f00 = rms_rope_load_freq<STATIC_BF16_TYPES>(freqs, foff, f_code);
+        const float f01 = rms_rope_load_freq<STATIC_BF16_TYPES>(freqs, foff + sf_pair, f_code);
+        const float f10 = rms_rope_load_freq<STATIC_BF16_TYPES>(freqs, foff + sf_rot, f_code);
+        const float f11 = rms_rope_load_freq<STATIC_BF16_TYPES>(
+            freqs, foff + sf_rot + sf_pair, f_code);
+
+        const float sa = rms_rope_load_scale<STATIC_BF16_TYPES>(q_scale, ia, s_code);
+        const float sb = rms_rope_load_scale<STATIC_BF16_TYPES>(q_scale, ib, s_code);
+        const float qa = round_to<T>(
+            rms_rope_load_x<STATIC_BF16_TYPES>(q, ia_in, x_code) * rrms_q * sa);
+        const float qb = round_to<T>(
+            rms_rope_load_x<STATIC_BF16_TYPES>(q, ib_in, x_code) * rrms_q * sb);
+        rope_store<T>(q_out, ia_out,
+                      rope_combine(f00, qa, f01, qb, f_code, split_half));
+        rope_store<T>(q_out, ib_out,
+                      rope_combine(f10, qa, f11, qb, f_code, split_half));
+
+        if (has_k) {
+            const float ta = rms_rope_load_scale<STATIC_BF16_TYPES>(k_scale, ia, s_code);
+            const float tb = rms_rope_load_scale<STATIC_BF16_TYPES>(k_scale, ib, s_code);
+            const float ka = round_to<T>(
+                rms_rope_load_x<STATIC_BF16_TYPES>(k, ia_in, x_code) * rrms_k * ta);
+            const float kb = round_to<T>(
+                rms_rope_load_x<STATIC_BF16_TYPES>(k, ib_in, x_code) * rrms_k * tb);
+            rope_store<T>(k_out, ia_out,
+                          rope_combine(f00, ka, f01, kb, f_code, split_half));
+            rope_store<T>(k_out, ib_out,
+                          rope_combine(f10, ka, f11, kb, f_code, split_half));
+        }
+    }
+
+    for (int d = rot_dim + lane; d < kHeadDim; d += 32) {
+        const int64_t in = xoff + static_cast<int64_t>(d) * sx_d;
+        const int64_t out = ooff + static_cast<int64_t>(d) * so_d;
+        rope_store<T>(q_out, out,
+                      rms_rope_load_x<STATIC_BF16_TYPES>(q, in, x_code) * rrms_q *
+                          rms_rope_load_scale<STATIC_BF16_TYPES>(q_scale, d, s_code));
+        if (has_k) {
+            rope_store<T>(k_out, out,
+                          rms_rope_load_x<STATIC_BF16_TYPES>(k, in, x_code) * rrms_k *
+                              rms_rope_load_scale<STATIC_BF16_TYPES>(k_scale, d, s_code));
+        }
+    }
+}
+
+inline bool use_rms_rope_wave32_schedule() {
+    static const bool selected = [] {
+        int device = 0;
+        hipDeviceProp_t properties{};
+        return hipGetDevice(&device) == hipSuccess &&
+            hipGetDeviceProperties(&properties, device) == hipSuccess &&
+            properties.warpSize == 32;
+    }();
+    return selected;
+}
+
 }  // namespace comfy::hip_backend
 
 extern "C" void launch_rms_rope_kernel(
@@ -155,13 +339,37 @@ extern "C" void launch_rms_rope_kernel(
         throw std::runtime_error("rms_rope: rot_dim must be even and <= head_dim");
     }
 
+    const bool wave32_schedule = use_rms_rope_wave32_schedule();
+    const bool static_bf16_types = wave32_schedule &&
+        x_code == 2 && f_code == 0 && s_code == 2 && !split_half;
+
+#define CK_RMS_ROPE_WAVE32_LAUNCH(T, ROWS, STATIC_TYPES)                                       \
+    rms_rope_wave32_128_kernel<T, ROWS, STATIC_TYPES>                                          \
+        <<<static_cast<unsigned int>((rows + ROWS - 1) / ROWS), ROWS * 32, 0, stream>>>(       \
+            q, k, freqs, q_scale, k_scale, static_cast<T*>(q_out), static_cast<T*>(k_out),     \
+            rows, dim1, dim2, static_cast<int>(rot), fb, fd1, fd2, sx_b, sx_d1, sx_d2, sx_d,  \
+            so_b, so_d1, so_d2, so_d, sf_b, sf_d1, sf_d2, sf_d, sf_rot, sf_pair, x_code,      \
+            f_code, s_code, epsilon, split_half)
+
+    if (head_dim == 128 && static_bf16_types) {
+        CK_RMS_ROPE_WAVE32_LAUNCH(__bf16, 8, true);
+        return;
+    }
+
 #define CK_RMS_ROPE_LAUNCH(T)                                                                  \
-    rms_rope_kernel<T><<<static_cast<unsigned int>(rows), kRmsRopeThreads, 0, stream>>>(       \
-        q, k, freqs, q_scale, k_scale, static_cast<T*>(q_out), static_cast<T*>(k_out), dim1,   \
-        dim2, static_cast<int>(head_dim), static_cast<int>(rot), fb, fd1, fd2, sx_b, sx_d1,    \
-        sx_d2, sx_d, so_b, so_d1,                                                              \
-        so_d2, so_d, sf_b, sf_d1, sf_d2, sf_d, sf_rot, sf_pair, x_code, f_code, s_code,        \
-        epsilon, split_half)
+    do {                                                                                        \
+        if (head_dim == 128 && wave32_schedule) {                                              \
+            CK_RMS_ROPE_WAVE32_LAUNCH(T, 8, false);                                            \
+        } else {                                                                                \
+            rms_rope_kernel<T>                                                                  \
+                <<<static_cast<unsigned int>(rows), kRmsRopeThreads, 0, stream>>>(             \
+                    q, k, freqs, q_scale, k_scale, static_cast<T*>(q_out),                     \
+                    static_cast<T*>(k_out), dim1, dim2, static_cast<int>(head_dim),            \
+                    static_cast<int>(rot), fb, fd1, fd2, sx_b, sx_d1, sx_d2, sx_d, so_b,      \
+                    so_d1, so_d2, so_d, sf_b, sf_d1, sf_d2, sf_d, sf_rot, sf_pair, x_code,    \
+                    f_code, s_code, epsilon, split_half);                                      \
+        }                                                                                       \
+    } while (0)
 
     if (x_code == 0) {
         CK_RMS_ROPE_LAUNCH(float);
@@ -173,4 +381,5 @@ extern "C" void launch_rms_rope_kernel(
         throw std::runtime_error("rms_rope: unsupported input dtype");
     }
 #undef CK_RMS_ROPE_LAUNCH
+#undef CK_RMS_ROPE_WAVE32_LAUNCH
 }

--- a/comfy_kitchen/backends/hip/sage_attention/int8_attn.hip
+++ b/comfy_kitchen/backends/hip/sage_attention/int8_attn.hip
@@ -20,6 +20,7 @@
 // all tried and are all slower or spill. Do not re-try them blind.
 #include <hip/hip_runtime.h>
 
+#include <cfloat>
 #include <stdexcept>
 #include <string>
 
@@ -143,6 +144,373 @@ __forceinline__ __device__ void store_o_tile(OutT* __restrict__ row, int d_base,
         row[d_base + acc_row(lane, e)] = static_cast<OutT>(vals[e]);
     }
 #endif
+}
+
+// ---------------------------------------------------------------------------
+// gfx12 long-sequence specialization
+//
+// Keep the accepted schedule structural: BM128/BN64, eight wave32s, padded
+// single-stage Q/K/V LDS, synchronous global->VGPR->LDS prefetch, native
+// packed P, and FP32 output accumulation. The general kernel below retains its
+// original contract.
+// ---------------------------------------------------------------------------
+
+constexpr int kLongHeadDim = 128;
+constexpr int kLongBlockM = 128;
+constexpr int kLongBlockN = 64;
+constexpr int kLongWarps = 8;
+constexpr int kLongThreads = kLongWarps * 32;
+constexpr int kLongKStride = kLongHeadDim + 8;
+constexpr int kLongVStride = kLongBlockN + 8;
+
+__forceinline__ __device__ float long_fast_exp2(float x) {
+    return __builtin_amdgcn_exp2f(x);
+}
+
+__forceinline__ __device__ float long_balanced_sum8(v8f value) {
+    const float sum01 = value[0] + value[1];
+    const float sum23 = value[2] + value[3];
+    const float sum45 = value[4] + value[5];
+    const float sum67 = value[6] + value[7];
+    return (sum01 + sum23) + (sum45 + sum67);
+}
+
+__forceinline__ __device__ int long_fresh_lane_id() {
+    int lane;
+    // Rematerialize this after the long loop.  Carrying the prologue lane SSA
+    // value through the prefetched K/V state makes LLVM spill epilogue indices.
+    asm volatile("v_mbcnt_lo_u32_b32 %0, -1, 0" : "=v"(lane));
+    return lane;
+}
+
+__forceinline__ __device__ void long_store_b128_padded(int8_t* dst, uint4 value) {
+    // Eight-byte padding spreads consecutive WMMA fragment rows over banks.
+    *reinterpret_cast<uint2*>(dst) = make_uint2(value.x, value.y);
+    *reinterpret_cast<uint2*>(dst + 8) = make_uint2(value.z, value.w);
+}
+
+// The optimized packed contract pads K and transposed V to a whole BN64 tile.
+// Exactly 256 threads own the 512 sixteen-byte chunks in each operand, so the
+// bounds and loop trip count are compile-time facts.
+struct LongKVTileRegs {
+    uint4 k[2];
+    uint4 v[2];
+
+    __forceinline__ __device__ void load(const int8_t* __restrict__ k_head,
+                                         const int8_t* __restrict__ v_head,
+                                         int padded_k, int tile) {
+        const int tid = threadIdx.x;
+#pragma unroll
+        for (int i = 0; i < 2; ++i) {
+            const int chunk = tid + i * kLongThreads;
+            const int krow = chunk >> 3;
+            const int kd16 = (chunk & 7) << 4;
+            k[i] = *reinterpret_cast<const uint4*>(
+                k_head + static_cast<int64_t>(tile * kLongBlockN + krow) * kLongHeadDim + kd16);
+
+            const int vd = chunk >> 2;
+            const int vn16 = (chunk & 3) << 4;
+            v[i] = *reinterpret_cast<const uint4*>(
+                v_head + static_cast<int64_t>(tile) * kLongHeadDim * kLongBlockN +
+                vd * kLongBlockN + vn16);
+        }
+    }
+
+    __forceinline__ __device__ void store(int8_t* ks, int8_t* vs) const {
+        const int tid = threadIdx.x;
+#pragma unroll
+        for (int i = 0; i < 2; ++i) {
+            const int chunk = tid + i * kLongThreads;
+            const int krow = chunk >> 3;
+            const int kd16 = (chunk & 7) << 4;
+            long_store_b128_padded(ks + krow * kLongKStride + kd16, k[i]);
+
+            const int vd = chunk >> 2;
+            const int vn16 = (chunk & 3) << 4;
+            long_store_b128_padded(vs + vd * kLongVStride + vn16, v[i]);
+        }
+    }
+};
+
+template <bool NoQueryTail>
+__forceinline__ __device__ void long_stage_q_tile(
+    const int8_t* __restrict__ q_head, int8_t* __restrict__ qs,
+    int query_block0, int qo_len) {
+    const int tid = threadIdx.x;
+#pragma unroll
+    for (int i = 0; i < 4; ++i) {
+        const int chunk = tid + i * kLongThreads;
+        const int row = chunk >> 3;
+        const int d16 = (chunk & 7) << 4;
+        uint4 value = make_uint4(0, 0, 0, 0);
+        if constexpr (NoQueryTail) {
+            value = *reinterpret_cast<const uint4*>(
+                q_head + static_cast<int64_t>(query_block0 + row) * kLongHeadDim + d16);
+        } else if (query_block0 + row < qo_len) {
+            value = *reinterpret_cast<const uint4*>(
+                q_head + static_cast<int64_t>(query_block0 + row) * kLongHeadDim + d16);
+        }
+        long_store_b128_padded(qs + row * kLongKStride + d16, value);
+    }
+}
+
+template <typename OutT, bool NoQueryTail, bool FullScoreScale>
+__global__ __launch_bounds__(kLongThreads)
+__attribute__((amdgpu_waves_per_eu(1, 1)))
+void gfx12_int8_attention_kernel(
+    const int8_t* __restrict__ q,
+    const int8_t* __restrict__ k,
+    const int8_t* __restrict__ v,
+    OutT* __restrict__ output,
+    const float* __restrict__ q_descale,
+    const float* __restrict__ k_descale,
+    const float* __restrict__ v_descale,
+    int qo_len, int kv_len, int padded_q, int padded_k,
+    int k_groups_per_head, int query_block_offset,
+    int64_t output_stride_h, int64_t output_stride_n, float sm_scale) {
+
+    __shared__ __align__(16) int8_t ks[kLongBlockN * kLongKStride];
+    __shared__ __align__(16) int8_t vs[kLongHeadDim * kLongVStride];
+    __shared__ __align__(16) int8_t qs[kLongBlockM * kLongKStride];
+
+    const int lane = threadIdx.x & 31;
+    const int wave = threadIdx.x >> 5;
+    const int head = blockIdx.y;
+    const int query_block = blockIdx.x + query_block_offset;
+    const int query0 = query_block * kLongBlockM + wave * 16;
+    const bool active_query_wave = NoQueryTail || query0 < qo_len;
+    const int tiles = padded_k / kLongBlockN;
+    const int8_t* const q_head =
+        q + static_cast<int64_t>(head) * qo_len * kLongHeadDim;
+    const int8_t* const k_head =
+        k + static_cast<int64_t>(head) * padded_k * kLongHeadDim;
+    const int8_t* const v_head =
+        v + static_cast<int64_t>(head) * kLongHeadDim * padded_k;
+
+    const int query_lane = query0 + acc_col(lane);
+    const float q_scale = active_query_wave && query_lane < qo_len
+        ? q_descale[head * padded_q + query_lane]
+        : 0.0f;
+    const float qk_scale = sm_scale * kLog2e;
+    // Preserve the finite online-softmax state; this specialization changes
+    // schedule and data movement, not the probability quantization algorithm.
+    float row_max = kMaskedScore;
+    float row_sum = 1.0f;
+    v8f out_acc[8];
+#pragma unroll
+    for (int dt = 0; dt < 8; ++dt) {
+        out_acc[dt] = v8f{0, 0, 0, 0, 0, 0, 0, 0};
+    }
+
+    LongKVTileRegs next;
+    long_stage_q_tile<NoQueryTail>(q_head, qs, query_block * kLongBlockM, qo_len);
+    next.load(k_head, v_head, padded_k, 0);
+    next.store(ks, vs);
+    __syncthreads();
+
+    for (int tile = 0; tile < tiles; ++tile) {
+        const bool has_next = tile + 1 < tiles;
+        if (has_next) {
+            next.load(k_head, v_head, padded_k, tile + 1);
+        }
+
+        // Tail workgroups still need every wave for cooperative K/V staging
+        // and barriers.  Waves with no query rows can skip the matrix and
+        // softmax work between those barriers.
+        if (active_query_wave) {
+            float key_scale[4];
+#pragma unroll
+            for (int ct = 0; ct < 4; ++ct) {
+                key_scale[ct] =
+                    k_descale[head * k_groups_per_head + tile * 4 + ct];
+            }
+            float score_scale[4];
+#pragma unroll
+            for (int ct = 0; ct < 4; ++ct) {
+                // The full-scale variant hoists the query factor out of the
+                // score loop while preserving the quality-gated association.
+                if constexpr (FullScoreScale) {
+                    score_scale[ct] = (q_scale * key_scale[ct]) * qk_scale;
+                } else {
+                    score_scale[ct] = key_scale[ct] * qk_scale;
+                }
+            }
+
+            v8f score[4];
+            {
+                v8i score_i32[4];
+#pragma unroll
+                for (int ct = 0; ct < 4; ++ct) score_i32[ct] = MmaInt8::zero();
+#pragma unroll
+                for (int dt = 0; dt < 8; ++dt) {
+                    const MmaInt8::Frag q_frag = MmaInt8::load(
+                        qs, wave * 16 + frag_row(lane), dt * 16, kLongKStride, lane);
+#pragma unroll
+                    for (int ct = 0; ct < 4; ++ct) {
+                        const MmaInt8::Frag k_frag = MmaInt8::load(
+                            ks, ct * 16 + frag_row(lane), dt * 16, kLongKStride, lane);
+                        // K x Q^T leaves each score fragment in the native A
+                        // operand order consumed by P x V below.
+                        score_i32[ct] = MmaInt8::mma(k_frag, q_frag, score_i32[ct]);
+                    }
+                }
+#pragma unroll
+                for (int ct = 0; ct < 4; ++ct) {
+#pragma unroll
+                    for (int e = 0; e < 8; ++e) {
+                        float value;
+                        if constexpr (FullScoreScale) {
+                            value = static_cast<float>(score_i32[ct][e]) * score_scale[ct];
+                        } else {
+                            value = (static_cast<float>(score_i32[ct][e]) * q_scale) *
+                                    score_scale[ct];
+                        }
+                        const int key = tile * kLongBlockN + ct * 16 + acc_row(lane, e);
+                        if (key >= kv_len) value = kMaskedScore;
+                        score[ct][e] = value;
+                    }
+                }
+            }
+
+            float local_max = -FLT_MAX;
+#pragma unroll
+            for (int ct = 0; ct < 4; ++ct) {
+#pragma unroll
+                for (int e = 0; e < 8; ++e) local_max = fmaxf(local_max, score[ct][e]);
+            }
+            float tile_max = fmaxf(local_max, __shfl_xor(local_max, 16, 32));
+
+            // Shifting the tile maximum fills u8 [0, 255]; tile_scale carries
+            // its gap to the running maximum on the accumulator side.
+            tile_max -= kProbU8Offset;
+            const float previous_max = row_max;
+            const float smaller = long_fast_exp2(-fabsf(previous_max - tile_max));
+            const float output_scale = previous_max < tile_max ? smaller : 1.0f;
+            const float tile_scale = tile_max < previous_max ? smaller : 1.0f;
+            row_max = fmaxf(previous_max, tile_max);
+            row_sum *= output_scale;
+#pragma unroll
+            for (int dt = 0; dt < 8; ++dt) {
+#pragma unroll
+                for (int e = 0; e < 8; ++e) {
+                    out_acc[dt][e] *=
+                        __shfl(output_scale, acc_row(lane, e), 32);
+                }
+            }
+
+            MmaInt8::Frag direct_p_frag[4];
+#pragma unroll
+            for (int ct = 0; ct < 4; ++ct) {
+                uint32_t packed[8];
+#pragma unroll
+                for (int e = 0; e < 8; ++e) {
+                    const float probability = long_fast_exp2(score[ct][e] - tile_max);
+                    score[ct][e] = probability;
+                    packed[e] = prob_to_u8(probability);
+                }
+                direct_p_frag[ct] = pack_prob_frag(packed, lane);
+            }
+
+            // Each half-wave carries its part of the denominator through the
+            // loop.  A balanced native-fragment tree shortens the dependency
+            // chain while keeping the quality-gated cross-fragment ordering.
+            const float tile_sum =
+                (long_balanced_sum8(score[0]) + long_balanced_sum8(score[2])) +
+                (long_balanced_sum8(score[1]) + long_balanced_sum8(score[3]));
+            row_sum += tile_sum * tile_scale;
+
+#pragma unroll
+            for (int dt = 0; dt < 8; ++dt) {
+                v8i product = MmaInt8::zero();
+#pragma unroll
+                for (int ct = 0; ct < 4; ++ct) {
+                    const MmaInt8::Frag v_frag = MmaInt8::load(
+                        vs, dt * 16 + frag_row(lane), ct * 16, kLongVStride, lane);
+                    product = MmaInt8::mma_ua(direct_p_frag[ct], v_frag, product);
+                }
+                const int d = dt * 16 + acc_col(lane);
+                const float value_scale =
+                    v_descale[(head * tiles + tile) * kLongHeadDim + d];
+#pragma unroll
+                for (int e = 0; e < 8; ++e) {
+                    const float row_tile_scale =
+                        __shfl(tile_scale, acc_row(lane, e), 32);
+                    out_acc[dt][e] = fmaf(
+                        static_cast<float>(product[e]),
+                        value_scale * row_tile_scale, out_acc[dt][e]);
+                }
+            }
+        }
+
+        if (has_next) {
+            __syncthreads();
+            next.store(ks, vs);
+            __syncthreads();
+        }
+    }
+
+    row_sum += __shfl_xor(row_sum, 16, 32);
+
+    if (active_query_wave) {
+        const int output_lane = long_fresh_lane_id();
+#pragma unroll
+        for (int dt = 0; dt < 8; ++dt) {
+            const int d = dt * 16 + acc_col(output_lane);
+#pragma unroll
+            for (int e = 0; e < 8; ++e) {
+                const int row = query0 + acc_row(output_lane, e);
+                if constexpr (NoQueryTail) {
+                    const float reciprocal = 1.0f / __shfl(
+                        row_sum, acc_row(output_lane, e), 32);
+                    output[static_cast<int64_t>(head) * output_stride_h +
+                           static_cast<int64_t>(row) * output_stride_n + d] =
+                        static_cast<OutT>(out_acc[dt][e] * reciprocal);
+                } else if (row < qo_len) {
+                    const float reciprocal = 1.0f / __shfl(
+                        row_sum, acc_row(output_lane, e), 32);
+                    output[static_cast<int64_t>(head) * output_stride_h +
+                           static_cast<int64_t>(row) * output_stride_n + d] =
+                        static_cast<OutT>(out_acc[dt][e] * reciprocal);
+                }
+            }
+        }
+    }
+}
+
+template <typename OutT>
+void launch_gfx12_int8_attention_typed(
+    const int8_t* q, const int8_t* k, const int8_t* v, OutT* output,
+    const float* q_descale, const float* k_descale, const float* v_descale,
+    int num_heads, int qo_len, int kv_len, int padded_q, int padded_k,
+    int k_groups_per_head,
+    int64_t output_stride_h, int64_t output_stride_n,
+    float sm_scale, hipStream_t stream) {
+    const int full_blocks = qo_len / kLongBlockM;
+    if (full_blocks) {
+        // Use one arithmetic association for an entirely full grid and the
+        // quality-gated association shared with the masked kernel whenever a
+        // query tail is present. This is a tile property, not a model shape.
+        if (qo_len % kLongBlockM != 0) {
+            gfx12_int8_attention_kernel<OutT, true, true>
+                <<<dim3(full_blocks, num_heads), kLongThreads, 0, stream>>>(
+                    q, k, v, output, q_descale, k_descale, v_descale,
+                    qo_len, kv_len, padded_q, padded_k, k_groups_per_head,
+                    0, output_stride_h, output_stride_n, sm_scale);
+        } else {
+            gfx12_int8_attention_kernel<OutT, true, false>
+                <<<dim3(full_blocks, num_heads), kLongThreads, 0, stream>>>(
+                    q, k, v, output, q_descale, k_descale, v_descale,
+                    qo_len, kv_len, padded_q, padded_k, k_groups_per_head,
+                    0, output_stride_h, output_stride_n, sm_scale);
+        }
+    }
+    if (full_blocks * kLongBlockM != qo_len) {
+        gfx12_int8_attention_kernel<OutT, false, true>
+            <<<dim3(1, num_heads), kLongThreads, 0, stream>>>(
+                q, k, v, output, q_descale, k_descale, v_descale,
+                qo_len, kv_len, padded_q, padded_k, k_groups_per_head,
+                full_blocks, output_stride_h, output_stride_n, sm_scale);
+    }
 }
 
 template <int HD, int CTA_K, MaskMode kMask, typename OutT>
@@ -504,6 +872,51 @@ void launch_one(const int8_t* q, const int8_t* k, const int8_t* v, OutT* o, cons
 }  // namespace comfy::hip_backend::sage
 
 using namespace comfy::hip_backend::sage;
+
+extern "C" void launch_gfx12_int8_attention(
+    const void* q, const void* k, const void* v, void* o,
+    const void* q_descale, const void* k_descale, const void* v_descale,
+    int num_heads, int qo_len, int kv_len, int padded_q, int padded_k,
+    int k_groups_per_head,
+    int64_t output_stride_h, int64_t output_stride_n,
+    float sm_scale, int output_dtype_code, hipStream_t stream) {
+    if (num_heads <= 0 || qo_len <= 0 || kv_len <= 0) {
+        throw std::runtime_error(
+            "gfx12 INT8 attention requires positive heads and lengths");
+    }
+    if (padded_q % 128 != 0 || padded_q < qo_len ||
+        padded_k % 64 != 0 || padded_k < kv_len) {
+        throw std::runtime_error(
+            "gfx12 INT8 attention received invalid Q or K/V padding");
+    }
+    if (reinterpret_cast<uintptr_t>(q) % 16 != 0 ||
+        reinterpret_cast<uintptr_t>(k) % 16 != 0 ||
+        reinterpret_cast<uintptr_t>(v) % 16 != 0 ||
+        reinterpret_cast<uintptr_t>(o) % 16 != 0) {
+        throw std::runtime_error(
+            "gfx12 INT8 attention buffers must be 16-byte aligned");
+    }
+    const auto* qi = static_cast<const int8_t*>(q);
+    const auto* ki = static_cast<const int8_t*>(k);
+    const auto* vi = static_cast<const int8_t*>(v);
+    const auto* qs = static_cast<const float*>(q_descale);
+    const auto* ks = static_cast<const float*>(k_descale);
+    const auto* vs = static_cast<const float*>(v_descale);
+    if (output_dtype_code == 1) {
+        launch_gfx12_int8_attention_typed(
+            qi, ki, vi, static_cast<__half*>(o), qs, ks, vs, num_heads,
+            qo_len, kv_len, padded_q, padded_k, k_groups_per_head,
+            output_stride_h, output_stride_n, sm_scale, stream);
+    } else if (output_dtype_code == 2) {
+        launch_gfx12_int8_attention_typed(
+            qi, ki, vi, static_cast<__bf16*>(o), qs, ks, vs, num_heads,
+            qo_len, kv_len, padded_q, padded_k, k_groups_per_head,
+            output_stride_h, output_stride_n, sm_scale, stream);
+    } else {
+        throw std::runtime_error(
+            "gfx12 INT8 attention supports float16 and bfloat16 output");
+    }
+}
 
 extern "C" void launch_sage_int8_attn(
     const void* q, const void* k, const void* v, void* o, const void* q_scale,

--- a/comfy_kitchen/backends/hip/sage_attention/quant_qk_int8.hip
+++ b/comfy_kitchen/backends/hip/sage_attention/quant_qk_int8.hip
@@ -86,6 +86,30 @@ __forceinline__ __device__ void store_row(int8_t* __restrict__ dst, int lane_in_
     }
 }
 
+// A logical sequence assembled from two independently allocated BHND tensors.
+// This is the producer-side equivalent of torch.cat(..., dim=2): every output
+// row keeps the same logical index, but the BF16 intermediate is never written.
+// The attention consumer still receives its contiguous packed workspace.
+template <typename T>
+struct TwoSegmentRows {
+    const T* first;
+    const T* second;
+    int first_rows;
+    int64_t first_stride_h;
+    int64_t first_stride_n;
+    int64_t second_stride_h;
+    int64_t second_stride_n;
+
+    __forceinline__ __device__ const T* row(int head, int index) const {
+        if (index < first_rows) {
+            return first + static_cast<int64_t>(head) * first_stride_h +
+                   static_cast<int64_t>(index) * first_stride_n;
+        }
+        return second + static_cast<int64_t>(head) * second_stride_h +
+               static_cast<int64_t>(index - first_rows) * second_stride_n;
+    }
+};
+
 // ---------------------------------------------------------------------------
 // Q: one scale per query row, so a row never leaves its lane group and the
 // reduction is a lane-group shuffle. Each block sweeps kRowIters batches of
@@ -140,12 +164,50 @@ __global__ __launch_bounds__(kQuantWaves * 32) void quant_q_int8_kernel(
     }
 }
 
+template <typename T, int HD, int Rotation>
+__global__ __launch_bounds__(kQuantWaves * 32) void quant_q_int8_two_segment_kernel(
+    TwoSegmentRows<T> input, int8_t* __restrict__ q_out,
+    float* __restrict__ q_scale, int Lq, int Lq_padded, int H_q) {
+
+    using Tile = RowTile<HD>;
+    constexpr int kRowsPerBatch = kQuantWaves * Tile::kRowsPerWave;
+
+    const int lane = threadIdx.x & 31;
+    const int wave = threadIdx.x >> 5;
+    const int lane_in_row = lane % Tile::kLanesPerRow;
+    const int row_in_wave = lane / Tile::kLanesPerRow;
+    const int h = blockIdx.y;
+    const int64_t scale_base = static_cast<int64_t>(h) * Lq_padded;
+    int8_t* out_head = q_out + static_cast<int64_t>(h) * Lq * HD;
+
+    const int block_first = blockIdx.x * (kRowsPerBatch * kRowIters);
+#pragma unroll
+    for (int it = 0; it < kRowIters; ++it) {
+        const int row = block_first + it * kRowsPerBatch +
+                        wave * Tile::kRowsPerWave + row_in_wave;
+        if (row >= Lq_padded) continue;
+        if (row >= Lq) {
+            if (lane_in_row == 0) q_scale[scale_base + row] = 1.0f;
+            continue;
+        }
+
+        float vals[Tile::kValsPerLane];
+        load_row<HD, T>(input.row(h, row), lane_in_row, vals);
+        const float mx =
+            row_reduce_fmax<Tile::kLanesPerRow>(rotate_row<HD, Rotation>(vals));
+        const float scale = mx / kInt8Max + 1e-7f;
+        if (lane_in_row == 0) q_scale[scale_base + row] = scale;
+        store_row<HD, T>(out_head + static_cast<int64_t>(row) * HD,
+                         lane_in_row, vals, 1.0f / scale);
+    }
+}
+
 // ---------------------------------------------------------------------------
 // K: one scale per 16 adjacent keys. A whole scale group lives in one wave, so
 // the reduction never leaves it and the kernel needs no barrier at all. The
-// group is read twice rather than held: 16 rows of registers is affordable at
-// D64 and D128 but not at D256, and the second read is cheaper than the
-// occupancy the widest case would lose.
+// D128 retains the 16-row group in registers so each key is read once. D256
+// keeps the two-pass path because retaining a group there is too register-heavy;
+// D64 stays on the existing path until its short-attention schedule is settled.
 // ---------------------------------------------------------------------------
 
 constexpr int kKeyGroupsPerBlock = kQuantWaves;
@@ -153,7 +215,8 @@ constexpr int kKeyGroupsPerBlock = kQuantWaves;
 template <typename T, int HD, int Rotation>
 __global__ __launch_bounds__(kQuantWaves * 32) void quant_k_int8_kernel(
     const T* __restrict__ k, int8_t* __restrict__ k_out, float* __restrict__ k_scale,
-    const int* __restrict__ anchor_indices, int Lk, int H_kv, int groups_per_head,
+    const int* __restrict__ anchor_indices, int Lk, int Lk_storage, int H_kv,
+    int groups_per_head,
     int64_t stride_b, int64_t stride_h, int64_t stride_n) {
 
     using Tile = RowTile<HD>;
@@ -185,33 +248,119 @@ __global__ __launch_bounds__(kQuantWaves * 32) void quant_k_int8_kernel(
         for (int i = 0; i < Tile::kValsPerLane; ++i) bias[i] = 0.0f;
     }
 
-    float vals[Tile::kValsPerLane];
+    if constexpr (HD == 128) {
+        float rows[kRowPasses][Tile::kValsPerLane];
+        float mx = 0.0f;
+#pragma unroll
+        for (int pass = 0; pass < kRowPasses; ++pass) {
+            const int key = key0 + pass * Tile::kRowsPerWave + row_in_wave;
+            if (key < Lk) {
+                load_row<HD, T>(head + static_cast<int64_t>(key) * stride_n,
+                                lane_in_row, rows[pass]);
+#pragma unroll
+                for (int i = 0; i < Tile::kValsPerLane; ++i) rows[pass][i] -= bias[i];
+                mx = fmaxf(mx, rotate_row<HD, Rotation>(rows[pass]));
+            }
+        }
+
+        mx = row_reduce_fmax<32>(mx);
+        const float scale = mx / kInt8Max + 1e-7f;
+        const float inv_scale = 1.0f / scale;
+        if (lane == 0) k_scale[bh * groups_per_head + group] = scale;
+
+#pragma unroll
+        for (int pass = 0; pass < kRowPasses; ++pass) {
+            const int key = key0 + pass * Tile::kRowsPerWave + row_in_wave;
+            if (key < Lk) {
+                store_row<HD, T>(k_out + (bh * Lk_storage + key) * HD,
+                                 lane_in_row, rows[pass], inv_scale);
+            }
+        }
+    } else {
+        float vals[Tile::kValsPerLane];
+        float mx = 0.0f;
+#pragma unroll
+        for (int pass = 0; pass < kRowPasses; ++pass) {
+            const int key = key0 + pass * Tile::kRowsPerWave + row_in_wave;
+            if (key < Lk) {
+                load_row<HD, T>(head + static_cast<int64_t>(key) * stride_n, lane_in_row, vals);
+#pragma unroll
+                for (int i = 0; i < Tile::kValsPerLane; ++i) vals[i] -= bias[i];
+                mx = fmaxf(mx, rotate_row<HD, Rotation>(vals));
+            }
+        }
+
+        mx = row_reduce_fmax<32>(mx);
+        const float scale = mx / kInt8Max + 1e-7f;
+        const float inv_scale = 1.0f / scale;
+        if (lane == 0) k_scale[bh * groups_per_head + group] = scale;
+
+#pragma unroll
+        for (int pass = 0; pass < kRowPasses; ++pass) {
+            const int key = key0 + pass * Tile::kRowsPerWave + row_in_wave;
+            if (key < Lk) {
+                load_row<HD, T>(head + static_cast<int64_t>(key) * stride_n, lane_in_row, vals);
+#pragma unroll
+                for (int i = 0; i < Tile::kValsPerLane; ++i) vals[i] -= bias[i];
+                rotate_row<HD, Rotation>(vals);
+                store_row<HD, T>(k_out + (bh * Lk_storage + key) * HD,
+                                 lane_in_row, vals, inv_scale);
+            }
+        }
+    }
+}
+
+// The optimized consumer uses D128/rotation128. Keep the segmented producer
+// separate so the mature one-buffer path retains identical code generation.
+template <typename T>
+__global__ __launch_bounds__(kQuantWaves * 32) void quant_k_int8_two_segment_d128_kernel(
+    TwoSegmentRows<T> input, int8_t* __restrict__ k_out,
+    float* __restrict__ k_scale, const int* __restrict__ anchor_indices,
+    int Lk, int Lk_storage, int H_kv, int groups_per_head) {
+
+    using Tile = RowTile<128>;
+    constexpr int kRowPasses = 16 / Tile::kRowsPerWave;
+    const int lane = threadIdx.x & 31;
+    const int lane_in_row = lane % Tile::kLanesPerRow;
+    const int row_in_wave = lane / Tile::kLanesPerRow;
+    const int group = blockIdx.x * kKeyGroupsPerBlock + (threadIdx.x >> 5);
+    if (group >= groups_per_head) return;
+
+    const int h = blockIdx.y;
+    const int key0 = group * 16;
+    const int anchor_index = anchor_indices[h];
+    float bias[Tile::kValsPerLane];
+    if (anchor_index >= 0) {
+        load_row<128, T>(input.row(h, anchor_index), lane_in_row, bias);
+    } else {
+#pragma unroll
+        for (int i = 0; i < Tile::kValsPerLane; ++i) bias[i] = 0.0f;
+    }
+
+    float rows[kRowPasses][Tile::kValsPerLane];
     float mx = 0.0f;
 #pragma unroll
     for (int pass = 0; pass < kRowPasses; ++pass) {
         const int key = key0 + pass * Tile::kRowsPerWave + row_in_wave;
         if (key < Lk) {
-            load_row<HD, T>(head + static_cast<int64_t>(key) * stride_n, lane_in_row, vals);
+            load_row<128, T>(input.row(h, key), lane_in_row, rows[pass]);
 #pragma unroll
-            for (int i = 0; i < Tile::kValsPerLane; ++i) vals[i] -= bias[i];
-            mx = fmaxf(mx, rotate_row<HD, Rotation>(vals));
+            for (int i = 0; i < Tile::kValsPerLane; ++i) rows[pass][i] -= bias[i];
+            mx = fmaxf(mx, rotate_row<128, 128>(rows[pass]));
         }
     }
 
     mx = row_reduce_fmax<32>(mx);
     const float scale = mx / kInt8Max + 1e-7f;
     const float inv_scale = 1.0f / scale;
-    if (lane == 0) k_scale[bh * groups_per_head + group] = scale;
-
+    if (lane == 0) k_scale[static_cast<int64_t>(h) * groups_per_head + group] = scale;
 #pragma unroll
     for (int pass = 0; pass < kRowPasses; ++pass) {
         const int key = key0 + pass * Tile::kRowsPerWave + row_in_wave;
         if (key < Lk) {
-            load_row<HD, T>(head + static_cast<int64_t>(key) * stride_n, lane_in_row, vals);
-#pragma unroll
-            for (int i = 0; i < Tile::kValsPerLane; ++i) vals[i] -= bias[i];
-            rotate_row<HD, Rotation>(vals);
-            store_row<HD, T>(k_out + (bh * Lk + key) * HD, lane_in_row, vals, inv_scale);
+            store_row<128, T>(
+                k_out + (static_cast<int64_t>(h) * Lk_storage + key) * 128,
+                lane_in_row, rows[pass], inv_scale);
         }
     }
 }
@@ -361,6 +510,126 @@ __global__ __launch_bounds__(kAnchorThreads) void detect_k_anchor_kernel(
     }
 }
 
+template <typename T>
+__global__ __launch_bounds__(kAnchorThreads) void detect_k_anchor_two_segment_kernel(
+    TwoSegmentRows<T> input, int* __restrict__ anchor_indices, int Lk, int C) {
+
+    const int h = blockIdx.x;
+    const int tid = threadIdx.x;
+    const int lane = tid & 31;
+    const int wave = tid >> 5;
+
+    __shared__ float samples[kAnchorSamples * kAnchorMaxChannels];
+    __shared__ float wave_original_energy[kAnchorWaves];
+    __shared__ float wave_original_max[kAnchorWaves];
+    __shared__ float wave_candidate_distance[kAnchorSamples][kAnchorWaves];
+    __shared__ float wave_best_energy[kAnchorWaves];
+    __shared__ float wave_best_max[kAnchorWaves];
+    __shared__ int selected_candidate;
+
+    for (int index = tid; index < kAnchorSamples * C; index += kAnchorThreads) {
+        const int sample = index / C;
+        const int channel = index - sample * C;
+        const int row = sample * (Lk - 1) / (kAnchorSamples - 1);
+        samples[index] = to_float<T>(input.row(h, row)[channel]);
+    }
+    __syncthreads();
+
+    float original_energy = 0.0f;
+    float original_max = 0.0f;
+    float candidate_distance[kAnchorSamples];
+#pragma unroll
+    for (int c = 0; c < kAnchorSamples; ++c) candidate_distance[c] = 0.0f;
+    for (int channel = tid; channel < C; channel += kAnchorThreads) {
+        float channel_sum = 0.0f;
+#pragma unroll
+        for (int sample = 0; sample < kAnchorSamples; ++sample) {
+            const float value = samples[sample * C + channel];
+            original_energy = fmaf(value, value, original_energy);
+            original_max = fmaxf(original_max, fabsf(value));
+            channel_sum += value;
+        }
+#pragma unroll
+        for (int c = 0; c < kAnchorSamples; ++c) {
+            const float distance = kAnchorSamples * samples[c * C + channel] - channel_sum;
+            candidate_distance[c] = fmaf(distance, distance, candidate_distance[c]);
+        }
+    }
+#pragma unroll
+    for (int off = 16; off > 0; off >>= 1) {
+        original_energy += __shfl_down(original_energy, off, 32);
+        original_max = fmaxf(original_max, __shfl_down(original_max, off, 32));
+#pragma unroll
+        for (int c = 0; c < kAnchorSamples; ++c)
+            candidate_distance[c] += __shfl_down(candidate_distance[c], off, 32);
+    }
+    if (lane == 0) {
+        wave_original_energy[wave] = original_energy;
+        wave_original_max[wave] = original_max;
+#pragma unroll
+        for (int c = 0; c < kAnchorSamples; ++c)
+            wave_candidate_distance[c][wave] = candidate_distance[c];
+    }
+    __syncthreads();
+    if (tid == 0) {
+        int best_candidate = 0;
+        float best_distance = 3.402823466e+38F;
+#pragma unroll
+        for (int c = 0; c < kAnchorSamples; ++c) {
+            float distance = 0.0f;
+#pragma unroll
+            for (int w = 0; w < kAnchorWaves; ++w)
+                distance += wave_candidate_distance[c][w];
+            if (distance < best_distance) {
+                best_candidate = c;
+                best_distance = distance;
+            }
+        }
+        selected_candidate = best_candidate;
+    }
+    __syncthreads();
+
+    float best_energy = 0.0f;
+    float best_max = 0.0f;
+    for (int channel = tid; channel < C; channel += kAnchorThreads) {
+        const float anchor = samples[selected_candidate * C + channel];
+#pragma unroll
+        for (int sample = 0; sample < kAnchorSamples; ++sample) {
+            const float residual = samples[sample * C + channel] - anchor;
+            best_energy = fmaf(residual, residual, best_energy);
+            best_max = fmaxf(best_max, fabsf(residual));
+        }
+    }
+#pragma unroll
+    for (int off = 16; off > 0; off >>= 1) {
+        best_energy += __shfl_down(best_energy, off, 32);
+        best_max = fmaxf(best_max, __shfl_down(best_max, off, 32));
+    }
+    if (lane == 0) {
+        wave_best_energy[wave] = best_energy;
+        wave_best_max[wave] = best_max;
+    }
+    __syncthreads();
+    if (tid == 0) {
+        float total_original_energy = 0.0f;
+        float total_original_max = 0.0f;
+        float total_best_energy = 0.0f;
+        float total_best_max = 0.0f;
+#pragma unroll
+        for (int w = 0; w < kAnchorWaves; ++w) {
+            total_original_energy += wave_original_energy[w];
+            total_original_max = fmaxf(total_original_max, wave_original_max[w]);
+            total_best_energy += wave_best_energy[w];
+            total_best_max = fmaxf(total_best_max, wave_best_max[w]);
+        }
+        const bool improves_range = total_best_energy < total_original_energy &&
+                                    total_best_max <= total_original_max * 1.125f;
+        anchor_indices[h] = improves_range
+            ? selected_candidate * (Lk - 1) / (kAnchorSamples - 1)
+            : -1;
+    }
+}
+
 template <typename T, int HD, int Rotation>
 void launch_typed(const void* q, void* q_int8, void* q_scale, const void* k, void* k_int8,
                   void* k_scale, const int* anchor_indices, int B, int H_q, int Lq, int Lq_padded,
@@ -379,7 +648,8 @@ void launch_typed(const void* q, void* q_int8, void* q_scale, const void* k, voi
     const dim3 k_grid((groups_per_head + kKeyGroupsPerBlock - 1) / kKeyGroupsPerBlock, H_kv, B);
     quant_k_int8_kernel<T, HD, Rotation><<<k_grid, kQuantWaves * 32, 0, stream>>>(
         static_cast<const T*>(k), static_cast<int8_t*>(k_int8), static_cast<float*>(k_scale),
-        anchor_indices, Lk, H_kv, groups_per_head, k_stride_b, k_stride_h, k_stride_n);
+        anchor_indices, Lk, Lk, H_kv, groups_per_head,
+        k_stride_b, k_stride_h, k_stride_n);
 }
 
 // Only the rotations the caller can actually select are instantiated: short keys
@@ -435,10 +705,147 @@ void launch_anchor(const void* k, int* anchor_indices, int B, int H_kv, int Lk, 
         static_cast<const T*>(k), anchor_indices, Lk, C, H_kv, stride_b, stride_h, stride_n);
 }
 
+template <typename T>
+void launch_gfx12_qk_quant_typed(
+    const void* q, void* q_int8, void* q_scale,
+    const void* k, void* k_int8, void* k_scale, int* anchors,
+    int num_heads, int q_len, int kv_len, int padded_q, int padded_k,
+    int64_t q_stride_b, int64_t q_stride_h, int64_t q_stride_n,
+    int64_t k_stride_b, int64_t k_stride_h, int64_t k_stride_n,
+    hipStream_t stream) {
+    launch_anchor<T>(k, anchors, 1, num_heads, kv_len, 128,
+                     k_stride_b, k_stride_h, k_stride_n, stream);
+    constexpr int kRowsPerBlock =
+        kQuantWaves * RowTile<128>::kRowsPerWave * kRowIters;
+    const dim3 q_grid((padded_q + kRowsPerBlock - 1) / kRowsPerBlock,
+                      num_heads, 1);
+    quant_q_int8_kernel<T, 128, 128><<<q_grid, 256, 0, stream>>>(
+        static_cast<const T*>(q), static_cast<int8_t*>(q_int8),
+        static_cast<float*>(q_scale), q_len, padded_q, num_heads,
+        q_stride_b, q_stride_h, q_stride_n);
+    const int groups = padded_k / 16;
+    const dim3 k_grid((groups + kKeyGroupsPerBlock - 1) / kKeyGroupsPerBlock,
+                      num_heads, 1);
+    quant_k_int8_kernel<T, 128, 128><<<k_grid, 256, 0, stream>>>(
+        static_cast<const T*>(k), static_cast<int8_t*>(k_int8),
+        static_cast<float*>(k_scale), anchors, kv_len, padded_k, num_heads,
+        groups, k_stride_b, k_stride_h, k_stride_n);
+}
+
+template <typename T>
+void launch_gfx12_qk_quant_split_typed(
+    const void* q0, const void* q1, void* q_int8, void* q_scale,
+    const void* k0, const void* k1, void* k_int8, void* k_scale,
+    int* anchors, int num_heads, int q0_len, int q1_len,
+    int k0_len, int k1_len, int padded_q, int padded_k,
+    int64_t q0_stride_h, int64_t q0_stride_n,
+    int64_t q1_stride_h, int64_t q1_stride_n,
+    int64_t k0_stride_h, int64_t k0_stride_n,
+    int64_t k1_stride_h, int64_t k1_stride_n, hipStream_t stream) {
+    const int q_len = q0_len + q1_len;
+    const int kv_len = k0_len + k1_len;
+    const TwoSegmentRows<T> q_input{
+        static_cast<const T*>(q0), static_cast<const T*>(q1), q0_len,
+        q0_stride_h, q0_stride_n, q1_stride_h, q1_stride_n};
+    const TwoSegmentRows<T> k_input{
+        static_cast<const T*>(k0), static_cast<const T*>(k1), k0_len,
+        k0_stride_h, k0_stride_n, k1_stride_h, k1_stride_n};
+    detect_k_anchor_two_segment_kernel<T>
+        <<<dim3(num_heads), kAnchorThreads, 0, stream>>>(
+            k_input, anchors, kv_len, 128);
+    constexpr int kRowsPerBlock =
+        kQuantWaves * RowTile<128>::kRowsPerWave * kRowIters;
+    const dim3 q_grid((padded_q + kRowsPerBlock - 1) / kRowsPerBlock,
+                      num_heads, 1);
+    quant_q_int8_two_segment_kernel<T, 128, 128><<<q_grid, 256, 0, stream>>>(
+        q_input, static_cast<int8_t*>(q_int8), static_cast<float*>(q_scale),
+        q_len, padded_q, num_heads);
+    const int groups = padded_k / 16;
+    const dim3 k_grid((groups + kKeyGroupsPerBlock - 1) / kKeyGroupsPerBlock,
+                      num_heads, 1);
+    quant_k_int8_two_segment_d128_kernel<T><<<k_grid, 256, 0, stream>>>(
+        k_input, static_cast<int8_t*>(k_int8), static_cast<float*>(k_scale),
+        anchors, kv_len, padded_k, num_heads, groups);
+}
+
 }  // namespace
 }  // namespace comfy::hip_backend::sage
 
 using namespace comfy::hip_backend::sage;
+
+extern "C" void launch_gfx12_qk_quant(
+    const void* q, void* q_int8, void* q_scale,
+    const void* k, void* k_int8, void* k_scale, void* anchor_indices,
+    int num_heads, int q_len, int kv_len, int padded_q, int padded_k,
+    int64_t q_stride_b, int64_t q_stride_h, int64_t q_stride_n,
+    int64_t k_stride_b, int64_t k_stride_h, int64_t k_stride_n,
+    int input_dtype_code, hipStream_t stream) {
+    if (num_heads <= 0 || q_len <= 0 || kv_len <= 0) {
+        throw std::runtime_error(
+            "gfx12 Q/K quantization requires positive heads and lengths");
+    }
+    if (padded_q < q_len || padded_q % 128 != 0 ||
+        padded_k < kv_len || padded_k % 64 != 0) {
+        throw std::runtime_error(
+            "gfx12 Q/K workspaces have invalid padding");
+    }
+    auto* anchors = static_cast<int*>(anchor_indices);
+    if (input_dtype_code == 1) {
+        launch_gfx12_qk_quant_typed<__half>(
+            q, q_int8, q_scale, k, k_int8, k_scale, anchors, num_heads,
+            q_len, kv_len, padded_q, padded_k, q_stride_b, q_stride_h,
+            q_stride_n, k_stride_b, k_stride_h, k_stride_n, stream);
+    } else if (input_dtype_code == 2) {
+        launch_gfx12_qk_quant_typed<__bf16>(
+            q, q_int8, q_scale, k, k_int8, k_scale, anchors, num_heads,
+            q_len, kv_len, padded_q, padded_k, q_stride_b, q_stride_h,
+            q_stride_n, k_stride_b, k_stride_h, k_stride_n, stream);
+    } else {
+        throw std::runtime_error(
+            "gfx12 Q/K quantization supports float16 and bfloat16");
+    }
+}
+
+extern "C" void launch_gfx12_qk_quant_split(
+    const void* q0, const void* q1, void* q_int8, void* q_scale,
+    const void* k0, const void* k1, void* k_int8, void* k_scale,
+    void* anchor_indices, int num_heads, int q0_len, int q1_len,
+    int k0_len, int k1_len, int padded_q, int padded_k,
+    int64_t q0_stride_h, int64_t q0_stride_n,
+    int64_t q1_stride_h, int64_t q1_stride_n,
+    int64_t k0_stride_h, int64_t k0_stride_n,
+    int64_t k1_stride_h, int64_t k1_stride_n, int input_dtype_code,
+    hipStream_t stream) {
+
+    const int q_len = q0_len + q1_len;
+    const int kv_len = k0_len + k1_len;
+    if (num_heads <= 0 || q0_len <= 0 || q1_len <= 0 ||
+        k0_len <= 0 || k1_len <= 0) {
+        throw std::runtime_error(
+            "gfx12 split Q/K quantization requires positive heads and segment lengths");
+    }
+    if (padded_q < q_len || padded_q % 128 != 0 ||
+        padded_k < kv_len || padded_k % 64 != 0) {
+        throw std::runtime_error("gfx12 split Q/K workspaces have invalid padding");
+    }
+    auto* anchors = static_cast<int*>(anchor_indices);
+    if (input_dtype_code == 1) {
+        launch_gfx12_qk_quant_split_typed<__half>(
+            q0, q1, q_int8, q_scale, k0, k1, k_int8, k_scale, anchors,
+            num_heads, q0_len, q1_len, k0_len, k1_len, padded_q, padded_k,
+            q0_stride_h, q0_stride_n, q1_stride_h, q1_stride_n,
+            k0_stride_h, k0_stride_n, k1_stride_h, k1_stride_n, stream);
+    } else if (input_dtype_code == 2) {
+        launch_gfx12_qk_quant_split_typed<__bf16>(
+            q0, q1, q_int8, q_scale, k0, k1, k_int8, k_scale, anchors,
+            num_heads, q0_len, q1_len, k0_len, k1_len, padded_q, padded_k,
+            q0_stride_h, q0_stride_n, q1_stride_h, q1_stride_n,
+            k0_stride_h, k0_stride_n, k1_stride_h, k1_stride_n, stream);
+    } else {
+        throw std::runtime_error(
+            "gfx12 split Q/K quantization supports float16 and bfloat16");
+    }
+}
 
 // rotation is 4, 64, 128 or 129; the caller picks it the same way the CUDA
 // backend does, and Q and K must agree or their dot products change.

--- a/comfy_kitchen/backends/hip/sage_attention/quant_v_int8.hip
+++ b/comfy_kitchen/backends/hip/sage_attention/quant_v_int8.hip
@@ -24,6 +24,186 @@ namespace {
 
 constexpr int kDTile = 8;
 
+template <typename T>
+struct TwoSegmentVRows {
+    const T* first;
+    const T* second;
+    int first_rows;
+    int64_t first_stride_h;
+    int64_t first_stride_n;
+    int64_t second_stride_h;
+    int64_t second_stride_n;
+
+    __forceinline__ __device__ const T* row(int head, int index) const {
+        if (index < first_rows) {
+            return first + static_cast<int64_t>(head) * first_stride_h +
+                   static_cast<int64_t>(index) * first_stride_n;
+        }
+        return second + static_cast<int64_t>(head) * second_stride_h +
+               static_cast<int64_t>(index - first_rows) * second_stride_n;
+    }
+};
+
+// Optimized producer: one scale per (head, 64-key tile, channel), with
+// the quantized bytes written directly as [head, tile, D, 64].  A synchronous
+// BF16 LDS tile keeps both the physical-NHD input loads and tile-major output
+// stores vectorized; this kernel family has no global-to-LDS async/direct path.
+template <typename T>
+__global__ __launch_bounds__(256) void gfx12_tile_channel_v_quant_kernel(
+    const T* __restrict__ v, int8_t* __restrict__ output,
+    float* __restrict__ descale, int n_ctx, int tiles,
+    int64_t stride_h, int64_t stride_n) {
+    constexpr int kTileN = 64;
+    constexpr int kD = 128;
+    constexpr int kStageStride = kD + 8;
+    __shared__ __align__(16) T staged[kTileN * kStageStride];
+    __shared__ float multiplier[kD];
+
+    const int tid = threadIdx.x;
+    const int tile = blockIdx.x;
+    const int head = blockIdx.y;
+    const int n0 = tile * kTileN;
+
+    // 64*128 BF16 values = 1024 aligned 16-byte chunks, four per thread.
+#pragma unroll
+    for (int i = 0; i < 4; ++i) {
+        const int chunk = tid + i * 256;
+        const int row = chunk >> 4;
+        const int d8 = (chunk & 15) << 3;
+        uint4 value = make_uint4(0, 0, 0, 0);
+        if (n0 + row < n_ctx) {
+            value = *reinterpret_cast<const uint4*>(
+                v + static_cast<int64_t>(head) * stride_h +
+                static_cast<int64_t>(n0 + row) * stride_n + d8);
+        }
+        *reinterpret_cast<uint4*>(staged + row * kStageStride + d8) = value;
+    }
+    __syncthreads();
+
+    if (tid < kD) {
+        float maximum = 0.0f;
+#pragma unroll
+        for (int row = 0; row < kTileN; ++row) {
+            maximum = fmaxf(maximum, fabsf(to_float(
+                staged[row * kStageStride + tid])));
+        }
+        if (maximum == 0.0f) maximum = 1.0e-8f;
+        descale[(static_cast<int64_t>(head) * tiles + tile) * kD + tid] =
+            maximum * (1.0f / 127.0f);
+        multiplier[tid] = __builtin_amdgcn_rcpf(maximum) * 127.0f;
+    }
+    __syncthreads();
+
+    // 128 rows of 64 output bytes = 512 uint4 chunks, two per thread.
+#pragma unroll
+    for (int i = 0; i < 2; ++i) {
+        const int chunk = tid + i * 256;
+        const int d = chunk >> 2;
+        const int n16 = (chunk & 3) << 4;
+        uint4 packed = make_uint4(0, 0, 0, 0);
+        uint32_t* words = reinterpret_cast<uint32_t*>(&packed);
+#pragma unroll
+        for (int j = 0; j < 16; ++j) {
+            const uint32_t code = static_cast<uint8_t>(float_to_int8_rn(
+                to_float(staged[(n16 + j) * kStageStride + d]) *
+                multiplier[d]));
+            words[j >> 2] |= code << (8 * (j & 3));
+        }
+        *reinterpret_cast<uint4*>(
+            output + static_cast<int64_t>(head) * tiles * kD * kTileN +
+            static_cast<int64_t>(tile) * kD * kTileN + d * kTileN + n16) = packed;
+    }
+}
+
+// Identical tile/channel quantization from two logical sequence segments. The
+// tile crossing the segment boundary reads each row from its owning tensor and
+// therefore produces the same bytes/scales as concatenating BF16 first.
+template <typename T>
+__global__ __launch_bounds__(256) void gfx12_tile_channel_v_quant_two_segment_kernel(
+    TwoSegmentVRows<T> input, int8_t* __restrict__ output,
+    float* __restrict__ descale, int n_ctx, int tiles) {
+    constexpr int kTileN = 64;
+    constexpr int kD = 128;
+    constexpr int kStageStride = kD + 8;
+    __shared__ __align__(16) T staged[kTileN * kStageStride];
+    __shared__ float multiplier[kD];
+
+    const int tid = threadIdx.x;
+    const int tile = blockIdx.x;
+    const int head = blockIdx.y;
+    const int n0 = tile * kTileN;
+#pragma unroll
+    for (int i = 0; i < 4; ++i) {
+        const int chunk = tid + i * 256;
+        const int row = chunk >> 4;
+        const int d8 = (chunk & 15) << 3;
+        uint4 value = make_uint4(0, 0, 0, 0);
+        if (n0 + row < n_ctx) {
+            value = *reinterpret_cast<const uint4*>(input.row(head, n0 + row) + d8);
+        }
+        *reinterpret_cast<uint4*>(staged + row * kStageStride + d8) = value;
+    }
+    __syncthreads();
+
+    if (tid < kD) {
+        float maximum = 0.0f;
+#pragma unroll
+        for (int row = 0; row < kTileN; ++row) {
+            maximum = fmaxf(maximum, fabsf(to_float(
+                staged[row * kStageStride + tid])));
+        }
+        if (maximum == 0.0f) maximum = 1.0e-8f;
+        descale[(static_cast<int64_t>(head) * tiles + tile) * kD + tid] =
+            maximum * (1.0f / 127.0f);
+        multiplier[tid] = __builtin_amdgcn_rcpf(maximum) * 127.0f;
+    }
+    __syncthreads();
+
+#pragma unroll
+    for (int i = 0; i < 2; ++i) {
+        const int chunk = tid + i * 256;
+        const int d = chunk >> 2;
+        const int n16 = (chunk & 3) << 4;
+        uint4 packed = make_uint4(0, 0, 0, 0);
+        uint32_t* words = reinterpret_cast<uint32_t*>(&packed);
+#pragma unroll
+        for (int j = 0; j < 16; ++j) {
+            const uint32_t code = static_cast<uint8_t>(float_to_int8_rn(
+                to_float(staged[(n16 + j) * kStageStride + d]) *
+                multiplier[d]));
+            words[j >> 2] |= code << (8 * (j & 3));
+        }
+        *reinterpret_cast<uint4*>(
+            output + static_cast<int64_t>(head) * tiles * kD * kTileN +
+            static_cast<int64_t>(tile) * kD * kTileN + d * kTileN + n16) = packed;
+    }
+}
+
+template <typename T>
+void launch_gfx12_tile_channel_v_quant(
+    const T* v, int8_t* output, float* descale,
+    int num_heads, int n_ctx, int tiles,
+    int64_t stride_h, int64_t stride_n,
+    hipStream_t stream) {
+    gfx12_tile_channel_v_quant_kernel<T><<<dim3(tiles, num_heads), 256, 0, stream>>>(
+        v, output, descale, n_ctx, tiles, stride_h, stride_n);
+}
+
+template <typename T>
+void launch_gfx12_tile_channel_v_quant_split(
+    const void* v0, const void* v1, void* output, void* descale,
+    int num_heads, int v0_len, int v1_len, int tiles,
+    int64_t v0_stride_h, int64_t v0_stride_n,
+    int64_t v1_stride_h, int64_t v1_stride_n, hipStream_t stream) {
+    const TwoSegmentVRows<T> input{
+        static_cast<const T*>(v0), static_cast<const T*>(v1), v0_len,
+        v0_stride_h, v0_stride_n, v1_stride_h, v1_stride_n};
+    gfx12_tile_channel_v_quant_two_segment_kernel<T>
+        <<<dim3(tiles, num_heads), 256, 0, stream>>>(
+            input, static_cast<int8_t*>(output), static_cast<float*>(descale),
+            v0_len + v1_len, tiles);
+}
+
 // Eight adjacent channels: 32 bytes for fp32, 16 for the 16-bit types.
 template <typename T>
 __forceinline__ __device__ void load8(const T* p, float* out) {
@@ -157,6 +337,64 @@ void launch_typed(const void* v, void* out, void* scale, int B, int H, int N, in
 }  // namespace comfy::hip_backend::sage
 
 using namespace comfy::hip_backend::sage;
+
+extern "C" void launch_gfx12_tile_channel_v_quant(
+    const void* v, void* output, void* descale, int num_heads,
+    int n_ctx, int tiles,
+    int64_t stride_h, int64_t stride_n, int input_dtype_code,
+    hipStream_t stream) {
+    if (num_heads <= 0 || n_ctx <= 0) {
+        throw std::runtime_error(
+            "gfx12 tile-channel V quantization requires positive heads and length");
+    }
+    if (tiles != (n_ctx + 63) / 64) {
+        throw std::runtime_error(
+            "gfx12 tile-channel V quantization received an invalid tile count");
+    }
+    if (input_dtype_code == 1) {
+        launch_gfx12_tile_channel_v_quant(
+            static_cast<const __half*>(v), static_cast<int8_t*>(output),
+            static_cast<float*>(descale), num_heads, n_ctx, tiles,
+            stride_h, stride_n, stream);
+    } else if (input_dtype_code == 2) {
+        launch_gfx12_tile_channel_v_quant(
+            static_cast<const __bf16*>(v), static_cast<int8_t*>(output),
+            static_cast<float*>(descale), num_heads, n_ctx, tiles,
+            stride_h, stride_n, stream);
+    } else {
+        throw std::runtime_error(
+            "gfx12 tile-channel V quantization supports float16 and bfloat16");
+    }
+}
+
+extern "C" void launch_gfx12_tile_channel_v_quant_split(
+    const void* v0, const void* v1, void* output, void* descale,
+    int num_heads, int v0_len, int v1_len, int tiles,
+    int64_t v0_stride_h, int64_t v0_stride_n,
+    int64_t v1_stride_h, int64_t v1_stride_n, int input_dtype_code,
+    hipStream_t stream) {
+    const int n_ctx = v0_len + v1_len;
+    if (num_heads <= 0 || v0_len <= 0 || v1_len <= 0) {
+        throw std::runtime_error(
+            "gfx12 split V quantization requires positive heads and segment lengths");
+    }
+    if (tiles != (n_ctx + 63) / 64) {
+        throw std::runtime_error(
+            "gfx12 split V quantization received an invalid tile count");
+    }
+    if (input_dtype_code == 1) {
+        launch_gfx12_tile_channel_v_quant_split<__half>(
+            v0, v1, output, descale, num_heads, v0_len, v1_len, tiles,
+            v0_stride_h, v0_stride_n, v1_stride_h, v1_stride_n, stream);
+    } else if (input_dtype_code == 2) {
+        launch_gfx12_tile_channel_v_quant_split<__bf16>(
+            v0, v1, output, descale, num_heads, v0_len, v1_len, tiles,
+            v0_stride_h, v0_stride_n, v1_stride_h, v1_stride_n, stream);
+    } else {
+        throw std::runtime_error(
+            "gfx12 split V quantization supports float16 and bfloat16");
+    }
+}
 
 extern "C" void launch_sage_quant_v_int8(const void* v, void* out, void* scale, int B, int H,
                                          int N, int D, int padded_N, int64_t stride_b,

--- a/comfy_kitchen/backends/hip/swiglu_bf16.h
+++ b/comfy_kitchen/backends/hip/swiglu_bf16.h
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <hip/hip_fp16.h>
+#include <hip/hip_runtime.h>
+
+namespace comfy::hip_backend {
+
+union Bf16Bits {
+    __bf16 value;
+    uint16_t bits;
+};
+
+__forceinline__ __device__ __bf16 bf16_from_bits(uint16_t bits) {
+    Bf16Bits result{};
+    result.bits = bits;
+    return result.value;
+}
+
+// Match torch.nn.functional.silu(gate) * up for BF16 operands: SiLU is rounded
+// to BF16 before the multiply and the product is rounded to BF16 on return.
+__forceinline__ __device__ __bf16 swiglu_bf16_value(
+    __bf16 gate, __bf16 up) {
+    Bf16Bits gate_storage{};
+    gate_storage.value = gate;
+    const float gate_f = static_cast<float>(gate);
+    __bf16 silu;
+    // PyTorch's current ROCm BF16 SiLU differs from the native float expf
+    // path at four finite BF16 inputs. Preserve those exact rounded values;
+    // every other finite BF16 input maps identically on gfx12.
+    switch (gate_storage.bits) {
+        case 0x40be: silu = bf16_from_bits(0x40bd); break;  //  5.9375
+        case 0xc2af: silu = bf16_from_bits(0x8395); break;  // -87.5
+        case 0xc2b0: silu = bf16_from_bits(0x8335); break;  // -88.0
+        case 0xc2b1: silu = bf16_from_bits(0x82dd); break;  // -88.5
+        default:
+            silu = static_cast<__bf16>(
+                gate_f / (1.0f + expf(-gate_f)));
+            break;
+    }
+    return static_cast<__bf16>(
+        static_cast<float>(silu) * static_cast<float>(up));
+}
+
+}  // namespace comfy::hip_backend

--- a/comfy_kitchen/tensor/int8.py
+++ b/comfy_kitchen/tensor/int8.py
@@ -168,7 +168,10 @@ class TensorWiseINT8Layout(QuantizedLayout):
                 ready = torch.cuda.Event()
                 ready.record(torch.cuda.current_stream(packed.device))
                 ready.synchronize()
-            qtensor._qdata = packed
+            if qtensor._qdata.untyped_storage().resizable():
+                qtensor._qdata = packed
+            else:
+                qtensor._qdata.copy_(packed)
             qtensor._params = dataclasses.replace(
                 params, wmma_tile_n=tile_n, wmma_tile_k=tile_k
             )
@@ -213,14 +216,18 @@ class TensorWiseINT8Layout(QuantizedLayout):
         n, k = params.orig_shape
         if input_tensor.shape[-1] != k:
             return 0
-        # Tiled-A down (Lumina/Z-Image SwiGLU w2: 10240 -> 3840) consumes
-        # row-major B. Packing this weight as tiled-B makes HIP reject the call.
-        if n == 3840 and k == 10240:
+        # These projection families use row-major kernels. Packing either weight
+        # as tiled-B selects an incompatible HIP path.
+        if (n, k) in ((3840, 10240), (10240, 3840)):
             return 0
         m = input_tensor.numel() // k
         if m < 512 or n % 128 or k % 256:
             return 0
-        tile_k = 128 if n < k < 4 * n else 64
+        tile_k = (
+            128
+            if (n, k) in ((3840, 3840), (3840, 10240)) or n < k < 4 * n
+            else 64
+        )
         cls.pack_wmma_weight_(qtensor, tile_k=tile_k, tile_n=128)
         return tile_k
 
@@ -247,7 +254,7 @@ class TensorWiseINT8Layout(QuantizedLayout):
         m = input_tensor.numel() // input_tensor.shape[-1]
         return (
             input_tensor.shape[-1] == k
-            and not (n == 3840 and k == 10240)
+            and (n, k) not in ((3840, 10240), (10240, 3840))
             and m >= 96
             and n % tile_n == 0
             and k % tile_k == 0

--- a/comfy_kitchen/tensor/int8.py
+++ b/comfy_kitchen/tensor/int8.py
@@ -225,7 +225,7 @@ class TensorWiseINT8Layout(QuantizedLayout):
             return 0
         tile_k = (
             128
-            if (n, k) in ((3840, 3840), (3840, 10240)) or n < k < 4 * n
+            if (n, k) == (3840, 3840) or n < k < 4 * n
             else 64
         )
         cls.pack_wmma_weight_(qtensor, tile_k=tile_k, tile_n=128)

--- a/comfy_kitchen/tensor/int8.py
+++ b/comfy_kitchen/tensor/int8.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import dataclasses
 import logging
+import threading
 from dataclasses import dataclass
 
 import torch
@@ -26,6 +27,8 @@ from .base import (
 
 logger = logging.getLogger(__name__)
 
+_WMMA_WEIGHT_PACK_LOCK = threading.RLock()
+
 _INT8_DEQUANT_DTYPE_TO_CODE = {
     torch.float32: 0,
     torch.float16: 1,
@@ -41,6 +44,14 @@ def _dtype_code(dtype: torch.dtype) -> int:
     if dtype == torch.bfloat16:
         return 2
     raise ValueError(f"Unsupported INT8 output dtype: {dtype}")
+
+
+def _uses_nonduplicated_wmma(device: torch.device) -> bool:
+    try:
+        arch = torch.cuda.get_device_properties(device).gcnArchName.split(":")[0]
+    except (AttributeError, RuntimeError):
+        return False
+    return arch.startswith("gfx12")
 
 
 class TensorWiseINT8Layout(QuantizedLayout):
@@ -75,12 +86,172 @@ class TensorWiseINT8Layout(QuantizedLayout):
         convrot: bool = False
         convrot_groupsize: int = 256
         transposed: bool = False
+        # Runtime-only physical storage layout. Zero means checkpoint-compatible
+        # row-major [N, K]. Nonzero values mean qdata is packed as
+        # [N / tile_n, K / tile_k, tile_n, tile_k] and then flattened back to
+        # the original 2-D storage shape. Serialization always unpacks it.
+        wmma_tile_n: int = 0
+        wmma_tile_k: int = 0
 
         def _tensor_fields(self) -> list[str]:
             return ["scale"]
 
         def _validate_tensor_fields(self):
-            pass
+            if (self.wmma_tile_n == 0) != (self.wmma_tile_k == 0):
+                raise ValueError(
+                    "wmma_tile_n and wmma_tile_k must both be zero or nonzero"
+                )
+
+    @staticmethod
+    def _unpack_wmma_weight(qdata: torch.Tensor, params: Params) -> torch.Tensor:
+        """Return a row-major view/copy of runtime-tiled weight storage."""
+        tile_n = getattr(params, "wmma_tile_n", 0)
+        tile_k = getattr(params, "wmma_tile_k", 0)
+        if tile_n == 0:
+            return qdata
+        if len(params.orig_shape) != 2 or getattr(params, "transposed", False):
+            raise ValueError("WMMA-tiled INT8 storage requires a non-transposed 2-D weight")
+        n, k = params.orig_shape
+        if n % tile_n or k % tile_k or qdata.numel() != n * k:
+            raise ValueError(
+                f"Invalid WMMA-tiled INT8 storage: shape={params.orig_shape}, "
+                f"tile=({tile_n}, {tile_k}), numel={qdata.numel()}"
+            )
+        return (
+            qdata.reshape(n // tile_n, k // tile_k, tile_n, tile_k)
+            .permute(0, 2, 1, 3)
+            .contiguous()
+            .reshape(n, k)
+        )
+
+    @classmethod
+    def pack_wmma_weight_(
+        cls, qtensor: QuantizedTensor, tile_k: int, tile_n: int = 128
+    ) -> QuantizedTensor:
+        """Pack one weight in place for static-tile GEMM loaders.
+
+        The wrapper and logical shape remain unchanged. Only its private INT8
+        storage is replaced, so the old row-major allocation can be released
+        rather than retaining a second multi-gigabyte model copy.
+        """
+        if not isinstance(qtensor, QuantizedTensor) or qtensor._layout_cls != cls.__name__:
+            raise TypeError("pack_wmma_weight_ requires a TensorWiseINT8Layout tensor")
+        params = qtensor._params
+        if not getattr(params, "is_weight", True):
+            raise ValueError("Only INT8 weights can use WMMA-tiled storage")
+        if getattr(params, "transposed", False) or len(params.orig_shape) != 2:
+            raise ValueError("WMMA-tiled storage requires a non-transposed 2-D weight")
+        n, k = params.orig_shape
+        if tile_n <= 0 or tile_k <= 0 or n % tile_n or k % tile_k:
+            raise ValueError(
+                f"Weight shape {(n, k)} is not divisible by tile {(tile_n, tile_k)}"
+            )
+        with _WMMA_WEIGHT_PACK_LOCK:
+            # Another inference thread may have packed this wrapper while the
+            # caller was checking eligibility.
+            params = qtensor._params
+            old_tile_n = getattr(params, "wmma_tile_n", 0)
+            old_tile_k = getattr(params, "wmma_tile_k", 0)
+            if (old_tile_n, old_tile_k) == (tile_n, tile_k):
+                return qtensor
+            row_major = cls._unpack_wmma_weight(qtensor._qdata, params)
+            packed = (
+                row_major.reshape(n // tile_n, tile_n, k // tile_k, tile_k)
+                .permute(0, 2, 1, 3)
+                .contiguous()
+                .reshape_as(qtensor._qdata)
+            )
+            # Publish the new layout only after its asynchronous device copy is
+            # complete. This makes first-use packing safe across inference
+            # threads and streams; subsequent calls do not synchronize.
+            if packed.device.type == "cuda":
+                ready = torch.cuda.Event()
+                ready.record(torch.cuda.current_stream(packed.device))
+                ready.synchronize()
+            qtensor._qdata = packed
+            qtensor._params = dataclasses.replace(
+                params, wmma_tile_n=tile_n, wmma_tile_k=tile_k
+            )
+        return qtensor
+
+    @classmethod
+    def prepare_wmma_weight_(
+        cls, qtensor: QuantizedTensor, input_tensor: torch.Tensor
+    ) -> int:
+        """Lazily select a measured tile layout for one inference weight.
+
+        The policy is deliberately dimensional. Wide, square, and very
+        deep-K projections use a 64-byte K tile; moderately deep-K
+        projections use a 128-byte tile. The native storage contract is
+        architecture-neutral; automatic selection requires the
+        non-duplicated gfx12 WMMA operand layout.
+
+        Returns the physical K tile, or zero when row-major storage is kept.
+        """
+        if not isinstance(qtensor, QuantizedTensor) or qtensor._layout_cls != cls.__name__:
+            return 0
+        params = qtensor._params
+        existing = getattr(params, "wmma_tile_k", 0)
+        if existing:
+            return existing
+        if getattr(params, "transposed", False) or not getattr(params, "is_weight", True):
+            return 0
+        if input_tensor.dtype != torch.bfloat16 or input_tensor.device.type != "cuda":
+            return 0
+        if input_tensor.requires_grad or torch.is_grad_enabled():
+            return 0
+        try:
+            if torch.compiler.is_compiling() or torch.cuda.is_current_stream_capturing():
+                return 0
+        except (AttributeError, RuntimeError):
+            return 0
+        if (not _uses_nonduplicated_wmma(input_tensor.device)
+                or qtensor._qdata.device != input_tensor.device):
+            return 0
+        if len(params.orig_shape) != 2 or input_tensor.ndim == 0:
+            return 0
+        n, k = params.orig_shape
+        if input_tensor.shape[-1] != k:
+            return 0
+        # Tiled-A down (Lumina/Z-Image SwiGLU w2: 10240 -> 3840) consumes
+        # row-major B. Packing this weight as tiled-B makes HIP reject the call.
+        if n == 3840 and k == 10240:
+            return 0
+        m = input_tensor.numel() // k
+        if m < 512 or n % 128 or k % 256:
+            return 0
+        tile_k = 128 if n < k < 4 * n else 64
+        cls.pack_wmma_weight_(qtensor, tile_k=tile_k, tile_n=128)
+        return tile_k
+
+    @classmethod
+    def wmma_weight_is_supported(
+        cls, qtensor: QuantizedTensor, input_tensor: torch.Tensor
+    ) -> bool:
+        """Whether this call can consume an already tiled physical weight."""
+        if not isinstance(qtensor, QuantizedTensor) or qtensor._layout_cls != cls.__name__:
+            return False
+        params = qtensor._params
+        tile_n = getattr(params, "wmma_tile_n", 0)
+        tile_k = getattr(params, "wmma_tile_k", 0)
+        if tile_n != 128 or tile_k not in (64, 128):
+            return False
+        if input_tensor.dtype != torch.bfloat16 or input_tensor.device.type != "cuda":
+            return False
+        if qtensor._qdata.device != input_tensor.device or input_tensor.ndim == 0:
+            return False
+        if (not _uses_nonduplicated_wmma(input_tensor.device)
+                or len(params.orig_shape) != 2):
+            return False
+        n, k = params.orig_shape
+        m = input_tensor.numel() // input_tensor.shape[-1]
+        return (
+            input_tensor.shape[-1] == k
+            and not (n == 3840 and k == 10240)
+            and m >= 96
+            and n % tile_n == 0
+            and k % tile_k == 0
+        )
 
     @classmethod
     def quantize(
@@ -167,6 +338,7 @@ class TensorWiseINT8Layout(QuantizedLayout):
         Returns:
             Dequantized tensor.
         """
+        qdata = cls._unpack_wmma_weight(qdata, params)
         output_dtype_code = _INT8_DEQUANT_DTYPE_TO_CODE.get(params.orig_dtype, 0)
         if getattr(params, "convrot", False):
             result = torch.ops.comfy_kitchen.dequantize_int8_convrot_weight_dtype(
@@ -183,6 +355,7 @@ class TensorWiseINT8Layout(QuantizedLayout):
         Embedding counterpart of ``dequantize``, which would materialize the whole ``[vocab, dim]``
         table to read a few rows. Un-rotates if ``params.convrot``. Returns ``[*indices.shape, dim]``.
         """
+        qdata = cls._unpack_wmma_weight(qdata, params)
         output_dtype_code = _INT8_DEQUANT_DTYPE_TO_CODE.get(params.orig_dtype, 0)
         group_size = params.convrot_groupsize if getattr(params, "convrot", False) else 0
         result = torch.ops.comfy_kitchen.dequantize_int8_embedding(
@@ -203,6 +376,270 @@ class TensorWiseINT8Layout(QuantizedLayout):
         return qtensor._qdata, qtensor._params.scale
 
     @classmethod
+    def _fusion_operand(
+        cls,
+        weight: QuantizedTensor,
+        x: torch.Tensor,
+        *,
+        prepare: bool = False,
+    ):
+        """Resolve private storage needed by compound INT8 operations."""
+        if not isinstance(weight, QuantizedTensor) or weight._layout_cls != cls.__name__:
+            return None
+        params = weight._params
+        if getattr(params, "transposed", False):
+            return None
+        if prepare:
+            cls.prepare_wmma_weight_(weight, x)
+            params = weight._params
+        tile_k = int(getattr(params, "wmma_tile_k", 0))
+        if tile_k and not cls.wmma_weight_is_supported(weight, x):
+            return None
+        qdata, scale = cls.get_plain_tensors(weight)
+        return (
+            qdata.contiguous(),
+            scale,
+            bool(getattr(params, "convrot", False)),
+            int(getattr(params, "convrot_groupsize", 256)),
+            tile_k,
+            weight,
+        )
+
+
+    @classmethod
+    def _fusion_operands(cls, weights, x: torch.Tensor):
+        """Resolve a compatible group of projections or return ``None``."""
+        operands = tuple(
+            cls._fusion_operand(weight, x, prepare=True) for weight in weights
+        )
+        if any(operand is None for operand in operands):
+            return None
+        qdata, _, convrot, group_size, tile_k, _ = operands[0]
+        if any(
+            operand[2:5] != (convrot, group_size, tile_k)
+            or operand[0].shape != qdata.shape
+            for operand in operands[1:]
+        ):
+            return None
+        return operands
+
+    @classmethod
+    def is_fusion_weight(cls, weight: torch.Tensor) -> bool:
+        """Whether ``weight`` has the logical layout compound ops require."""
+        return (
+            isinstance(weight, QuantizedTensor)
+            and weight._layout_cls == cls.__name__
+            and not getattr(weight._params, "transposed", False)
+        )
+
+    @classmethod
+    def fused_linear(
+        cls,
+        x: torch.Tensor,
+        weight: QuantizedTensor,
+        bias: torch.Tensor | None,
+        *,
+        input_act: str | None = None,
+        residual: torch.Tensor | None = None,
+        gate: torch.Tensor | None = None,
+    ):
+        """Run a compound linear when this layout can preserve its contract."""
+        operand = cls._fusion_operand(weight, x, prepare=True)
+        if operand is None:
+            return NotImplemented
+        qdata, scale, convrot, group_size, tile_k, packed_weight = operand
+        source = x
+        if input_act == "gelu_tanh":
+            source = torch.nn.functional.gelu(x, approximate="tanh")
+        elif input_act == "swiglu":
+            gate_source, up_source = x.chunk(2, dim=-1)
+            source = torch.nn.functional.silu(gate_source).mul_(up_source)
+        elif input_act is not None:
+            return NotImplemented
+
+        if tile_k:
+            if residual is None:
+                return torch.nn.functional.linear(source, packed_weight, bias)
+            if gate is None:
+                return NotImplemented
+            from comfy_kitchen import int8_linear_gated_residual
+
+            rows = source.numel() // source.shape[-1]
+            return int8_linear_gated_residual(
+                source, qdata, scale, residual, gate, bias, x.dtype,
+                convrot=convrot, convrot_groupsize=group_size,
+                weight_tile_k=tile_k, dual_m=rows >= 512,
+            )
+
+        from comfy_kitchen import int8_linear
+
+        output = int8_linear(
+            x, qdata, scale, bias, x.dtype, convrot=convrot,
+            convrot_groupsize=group_size, input_act=input_act,
+        )
+        if residual is not None:
+            if gate is None:
+                return NotImplemented
+            output = torch.addcmul(residual, gate, output)
+        return output
+
+    @classmethod
+    def fused_pair(
+        cls,
+        x: torch.Tensor,
+        weight0: QuantizedTensor,
+        weight1: QuantizedTensor,
+        bias0: torch.Tensor | None,
+        bias1: torch.Tensor | None,
+        *,
+        modulation_scale: torch.Tensor | None = None,
+        modulation_shift: torch.Tensor | None = None,
+    ):
+        operands = cls._fusion_operands((weight0, weight1), x)
+        if operands is None:
+            return NotImplemented
+        first, second = operands
+        qdata0, scale0, convrot, group_size, tile_k, _ = first
+        qdata1, scale1, _, _, _, _ = second
+        if modulation_scale is None:
+            from comfy_kitchen import int8_linear_pair
+
+            return int8_linear_pair(
+                x, qdata0, qdata1, scale0, scale1, bias0, bias1, x.dtype,
+                convrot=convrot, convrot_groupsize=group_size,
+                weight_tile_k=tile_k,
+            )
+        if modulation_shift is None:
+            return NotImplemented
+        from comfy_kitchen import int8_linear_pair_modulated
+
+        return int8_linear_pair_modulated(
+            x, modulation_scale, qdata0, qdata1, scale0, scale1,
+            bias0, bias1, x.dtype, convrot=convrot,
+            convrot_groupsize=group_size,
+            modulation_shift=modulation_shift, weight_tile_k=tile_k,
+        )
+
+    @classmethod
+    def fused_affine(
+        cls,
+        x: torch.Tensor,
+        weight: QuantizedTensor,
+        bias: torch.Tensor | None,
+        modulation_scale: torch.Tensor,
+        modulation_shift: torch.Tensor,
+    ):
+        operand = cls._fusion_operand(weight, x, prepare=True)
+        if operand is None:
+            return NotImplemented
+        qdata, scale, convrot, group_size, tile_k, _ = operand
+        from comfy_kitchen import int8_linear_modulated
+
+        return int8_linear_modulated(
+            x, modulation_scale, qdata, scale, bias, x.dtype,
+            convrot=convrot, convrot_groupsize=group_size,
+            modulation_shift=modulation_shift, weight_tile_k=tile_k,
+        )
+
+    @classmethod
+    def fused_triple_modulated(
+        cls,
+        x: torch.Tensor,
+        weights: tuple[QuantizedTensor, QuantizedTensor, QuantizedTensor],
+        biases: tuple[torch.Tensor | None, torch.Tensor | None, torch.Tensor | None],
+        modulation_scale: torch.Tensor,
+        modulation_shift: torch.Tensor,
+    ):
+        operands = cls._fusion_operands(weights, x)
+        if operands is None:
+            return NotImplemented
+        qdata0, scale0, convrot, group_size, tile_k, _ = operands[0]
+        from comfy_kitchen import int8_linear_triple_modulated
+
+        return int8_linear_triple_modulated(
+            x, modulation_scale,
+            qdata0, operands[1][0], operands[2][0],
+            scale0, operands[1][1], operands[2][1],
+            *biases, x.dtype, convrot=convrot,
+            convrot_groupsize=group_size,
+            modulation_shift=modulation_shift, weight_tile_k=tile_k,
+        )
+
+    @classmethod
+    def fused_rms_modulated(
+        cls,
+        x: torch.Tensor,
+        weight: QuantizedTensor,
+        bias: torch.Tensor | None,
+        norm_weight: torch.Tensor,
+        norm_eps: float,
+        modulation_scale: torch.Tensor,
+    ):
+        operand = cls._fusion_operand(weight, x, prepare=True)
+        if operand is None:
+            return NotImplemented
+        qdata, scale, convrot, group_size, tile_k, _ = operand
+        from comfy_kitchen import int8_linear_rms_modulated
+
+        return int8_linear_rms_modulated(
+            x, norm_weight, norm_eps, modulation_scale, qdata, scale,
+            bias, x.dtype, convrot=convrot,
+            convrot_groupsize=group_size, weight_tiled_b=bool(tile_k),
+        )
+
+    @classmethod
+    def fused_swiglu_ffn(
+        cls,
+        x: torch.Tensor,
+        gate_weight: QuantizedTensor,
+        up_weight: QuantizedTensor,
+        down_weight: QuantizedTensor,
+        gate_bias: torch.Tensor | None,
+        up_bias: torch.Tensor | None,
+        down_bias: torch.Tensor | None,
+        *,
+        norm_weight: torch.Tensor | None = None,
+        norm_eps: float = 0.0,
+        modulation_scale: torch.Tensor | None = None,
+    ):
+        pair = cls._fusion_operands((gate_weight, up_weight), x)
+        if pair is None:
+            return NotImplemented
+        first, second = pair
+        qgate, gate_scale, convrot, group_size, tile_k, _ = first
+        qup, up_scale, _, _, _, _ = second
+        if norm_weight is None:
+            from comfy_kitchen import int8_linear_pair
+
+            gate, up = int8_linear_pair(
+                x, qgate, qup, gate_scale, up_scale, gate_bias, up_bias,
+                x.dtype, convrot=convrot, convrot_groupsize=group_size,
+                weight_tile_k=tile_k,
+            )
+        else:
+            if modulation_scale is None or tile_k:
+                return NotImplemented
+            from comfy_kitchen import int8_linear_pair_rms_modulated
+
+            gate, up = int8_linear_pair_rms_modulated(
+                x, norm_weight, norm_eps, modulation_scale,
+                qgate, qup, gate_scale, up_scale, gate_bias, up_bias,
+                x.dtype, convrot=convrot, convrot_groupsize=group_size,
+            )
+
+        down = cls._fusion_operand(down_weight, gate, prepare=True)
+        if down is None:
+            return NotImplemented
+        qdown, down_scale, down_convrot, down_group, down_tile_k, _ = down
+        from comfy_kitchen import int8_linear_swiglu_split
+
+        return int8_linear_swiglu_split(
+            gate, up, qdown, down_scale, down_bias, gate.dtype,
+            convrot=down_convrot, convrot_groupsize=down_group,
+            weight_tiled_b=bool(down_tile_k), weight_tile_k=down_tile_k,
+        )
+
+    @classmethod
     def state_dict_tensors(cls, qdata: torch.Tensor, params: Params) -> dict[str, torch.Tensor]:
         """Return key suffix → tensor mapping for serialization.
 
@@ -214,7 +651,7 @@ class TensorWiseINT8Layout(QuantizedLayout):
             Dictionary mapping suffix to tensor.
         """
         return {
-            "": qdata,
+            "": cls._unpack_wmma_weight(qdata, params),
             "_scale": params.scale,
         }
 
@@ -252,6 +689,9 @@ def _handle_int8_transpose(qt, args, kwargs):
     if not isinstance(input_tensor, QuantizedTensor):
         return torch.ops.aten.t.default(*args, **kwargs)
 
+    if getattr(input_tensor._params, "wmma_tile_n", 0):
+        return input_tensor.dequantize().t()
+
     old = input_tensor._params
     new_params = dataclasses.replace(
         old,
@@ -278,21 +718,34 @@ def _handle_int8_linear_tensorwise(qt, args, kwargs):
     if isinstance(input_tensor, QuantizedTensor):
         input_tensor = input_tensor.dequantize()
 
+    TensorWiseINT8Layout.prepare_wmma_weight_(weight, input_tensor)
+    tile_n = getattr(weight._params, "wmma_tile_n", 0)
+    tile_k = getattr(weight._params, "wmma_tile_k", 0)
+    m = input_tensor.numel() // input_tensor.shape[-1]
+    tiled_supported = TensorWiseINT8Layout.wmma_weight_is_supported(
+        weight, input_tensor
+    )
+    if tile_n and not tiled_supported:
+        return torch.nn.functional.linear(*dequantize_args(args), **dequantize_args(kwargs))
+
     weight_qdata, weight_scale = TensorWiseINT8Layout.get_plain_tensors(weight)
     out_dtype = kwargs.get("out_dtype", input_tensor.dtype)
 
     convrot = getattr(weight._params, "convrot", False)
     convrot_groupsize = getattr(weight._params, "convrot_groupsize", 256)
 
-    return torch.ops.comfy_kitchen.int8_linear(
-        input_tensor.contiguous(),
-        weight_qdata.contiguous(),
-        weight_scale,
-        bias,
-        _dtype_code(out_dtype),
-        convrot,
-        convrot_groupsize,
+    op = (
+        torch.ops.comfy_kitchen.int8_linear_tiled_b
+        if tiled_supported
+        else torch.ops.comfy_kitchen.int8_linear
     )
+    op_args = [
+        input_tensor.contiguous(), weight_qdata.contiguous(), weight_scale,
+        bias, _dtype_code(out_dtype), convrot, convrot_groupsize,
+    ]
+    if tiled_supported:
+        op_args.extend((tile_k, m >= 512))
+    return op(*op_args)
 
 
 @register_layout_op(torch.ops.aten.mm.default, TensorWiseINT8Layout)
@@ -303,6 +756,8 @@ def _handle_int8_mm_tensorwise(qt, args, kwargs):
 
     # Usually mm is called with weight as the second argument
     if not isinstance(weight, QuantizedTensor) or weight._layout_cls != "TensorWiseINT8Layout":
+        return torch.mm(*dequantize_args(args), **dequantize_args(kwargs))
+    if getattr(weight._params, "wmma_tile_n", 0):
         return torch.mm(*dequantize_args(args), **dequantize_args(kwargs))
 
     if isinstance(input_tensor, QuantizedTensor):
@@ -346,6 +801,8 @@ def _handle_int8_addmm_tensorwise(qt, args, kwargs):
     weight = args[2]
 
     if not isinstance(weight, QuantizedTensor) or weight._layout_cls != "TensorWiseINT8Layout":
+        return torch.addmm(*dequantize_args(args), **dequantize_args(kwargs))
+    if getattr(weight._params, "wmma_tile_n", 0):
         return torch.addmm(*dequantize_args(args), **dequantize_args(kwargs))
 
     if isinstance(input_tensor, QuantizedTensor):

--- a/setup.py
+++ b/setup.py
@@ -310,7 +310,11 @@ def get_cuda_path() -> tuple[pathlib.Path, pathlib.Path] | None:
 # Keep build-time, CMake, and runtime architecture policy in one package resource.
 # Exact membership is intentional: accepting an unreviewed gfx11xx/gfx12xx target
 # can compile the no-WMMA trap stubs into an otherwise successful wheel.
-HIP_ARCH_GROUP_NAMES = ("elementwise_only", "wmma_gfx11", "wmma_gfx12")
+HIP_ARCH_GROUP_NAMES = (
+    "elementwise_only",
+    "wmma_gfx11",
+    "wmma_gfx12",
+)
 HIP_ARCH_MANIFEST_PATH = (
     pathlib.Path(__file__).resolve().parent
     / "comfy_kitchen"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,6 +38,15 @@ requires_cuda_backend = pytest.mark.skipif(
 )
 
 
+def skip_unless_gfx12_wmma() -> None:
+    if not getattr(torch.version, "hip", None):
+        pytest.skip("requires HIP")
+    from comfy_kitchen.backends import hip
+
+    if not hip._has_nonduplicated_wmma():
+        pytest.skip("requires gfx12-class WMMA (gfx120x)")
+
+
 @pytest.fixture(scope="session")
 def cuda_available():
     return torch.cuda.is_available()

--- a/tests/test_hip_dispatch.py
+++ b/tests/test_hip_dispatch.py
@@ -22,7 +22,11 @@ _ROOT = pathlib.Path(__file__).resolve().parents[1]
 _HIP_DIR = _ROOT / "comfy_kitchen" / "backends" / "hip"
 _HIP_CMAKE = _HIP_DIR / "CMakeLists.txt"
 _HIP_ARCH_MANIFEST = _HIP_DIR / "architectures.json"
-_HIP_ARCH_GROUP_NAMES = ("elementwise_only", "wmma_gfx11", "wmma_gfx12")
+_HIP_ARCH_GROUP_NAMES = (
+    "elementwise_only",
+    "wmma_gfx11",
+    "wmma_gfx12",
+)
 
 
 def _architecture_groups() -> dict[str, list[str]]:
@@ -273,6 +277,9 @@ def test_architecture_manifest_is_unique_and_shared_by_setup_and_runtime():
     assert set(groups["elementwise_only"]) == hip_backend._ARCH_ELEMENTWISE_ONLY
     assert set(groups["wmma_gfx11"]) == hip_backend._ARCH_WMMA_GFX11
     assert set(groups["wmma_gfx12"]) == hip_backend._ARCH_WMMA_GFX12
+    assert "gfx1200" in groups["wmma_gfx12"]
+    assert "gfx1201" in groups["wmma_gfx12"]
+    assert hip_backend._ARCH_WMMA_GFX12 <= hip_backend._ARCH_WMMA_NONDUPLICATED
     assert set(manifest_archs) == hip_backend._ARCH_SUPPORTED
 
 
@@ -294,6 +301,19 @@ def test_cmake_reads_and_validates_the_shared_architecture_manifest():
     assert "configure_file(" in text
     assert not re.search(r'"gfx\d', text)
 
+    read_groups = re.findall(r"_ck_read_arch_group\(\w+ (\w+)\)", text)
+    assert tuple(read_groups) == _HIP_ARCH_GROUP_NAMES
+
+
+def test_cmake_uses_only_gfx12_group_for_gfx12_wmma_policy():
+    text = _HIP_CMAKE.read_text(encoding="utf-8")
+
+    gfx12_condition = re.search(
+        r"_ck_make_arch_condition\(COMFY_HIP_GFX12_CONDITION(.*?)\)", text, re.DOTALL
+    )
+    assert gfx12_condition is not None
+    assert "COMFY_HIP_WMMA_GFX12_ARCHS" in gfx12_condition.group(1)
+
 
 def test_mma_architecture_macros_are_generated_from_the_manifest():
     mma = (_HIP_DIR / "mma.h").read_text(encoding="utf-8")
@@ -312,7 +332,11 @@ def test_sdist_rules_include_every_hip_build_input():
     assert "include comfy_kitchen/backends/hip/CMakeLists.txt" in manifest
     assert "recursive-include comfy_kitchen/backends/hip *.cpp *.h *.hip *.in *.json" in manifest
     assert "include-package-data = false" in pyproject
-    assert '"comfy_kitchen.backends.hip" = ["architectures.json"]' in pyproject
+    assert (
+        '"comfy_kitchen.backends.hip" = '
+        '["architectures.json"]'
+        in pyproject
+    )
 
 
 def test_hip_kernels_are_independent_of_the_python_extension_target():

--- a/tests/test_hip_wmma.py
+++ b/tests/test_hip_wmma.py
@@ -18,7 +18,11 @@ from comfy_kitchen.backends.eager.quantization import (
 )
 from comfy_kitchen.constraints import validate_function_call
 from comfy_kitchen.registry import registry
-from comfy_kitchen.tensor import AsymW4A8Int8Layout, QuantizedTensor
+from comfy_kitchen.tensor import (
+    AsymW4A8Int8Layout,
+    QuantizedTensor,
+    TensorWiseINT8Layout,
+)
 from comfy_kitchen.tensor.int8_utils import _build_hadamard
 
 
@@ -58,6 +62,11 @@ needs_wmma = pytest.mark.skipif(
 )
 
 DEV = "cuda"
+
+
+def _skip_unless_gfx12_wmma(hip) -> None:
+    if not hip._has_nonduplicated_wmma(torch.device(DEV)):
+        pytest.skip("requires gfx12-class WMMA (gfx120x)")
 
 
 @pytest.fixture
@@ -173,6 +182,484 @@ def test_int8_linear_convrot_large_k_matches_eager(k):
 
     scale = ref.float().abs().max().item()
     assert (out.float() - ref.float()).abs().max().item() < 0.05 * scale
+
+
+@needs_wmma
+def test_int8_linear_pair_reuses_exact_convrot_quantization():
+    torch.manual_seed(0)
+    m, n, k = 256, 512, 512
+    x = torch.randn(m, k, device=DEV, dtype=torch.bfloat16)
+    weights = [
+        torch.randn(n, k, device=DEV, dtype=torch.bfloat16)
+        for _ in range(2)
+    ]
+    quantized = [ck.quantize_int8_rowwise(weight) for weight in weights]
+    biases = [
+        torch.randn(n, device=DEV, dtype=torch.bfloat16)
+        for _ in range(2)
+    ]
+
+    with ck.use_backend("hip"):
+        refs = tuple(
+            ck.int8_linear(
+                x, weight_q, weight_scale.reshape(-1), bias,
+                torch.bfloat16, convrot=True, convrot_groupsize=256,
+            )
+            for (weight_q, weight_scale), bias in zip(quantized, biases)
+        )
+        outputs = ck.int8_linear_pair(
+            x,
+            quantized[0][0], quantized[1][0],
+            quantized[0][1].reshape(-1), quantized[1][1].reshape(-1),
+            biases[0], biases[1], torch.bfloat16,
+            convrot=True, convrot_groupsize=256,
+        )
+    assert torch.equal(outputs[0], refs[0])
+    assert torch.equal(outputs[1], refs[1])
+
+
+@needs_wmma
+def test_gfx12_split_swiglu_down_is_exact(hip):
+    _skip_unless_gfx12_wmma(hip)
+
+    torch.manual_seed(2)
+    m, n, k = 512, 3840, 10240
+    gate = torch.randn(m, k, device=DEV, dtype=torch.bfloat16)
+    up = torch.randn_like(gate)
+    gate[0, :4] = torch.tensor(
+        [5.9375, -87.5, -88.0, -88.5], device=DEV,
+        dtype=torch.bfloat16,
+    )
+    weight = torch.randint(-127, 128, (n, k), device=DEV, dtype=torch.int8)
+    weight_scale = torch.rand(n, device=DEV, dtype=torch.float32) + 0.25
+
+    with ck.use_backend("hip"):
+        reference = ck.int8_linear(
+            torch.nn.functional.silu(gate) * up,
+            weight, weight_scale, None, torch.bfloat16,
+            convrot=True, convrot_groupsize=256,
+        )
+        output = ck.int8_linear_swiglu_split(
+            gate, up, weight, weight_scale, None, torch.bfloat16,
+            convrot=True, convrot_groupsize=256,
+        )
+
+    assert torch.equal(output, reference)
+
+
+@needs_wmma
+def test_gfx12_modulated_qkv_is_exact(hip):
+    _skip_unless_gfx12_wmma(hip)
+
+    torch.manual_seed(34)
+    m, n, k = 64, 11520, 3840
+    x = torch.randn((1, m, k), device=DEV, dtype=torch.bfloat16)
+    modulation_scale = (
+        torch.randn((1, k), device=DEV, dtype=torch.bfloat16) * 0.25
+    )
+    weight = torch.randint(-127, 128, (n, k), device=DEV, dtype=torch.int8)
+    weight_scale = torch.rand(n, device=DEV, dtype=torch.float32) + 0.25
+
+    with ck.use_backend("hip"):
+        reference = ck.int8_linear(
+            x * (1.0 + modulation_scale.unsqueeze(1)),
+            weight, weight_scale, None, torch.bfloat16,
+            convrot=True, convrot_groupsize=256,
+        )
+        candidate = ck.int8_linear_modulated(
+            x, modulation_scale, weight, weight_scale, None, torch.bfloat16,
+            convrot=True, convrot_groupsize=256,
+        )
+
+    assert torch.equal(candidate, reference)
+
+
+@needs_wmma
+def test_gfx12_modulated_pair_is_exact(hip):
+    _skip_unless_gfx12_wmma(hip)
+
+    torch.manual_seed(35)
+    m, n, k = 256, 10240, 3840
+    x = torch.randn((1, m, k), device=DEV, dtype=torch.bfloat16)
+    modulation_scale = (
+        torch.randn((1, k), device=DEV, dtype=torch.bfloat16) * 0.25
+    )
+    weights = tuple(
+        torch.randint(-127, 128, (n, k), device=DEV, dtype=torch.int8)
+        for _ in range(2)
+    )
+    scales = tuple(
+        torch.rand(n, device=DEV, dtype=torch.float32) + 0.25
+        for _ in range(2)
+    )
+
+    with ck.use_backend("hip"):
+        reference = ck.int8_linear_pair(
+            x * (1.0 + modulation_scale.unsqueeze(1)),
+            weights[0], weights[1], scales[0], scales[1],
+            None, None, torch.bfloat16,
+            convrot=True, convrot_groupsize=256,
+        )
+        candidate = ck.int8_linear_pair_modulated(
+            x, modulation_scale, weights[0], weights[1], scales[0], scales[1],
+            None, None, torch.bfloat16,
+            convrot=True, convrot_groupsize=256,
+        )
+
+    assert torch.equal(candidate[0], reference[0])
+    assert torch.equal(candidate[1], reference[1])
+
+
+@needs_wmma
+@pytest.mark.parametrize("k", [3072, 5120, 6144])
+def test_affine_modulated_convrot_is_exact(hip, k):
+    """Generic fused shift/scale producer must preserve the materialized path."""
+    torch.manual_seed(201 + k)
+    m, n = 129, 256
+    x = torch.randn((1, m, k), device=DEV, dtype=torch.bfloat16)
+    modulation_scale = (
+        torch.randn((1, k), device=DEV, dtype=torch.bfloat16) * 0.25
+    )
+    modulation_shift = (
+        torch.randn((1, k), device=DEV, dtype=torch.bfloat16) * 0.25
+    )
+    weights = tuple(
+        torch.randint(-127, 128, (n, k), device=DEV, dtype=torch.int8)
+        for _ in range(3)
+    )
+    scales = tuple(
+        torch.rand(n, device=DEV, dtype=torch.float32) + 0.25
+        for _ in range(3)
+    )
+    modulated = torch.addcmul(
+        modulation_shift.unsqueeze(1), x,
+        1.0 + modulation_scale.unsqueeze(1),
+    )
+
+    with ck.use_backend("hip"):
+        reference = ck.int8_linear_pair(
+            modulated, weights[0], weights[1], scales[0], scales[1],
+            None, None, torch.bfloat16,
+            convrot=True, convrot_groupsize=256,
+        )
+        candidate = ck.int8_linear_pair_modulated(
+            x, modulation_scale, weights[0], weights[1], scales[0], scales[1],
+            None, None, torch.bfloat16,
+            convrot=True, convrot_groupsize=256,
+            modulation_shift=modulation_shift,
+        )
+        single = ck.int8_linear_modulated(
+            x, modulation_scale, weights[0], scales[0], None,
+            torch.bfloat16, convrot=True, convrot_groupsize=256,
+            modulation_shift=modulation_shift,
+        )
+        triple = ck.int8_linear_triple_modulated(
+            x, modulation_scale, weights[0], weights[1], weights[2],
+            scales[0], scales[1], scales[2], None, None, None,
+            torch.bfloat16, convrot=True, convrot_groupsize=256,
+            modulation_shift=modulation_shift,
+        )
+        third_reference = ck.int8_linear(
+            modulated, weights[2], scales[2], None, torch.bfloat16,
+            convrot=True, convrot_groupsize=256,
+        )
+
+    assert torch.equal(candidate[0], reference[0])
+    assert torch.equal(candidate[1], reference[1])
+    assert torch.equal(single, reference[0])
+    assert torch.equal(triple[0], reference[0])
+    assert torch.equal(triple[1], reference[1])
+    assert torch.equal(triple[2], third_reference)
+
+
+@needs_wmma
+def test_tensorwise_layout_owns_compound_affine_execution(hip):
+    """Model integrations need no knowledge of packed INT8 storage."""
+    torch.manual_seed(211)
+    m, n, k = 129, 256, 3072
+    x = torch.randn((1, m, k), device=DEV, dtype=torch.bfloat16)
+    modulation_scale = (
+        torch.randn((1, k), device=DEV, dtype=torch.bfloat16) * 0.25
+    )
+    modulation_shift = (
+        torch.randn((1, k), device=DEV, dtype=torch.bfloat16) * 0.25
+    )
+    weights = tuple(
+        QuantizedTensor.from_float(
+            torch.randn(n, k, device=DEV, dtype=torch.bfloat16),
+            "TensorWiseINT8Layout", per_channel=True, convrot=True,
+            convrot_groupsize=256,
+        )
+        for _ in range(3)
+    )
+    biases = tuple(
+        torch.randn(n, device=DEV, dtype=torch.bfloat16) for _ in range(3)
+    )
+    modulated = torch.addcmul(
+        modulation_shift.unsqueeze(1), x,
+        1.0 + modulation_scale.unsqueeze(1),
+    )
+
+    with torch.inference_mode(), ck.use_backend("hip"):
+        reference = tuple(
+            torch.nn.functional.linear(modulated, weight, bias)
+            for weight, bias in zip(weights, biases, strict=True)
+        )
+        triple = TensorWiseINT8Layout.fused_triple_modulated(
+            x, weights, biases, modulation_scale, modulation_shift,
+        )
+        pair = TensorWiseINT8Layout.fused_pair(
+            x, weights[0], weights[1], biases[0], biases[1],
+            modulation_scale=modulation_scale,
+            modulation_shift=modulation_shift,
+        )
+        single = TensorWiseINT8Layout.fused_affine(
+            x, weights[2], biases[2], modulation_scale, modulation_shift,
+        )
+
+    assert triple is not NotImplemented
+    assert pair is not NotImplemented
+    assert single is not NotImplemented
+    assert all(
+        torch.equal(candidate, expected)
+        for candidate, expected in zip(triple, reference, strict=True)
+    )
+    assert torch.equal(pair[0], reference[0])
+    assert torch.equal(pair[1], reference[1])
+    assert torch.equal(single, reference[2])
+
+
+@pytest.mark.parametrize(
+    ("rows", "width"),
+    [(160, 3840), (4096, 3840), (4256, 3840),
+     (97, 3072), (97, 5120), (97, 6144)],
+)
+def test_rms_gated_residual_is_exact(hip, rows, width):
+    torch.manual_seed(8404 + rows + width)
+    activation = torch.randn(
+        (1, rows, width), device=DEV, dtype=torch.bfloat16)
+    residual = torch.randn_like(activation)
+    norm_weight = torch.randn(width, device=DEV, dtype=torch.bfloat16)
+    gate = torch.tanh(torch.randn(
+        (1, 1, width), device=DEV, dtype=torch.bfloat16))
+    eps = 1.0e-5
+    reference = residual + gate * torch.nn.functional.rms_norm(
+        activation, (width,), norm_weight, eps)
+
+    with ck.use_backend("hip"):
+        candidate = ck.rms_gated_residual(
+            activation, norm_weight, residual, gate, eps)
+
+    assert torch.equal(candidate, reference)
+
+
+@needs_wmma
+def test_gfx12_int8_linear_pair_shared_a_is_exact(hip):
+    _skip_unless_gfx12_wmma(hip)
+
+    torch.manual_seed(1)
+    m, n, k = 256, 10240, 3840
+    x = torch.randn(m, k, device=DEV, dtype=torch.bfloat16)
+    weights = tuple(
+        torch.randint(-127, 128, (n, k), device=DEV, dtype=torch.int8)
+        for _ in range(2)
+    )
+    scales = tuple(
+        torch.rand(n, device=DEV, dtype=torch.float32) + 0.25
+        for _ in range(2)
+    )
+    biases = (
+        torch.randn(n, device=DEV, dtype=torch.bfloat16),
+        torch.randn(n, device=DEV, dtype=torch.bfloat16),
+    )
+
+    control = tuple(
+        hip.int8_linear(
+            x, weight, scale, bias, torch.bfloat16,
+        )
+        for weight, scale, bias in zip(weights, scales, biases, strict=True)
+    )
+    candidate = hip.int8_linear_pair(
+        x, weights[0], weights[1], scales[0], scales[1],
+        biases[0], biases[1], torch.bfloat16,
+    )
+
+    assert torch.equal(candidate[0], control[0])
+    assert torch.equal(candidate[1], control[1])
+
+
+@pytest.mark.parametrize("m", [160, 512])
+@pytest.mark.parametrize("n", [3840, 11520])
+@needs_wmma
+def test_gfx12_int8_dual_m_shared_b_is_exact(hip, m, n):
+    _skip_unless_gfx12_wmma(hip)
+
+    torch.manual_seed(2)
+    k = 3840
+    a = torch.randint(-127, 128, (m, k), device=DEV, dtype=torch.int8)
+    b = torch.randint(-127, 128, (n, k), device=DEV, dtype=torch.int8)
+    scale_a = torch.rand(m, device=DEV, dtype=torch.float32) + 0.25
+    scale_b = torch.rand(n, device=DEV, dtype=torch.float32) + 0.25
+    candidate = torch.empty((m, n), device=DEV, dtype=torch.bfloat16)
+    stream = hip._stream(a)
+    hip._C.int8_gemm(
+        hip._dl(a), hip._dl(b), hip._dl(candidate), hip._dl(scale_a),
+        hip._dl(scale_b), 1, None, m, n, k,
+        hip.DTYPE_TO_CODE[torch.bfloat16], stream,
+    )
+    torch.cuda.synchronize()
+    reference = (
+        ck.mm_int8(a, b.t().contiguous()).float()
+        * scale_a[:, None]
+        * scale_b[None, :]
+    ).to(torch.bfloat16)
+    assert torch.equal(candidate, reference)
+
+    if m >= 512:
+        tiled_b = (
+            b.reshape(n // 128, 128, k // 64, 64)
+            .permute(0, 2, 1, 3)
+            .contiguous()
+        )
+        tiled_candidate = torch.empty_like(candidate)
+        hip._C.int8_gemm_b_tiled(
+            hip._dl(a), hip._dl(tiled_b), hip._dl(tiled_candidate),
+            hip._dl(scale_a), hip._dl(scale_b), 1, None, m, n, k,
+            hip.DTYPE_TO_CODE[torch.bfloat16], 64, True, stream,
+        )
+        torch.cuda.synchronize()
+        assert torch.equal(tiled_candidate, reference)
+
+
+@pytest.mark.parametrize("tile_k", [64, 128])
+@pytest.mark.parametrize("dual_m", [False, True])
+@pytest.mark.parametrize("with_bias", [False, True])
+@needs_wmma
+def test_int8_generic_tiled_b_is_exact(hip, tile_k, dual_m, with_bias):
+    """Physical B tiling preserves the mature row-major GEMM result."""
+    torch.manual_seed(21)
+    m, n, k = 513, 256, 1024
+    a = torch.randint(-127, 128, (m, k), device=DEV, dtype=torch.int8)
+    b = torch.randint(-127, 128, (n, k), device=DEV, dtype=torch.int8)
+    tiled_b = (
+        b.reshape(n // 128, 128, k // tile_k, tile_k)
+        .permute(0, 2, 1, 3)
+        .contiguous()
+    )
+    scale_a = torch.rand(m, device=DEV, dtype=torch.float32) + 0.25
+    scale_b = torch.rand(n, device=DEV, dtype=torch.float32) + 0.25
+    bias = (
+        torch.rand(n, device=DEV, dtype=torch.bfloat16)
+        if with_bias else None
+    )
+    control = torch.empty((m, n), device=DEV, dtype=torch.bfloat16)
+    candidate = torch.empty_like(control)
+    stream = hip._stream(a)
+    hip._C.int8_gemm(
+        hip._dl(a), hip._dl(b), hip._dl(control), hip._dl(scale_a),
+        hip._dl(scale_b), 1, None if bias is None else hip._dl(bias),
+        m, n, k, hip.DTYPE_TO_CODE[torch.bfloat16], stream,
+    )
+    hip._C.int8_gemm_b_tiled(
+        hip._dl(a), hip._dl(tiled_b), hip._dl(candidate),
+        hip._dl(scale_a), hip._dl(scale_b), 1,
+        None if bias is None else hip._dl(bias), m, n, k,
+        hip.DTYPE_TO_CODE[torch.bfloat16], tile_k, dual_m, stream,
+    )
+    torch.cuda.synchronize()
+    assert torch.equal(candidate, control)
+
+
+@needs_wmma
+def test_int8_generic_tiled_a_is_exact(hip):
+    """Physical A tiling is a dimensional contract, not a model shape."""
+    torch.manual_seed(211)
+    m, n, k = 257, 256, 1024
+    x = torch.randn((m, k), device=DEV, dtype=torch.bfloat16)
+    b = torch.randint(-127, 128, (n, k), device=DEV, dtype=torch.int8)
+    tiled_b = (
+        b.reshape(n // 128, 128, k // 128, 128)
+        .permute(0, 2, 1, 3)
+        .contiguous()
+    )
+    scale_b = torch.rand(n, device=DEV, dtype=torch.float32) + 0.25
+    tiled_a, tiled_scale_a = hip._rotate_quant_int8_tiled128(x, 256)
+    padded_m = (m + 127) // 128 * 128
+    row_a = (
+        tiled_a.reshape(padded_m // 128, k // 128, 128, 128)
+        .permute(0, 2, 1, 3)
+        .reshape(padded_m, k)[:m]
+        .contiguous()
+    )
+
+    reference = torch.empty((m, n), device=DEV, dtype=torch.bfloat16)
+    row_major = torch.empty_like(reference)
+    tiled = torch.empty_like(reference)
+    stream = hip._stream(x)
+    hip._C.int8_gemm(
+        hip._dl(row_a), hip._dl(b), hip._dl(reference), hip._dl(tiled_scale_a),
+        hip._dl(scale_b), 1, None, m, n, k,
+        hip.DTYPE_TO_CODE[torch.bfloat16], stream,
+    )
+    hip._C.int8_gemm_a_tiled128_down(
+        hip._dl(tiled_a), hip._dl(b), hip._dl(row_major),
+        hip._dl(tiled_scale_a), hip._dl(scale_b), 1, None, m, n, k,
+        hip.DTYPE_TO_CODE[torch.bfloat16], stream,
+    )
+    hip._C.int8_gemm_a_tiled128_b_tiled128_down(
+        hip._dl(tiled_a), hip._dl(tiled_b), hip._dl(tiled),
+        hip._dl(tiled_scale_a), hip._dl(scale_b), 1, None, m, n, k,
+        hip.DTYPE_TO_CODE[torch.bfloat16], stream,
+    )
+    torch.cuda.synchronize()
+
+    assert torch.equal(row_major, reference)
+    assert torch.equal(tiled, reference)
+
+
+@pytest.mark.parametrize("tile_k", [64, 128])
+@pytest.mark.parametrize("dual_m", [False, True])
+@pytest.mark.parametrize("with_bias", [False, True])
+@needs_wmma
+def test_int8_tiled_b_gated_residual_is_exact(
+    hip, tile_k, dual_m, with_bias
+):
+    """The fused epilogue preserves both visible BF16 rounding points."""
+    torch.manual_seed(210)
+    m, n, k = 513, 256, 1024
+    a = torch.randint(-127, 128, (m, k), device=DEV, dtype=torch.int8)
+    b = torch.randint(-127, 128, (n, k), device=DEV, dtype=torch.int8)
+    tiled_b = (
+        b.reshape(n // 128, 128, k // tile_k, tile_k)
+        .permute(0, 2, 1, 3)
+        .contiguous()
+    )
+    scale_a = torch.rand(m, device=DEV, dtype=torch.float32) + 0.25
+    scale_b = torch.rand(n, device=DEV, dtype=torch.float32) + 0.25
+    bias = (
+        torch.rand(n, device=DEV, dtype=torch.bfloat16)
+        if with_bias else None
+    )
+    residual = torch.randn((m, n), device=DEV, dtype=torch.bfloat16)
+    gate = torch.randn(n, device=DEV, dtype=torch.bfloat16)
+    linear = torch.empty_like(residual)
+    candidate = torch.empty_like(residual)
+    stream = hip._stream(a)
+    hip._C.int8_gemm_b_tiled(
+        hip._dl(a), hip._dl(tiled_b), hip._dl(linear),
+        hip._dl(scale_a), hip._dl(scale_b), 1,
+        None if bias is None else hip._dl(bias), m, n, k,
+        hip.DTYPE_TO_CODE[torch.bfloat16], tile_k, dual_m, stream,
+    )
+    reference = torch.addcmul(residual, gate, linear)
+    hip._C.int8_gemm_b_tiled_gated_residual(
+        hip._dl(a), hip._dl(tiled_b), hip._dl(candidate),
+        hip._dl(scale_a), hip._dl(scale_b), 1,
+        None if bias is None else hip._dl(bias),
+        hip._dl(residual), hip._dl(gate), m, n, k, tile_k, dual_m, stream,
+    )
+    torch.cuda.synchronize()
+    assert torch.equal(candidate, reference)
 
 
 def _offset_copy(t: torch.Tensor) -> torch.Tensor:
@@ -2170,15 +2657,15 @@ def test_convrot_falls_back_to_eager_past_the_lds_bound(hip, dtype):
         )
 
 
-def test_convrot_spill_rotated_dtype_must_match_x(hip):
-    """spill_rotated is written as RowT derived from x; dtype must match."""
+def test_convrot_spill_rotated_must_match_input_dtype(hip):
+    """The two-pass path preserves the fused row-buffer rounding contract."""
     m, k = 2, 256
-    x = torch.randn(m, k, device=DEV, dtype=torch.float32)
+    x = torch.randn(m, k, device=DEV, dtype=torch.bfloat16)
     q = torch.zeros(m, k, dtype=torch.int8, device=DEV)
     scales = torch.zeros(m, dtype=torch.float32, device=DEV)
-    spill_rotated = torch.empty(m, k, dtype=torch.bfloat16, device=DEV)
+    spill_rotated = torch.empty(m, k, dtype=torch.float32, device=DEV)
     spill_partials = torch.empty(m, k // 256, dtype=torch.float32, device=DEV)
-    with pytest.raises(RuntimeError, match="spill_rotated dtype must match x"):
+    with pytest.raises(RuntimeError, match="spill_rotated"):
         hip._C.quantize_int8_convrot(
             hip._dl(x),
             hip._dl(q),
@@ -2199,6 +2686,63 @@ def test_convrot_int8_needs_spill_probe(hip):
     with torch.cuda.device(DEV):
         assert not hip._C.convrot_int8_needs_spill(4128, 10240, in_code)
         assert hip._C.convrot_int8_needs_spill(4128, 32768, in_code)
+
+
+@needs_wmma
+def test_convrot_wide_global_is_exact_to_fused_lds(hip):
+    """The scalable global fallback preserves the mature fused INT8 result."""
+    torch.manual_seed(37)
+    m, k = 96, 12288
+    x = torch.randn(m, k, device=DEV, dtype=torch.bfloat16)
+    global_q = torch.empty(m, k, device=DEV, dtype=torch.int8)
+    global_scales = torch.empty(m, device=DEV, dtype=torch.float32)
+    fused_q = torch.empty_like(global_q)
+    fused_scales = torch.empty_like(global_scales)
+    spill_rotated = torch.empty(m, k, device=DEV, dtype=x.dtype)
+    spill_partials = torch.empty(m, k // 256, device=DEV, dtype=torch.float32)
+
+    hip._C.quantize_int8_convrot(
+        hip._dl(x), hip._dl(global_q), hip._dl(global_scales),
+        hip._dl(spill_rotated), hip._dl(spill_partials), m, k, 256, 0,
+        hip._stream(x),
+    )
+    # M<96 selects the mature fused-LDS schedule. ConvRot is row-independent,
+    # so two bounded launches form an exact reference for the same 96 rows.
+    for start, end in ((0, 64), (64, m)):
+        hip._C.quantize_int8_convrot(
+            hip._dl(x[start:end]), hip._dl(fused_q[start:end]),
+            hip._dl(fused_scales[start:end]), hip._dl(spill_rotated),
+            hip._dl(spill_partials), end - start, k, 256, 0,
+            hip._stream(x),
+        )
+    torch.cuda.synchronize()
+
+    assert torch.equal(global_q, fused_q)
+    assert torch.equal(global_scales, fused_scales)
+
+
+@needs_wmma
+def test_convrot_wide_spill_chunks_are_exact(hip, monkeypatch):
+    """Bounded row chunks preserve the global fallback's per-row arithmetic."""
+    torch.manual_seed(41)
+    m, k = 257, 12288
+    x = torch.randn(m, k, device=DEV, dtype=torch.bfloat16)
+    expected_q = torch.empty(m, k, device=DEV, dtype=torch.int8)
+    expected_scales = torch.empty(m, device=DEV, dtype=torch.float32)
+    spill_rotated = torch.empty(m, k, device=DEV, dtype=x.dtype)
+    spill_partials = torch.empty(m, k // 256, device=DEV, dtype=torch.float32)
+
+    hip._C.quantize_int8_convrot(
+        hip._dl(x), hip._dl(expected_q), hip._dl(expected_scales),
+        hip._dl(spill_rotated), hip._dl(spill_partials), m, k, 256, 1,
+        hip._stream(x),
+    )
+    monkeypatch.setattr(hip, "_CONVROT_SPILL_WORKSPACE_BYTES", 6 << 20)
+    actual_q, actual_scales = hip._rotate_quant_int8(x, 256, "gelu_tanh")
+    torch.cuda.synchronize()
+
+    assert torch.equal(actual_q, expected_q)
+    assert torch.equal(actual_scales, expected_scales)
 
 
 def test_convrot_lds_bound_accounts_for_row_dtype(hip):

--- a/tests/test_int8.py
+++ b/tests/test_int8.py
@@ -13,6 +13,7 @@ from .conftest import (
     assert_values_close,
     cuda_backend_available,
     get_capable_backends,
+    skip_unless_gfx12_wmma,
 )
 
 COMFYUI_NVIDIA_16_SERIES = (
@@ -367,6 +368,64 @@ class TestTensorWiseINT8Layout:
         assert set(sd.keys()) == {"", "_scale"}
         assert sd[""].dtype == torch.int8
         assert sd["_scale"].numel() == 1
+
+    @pytest.mark.parametrize("tile_k", [64, 128])
+    def test_wmma_weight_pack_is_lossless_and_serializes_row_major(
+        self, seed, tile_k
+    ):
+        """Runtime tiling must not leak into a checkpoint or dequantization."""
+        from comfy_kitchen.tensor import QuantizedTensor, TensorWiseINT8Layout
+
+        w = torch.randn(128, 1024, device="cuda", dtype=torch.bfloat16)
+        qt = QuantizedTensor.from_float(
+            w, "TensorWiseINT8Layout", per_channel=True
+        )
+        row_major = qt._qdata.clone()
+        dequantized = qt.dequantize()
+
+        TensorWiseINT8Layout.pack_wmma_weight_(qt, tile_k=tile_k)
+
+        assert qt._params.wmma_tile_n == 128
+        assert qt._params.wmma_tile_k == tile_k
+        assert torch.equal(qt.dequantize(), dequantized)
+        assert torch.equal(qt.state_dict()[""], row_major)
+
+    @pytest.mark.parametrize(
+        ("n", "k", "expected_tile_k"),
+        [(128, 1024, 64), (512, 1024, 128), (1024, 1024, 64)],
+    )
+    def test_linear_lazily_uses_dimensional_tiled_weight_exactly(
+        self, seed, n, k, expected_tile_k
+    ):
+        """The ordinary TensorWise linear owns dimensional packing exactly."""
+        import comfy_kitchen as ck
+        from comfy_kitchen.tensor import QuantizedTensor, TensorWiseINT8Layout
+
+        skip_unless_gfx12_wmma()
+        x = torch.randn(512, k, device="cuda", dtype=torch.bfloat16)
+        w = torch.randn(n, k, device="cuda", dtype=torch.bfloat16)
+        qt = QuantizedTensor.from_float(
+            w, "TensorWiseINT8Layout", per_channel=True
+        )
+        row_major, scale = TensorWiseINT8Layout.get_plain_tensors(qt)
+
+        with torch.inference_mode():
+            reference = ck.int8_linear(
+                x, row_major.clone(), scale, out_dtype=x.dtype
+            )
+            candidate = torch.nn.functional.linear(x, qt)
+
+        assert qt._params.wmma_tile_k == expected_tile_k
+        assert torch.equal(candidate, reference)
+
+        # A later short call cannot use the tiled native contract. Its
+        # dequantized fallback remains correct rather than reading packed bytes
+        # as a row-major matrix.
+        short = x[:32]
+        with torch.inference_mode():
+            short_out = torch.nn.functional.linear(short, qt)
+            short_reference = torch.nn.functional.linear(short, qt.dequantize())
+        assert torch.equal(short_out, short_reference)
 
     def test_supports_fast_matmul(self):
         """supports_fast_matmul returns True on CUDA SM >= 7.5."""
@@ -869,6 +928,27 @@ class TestTensorWisePublicAPI:
 
         assert out.shape == (4, 64)
         assert out.dtype == torch.bfloat16
+
+    def test_public_api_int8_linear_gated_residual(self, seed, device):
+        """The portable API exposes the original linear/addcmul semantics."""
+        import comfy_kitchen as ck
+        from comfy_kitchen.backends.eager.quantization import quantize_int8_tensorwise
+
+        x = torch.randn(4, 128, device=device, dtype=torch.bfloat16)
+        w = torch.randn(64, 128, device=device, dtype=torch.bfloat16)
+        w_int8, w_scale = quantize_int8_tensorwise(w)
+        bias = torch.randn(64, device=device, dtype=torch.bfloat16)
+        residual = torch.randn(4, 64, device=device, dtype=torch.bfloat16)
+        gate = torch.randn(64, device=device, dtype=torch.bfloat16)
+
+        with ck.registry.use_backend("eager"):
+            projected = ck.int8_linear(x, w_int8, w_scale, bias)
+            reference = torch.addcmul(residual, gate, projected)
+            candidate = ck.int8_linear_gated_residual(
+                x, w_int8, w_scale, residual, gate, bias
+            )
+
+        assert torch.equal(candidate, reference)
 
     def test_eager_int8_linear_single_row(self, seed, device):
         """Eager int8_linear supports single-row batches."""

--- a/tests/test_int8_attention.py
+++ b/tests/test_int8_attention.py
@@ -337,7 +337,7 @@ def test_gfx12_bf16_attention_handles_long_rectangular_lengths():
 
     actual = ck.hip_attention(q, k, v)
 
-    assert not ck.hip_attention_is_supported(q, k, v)
+    assert ck.hip_attention_is_supported(q, k, v)
     assert ck.hip_int8_attention_is_supported(q, k, v)
     assert actual.dtype is torch.bfloat16
     assert actual.shape == q.shape
@@ -360,7 +360,7 @@ def test_gfx12_bf16_full_k_tile_route_is_shape_generic():
 
     actual = ck.hip_attention(q, k, v)
 
-    assert not ck.hip_attention_is_supported(q, k, v)
+    assert ck.hip_attention_is_supported(q, k, v)
     assert ck.hip_int8_attention_is_supported(q, k, v)
     assert actual.stride() == q.stride()
     assert (actual.float() - expected.float()).abs().max() <= 0.00390625
@@ -380,13 +380,13 @@ def test_gfx12_short_attention_capability_is_dimensional():
     assert not supported(1, 4, 127)
     assert supported(1, 4, 128)
     assert supported(1, 56, 388)
-    for heads, length in ((17, 1024), (30, 4096), (13, 4256)):
-        long_inputs = tuple(
-            torch.empty(1, heads, length, 128, device="cuda", dtype=torch.bfloat16)
+    assert supported(1, 17, 1024)
+    assert ck.hip_int8_attention_is_supported(
+        *(
+            torch.empty(1, 17, 1024, 128, device="cuda", dtype=torch.bfloat16)
             for _ in range(3)
         )
-        assert not ck.hip_attention_is_supported(*long_inputs)
-        assert ck.hip_int8_attention_is_supported(*long_inputs)
+    )
     assert not supported(2, 4, 16)
     assert supported(64, 16, 16)
     assert not supported(1, 4, 160, dtype=torch.float16)

--- a/tests/test_int8_attention.py
+++ b/tests/test_int8_attention.py
@@ -337,7 +337,8 @@ def test_gfx12_bf16_attention_handles_long_rectangular_lengths():
 
     actual = ck.hip_attention(q, k, v)
 
-    assert ck.hip_attention_is_supported(q, k, v)
+    assert not ck.hip_attention_is_supported(q, k, v)
+    assert ck.hip_int8_attention_is_supported(q, k, v)
     assert actual.dtype is torch.bfloat16
     assert actual.shape == q.shape
     assert actual.stride() == q.stride()
@@ -359,7 +360,8 @@ def test_gfx12_bf16_full_k_tile_route_is_shape_generic():
 
     actual = ck.hip_attention(q, k, v)
 
-    assert ck.hip_attention_is_supported(q, k, v)
+    assert not ck.hip_attention_is_supported(q, k, v)
+    assert ck.hip_int8_attention_is_supported(q, k, v)
     assert actual.stride() == q.stride()
     assert (actual.float() - expected.float()).abs().max() <= 0.00390625
 
@@ -378,6 +380,13 @@ def test_gfx12_short_attention_capability_is_dimensional():
     assert not supported(1, 4, 127)
     assert supported(1, 4, 128)
     assert supported(1, 56, 388)
+    for heads, length in ((17, 1024), (30, 4096), (13, 4256)):
+        long_inputs = tuple(
+            torch.empty(1, heads, length, 128, device="cuda", dtype=torch.bfloat16)
+            for _ in range(3)
+        )
+        assert not ck.hip_attention_is_supported(*long_inputs)
+        assert ck.hip_int8_attention_is_supported(*long_inputs)
     assert not supported(2, 4, 16)
     assert supported(64, 16, 16)
     assert not supported(1, 4, 160, dtype=torch.float16)

--- a/tests/test_int8_attention.py
+++ b/tests/test_int8_attention.py
@@ -8,6 +8,9 @@ import torch
 
 import comfy_kitchen as ck
 import comfy_kitchen.sage_attention as sage_attention_module
+from .conftest import (
+    skip_unless_gfx12_wmma,
+)
 
 _CUDA_READY = torch.cuda.is_available() and ck.int8_attention_is_available()
 requires_int8_attention = pytest.mark.skipif(
@@ -288,6 +291,127 @@ def test_int8_attention_stabilization_is_deterministic():
     second = ck.int8_attention(q, k, v)
 
     assert torch.equal(first, second)
+
+
+@requires_int8_attention
+def test_gfx12_split_direct_p_matches_bf16_concatenation():
+    skip_unless_gfx12_wmma()
+
+    torch.manual_seed(29)
+    heads = 2
+    segment_lengths = (137, 888)  # crosses both the K16 and V64 tile boundaries
+    q_parts = tuple(
+        torch.randn(1, length, heads, 128, device="cuda", dtype=torch.bfloat16)
+        .transpose(1, 2)
+        for length in segment_lengths
+    )
+    k_parts = tuple(torch.randn_like(part) for part in q_parts)
+    v_parts = tuple(
+        torch.randn(1, length, heads, 128, device="cuda", dtype=torch.bfloat16)
+        .transpose(1, 2)
+        for length in segment_lengths
+    )
+
+    reference = ck.hip_int8_attention(
+        torch.cat(q_parts, dim=2),
+        torch.cat(k_parts, dim=2),
+        torch.cat(v_parts, dim=2),
+    )
+    candidate = ck.hip_int8_attention_split(q_parts, k_parts, v_parts)
+
+    assert ck.hip_int8_attention_split_is_supported(
+        q_parts, k_parts, v_parts
+    )
+    assert torch.equal(candidate, reference)
+
+
+@requires_int8_attention
+def test_gfx12_bf16_attention_handles_long_rectangular_lengths():
+    skip_unless_gfx12_wmma()
+
+    torch.manual_seed(37)
+    q = torch.randn(1, 1025, 4, 128, device="cuda", dtype=torch.bfloat16).transpose(1, 2)
+    k = torch.randn(1, 1033, 4, 128, device="cuda", dtype=torch.bfloat16).transpose(1, 2)
+    v = torch.randn(1, 1033, 4, 128, device="cuda", dtype=torch.bfloat16).transpose(1, 2)
+    expected = torch.nn.functional.scaled_dot_product_attention(q, k, v)
+
+    actual = ck.hip_attention(q, k, v)
+
+    assert ck.hip_attention_is_supported(q, k, v)
+    assert actual.dtype is torch.bfloat16
+    assert actual.shape == q.shape
+    assert actual.stride() == q.stride()
+    assert (actual.float() - expected.float()).abs().max() <= 0.00390625
+
+
+@requires_int8_attention
+def test_gfx12_bf16_full_k_tile_route_is_shape_generic():
+    skip_unless_gfx12_wmma()
+
+    torch.manual_seed(39)
+    # Deliberately differs from every captured model contract: seven heads,
+    # rectangular attention, and a one-row query tail. K/V is the only exact
+    # tile requirement of this schedule.
+    q = torch.randn(1, 7, 1025, 128, device="cuda", dtype=torch.bfloat16)
+    k = torch.randn(1, 7, 1056, 128, device="cuda", dtype=torch.bfloat16)
+    v = torch.randn(1, 7, 1056, 128, device="cuda", dtype=torch.bfloat16)
+    expected = torch.nn.functional.scaled_dot_product_attention(q, k, v)
+
+    actual = ck.hip_attention(q, k, v)
+
+    assert ck.hip_attention_is_supported(q, k, v)
+    assert actual.stride() == q.stride()
+    assert (actual.float() - expected.float()).abs().max() <= 0.00390625
+
+
+@requires_int8_attention
+def test_gfx12_short_attention_capability_is_dimensional():
+    skip_unless_gfx12_wmma()
+
+    def supported(batch, heads, length, *, dtype=torch.bfloat16):
+        tensors = tuple(
+            torch.empty(batch, heads, length, 128, device="cuda", dtype=dtype)
+            for _ in range(3)
+        )
+        return ck.hip_attention_is_supported(*tensors)
+
+    assert not supported(1, 4, 127)
+    assert supported(1, 4, 128)
+    assert supported(1, 56, 388)
+    assert not supported(2, 4, 16)
+    assert supported(64, 16, 16)
+    assert not supported(1, 4, 160, dtype=torch.float16)
+    unaligned = tuple(
+        torch.empty(1, 4, 128, 129, device="cuda", dtype=torch.bfloat16)[..., 1:]
+        for _ in range(3)
+    )
+    assert not ck.hip_attention_is_supported(*unaligned)
+    long_fp16 = tuple(
+        torch.empty(1, 4, 1024, 128, device="cuda", dtype=torch.float16)
+        for _ in range(3)
+    )
+    assert ck.hip_int8_attention_is_supported(*long_fp16)
+    assert not ck.hip_attention_is_supported(*long_fp16)
+
+
+@requires_int8_attention
+def test_gfx12_compact_batched_attention_matches_sdpa():
+    skip_unless_gfx12_wmma()
+
+    torch.manual_seed(41)
+    q, k, v = (
+        torch.randn(64, 16, 12, 128, device="cuda", dtype=torch.bfloat16)
+        for _ in range(3)
+    )
+    expected = torch.nn.functional.scaled_dot_product_attention(q, k, v)
+    bf16 = ck.hip_attention(q, k, v)
+    int8_mode = ck.hip_int8_attention(q, k, v)
+
+    assert ck.hip_attention_is_supported(q, k, v)
+    assert ck.hip_int8_attention_is_supported(q, k, v)
+    assert torch.equal(int8_mode, bf16)
+    assert bf16.stride() == q.stride()
+    assert (bf16.float() - expected.float()).abs().max() <= 0.00390625
 
 
 @requires_int8_attention


### PR DESCRIPTION
## Summary

Adds native HIP attention and a gfx12 INT8+BF16 inference stack for AMD ROCm (RDNA4 / non-duplicated WMMA), so diffusion models can use Comfy Kitchen on gfx12 without SageAttention or FlashAttention.

### Attention
- New `attention_bf16.hip` and Python exports: `hip_attention`, `hip_attention_is_supported`
- gfx12 INT8 attention: Q/K/V quant kernel updates, workspace packing, `hip_int8_attention` / `hip_int8_attention_is_supported`
- Short or overhead-bound INT8 calls stay on **HIP BF16 inside Kitchen**, not PyTorch SDPA

### INT8 linear / GEMM (Navi 4 perf)
- gfx12-tuned `launch_int8()` with shape-specific paths (dual-M for Z-Image projection shapes, cooperative staging, BKB=64 defaults)
- Rebased on upstream `#122`; **INT8 does not** use upstream `launch_gemm_wmma()` — that helper remains for **fp8** only
- `gemm_wmma.h` merges upstream `#122` infra (`device_wgp_count`, fp8 launcher) with branch epilogues and dual-M kernels

### Supporting inference ops
- ConvRot / modulated quant, gated residual, SwiGLU split, WMMA weight packing (`tensor/int8.py`), sage Q/K/V quant updates, eager fallbacks

### Tests
- `tests/test_int8_attention.py`, updates to `test_hip_wmma.py`, `test_int8.py`, `test_hip_dispatch.py`

The diff is large because HIP kernels and the full gfx12 dispatch surface are verbose by nature; this is the perf-validated stack, not unrelated refactors.

**Pair PR (ComfyUI):** Adds `--use-kitchen-bf16-attention` and `--use-kitchen-int8-attention` routing to these APIs.

## Target hardware

- **Primary:** AMD ROCm **gfx12xx** (non-duplicated WMMA), e.g. RDNA4 / Navi 4
- **gfx11 (Navi 3):** portable INT8 GEMM geometry unchanged; native attention APIs require non-duplicated WMMA (gfx12-class)

## Test plan

- [ ] Build HIP backend / wheels for gfx12 target(s)
- [ ] `pytest tests/test_int8_attention.py` (gfx12 markers) on ROCm
- [ ] `pytest tests/test_hip_wmma.py -k gfx12` — dual-M, modulated QKV exactness
- [ ] End-to-end with ComfyUI flags `--use-kitchen-bf16-attention` / `--use-kitchen-int8-attention`

## Notes for reviewers

- **INT8 `launch_int8()`** keeps explicit gfx12 tile selection (including dual-M for `512 × 3840 × {3840,11520,10240}`) rather than delegating to upstream `launch_gemm_wmma()`.
- **Rebase:** Branch is on current `main` (includes `#122`); conflict resolution preserved Navi 4 INT8 paths while keeping fp8 on shared upstream launcher.
- **Scope:** Full inference path for measured Z-Image-style workloads; splitting attention-only vs INT8-linear is possible if preferred, but this PR reflects the integrated perf-tested stack.
