### PR TITLE
[ROCm] Add native gfx12 HIP attention and Z-Image INT8 fusions

### DIFF
--- a/comfy_kitchen/__init__.py
+++ b/comfy_kitchen/__init__.py
@@ -51,6 +51,7 @@ else:
 __all__ = [
     # Normalization
     "adaln",
+    "rms_gated_residual",
     "rms_adaln",
     # Attention
     "PrequantizedInt8Attention",
@@ -62,6 +63,10 @@ __all__ = [
     "flash_attention_decode_is_available",
     "na2d",
     "na3d",
+    "hip_attention",
+    "hip_attention_is_supported",
+    "hip_int8_attention",
+    "hip_int8_attention_is_supported",
     # Quantization / dequantization
     "quantize_per_tensor_fp8",
     "dequantize_per_tensor_fp8",
@@ -84,6 +89,14 @@ __all__ = [
     "dequantize_w4a8_int8_weight",
     "gemv_awq_w4a16",
     "int8_linear",
+    "int8_linear_gated_residual",
+    "int8_linear_modulated",
+    "int8_linear_rms_modulated",
+    "int8_linear_pair",
+    "int8_linear_pair_modulated",
+    "int8_linear_triple_modulated",
+    "int8_linear_pair_rms_modulated",
+    "int8_linear_swiglu_split",
     "w4a8_int8_linear",
     # Positional encoding
     "apply_rope",
@@ -124,6 +137,66 @@ __all__ = [
 # =============================================================================
 # Public API Functions
 # =============================================================================
+
+
+def _call_backend(name: str, kwargs: dict):
+    """Dispatch a thin public wrapper whose signature matches its backends."""
+    impl = registry.get_implementation(name, kwargs=kwargs)
+    return impl(**kwargs)
+
+
+def hip_attention_is_supported(
+    q: torch.Tensor, k: torch.Tensor, v: torch.Tensor
+) -> bool:
+    """Return whether the floating-point HIP kernel accepts this SDPA call."""
+    return (
+        bool(getattr(torch.version, "hip", None))
+        and registry.is_available("hip")
+        and _hip_backend.hip_attention_is_supported(q, k, v)
+    )
+
+
+def hip_int8_attention_is_supported(
+    q: torch.Tensor, k: torch.Tensor, v: torch.Tensor
+) -> bool:
+    """Return whether the quantized HIP kernel accepts this SDPA call."""
+    return (
+        bool(getattr(torch.version, "hip", None))
+        and registry.is_available("hip")
+        and _hip_backend.hip_int8_attention_is_supported(q, k, v)
+    )
+
+
+def hip_attention(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    scale: float | None = None,
+) -> torch.Tensor:
+    """Run FP16/BF16 HIP attention after a positive capability check."""
+    if not (
+        bool(getattr(torch.version, "hip", None)) and registry.is_available("hip")
+    ):
+        raise RuntimeError("HIP attention requires the HIP backend")
+    return _hip_backend.hip_attention(q, k, v, scale)
+
+
+def hip_int8_attention(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    scale: float | None = None,
+) -> torch.Tensor:
+    """Run HIP attention after a positive capability check.
+
+    Long calls use INT8; overhead-bound short calls retain BF16.
+    """
+    if not (
+        bool(getattr(torch.version, "hip", None)) and registry.is_available("hip")
+    ):
+        raise RuntimeError("INT8 HIP attention requires the HIP backend")
+    resolved_scale = float(scale if scale is not None else q.shape[-1] ** -0.5)
+    return _hip_backend.hip_int8_attention(q, k, v, resolved_scale)
 
 
 def na3d(
@@ -804,6 +877,17 @@ def mm_int8(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
     return _mm_int8(a, b)
 
 
+def rms_gated_residual(
+    activation: torch.Tensor,
+    norm_weight: torch.Tensor,
+    residual: torch.Tensor,
+    gate: torch.Tensor,
+    eps: float = 1.0e-5,
+) -> torch.Tensor:
+    """Compute exact RMSNorm followed by a visible gate product and residual add."""
+    return _call_backend("rms_gated_residual", locals())
+
+
 def int8_linear(
     x: torch.Tensor,
     weight: torch.Tensor,
@@ -847,6 +931,167 @@ def int8_linear(
     }
     impl = registry.get_implementation("int8_linear", kwargs=kwargs)
     return impl(**kwargs)
+
+
+def int8_linear_gated_residual(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    residual: torch.Tensor,
+    gate: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    out_dtype: torch.dtype | None = None,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+    input_act: str | None = None,
+    weight_tile_k: int = 0,
+    dual_m: bool = False,
+) -> torch.Tensor:
+    """INT8 linear with an exact BF16 gated-residual writeback."""
+    if out_dtype is None:
+        out_dtype = torch.bfloat16
+    return _call_backend("int8_linear_gated_residual", locals())
+
+
+def int8_linear_modulated(
+    x: torch.Tensor,
+    modulation_scale: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    out_dtype: torch.dtype | None = None,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+    weight_tiled_b: bool = False,
+    modulation_shift: torch.Tensor | None = None,
+    weight_tile_k: int = 0,
+) -> torch.Tensor:
+    """Batch-one affine modulation with fused INT8 quantization."""
+    if out_dtype is None:
+        out_dtype = torch.bfloat16
+    return _call_backend("int8_linear_modulated", locals())
+
+
+def int8_linear_rms_modulated(
+    x: torch.Tensor,
+    norm_weight: torch.Tensor,
+    norm_eps: float,
+    modulation_scale: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    out_dtype: torch.dtype | None = None,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+    weight_tiled_b: bool = False,
+) -> torch.Tensor:
+    """INT8 projection with RMSNorm and batch-one modulation in its producer."""
+    if out_dtype is None:
+        out_dtype = torch.bfloat16
+    return _call_backend("int8_linear_rms_modulated", locals())
+
+
+def int8_linear_pair(
+    x: torch.Tensor,
+    weight0: torch.Tensor,
+    weight1: torch.Tensor,
+    weight_scale0: torch.Tensor,
+    weight_scale1: torch.Tensor,
+    bias0: torch.Tensor | None = None,
+    bias1: torch.Tensor | None = None,
+    out_dtype: torch.dtype | None = None,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+    weight_tile_k: int = 0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Two equal-width INT8 linears sharing activation quantization when supported."""
+    if out_dtype is None:
+        out_dtype = torch.bfloat16
+    return _call_backend("int8_linear_pair", locals())
+
+
+def int8_linear_pair_modulated(
+    x: torch.Tensor,
+    modulation_scale: torch.Tensor,
+    weight0: torch.Tensor,
+    weight1: torch.Tensor,
+    weight_scale0: torch.Tensor,
+    weight_scale1: torch.Tensor,
+    bias0: torch.Tensor | None = None,
+    bias1: torch.Tensor | None = None,
+    out_dtype: torch.dtype | None = None,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+    modulation_shift: torch.Tensor | None = None,
+    weight_tile_k: int = 0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Two batch-one affine-modulated linears sharing INT8 quantization."""
+    if out_dtype is None:
+        out_dtype = torch.bfloat16
+    return _call_backend("int8_linear_pair_modulated", locals())
+
+
+def int8_linear_triple_modulated(
+    x: torch.Tensor,
+    modulation_scale: torch.Tensor,
+    weight0: torch.Tensor,
+    weight1: torch.Tensor,
+    weight2: torch.Tensor,
+    weight_scale0: torch.Tensor,
+    weight_scale1: torch.Tensor,
+    weight_scale2: torch.Tensor,
+    bias0: torch.Tensor | None = None,
+    bias1: torch.Tensor | None = None,
+    bias2: torch.Tensor | None = None,
+    out_dtype: torch.dtype | None = None,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+    modulation_shift: torch.Tensor | None = None,
+    weight_tile_k: int = 0,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Three affine-modulated INT8 linears sharing one activation quantization."""
+    if out_dtype is None:
+        out_dtype = torch.bfloat16
+    return _call_backend("int8_linear_triple_modulated", locals())
+
+
+def int8_linear_pair_rms_modulated(
+    x: torch.Tensor,
+    norm_weight: torch.Tensor,
+    norm_eps: float,
+    modulation_scale: torch.Tensor,
+    weight0: torch.Tensor,
+    weight1: torch.Tensor,
+    weight_scale0: torch.Tensor,
+    weight_scale1: torch.Tensor,
+    bias0: torch.Tensor | None = None,
+    bias1: torch.Tensor | None = None,
+    out_dtype: torch.dtype | None = None,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Paired INT8 projections sharing RMSNorm, modulation, and quantization."""
+    if out_dtype is None:
+        out_dtype = torch.bfloat16
+    return _call_backend("int8_linear_pair_rms_modulated", locals())
+
+
+def int8_linear_swiglu_split(
+    gate: torch.Tensor,
+    up: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    out_dtype: torch.dtype | None = None,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+    weight_tiled_b: bool = False,
+    weight_tile_k: int = 0,
+) -> torch.Tensor:
+    """INT8 down projection that may absorb split BF16 SwiGLU inputs."""
+    if out_dtype is None:
+        out_dtype = torch.bfloat16
+    return _call_backend("int8_linear_swiglu_split", locals())
 
 
 # =============================================================================

--- a/comfy_kitchen/__init__.py
+++ b/comfy_kitchen/__init__.py
@@ -885,7 +885,16 @@ def rms_gated_residual(
     eps: float = 1.0e-5,
 ) -> torch.Tensor:
     """Compute exact RMSNorm followed by a visible gate product and residual add."""
-    return _call_backend("rms_gated_residual", locals())
+    return _call_backend(
+        "rms_gated_residual",
+        {
+            "activation": activation,
+            "norm_weight": norm_weight,
+            "residual": residual,
+            "gate": gate,
+            "eps": eps,
+        },
+    )
 
 
 def int8_linear(
@@ -950,7 +959,23 @@ def int8_linear_gated_residual(
     """INT8 linear with an exact BF16 gated-residual writeback."""
     if out_dtype is None:
         out_dtype = torch.bfloat16
-    return _call_backend("int8_linear_gated_residual", locals())
+    return _call_backend(
+        "int8_linear_gated_residual",
+        {
+            "x": x,
+            "weight": weight,
+            "weight_scale": weight_scale,
+            "residual": residual,
+            "gate": gate,
+            "bias": bias,
+            "out_dtype": out_dtype,
+            "convrot": convrot,
+            "convrot_groupsize": convrot_groupsize,
+            "input_act": input_act,
+            "weight_tile_k": weight_tile_k,
+            "dual_m": dual_m,
+        },
+    )
 
 
 def int8_linear_modulated(
@@ -969,7 +994,22 @@ def int8_linear_modulated(
     """Batch-one affine modulation with fused INT8 quantization."""
     if out_dtype is None:
         out_dtype = torch.bfloat16
-    return _call_backend("int8_linear_modulated", locals())
+    return _call_backend(
+        "int8_linear_modulated",
+        {
+            "x": x,
+            "modulation_scale": modulation_scale,
+            "weight": weight,
+            "weight_scale": weight_scale,
+            "bias": bias,
+            "out_dtype": out_dtype,
+            "convrot": convrot,
+            "convrot_groupsize": convrot_groupsize,
+            "weight_tiled_b": weight_tiled_b,
+            "modulation_shift": modulation_shift,
+            "weight_tile_k": weight_tile_k,
+        },
+    )
 
 
 def int8_linear_rms_modulated(
@@ -988,7 +1028,22 @@ def int8_linear_rms_modulated(
     """INT8 projection with RMSNorm and batch-one modulation in its producer."""
     if out_dtype is None:
         out_dtype = torch.bfloat16
-    return _call_backend("int8_linear_rms_modulated", locals())
+    return _call_backend(
+        "int8_linear_rms_modulated",
+        {
+            "x": x,
+            "norm_weight": norm_weight,
+            "norm_eps": norm_eps,
+            "modulation_scale": modulation_scale,
+            "weight": weight,
+            "weight_scale": weight_scale,
+            "bias": bias,
+            "out_dtype": out_dtype,
+            "convrot": convrot,
+            "convrot_groupsize": convrot_groupsize,
+            "weight_tiled_b": weight_tiled_b,
+        },
+    )
 
 
 def int8_linear_pair(
@@ -1007,7 +1062,22 @@ def int8_linear_pair(
     """Two equal-width INT8 linears sharing activation quantization when supported."""
     if out_dtype is None:
         out_dtype = torch.bfloat16
-    return _call_backend("int8_linear_pair", locals())
+    return _call_backend(
+        "int8_linear_pair",
+        {
+            "x": x,
+            "weight0": weight0,
+            "weight1": weight1,
+            "weight_scale0": weight_scale0,
+            "weight_scale1": weight_scale1,
+            "bias0": bias0,
+            "bias1": bias1,
+            "out_dtype": out_dtype,
+            "convrot": convrot,
+            "convrot_groupsize": convrot_groupsize,
+            "weight_tile_k": weight_tile_k,
+        },
+    )
 
 
 def int8_linear_pair_modulated(
@@ -1028,7 +1098,24 @@ def int8_linear_pair_modulated(
     """Two batch-one affine-modulated linears sharing INT8 quantization."""
     if out_dtype is None:
         out_dtype = torch.bfloat16
-    return _call_backend("int8_linear_pair_modulated", locals())
+    return _call_backend(
+        "int8_linear_pair_modulated",
+        {
+            "x": x,
+            "modulation_scale": modulation_scale,
+            "weight0": weight0,
+            "weight1": weight1,
+            "weight_scale0": weight_scale0,
+            "weight_scale1": weight_scale1,
+            "bias0": bias0,
+            "bias1": bias1,
+            "out_dtype": out_dtype,
+            "convrot": convrot,
+            "convrot_groupsize": convrot_groupsize,
+            "modulation_shift": modulation_shift,
+            "weight_tile_k": weight_tile_k,
+        },
+    )
 
 
 def int8_linear_triple_modulated(
@@ -1052,7 +1139,27 @@ def int8_linear_triple_modulated(
     """Three affine-modulated INT8 linears sharing one activation quantization."""
     if out_dtype is None:
         out_dtype = torch.bfloat16
-    return _call_backend("int8_linear_triple_modulated", locals())
+    return _call_backend(
+        "int8_linear_triple_modulated",
+        {
+            "x": x,
+            "modulation_scale": modulation_scale,
+            "weight0": weight0,
+            "weight1": weight1,
+            "weight2": weight2,
+            "weight_scale0": weight_scale0,
+            "weight_scale1": weight_scale1,
+            "weight_scale2": weight_scale2,
+            "bias0": bias0,
+            "bias1": bias1,
+            "bias2": bias2,
+            "out_dtype": out_dtype,
+            "convrot": convrot,
+            "convrot_groupsize": convrot_groupsize,
+            "modulation_shift": modulation_shift,
+            "weight_tile_k": weight_tile_k,
+        },
+    )
 
 
 def int8_linear_pair_rms_modulated(
@@ -1073,7 +1180,24 @@ def int8_linear_pair_rms_modulated(
     """Paired INT8 projections sharing RMSNorm, modulation, and quantization."""
     if out_dtype is None:
         out_dtype = torch.bfloat16
-    return _call_backend("int8_linear_pair_rms_modulated", locals())
+    return _call_backend(
+        "int8_linear_pair_rms_modulated",
+        {
+            "x": x,
+            "norm_weight": norm_weight,
+            "norm_eps": norm_eps,
+            "modulation_scale": modulation_scale,
+            "weight0": weight0,
+            "weight1": weight1,
+            "weight_scale0": weight_scale0,
+            "weight_scale1": weight_scale1,
+            "bias0": bias0,
+            "bias1": bias1,
+            "out_dtype": out_dtype,
+            "convrot": convrot,
+            "convrot_groupsize": convrot_groupsize,
+        },
+    )
 
 
 def int8_linear_swiglu_split(
@@ -1091,7 +1215,21 @@ def int8_linear_swiglu_split(
     """INT8 down projection that may absorb split BF16 SwiGLU inputs."""
     if out_dtype is None:
         out_dtype = torch.bfloat16
-    return _call_backend("int8_linear_swiglu_split", locals())
+    return _call_backend(
+        "int8_linear_swiglu_split",
+        {
+            "gate": gate,
+            "up": up,
+            "weight": weight,
+            "weight_scale": weight_scale,
+            "bias": bias,
+            "out_dtype": out_dtype,
+            "convrot": convrot,
+            "convrot_groupsize": convrot_groupsize,
+            "weight_tiled_b": weight_tiled_b,
+            "weight_tile_k": weight_tile_k,
+        },
+    )
 
 
 # =============================================================================

--- a/comfy_kitchen/__init__.py
+++ b/comfy_kitchen/__init__.py
@@ -40,7 +40,7 @@ from .tensor.w4a8_int8 import (
 # ROCm PyTorch build so CUDA/CPU processes do not pay the import cost or acquire
 # an unrelated GPU runtime merely because a combined wheel contains the module.
 if getattr(torch.version, "hip", None):
-    from .backends import hip as _hip_backend  # noqa: F401
+    from .backends import hip as _hip_backend
 
     # The HIP backend registers only on a supported AMD device (RDNA2/3/3.5/4),
     # and advertises only the ops that device can run; prefer it where it registers.

--- a/comfy_kitchen/__init__.py
+++ b/comfy_kitchen/__init__.py
@@ -19,6 +19,7 @@ from .float_utils import from_blocked, swap_nibbles, to_blocked
 from .registry import registry
 from .sage_attention import (
     PrequantizedInt8Attention,
+    _validate_attention_scale,
     int8_attention,
     int8_attention_from_prequantized,
     prequantize_int8_attention,
@@ -179,6 +180,7 @@ def hip_attention(
         bool(getattr(torch.version, "hip", None)) and registry.is_available("hip")
     ):
         raise RuntimeError("HIP attention requires the HIP backend")
+    scale = _validate_attention_scale(scale, 1.0 / (q.shape[-1] ** 0.5))
     return _hip_backend.hip_attention(q, k, v, scale)
 
 
@@ -196,7 +198,7 @@ def hip_int8_attention(
         bool(getattr(torch.version, "hip", None)) and registry.is_available("hip")
     ):
         raise RuntimeError("INT8 HIP attention requires the HIP backend")
-    resolved_scale = float(scale if scale is not None else q.shape[-1] ** -0.5)
+    resolved_scale = _validate_attention_scale(scale, q.shape[-1] ** -0.5)
     return _hip_backend.hip_int8_attention(q, k, v, resolved_scale)
 def sol_attn(
     q: torch.Tensor,

--- a/comfy_kitchen/backends/eager/__init__.py
+++ b/comfy_kitchen/backends/eager/__init__.py
@@ -80,7 +80,6 @@ from .convrot_w4a4 import (
     quantize_convrot_w4a4_weight,
 )
 from .na import na3d
-from .residual import rms_gated_residual
 from .quantization import (
     dequantize_int8_convrot_weight,
     dequantize_int8_convrot_weight_dtype,
@@ -93,12 +92,12 @@ from .quantization import (
     int8_linear,
     int8_linear_gated_residual,
     int8_linear_modulated,
-    int8_linear_rms_modulated,
     int8_linear_pair,
     int8_linear_pair_modulated,
-    int8_linear_triple_modulated,
     int8_linear_pair_rms_modulated,
+    int8_linear_rms_modulated,
     int8_linear_swiglu_split,
+    int8_linear_triple_modulated,
     quantize_and_rotate_rowwise,
     quantize_int8_convrot_weight,
     quantize_int8_rowwise,
@@ -111,6 +110,7 @@ from .quantization import (
     scaled_mm_nvfp4,
     stochastic_rounding_fp8,
 )
+from .residual import rms_gated_residual
 from .rope import (
     apply_rope,
     apply_rope1,

--- a/comfy_kitchen/backends/eager/__init__.py
+++ b/comfy_kitchen/backends/eager/__init__.py
@@ -1,5 +1,6 @@
 __all__ = [
     "adaln",
+    "rms_gated_residual",
     "na3d",
     "rms_adaln",
     "apply_rope",
@@ -47,6 +48,14 @@ __all__ = [
     "scaled_mm_svdquant_w4a4",
     "stochastic_rounding_fp8",
     "int8_linear",
+    "int8_linear_gated_residual",
+    "int8_linear_modulated",
+    "int8_linear_rms_modulated",
+    "int8_linear_pair",
+    "int8_linear_pair_modulated",
+    "int8_linear_triple_modulated",
+    "int8_linear_pair_rms_modulated",
+    "int8_linear_swiglu_split",
     "w4a8_int8_linear",
 ]
 
@@ -69,6 +78,7 @@ from .convrot_w4a4 import (
     quantize_convrot_w4a4_weight,
 )
 from .na import na3d
+from .residual import rms_gated_residual
 from .quantization import (
     dequantize_int8_convrot_weight,
     dequantize_int8_convrot_weight_dtype,
@@ -79,6 +89,14 @@ from .quantization import (
     dequantize_nvfp4,
     dequantize_per_tensor_fp8,
     int8_linear,
+    int8_linear_gated_residual,
+    int8_linear_modulated,
+    int8_linear_rms_modulated,
+    int8_linear_pair,
+    int8_linear_pair_modulated,
+    int8_linear_triple_modulated,
+    int8_linear_pair_rms_modulated,
+    int8_linear_swiglu_split,
     quantize_and_rotate_rowwise,
     quantize_int8_convrot_weight,
     quantize_int8_rowwise,
@@ -440,6 +458,16 @@ def _build_constraints() -> dict:
         },
         default_devices=all_devices,
     )
+    out["rms_gated_residual"] = FunctionConstraints(
+        params={
+            "activation": ParamConstraint(dtypes=standard_floats),
+            "norm_weight": ParamConstraint(dtypes=standard_floats),
+            "residual": ParamConstraint(dtypes=standard_floats),
+            "gate": ParamConstraint(dtypes=standard_floats),
+            "eps": ParamConstraint(dtypes=frozenset({float})),
+        },
+        default_devices=all_devices,
+    )
     out["quantize_int8_rowwise"] = FunctionConstraints(
         params={
             "x": ParamConstraint(dtypes=standard_floats),
@@ -524,6 +552,73 @@ def _build_constraints() -> dict:
         },
         default_devices=all_devices,
     )
+    float_param = ParamConstraint(dtypes=standard_floats)
+    int8_param = ParamConstraint(dtypes=frozenset({torch.int8}))
+    int_param = ParamConstraint(dtypes=frozenset({int}))
+    float_value = ParamConstraint(dtypes=frozenset({float}))
+    bool_param = ParamConstraint(dtypes=frozenset({bool}))
+    fusion_options = {
+        "out_dtype": float_param,
+        "convrot": bool_param,
+        "convrot_groupsize": int_param,
+    }
+
+    def fusion_constraints(params):
+        return FunctionConstraints(
+            params=params | fusion_options, default_devices=all_devices
+        )
+
+    def projections(count):
+        return {
+            name: constraint
+            for index in range(count)
+            for name, constraint in (
+                (f"weight{index}", int8_param),
+                (f"weight_scale{index}", float_param),
+                (f"bias{index}", float_param),
+            )
+        }
+
+    single = {
+        "x": float_param,
+        "weight": int8_param,
+        "weight_scale": float_param,
+        "bias": float_param,
+    }
+    modulation = {
+        "modulation_scale": float_param,
+        "modulation_shift": float_param,
+    }
+    tiled = {"weight_tiled_b": bool_param, "weight_tile_k": int_param}
+    out.update({
+        "int8_linear_gated_residual": fusion_constraints(single | {
+            "residual": float_param, "gate": float_param,
+            "weight_tile_k": int_param, "dual_m": bool_param,
+        }),
+        "int8_linear_modulated": fusion_constraints(single | modulation | tiled),
+        "int8_linear_rms_modulated": fusion_constraints(single | modulation | {
+            "norm_weight": float_param, "norm_eps": float_value,
+            "weight_tiled_b": bool_param,
+        }),
+        "int8_linear_pair": fusion_constraints({"x": float_param} | projections(2) | {
+            "weight_tile_k": int_param,
+        }),
+        "int8_linear_pair_modulated": fusion_constraints(
+            {"x": float_param} | projections(2) | modulation | {"weight_tile_k": int_param}
+        ),
+        "int8_linear_triple_modulated": fusion_constraints(
+            {"x": float_param} | projections(3) | modulation | {"weight_tile_k": int_param}
+        ),
+        "int8_linear_pair_rms_modulated": fusion_constraints(
+            {"x": float_param} | projections(2) | modulation | {
+                "norm_weight": float_param, "norm_eps": float_value,
+            }
+        ),
+        "int8_linear_swiglu_split": fusion_constraints({
+            "gate": float_param, "up": float_param, "weight": int8_param,
+            "weight_scale": float_param, "bias": float_param,
+        } | tiled),
+    })
 
     if hasattr(torch, "float8_e8m0fnu"):
         out["quantize_mxfp8"] = FunctionConstraints(

--- a/comfy_kitchen/backends/eager/quantization.py
+++ b/comfy_kitchen/backends/eager/quantization.py
@@ -1071,7 +1071,9 @@ def int8_linear_gated_residual(
     dual_m: bool = False,
 ) -> torch.Tensor:
     """Portable ``residual + gate * int8_linear(...)`` reference."""
-    del weight_tile_k, dual_m
+    if weight_tile_k:
+        raise ValueError("The eager backend does not support WMMA-tiled INT8 weights")
+    del dual_m
     projected = int8_linear(
         x, weight, weight_scale, bias, out_dtype, convrot,
         convrot_groupsize, input_act,

--- a/comfy_kitchen/backends/eager/quantization.py
+++ b/comfy_kitchen/backends/eager/quantization.py
@@ -1056,6 +1056,252 @@ def int8_linear(
     return result.reshape(*orig_shape[:-1], weight.shape[0])
 
 
+def int8_linear_gated_residual(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    residual: torch.Tensor,
+    gate: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    out_dtype: torch.dtype = torch.bfloat16,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+    input_act: str | None = None,
+    weight_tile_k: int = 0,
+    dual_m: bool = False,
+) -> torch.Tensor:
+    """Portable ``residual + gate * int8_linear(...)`` reference."""
+    del weight_tile_k, dual_m
+    projected = int8_linear(
+        x, weight, weight_scale, bias, out_dtype, convrot,
+        convrot_groupsize, input_act,
+    )
+    return torch.addcmul(residual, gate, projected)
+
+
+def _modulate_int8_input(
+    x: torch.Tensor,
+    scale: torch.Tensor,
+    shift: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Materialize the portable batch-one modulation contract once."""
+    k = x.shape[-1]
+    if scale.numel() != k:
+        raise ValueError(
+            f"modulation_scale must contain one batch-one row of {k} values, "
+            f"got {scale.numel()}"
+        )
+    shape = (1,) * (x.ndim - 1) + (k,)
+    factor = 1.0 + scale.reshape(shape)
+    if shift is None:
+        return x * factor
+    if shift.numel() != k:
+        raise ValueError(
+            f"modulation_shift must contain one batch-one row of {k} values, "
+            f"got {shift.numel()}"
+        )
+    return torch.addcmul(shift.reshape(shape), x, factor)
+
+
+def _int8_linear_group(x, projections, out_dtype, convrot, group_size):
+    return tuple(
+        int8_linear(
+            x, weight, scale, bias, out_dtype, convrot, group_size
+        )
+        for weight, scale, bias in projections
+    )
+
+
+def int8_linear_pair(
+    x: torch.Tensor,
+    weight0: torch.Tensor,
+    weight1: torch.Tensor,
+    weight_scale0: torch.Tensor,
+    weight_scale1: torch.Tensor,
+    bias0: torch.Tensor | None = None,
+    bias1: torch.Tensor | None = None,
+    out_dtype: torch.dtype = torch.bfloat16,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+    weight_tile_k: int = 0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Portable reference for two equal-width INT8 projections."""
+    if weight_tile_k:
+        raise ValueError("The eager backend cannot consume WMMA-tiled weights")
+    if weight0.shape != weight1.shape:
+        raise ValueError(
+            f"paired INT8 weights must have the same shape, got "
+            f"{tuple(weight0.shape)} and {tuple(weight1.shape)}"
+        )
+    return _int8_linear_group(
+        x,
+        ((weight0, weight_scale0, bias0), (weight1, weight_scale1, bias1)),
+        out_dtype,
+        convrot,
+        convrot_groupsize,
+    )
+
+
+def int8_linear_modulated(
+    x: torch.Tensor,
+    modulation_scale: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    out_dtype: torch.dtype = torch.bfloat16,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+    weight_tiled_b: bool = False,
+    modulation_shift: torch.Tensor | None = None,
+    weight_tile_k: int = 0,
+) -> torch.Tensor:
+    """Portable batch-one affine-modulation reference for an INT8 projection."""
+    if weight_tiled_b or weight_tile_k:
+        raise ValueError("The eager backend cannot consume WMMA-tiled weights")
+    return int8_linear(
+        _modulate_int8_input(x, modulation_scale, modulation_shift),
+        weight, weight_scale, bias, out_dtype,
+        convrot, convrot_groupsize,
+    )
+
+
+def int8_linear_rms_modulated(
+    x: torch.Tensor,
+    norm_weight: torch.Tensor,
+    norm_eps: float,
+    modulation_scale: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    out_dtype: torch.dtype = torch.bfloat16,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+    weight_tiled_b: bool = False,
+) -> torch.Tensor:
+    """Portable RMSNorm plus batch-one modulation reference."""
+    if weight_tiled_b:
+        raise ValueError("The eager backend cannot consume WMMA-tiled weights")
+    normalized = torch.nn.functional.rms_norm(
+        x, (x.shape[-1],), norm_weight, norm_eps
+    )
+    return int8_linear_modulated(
+        normalized, modulation_scale, weight, weight_scale, bias, out_dtype,
+        convrot, convrot_groupsize, weight_tiled_b,
+    )
+
+
+def int8_linear_pair_modulated(
+    x: torch.Tensor,
+    modulation_scale: torch.Tensor,
+    weight0: torch.Tensor,
+    weight1: torch.Tensor,
+    weight_scale0: torch.Tensor,
+    weight_scale1: torch.Tensor,
+    bias0: torch.Tensor | None = None,
+    bias1: torch.Tensor | None = None,
+    out_dtype: torch.dtype = torch.bfloat16,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+    modulation_shift: torch.Tensor | None = None,
+    weight_tile_k: int = 0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Portable batch-one affine-modulation reference for paired projections."""
+    if weight_tile_k:
+        raise ValueError("The eager backend cannot consume WMMA-tiled weights")
+    return int8_linear_pair(
+        _modulate_int8_input(x, modulation_scale, modulation_shift),
+        weight0, weight1, weight_scale0, weight_scale1,
+        bias0, bias1, out_dtype, convrot, convrot_groupsize,
+    )
+
+
+def int8_linear_triple_modulated(
+    x: torch.Tensor,
+    modulation_scale: torch.Tensor,
+    weight0: torch.Tensor,
+    weight1: torch.Tensor,
+    weight2: torch.Tensor,
+    weight_scale0: torch.Tensor,
+    weight_scale1: torch.Tensor,
+    weight_scale2: torch.Tensor,
+    bias0: torch.Tensor | None = None,
+    bias1: torch.Tensor | None = None,
+    bias2: torch.Tensor | None = None,
+    out_dtype: torch.dtype = torch.bfloat16,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+    modulation_shift: torch.Tensor | None = None,
+    weight_tile_k: int = 0,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Portable affine-modulation reference for three projections."""
+    if weight_tile_k:
+        raise ValueError("The eager backend cannot consume WMMA-tiled weights")
+    return _int8_linear_group(
+        _modulate_int8_input(x, modulation_scale, modulation_shift),
+        (
+            (weight0, weight_scale0, bias0),
+            (weight1, weight_scale1, bias1),
+            (weight2, weight_scale2, bias2),
+        ),
+        out_dtype,
+        convrot,
+        convrot_groupsize,
+    )
+
+
+def int8_linear_pair_rms_modulated(
+    x: torch.Tensor,
+    norm_weight: torch.Tensor,
+    norm_eps: float,
+    modulation_scale: torch.Tensor,
+    weight0: torch.Tensor,
+    weight1: torch.Tensor,
+    weight_scale0: torch.Tensor,
+    weight_scale1: torch.Tensor,
+    bias0: torch.Tensor | None = None,
+    bias1: torch.Tensor | None = None,
+    out_dtype: torch.dtype = torch.bfloat16,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Portable paired RMSNorm plus batch-one modulation reference."""
+    normalized = torch.nn.functional.rms_norm(
+        x, (x.shape[-1],), norm_weight, norm_eps
+    )
+    return int8_linear_pair_modulated(
+        normalized, modulation_scale, weight0, weight1,
+        weight_scale0, weight_scale1, bias0, bias1, out_dtype,
+        convrot, convrot_groupsize,
+    )
+
+
+def int8_linear_swiglu_split(
+    gate: torch.Tensor,
+    up: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    out_dtype: torch.dtype = torch.bfloat16,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+    weight_tiled_b: bool = False,
+    weight_tile_k: int = 0,
+) -> torch.Tensor:
+    """Portable reference for a down projection consuming split SwiGLU inputs."""
+    if weight_tiled_b or weight_tile_k:
+        raise ValueError("The eager backend cannot consume WMMA-tiled weights")
+    if gate.shape != up.shape:
+        raise ValueError(
+            f"split SwiGLU inputs must have the same shape, got "
+            f"{tuple(gate.shape)} and {tuple(up.shape)}"
+        )
+    activated = torch.nn.functional.silu(gate) * up
+    return int8_linear(
+        activated, weight, weight_scale, bias, out_dtype,
+        convrot, convrot_groupsize,
+    )
+
+
 # =============================================================================
 # torch.library Custom Op Definitions — INT8 Tensor-wise
 # =============================================================================
@@ -1233,3 +1479,43 @@ def _op_int8_linear_fake(x, weight, weight_scale, bias, output_dtype_code,
                          convrot=False, convrot_groupsize=256, input_act=None):
     out_dtype = DTYPE_CODE_TO_DTYPE[output_dtype_code]
     return torch.empty(*x.shape[:-1], weight.shape[0], dtype=out_dtype, device=x.device)
+
+
+@torch.library.custom_op("comfy_kitchen::int8_linear_tiled_b", mutates_args=())
+def _op_int8_linear_tiled_b(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    bias: torch.Tensor | None,
+    output_dtype_code: int,
+    convrot: bool,
+    convrot_groupsize: int,
+    tile_k: int,
+    dual_m: bool,
+) -> torch.Tensor:
+    """Internal dispatch for physically tiled TensorWise INT8 weights."""
+    out_dtype = DTYPE_CODE_TO_DTYPE[output_dtype_code]
+    kwargs = {
+        "x": x,
+        "weight": weight,
+        "weight_scale": weight_scale,
+        "bias": bias,
+        "out_dtype": out_dtype,
+        "convrot": convrot,
+        "convrot_groupsize": convrot_groupsize,
+        "tile_k": tile_k,
+        "dual_m": dual_m,
+    }
+    impl = registry.get_implementation("int8_linear_tiled_b", kwargs=kwargs)
+    return impl(**kwargs)
+
+
+@_op_int8_linear_tiled_b.register_fake
+def _op_int8_linear_tiled_b_fake(
+    x, weight, weight_scale, bias, output_dtype_code, convrot,
+    convrot_groupsize, tile_k, dual_m,
+):
+    out_dtype = DTYPE_CODE_TO_DTYPE[output_dtype_code]
+    return torch.empty(
+        *x.shape[:-1], weight.shape[0], dtype=out_dtype, device=x.device
+    )

--- a/comfy_kitchen/backends/eager/residual.py
+++ b/comfy_kitchen/backends/eager/residual.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+import torch
+import torch.nn.functional as F
+
+
+def rms_gated_residual(
+    activation: torch.Tensor,
+    norm_weight: torch.Tensor,
+    residual: torch.Tensor,
+    gate: torch.Tensor,
+    eps: float = 1.0e-5,
+) -> torch.Tensor:
+    """Reference RMSNorm followed by the visible gate product and residual add."""
+    normalized = F.rms_norm(
+        activation, (activation.shape[-1],), norm_weight, eps
+    )
+    return residual + gate * normalized

--- a/comfy_kitchen/backends/eager/residual.py
+++ b/comfy_kitchen/backends/eager/residual.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 import torch
-import torch.nn.functional as F
+import torch.nn.functional as functional
 
 
 def rms_gated_residual(
@@ -12,7 +12,7 @@ def rms_gated_residual(
     eps: float = 1.0e-5,
 ) -> torch.Tensor:
     """Reference RMSNorm followed by the visible gate product and residual add."""
-    normalized = F.rms_norm(
+    normalized = functional.rms_norm(
         activation, (activation.shape[-1],), norm_weight, eps
     )
     return residual + gate * normalized

--- a/comfy_kitchen/backends/hip/CMakeLists.txt
+++ b/comfy_kitchen/backends/hip/CMakeLists.txt
@@ -155,10 +155,13 @@ set(HIP_SOURCES
     ops/per_tensor_fp8.hip
     ops/stochastic_round_fp8.hip
     ops/quantize_int8.hip
+    ops/attention_bf16.hip
+    ops/rms_gated_residual.hip
     ops/gemm_fp8.hip
     ops/gemm_int8.hip
     ops/convrot_w4a4.hip
     ops/adaln.hip
+    ops/rms_convrot_quant.hip
     ops/na3d.hip
     sage_attention/quant_qk_int8.hip
     sage_attention/quant_v_int8.hip
@@ -183,6 +186,12 @@ add_library(comfy_kitchen_hip_kernels OBJECT ${HIP_SOURCES})
 target_compile_options(comfy_kitchen_hip_kernels PRIVATE
     $<$<COMPILE_LANGUAGE:HIP>:-O3>
     $<$<COMPILE_LANGUAGE:HIP>:-ffast-math>
+)
+# The quantized attention specialization preserves ordered FP32 softmax and
+# normalization arithmetic; contraction or reassociation changes its BF16
+# output boundary even when aggregate cosine rounds to one.
+set_source_files_properties(sage_attention/int8_attn.hip PROPERTIES
+    COMPILE_OPTIONS "$<$<COMPILE_LANGUAGE:HIP>:-fno-fast-math>"
 )
 if(COMFY_ENABLE_LINEINFO OR CMAKE_BUILD_TYPE STREQUAL "Debug")
     target_compile_options(

--- a/comfy_kitchen/backends/hip/__init__.py
+++ b/comfy_kitchen/backends/hip/__init__.py
@@ -2599,7 +2599,11 @@ def hip_int8_attention(
         return hip_attention(q, k, v, scale)
     q_len = int(q.shape[2])
     kv_len = int(k.shape[2])
-    output = torch.empty_strided(q.shape, q.stride(), device=q.device, dtype=q.dtype)
+    output = torch.empty(
+        (q.shape[0], q.shape[2], q.shape[1], q.shape[3]),
+        device=q.device,
+        dtype=q.dtype,
+    ).movedim(1, 2)
     workspaces = _int8_attention_workspace(q, q_len, kv_len)
     _C.hip_int8_attention(
         _dl(q),

--- a/comfy_kitchen/backends/hip/__init__.py
+++ b/comfy_kitchen/backends/hip/__init__.py
@@ -539,6 +539,14 @@ _convrot_max_k: dict[tuple[int, torch.dtype], int] = {}
 _CONVROT_SPILL_WORKSPACE_BYTES = 32 << 20
 
 
+def _convrot_int8_needs_spill(
+    m: int, k: int, input_dtype_code: int, device: torch.device
+) -> bool:
+    """Query the ConvRot capability for the operand's device."""
+    with torch.cuda.device(device):
+        return bool(_C.convrot_int8_needs_spill(m, k, input_dtype_code))
+
+
 def _convrot_supported(
     k: int, group_size: int, device: torch.device, dtype: torch.dtype,
     *, int8_global_spill: bool = False,
@@ -580,8 +588,8 @@ def _rotate_quant_int8(
     # check_convrot_k queries the current device's LDS budget, so pin it to the
     # operand's device rather than trusting the caller thread's current device.
     with torch.cuda.device(x2d.device):
-        if group_size != 256 or not _C.convrot_int8_needs_spill(
-            m, k, DTYPE_TO_CODE[x2d.dtype]
+        if group_size != 256 or not _convrot_int8_needs_spill(
+            m, k, DTYPE_TO_CODE[x2d.dtype], x2d.device
         ):
             _C.quantize_int8_convrot(
                 _dl(_aligned(x_arg)), _dl(_aligned(q)), _dl(_aligned(scales)),
@@ -1029,7 +1037,9 @@ def int8_linear_modulated(
         and out_dtype == torch.bfloat16
         and convrot
         and convrot_groupsize == 256
-        and not _C.convrot_int8_needs_spill(m, k, DTYPE_TO_CODE[x2d.dtype])
+        and not _convrot_int8_needs_spill(
+            m, k, DTYPE_TO_CODE[x2d.dtype], x2d.device
+        )
     )
     use_scale_fused = (
         modulation_shift is None
@@ -1405,7 +1415,9 @@ def int8_linear_pair_modulated(
         and out_dtype == torch.bfloat16
         and convrot
         and convrot_groupsize == 256
-        and not _C.convrot_int8_needs_spill(m, k, DTYPE_TO_CODE[x.dtype])
+        and not _convrot_int8_needs_spill(
+            m, k, DTYPE_TO_CODE[x.dtype], x.device
+        )
     )
     use_scale_fused = (
         modulation_shift is None
@@ -1505,7 +1517,9 @@ def int8_linear_triple_modulated(
         and out_dtype == torch.bfloat16
         and convrot
         and convrot_groupsize == 256
-        and not _C.convrot_int8_needs_spill(m, k, DTYPE_TO_CODE[x2d.dtype])
+        and not _convrot_int8_needs_spill(
+            m, k, DTYPE_TO_CODE[x2d.dtype], x2d.device
+        )
     )
     if not use_fused:
         if weight_tile_k:

--- a/comfy_kitchen/backends/hip/__init__.py
+++ b/comfy_kitchen/backends/hip/__init__.py
@@ -2474,6 +2474,18 @@ def _attention_device_is_supported(tensor: torch.Tensor) -> bool:
     return bool(tensor.is_cuda and _has_nonduplicated_wmma(tensor.device))
 
 
+def _attention_layout_is_supported(tensor: torch.Tensor) -> bool:
+    return (
+        tensor.stride(3) == 1
+        and tensor.stride(2) % 8 == 0
+        and all(
+            tensor.shape[dim] <= 1 or tensor.stride(dim) % 8 == 0
+            for dim in (0, 1)
+        )
+        and tensor.data_ptr() % 16 == 0
+    )
+
+
 def _attention_inputs_are_supported(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -2494,9 +2506,7 @@ def _attention_inputs_are_supported(
         and q_shape[2] > 0
         and k_shape[2] == v_shape[2] > 0
         and q_shape[3] == k_shape[3] == v_shape[3] == 128
-        and q.stride(3) == k.stride(3) == v.stride(3) == 1
-        and q.stride(2) % 8 == k.stride(2) % 8 == v.stride(2) % 8 == 0
-        and q.data_ptr() % 16 == k.data_ptr() % 16 == v.data_ptr() % 16 == 0
+        and all(_attention_layout_is_supported(tensor) for tensor in (q, k, v))
     ):
         return False
     long = q_shape[0] == 1 and q_shape[2] >= 1024

--- a/comfy_kitchen/backends/hip/__init__.py
+++ b/comfy_kitchen/backends/hip/__init__.py
@@ -927,6 +927,11 @@ def rms_gated_residual(
     eps: float = 1.0e-5,
 ) -> torch.Tensor:
     """Exact BF16 RMSNorm, gate multiplication, and residual add."""
+    width = activation.shape[-1] if activation.ndim else 0
+    max_k = 0
+    if activation.dtype == torch.bfloat16 and activation.device.type == "cuda":
+        with torch.cuda.device(activation.device):
+            max_k = _C.convrot_max_k(DTYPE_TO_CODE[activation.dtype])
     use_fused = (
         activation.dtype == torch.bfloat16
         and norm_weight.dtype == torch.bfloat16
@@ -936,11 +941,11 @@ def rms_gated_residual(
         and activation.ndim == 3
         and activation.shape[0] == 1
         and activation.shape == residual.shape
-        and activation.shape[-1] > 0
-        and activation.shape[-1] % 4 == 0
-        and activation.shape[-1] <= _C.convrot_max_k(DTYPE_TO_CODE[activation.dtype])
-        and norm_weight.numel() == activation.shape[-1]
-        and gate.numel() == activation.shape[-1]
+        and width > 0
+        and width % 4 == 0
+        and width <= max_k
+        and norm_weight.numel() == width
+        and gate.numel() == width
     )
     if not use_fused:
         return _eager.rms_gated_residual(
@@ -948,7 +953,6 @@ def rms_gated_residual(
         )
 
     shape = activation.shape
-    width = activation.shape[-1]
     activation_2d = activation.reshape(-1, width).contiguous()
     norm_weight_1d = norm_weight.reshape(-1).contiguous()
     residual_2d = residual.reshape(-1, width).contiguous()
@@ -1223,6 +1227,10 @@ def _int8_linear_pair_impl(
             "tiled-B INT8 pair requires non-duplicated WMMA BF16, M>=96, "
             "N divisible by 128, and K divisible by tile_k"
         )
+    if modulation_shift is not None and norm_weight is not None:
+        raise ValueError(
+            "modulation_shift and norm_weight are mutually exclusive"
+        )
 
     if convrot:
         if convrot_groupsize not in (16, 64, 256):
@@ -1233,7 +1241,9 @@ def _int8_linear_pair_impl(
             raise ValueError(
                 f"ConvRot group size {convrot_groupsize} does not divide input features {k}"
             )
-        if not _convrot_supported(k, convrot_groupsize, x.device, x.dtype):
+        if not _convrot_supported(
+            k, convrot_groupsize, x.device, x.dtype, int8_global_spill=True
+        ):
             return _eager.int8_linear_pair(
                 x, weight0, weight1, weight_scale0, weight_scale1,
                 bias0, bias1, out_dtype, convrot, convrot_groupsize,

--- a/comfy_kitchen/backends/hip/__init__.py
+++ b/comfy_kitchen/backends/hip/__init__.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""HIP backend for AMD RDNA2, RDNA3/3.5 and RDNA4.
+"""HIP backend for AMD RDNA2, RDNA3/3.5, RDNA4 and gfx117x.
 
 Every matmul is a WMMA kernel compiled from the sources in this directory; the
 backend does not link or call hipBLAS/hipBLASLt.
@@ -183,8 +183,8 @@ def _visible_gfx_arches() -> tuple[str | None, ...]:
     return tuple(_gfx_arch(i) for i in range(torch.cuda.device_count()))
 
 
-# RDNA2 has no matrix cores; RDNA3/3.5 and RDNA4 do. This exact manifest is also
-# consumed by setup.py and CMake. Never infer support from a gfx prefix: a new
+# RDNA2 has no matrix cores; RDNA3/3.5, gfx117x and RDNA4 do. This exact manifest
+# is also consumed by setup.py and CMake. Never infer support from a gfx prefix: a new
 # compiler-recognized target needs its WMMA policy reviewed before it is safe.
 _ARCH_MANIFEST_PATH = os.path.join(os.path.dirname(__file__), "architectures.json")
 _ARCH_GROUPS = json.loads(
@@ -192,14 +192,17 @@ _ARCH_GROUPS = json.loads(
 )
 _ARCH_ELEMENTWISE_ONLY = frozenset(_ARCH_GROUPS["elementwise_only"])
 _ARCH_WMMA_GFX11 = frozenset(_ARCH_GROUPS["wmma_gfx11"])
+_ARCH_WMMA_GFX117 = frozenset(_ARCH_GROUPS.get("wmma_gfx117", []))
 _ARCH_WMMA_GFX12 = frozenset(_ARCH_GROUPS["wmma_gfx12"])
-_ARCH_WMMA = _ARCH_WMMA_GFX11 | _ARCH_WMMA_GFX12
+_ARCH_WMMA = _ARCH_WMMA_GFX11 | _ARCH_WMMA_GFX117 | _ARCH_WMMA_GFX12
 _ARCH_SUPPORTED = _ARCH_ELEMENTWISE_ONLY | _ARCH_WMMA
+
+_GFX117_WMMA_POLICIES_READY = True
 
 
 def _has_nonduplicated_wmma(device: torch.device | int | None = None) -> bool:
     """Whether WMMA operands use the gfx12 128-bit layout."""
-    return _gfx_arch(device) in _ARCH_WMMA_GFX12
+    return _gfx_arch(device) in (_ARCH_WMMA_GFX12 | _ARCH_WMMA_GFX117)
 
 # The GEMMs, and only the GEMMs, need matrix cores. Everything else is elementwise
 # or a scalar reduction and runs on any supported architecture. This set names the
@@ -247,7 +250,13 @@ def _has_wmma(arches: Sequence[str | None]) -> bool:
     the capability set has to be the intersection over the visible devices: one
     RDNA2 card in an otherwise RDNA4 box means no GEMM is safe to advertise.
     """
-    return bool(arches) and all(a in _ARCH_WMMA for a in arches)
+    if not arches or any(a is None for a in arches):
+        return False
+    if not all(a in _ARCH_WMMA for a in arches):
+        return False
+    if any(a in _ARCH_WMMA_GFX117 for a in arches) and not _GFX117_WMMA_POLICIES_READY:
+        return False
+    return True
 
 
 def is_available() -> bool:

--- a/comfy_kitchen/backends/hip/__init__.py
+++ b/comfy_kitchen/backends/hip/__init__.py
@@ -60,6 +60,8 @@ def _validate_attention_scale(scale: object, default: float) -> float:
     if isinstance(scale, torch.Tensor):
         if scale.numel() != 1:
             raise ValueError(f"scale must be a scalar, got shape {tuple(scale.shape)}")
+        if scale.dtype == torch.bool:
+            raise TypeError(f"scale must be a real numeric scalar, got {scale.dtype}")
         if scale.is_complex():
             raise TypeError(f"scale must be a real numeric scalar, got {scale.dtype}")
         try:

--- a/comfy_kitchen/backends/hip/__init__.py
+++ b/comfy_kitchen/backends/hip/__init__.py
@@ -26,6 +26,22 @@ from collections.abc import Sequence
 
 import torch
 
+from comfy_kitchen._rope_utils import check_rope_inplace, trim_rope_freqs
+from comfy_kitchen.backends import eager as _eager
+from comfy_kitchen.backends._activations import apply_input_act as _apply_input_act
+from comfy_kitchen.backends._activations import input_act_code as _input_act_code
+from comfy_kitchen.backends._activations import input_act_width as _input_act_width
+from comfy_kitchen.backends.eager import rope as _eager_rope
+from comfy_kitchen.backends.eager.quantization import DTYPE_CODE_TO_DTYPE, DTYPE_TO_CODE
+from comfy_kitchen.backends.eager.w4a8_int8 import (
+    _QUANT_ROW_ELEM_BUDGET,
+    _decide_codebook,
+    _dequantize_w4a8_int8_weight_from_int8,
+    _quantize_w4a8_chunked,
+    validate_w4a8_operands,
+    validate_w4a8_weight_shape,
+)
+
 
 def _validate_attention_scale(scale: object, default: float) -> float:
     """Normalize the public HIP attention scale contract."""
@@ -48,21 +64,6 @@ def _validate_attention_scale(scale: object, default: float) -> float:
         raise ValueError(f"scale must be finite, got {value}")
     return value
 
-from comfy_kitchen._rope_utils import check_rope_inplace, trim_rope_freqs
-from comfy_kitchen.backends import eager as _eager
-from comfy_kitchen.backends._activations import apply_input_act as _apply_input_act
-from comfy_kitchen.backends._activations import input_act_code as _input_act_code
-from comfy_kitchen.backends._activations import input_act_width as _input_act_width
-from comfy_kitchen.backends.eager import rope as _eager_rope
-from comfy_kitchen.backends.eager.quantization import DTYPE_CODE_TO_DTYPE, DTYPE_TO_CODE
-from comfy_kitchen.backends.eager.w4a8_int8 import (
-    _QUANT_ROW_ELEM_BUDGET,
-    _decide_codebook,
-    _dequantize_w4a8_int8_weight_from_int8,
-    _quantize_w4a8_chunked,
-    validate_w4a8_operands,
-    validate_w4a8_weight_shape,
-)
 
 logger = logging.getLogger("comfy_kitchen.hip")
 
@@ -852,13 +853,14 @@ def int8_linear(
                 convrot_groupsize, input_act, _weight_tile_k, _dual_m,
             )
             return torch.addcmul(_residual, _gate, projected)
-    if _weight_tile_k:
-        if (not _tiled_b_supported(x, m, n, k, out_dtype, _weight_tile_k)
-                or input_act is not None):
-            raise ValueError(
-                "tiled-B INT8 linear requires non-duplicated WMMA BF16, M>=96, "
-                "N divisible by 128, K divisible by tile_k, and no input activation"
-            )
+    if _weight_tile_k and (
+        not _tiled_b_supported(x, m, n, k, out_dtype, _weight_tile_k)
+        or input_act is not None
+    ):
+        raise ValueError(
+            "tiled-B INT8 linear requires non-duplicated WMMA BF16, M>=96, "
+            "N divisible by 128, K divisible by tile_k, and no input activation"
+        )
     # The WMMA K-step and the small-M GEMV both read a row 16 bytes at a time.
     if k % 16 != 0:
         raise ValueError(f"int8_linear requires K divisible by 16, got {k}")

--- a/comfy_kitchen/backends/hip/__init__.py
+++ b/comfy_kitchen/backends/hip/__init__.py
@@ -267,9 +267,10 @@ def _has_wmma(arches: Sequence[str | None]) -> bool:
         return False
     if not all(a in _ARCH_WMMA for a in arches):
         return False
-    if any(a in _ARCH_WMMA_GFX117 for a in arches) and not _GFX117_WMMA_POLICIES_READY:
-        return False
-    return True
+    return not (
+        any(a in _ARCH_WMMA_GFX117 for a in arches)
+        and not _GFX117_WMMA_POLICIES_READY
+    )
 
 
 def is_available() -> bool:
@@ -646,12 +647,21 @@ def _rotate_quant_int8(
 
         workspace_per_row = x_arg.element_size() * k + 4 * (k // 256)
         row_cap = max(1, _CONVROT_SPILL_WORKSPACE_BYTES // workspace_per_row)
-        chunk_count = (m + row_cap - 1) // row_cap
+        capacity_chunk_count = (m + row_cap - 1) // row_cap
         # The native policy chooses the exact global implementation for wide
         # chunks of at least 96 rows. Balance chunks so a short final slice does
         # not switch to the otherwise-equivalent one-wave LDS schedule, whose
-        # activation rounding can differ at quantization boundaries.
-        chunk_count = min(chunk_count, max(1, m // 96))
+        # activation rounding can differ at quantization boundaries. Keep the
+        # capacity-safe count when rebalancing would exceed the workspace cap.
+        balanced_chunk_count = min(capacity_chunk_count, max(1, m // 96))
+        balanced_chunk_rows = (
+            m + balanced_chunk_count - 1
+        ) // balanced_chunk_count
+        chunk_count = (
+            balanced_chunk_count
+            if balanced_chunk_rows <= row_cap
+            else capacity_chunk_count
+        )
         chunk_rows = (m + chunk_count - 1) // chunk_count
         spill_rotated = torch.empty(
             (chunk_rows, k), dtype=x_arg.dtype, device=x2d.device
@@ -856,8 +866,18 @@ def int8_linear(
             raise ValueError(
                 f"residual shape must be {expected}, got {tuple(_residual.shape)}"
             )
-        if _gate.numel() != n:
-            raise ValueError(f"gate must contain N={n} elements")
+        gate_shape = tuple(_gate.shape)
+        if (
+            not gate_shape
+            or gate_shape[-1] != n
+            or _gate.numel() != n
+            or len(gate_shape) > len(expected)
+            or any(size != 1 for size in gate_shape[:-1])
+        ):
+            raise ValueError(
+                f"gate must be one broadcastable row ending in N={n}, "
+                f"got {gate_shape}"
+            )
         native_gated = (
             _weight_tile_k in (64, 128)
             and _tiled_b_supported(x, m, n, k, out_dtype, _weight_tile_k)

--- a/comfy_kitchen/backends/hip/__init__.py
+++ b/comfy_kitchen/backends/hip/__init__.py
@@ -584,7 +584,8 @@ def _rotate_quant_int8(
             m, k, DTYPE_TO_CODE[x2d.dtype]
         ):
             _C.quantize_int8_convrot(
-                _dl(x_arg), _dl(q), _dl(scales), None, None, m, k,
+                _dl(_aligned(x_arg)), _dl(_aligned(q)), _dl(_aligned(scales)),
+                None, None, m, k,
                 group_size, _input_act_code(input_act), _stream(x2d),
             )
             return q, scales
@@ -609,9 +610,9 @@ def _rotate_quant_int8(
             rows = m // chunk_count + (chunk < m % chunk_count)
             end = start + rows
             _C.quantize_int8_convrot(
-                _dl(x_arg[start:end]),
-                _dl(q[start:end]),
-                _dl(scales[start:end]),
+                _dl(_aligned(x_arg[start:end])),
+                _dl(_aligned(q[start:end])),
+                _dl(_aligned(scales[start:end])),
                 _dl(spill_rotated),
                 _dl(spill_partials),
                 rows,
@@ -633,7 +634,8 @@ def _rotate_quant_int8_modulated(
     scales = torch.empty((m,), dtype=torch.float32, device=x2d.device)
     with torch.cuda.device(x2d.device):
         _C.quantize_int8_convrot_modulated(
-            _dl(x2d), _dl(modulation_scale), _dl(q), _dl(scales),
+            _dl(_aligned(x2d)), _dl(_aligned(modulation_scale)),
+            _dl(_aligned(q)), _dl(_aligned(scales)),
             m, k, group_size, _stream(x2d),
         )
     return q, scales
@@ -651,8 +653,9 @@ def _rotate_quant_int8_affine(
     scales = torch.empty((m,), dtype=torch.float32, device=x2d.device)
     with torch.cuda.device(x2d.device):
         _C.quantize_int8_convrot_affine(
-            _dl(x2d), _dl(modulation_scale), _dl(modulation_shift),
-            _dl(q), _dl(scales), m, k, group_size, _stream(x2d),
+            _dl(_aligned(x2d)), _dl(_aligned(modulation_scale)),
+            _dl(_aligned(modulation_shift)), _dl(_aligned(q)),
+            _dl(_aligned(scales)), m, k, group_size, _stream(x2d),
         )
     return q, scales
 
@@ -670,8 +673,9 @@ def _rotate_quant_int8_rms_modulated(
     scales = torch.empty((m,), dtype=torch.float32, device=x2d.device)
     with torch.cuda.device(x2d.device):
         _C.quantize_int8_convrot_rms_modulated_fused_stats(
-            _dl(x2d), _dl(norm_weight), _dl(modulation_scale),
-            _dl(q), _dl(scales), m, k, group_size, norm_eps, _stream(x2d),
+            _dl(_aligned(x2d)), _dl(_aligned(norm_weight)),
+            _dl(_aligned(modulation_scale)), _dl(_aligned(q)),
+            _dl(_aligned(scales)), m, k, group_size, norm_eps, _stream(x2d),
         )
     return q, scales
 
@@ -686,7 +690,8 @@ def _rotate_quant_int8_swiglu_split_tiled128(
     scales = torch.empty((m,), dtype=torch.float32, device=gate2d.device)
     with torch.cuda.device(gate2d.device):
         _C.quantize_int8_convrot_swiglu_split_tiled128(
-            _dl(gate2d), _dl(up2d), _dl(q), _dl(scales),
+            _dl(_aligned(gate2d)), _dl(_aligned(up2d)),
+            _dl(_aligned(q)), _dl(_aligned(scales)),
             m, k, group_size, _stream(gate2d),
         )
     return q, scales
@@ -801,6 +806,7 @@ def int8_linear(
             raise ValueError(f"gate must contain N={n} elements")
         native_gated = (
             _weight_tile_k in (64, 128)
+            and _tiled_b_supported(x, m, n, k, out_dtype, _weight_tile_k)
             and input_act is None
             and out_dtype == torch.bfloat16
             and x.dtype == torch.bfloat16
@@ -959,8 +965,9 @@ def rms_gated_residual(
     gate_1d = gate.reshape(-1).contiguous()
     output = torch.empty_like(activation_2d)
     _C.rms_gated_residual_bf16(
-        _dl(activation_2d), _dl(norm_weight_1d), _dl(residual_2d),
-        _dl(gate_1d), _dl(output), activation_2d.shape[0], width,
+        _dl(_aligned(activation_2d)), _dl(_aligned(norm_weight_1d)),
+        _dl(_aligned(residual_2d)), _dl(_aligned(gate_1d)), _dl(output),
+        activation_2d.shape[0], width,
         float(eps), _stream(activation),
     )
     return output.reshape(shape)
@@ -1244,6 +1251,12 @@ def _int8_linear_pair_impl(
         if not _convrot_supported(
             k, convrot_groupsize, x.device, x.dtype, int8_global_spill=True
         ):
+            if any(value is not None for value in (
+                modulation_scale, modulation_shift, norm_weight
+            )):
+                raise ValueError(
+                    "Unsupported ConvRot pair fallback does not support modulation"
+                )
             return _eager.int8_linear_pair(
                 x, weight0, weight1, weight_scale0, weight_scale1,
                 bias0, bias1, out_dtype, convrot, convrot_groupsize,

--- a/comfy_kitchen/backends/hip/__init__.py
+++ b/comfy_kitchen/backends/hip/__init__.py
@@ -18,12 +18,35 @@ import importlib.util
 import json
 import logging
 import math
+import numbers
 import os
 import pathlib
 import sys
 from collections.abc import Sequence
 
 import torch
+
+
+def _validate_attention_scale(scale: object, default: float) -> float:
+    """Normalize the public HIP attention scale contract."""
+    if scale is None:
+        return default
+    if isinstance(scale, torch.Tensor):
+        if scale.numel() != 1:
+            raise ValueError(f"scale must be a scalar, got shape {tuple(scale.shape)}")
+        if scale.is_complex():
+            raise TypeError(f"scale must be a real numeric scalar, got {scale.dtype}")
+        try:
+            value = float(scale.item())
+        except (TypeError, ValueError, RuntimeError) as error:
+            raise TypeError(f"scale must be a real numeric scalar, got {scale.dtype}") from error
+    elif isinstance(scale, numbers.Real) and not isinstance(scale, bool):
+        value = float(scale)
+    else:
+        raise TypeError(f"scale must be a real numeric scalar, got {type(scale).__name__}")
+    if not math.isfinite(value):
+        raise ValueError(f"scale must be finite, got {value}")
+    return value
 
 from comfy_kitchen._rope_utils import check_rope_inplace, trim_rope_freqs
 from comfy_kitchen.backends import eager as _eager
@@ -2484,7 +2507,7 @@ def hip_attention(
         device=q.device,
         dtype=q.dtype,
     ).movedim(1, 2)
-    resolved_scale = float(scale if scale is not None else 1.0 / math.sqrt(q.shape[3]))
+    resolved_scale = _validate_attention_scale(scale, 1.0 / math.sqrt(q.shape[3]))
     _C.bf16_sdpa_hip(
         _dl(q), _dl(k), _dl(v), _dl(output), resolved_scale, _stream(q)
     )
@@ -2515,6 +2538,7 @@ def hip_int8_attention(
     scale: float,
 ) -> torch.Tensor:
     """Run INT8 attention, retaining BF16 for overhead-bound short calls."""
+    scale = _validate_attention_scale(scale, 1.0 / math.sqrt(q.shape[3]))
     # Capability is checked by the public caller; any supported sub-1024 or
     # multi-batch contract is one of the measured BF16 short routes.
     if q.shape[0] > 1 or q.shape[2] < 1024:
@@ -3388,6 +3412,7 @@ def sage_int8_sdpa(
 ) -> torch.Tensor:
     """Quantize and attend in one call. q, k and v are already padded to a
     supported head dimension; the output keeps that width."""
+    attention_scale = _validate_attention_scale(attention_scale, 1.0)
     batch, q_heads, q_length, head_dim = q.shape
     output_dtype = torch.bfloat16 if q.dtype == torch.float32 else q.dtype
     output = torch.empty(
@@ -3459,6 +3484,7 @@ def sage_int8_attend(
     cta_k: int = _SAGE_CTA_K,
 ) -> torch.Tensor:
     """Attend over the packed layouts sage_int8_quantize produced."""
+    attention_scale = _validate_attention_scale(attention_scale, 1.0)
     batch, q_heads, q_length, head_dim = q_int8.shape
     output = torch.empty(
         batch, q_heads, q_length, head_dim, dtype=output_dtype, device=q_int8.device

--- a/comfy_kitchen/backends/hip/__init__.py
+++ b/comfy_kitchen/backends/hip/__init__.py
@@ -17,6 +17,7 @@ import functools
 import importlib.util
 import json
 import logging
+import math
 import os
 import pathlib
 import sys
@@ -47,6 +48,7 @@ __all__ = [
     "na3d",
     "rms_adaln",
     "gemv_awq_w4a16",
+    "rms_gated_residual",
     "quantize_svdquant_w4a4",
     "scaled_mm_svdquant_w4a4",
     "apply_rope",
@@ -65,9 +67,18 @@ __all__ = [
     "dequantize_w4a8_int8_weight",
     "has_wmma",
     "int8_linear",
+    "int8_linear_gated_residual",
+    "int8_linear_tiled_b",
     "int8_attention_is_available",
     "flash_attention_decode_is_available",
     "flash_decode",
+    "int8_linear_modulated",
+    "int8_linear_rms_modulated",
+    "int8_linear_pair",
+    "int8_linear_pair_modulated",
+    "int8_linear_triple_modulated",
+    "int8_linear_pair_rms_modulated",
+    "int8_linear_swiglu_split",
     "is_available",
     "sage_int8_attend",
     "sage_int8_quantize",
@@ -161,6 +172,11 @@ _ARCH_WMMA_GFX12 = frozenset(_ARCH_GROUPS["wmma_gfx12"])
 _ARCH_WMMA = _ARCH_WMMA_GFX11 | _ARCH_WMMA_GFX12
 _ARCH_SUPPORTED = _ARCH_ELEMENTWISE_ONLY | _ARCH_WMMA
 
+
+def _has_nonduplicated_wmma(device: torch.device | int | None = None) -> bool:
+    """Whether WMMA operands use the gfx12 128-bit layout."""
+    return _gfx_arch(device) in _ARCH_WMMA_GFX12
+
 # The GEMMs, and only the GEMMs, need matrix cores. Everything else is elementwise
 # or a scalar reduction and runs on any supported architecture. This set names the
 # registry-dispatched GEMMs so _build_constraints can drop them on RDNA2; the fp8
@@ -168,6 +184,15 @@ _ARCH_SUPPORTED = _ARCH_ELEMENTWISE_ONLY | _ARCH_WMMA
 # which gates on has_wmma() itself rather than through the registry.
 _WMMA_ONLY_OPS = frozenset({
     "int8_linear",
+    "int8_linear_gated_residual",
+    "int8_linear_tiled_b",
+    "int8_linear_modulated",
+    "int8_linear_rms_modulated",
+    "int8_linear_pair",
+    "int8_linear_pair_modulated",
+    "int8_linear_triple_modulated",
+    "int8_linear_pair_rms_modulated",
+    "int8_linear_swiglu_split",
     "na3d",
     "convrot_w4a4_linear",
     "scaled_mm_svdquant_w4a4",
@@ -511,6 +536,7 @@ def dequantize_int8_convrot_weight_dtype(
 # Keyed by device and dtype: convrot_max_k() reports the LDS budget of whichever
 # device is current and FP32 rows consume twice the LDS of FP16/BF16 rows.
 _convrot_max_k: dict[tuple[int, torch.dtype], int] = {}
+_CONVROT_SPILL_WORKSPACE_BYTES = 32 << 20
 
 
 def _convrot_supported(
@@ -551,27 +577,134 @@ def _rotate_quant_int8(
     q = torch.empty((m, k), dtype=torch.int8, device=x2d.device)
     scales = torch.empty((m,), dtype=torch.float32, device=x2d.device)
     x_arg = _operand(x2d, x2d.device, "x2d")
-    spill_rotated = None
-    spill_partials = None
     # check_convrot_k queries the current device's LDS budget, so pin it to the
     # operand's device rather than trusting the caller thread's current device.
     with torch.cuda.device(x2d.device):
-        if group_size == 256 and _C.convrot_int8_needs_spill(m, k, DTYPE_TO_CODE[x2d.dtype]):
-            spill_rotated = torch.empty((m, k), dtype=x2d.dtype, device=x2d.device)
-            spill_partials = torch.empty((m, k // 256), dtype=torch.float32, device=x2d.device)
-        _C.quantize_int8_convrot(
-            _dl(x_arg),
-            _dl(q),
-            _dl(scales),
-            None if spill_rotated is None else _dl(spill_rotated),
-            None if spill_partials is None else _dl(spill_partials),
-            m,
-            k,
-            group_size,
-            _input_act_code(input_act),
-            _stream(x2d),
+        if group_size != 256 or not _C.convrot_int8_needs_spill(
+            m, k, DTYPE_TO_CODE[x2d.dtype]
+        ):
+            _C.quantize_int8_convrot(
+                _dl(x_arg), _dl(q), _dl(scales), None, None, m, k,
+                group_size, _input_act_code(input_act), _stream(x2d),
+            )
+            return q, scales
+
+        workspace_per_row = x_arg.element_size() * k + 4 * (k // 256)
+        row_cap = max(1, _CONVROT_SPILL_WORKSPACE_BYTES // workspace_per_row)
+        chunk_count = (m + row_cap - 1) // row_cap
+        # The native policy chooses the exact global implementation for wide
+        # chunks of at least 96 rows. Balance chunks so a short final slice does
+        # not switch to the otherwise-equivalent one-wave LDS schedule, whose
+        # activation rounding can differ at quantization boundaries.
+        chunk_count = min(chunk_count, max(1, m // 96))
+        chunk_rows = (m + chunk_count - 1) // chunk_count
+        spill_rotated = torch.empty(
+            (chunk_rows, k), dtype=x_arg.dtype, device=x2d.device
+        )
+        spill_partials = torch.empty(
+            (chunk_rows, k // 256), dtype=torch.float32, device=x2d.device
+        )
+        start = 0
+        for chunk in range(chunk_count):
+            rows = m // chunk_count + (chunk < m % chunk_count)
+            end = start + rows
+            _C.quantize_int8_convrot(
+                _dl(x_arg[start:end]),
+                _dl(q[start:end]),
+                _dl(scales[start:end]),
+                _dl(spill_rotated),
+                _dl(spill_partials),
+                rows,
+                k,
+                group_size,
+                _input_act_code(input_act),
+                _stream(x2d),
+            )
+            start = end
+    return q, scales
+
+
+def _rotate_quant_int8_modulated(
+    x2d: torch.Tensor, modulation_scale: torch.Tensor, group_size: int
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Fold exact twice-rounded BF16 batch-one modulation into ConvRot."""
+    m, k = x2d.shape
+    q = torch.empty((m, k), dtype=torch.int8, device=x2d.device)
+    scales = torch.empty((m,), dtype=torch.float32, device=x2d.device)
+    with torch.cuda.device(x2d.device):
+        _C.quantize_int8_convrot_modulated(
+            _dl(x2d), _dl(modulation_scale), _dl(q), _dl(scales),
+            m, k, group_size, _stream(x2d),
         )
     return q, scales
+
+
+def _rotate_quant_int8_affine(
+    x2d: torch.Tensor,
+    modulation_scale: torch.Tensor,
+    modulation_shift: torch.Tensor,
+    group_size: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Fold exact BF16 shift-and-scale modulation into generic ConvRot."""
+    m, k = x2d.shape
+    q = torch.empty((m, k), dtype=torch.int8, device=x2d.device)
+    scales = torch.empty((m,), dtype=torch.float32, device=x2d.device)
+    with torch.cuda.device(x2d.device):
+        _C.quantize_int8_convrot_affine(
+            _dl(x2d), _dl(modulation_scale), _dl(modulation_shift),
+            _dl(q), _dl(scales), m, k, group_size, _stream(x2d),
+        )
+    return q, scales
+
+
+def _rotate_quant_int8_rms_modulated(
+    x2d: torch.Tensor,
+    norm_weight: torch.Tensor,
+    norm_eps: float,
+    modulation_scale: torch.Tensor,
+    group_size: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Fold exact BF16 RMSNorm and modulation into the ConvRot producer."""
+    m, k = x2d.shape
+    q = torch.empty((m, k), dtype=torch.int8, device=x2d.device)
+    scales = torch.empty((m,), dtype=torch.float32, device=x2d.device)
+    with torch.cuda.device(x2d.device):
+        _C.quantize_int8_convrot_rms_modulated_fused_stats(
+            _dl(x2d), _dl(norm_weight), _dl(modulation_scale),
+            _dl(q), _dl(scales), m, k, group_size, norm_eps, _stream(x2d),
+        )
+    return q, scales
+
+
+def _rotate_quant_int8_swiglu_split_tiled128(
+    gate2d: torch.Tensor, up2d: torch.Tensor, group_size: int
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Apply exact BF16 SwiGLU while emitting the down GEMM's tiled INT8 A."""
+    m, k = gate2d.shape
+    padded_m = (m + 127) // 128 * 128
+    q = torch.empty((padded_m, k), dtype=torch.int8, device=gate2d.device)
+    scales = torch.empty((m,), dtype=torch.float32, device=gate2d.device)
+    with torch.cuda.device(gate2d.device):
+        _C.quantize_int8_convrot_swiglu_split_tiled128(
+            _dl(gate2d), _dl(up2d), _dl(q), _dl(scales),
+            m, k, group_size, _stream(gate2d),
+        )
+    return q, scales
+
+
+def _tiled_b_supported(
+    x: torch.Tensor, m: int, n: int, k: int,
+    out_dtype: torch.dtype, tile_k: int,
+) -> bool:
+    return (
+        _has_nonduplicated_wmma(x.device)
+        and x.dtype == torch.bfloat16
+        and out_dtype == torch.bfloat16
+        and m >= 96
+        and n % 128 == 0
+        and tile_k in (64, 128)
+        and k % tile_k == 0
+    )
 
 
 def quantize_and_rotate_rowwise(
@@ -628,6 +761,10 @@ def int8_linear(
     convrot: bool = False,
     convrot_groupsize: int = 256,
     input_act: str | None = None,
+    _weight_tile_k: int = 0,
+    _dual_m: bool = False,
+    _residual: torch.Tensor | None = None,
+    _gate: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """INT8 linear with dynamic row-wise activation quantization, on WMMA."""
     # Rejected here so every route fails the same way, not just the fused one.
@@ -651,7 +788,40 @@ def int8_linear(
     m = x2d.shape[0]
     k = k_act
     n = weight.shape[0]
-
+    gated = _residual is not None or _gate is not None
+    if gated:
+        if _residual is None or _gate is None:
+            raise ValueError("residual and gate must be provided together")
+        expected = (*orig_shape[:-1], n)
+        if tuple(_residual.shape) != expected:
+            raise ValueError(
+                f"residual shape must be {expected}, got {tuple(_residual.shape)}"
+            )
+        if _gate.numel() != n:
+            raise ValueError(f"gate must contain N={n} elements")
+        native_gated = (
+            _weight_tile_k in (64, 128)
+            and input_act is None
+            and out_dtype == torch.bfloat16
+            and x.dtype == torch.bfloat16
+            and _residual.dtype == torch.bfloat16
+            and _gate.dtype == torch.bfloat16
+            and _residual.device == x.device
+            and _gate.device == x.device
+        )
+        if not native_gated:
+            projected = int8_linear(
+                x, weight, weight_scale, bias, out_dtype, convrot,
+                convrot_groupsize, input_act, _weight_tile_k, _dual_m,
+            )
+            return torch.addcmul(_residual, _gate, projected)
+    if _weight_tile_k:
+        if (not _tiled_b_supported(x, m, n, k, out_dtype, _weight_tile_k)
+                or input_act is not None):
+            raise ValueError(
+                "tiled-B INT8 linear requires non-duplicated WMMA BF16, M>=96, "
+                "N divisible by 128, K divisible by tile_k, and no input activation"
+            )
     # The WMMA K-step and the small-M GEMV both read a row 16 bytes at a time.
     if k % 16 != 0:
         raise ValueError(f"int8_linear requires K divisible by 16, got {k}")
@@ -670,7 +840,6 @@ def int8_linear(
                 x, weight, weight_scale, bias, out_dtype, convrot, convrot_groupsize,
                 input_act=input_act,
             )
-        # The only route that absorbs the activation; the rest apply it eagerly.
         q, x_scale = _rotate_quant_int8(x2d, convrot_groupsize, input_act)
     else:
         x2d = _apply_input_act(x2d, input_act)
@@ -683,13 +852,836 @@ def int8_linear(
         bias = _bias_operand(bias, n, x.device)
 
     out = torch.empty((m, n), dtype=out_dtype, device=x.device)
-    _C.int8_gemm(
-        _dl(q), _dl(weight), _dl(out),
-        _dl(x_scale), _dl(weight_scale), 0 if weight_scale.numel() == 1 else 1,
-        None if bias is None else _dl(bias),
-        m, n, k, DTYPE_TO_CODE[out_dtype], _stream(x),
-    )
+    if gated:
+        residual2d = _residual.reshape(m, n).contiguous()
+        gate1d = _gate.reshape(n).contiguous()
+        _C.int8_gemm_b_tiled_gated_residual(
+            _dl(q), _dl(weight), _dl(out), _dl(x_scale), _dl(weight_scale),
+            0 if weight_scale.numel() == 1 else 1,
+            None if bias is None else _dl(bias), _dl(residual2d), _dl(gate1d),
+            m, n, k, _weight_tile_k, _dual_m, _stream(x),
+        )
+        return out.reshape(*orig_shape[:-1], n)
+    if _weight_tile_k:
+        gemm = _C.int8_gemm_b_tiled
+    else:
+        gemm = _C.int8_gemm
+    gemm_args = [
+        _dl(q), _dl(weight), _dl(out), _dl(x_scale), _dl(weight_scale),
+        0 if weight_scale.numel() == 1 else 1,
+        None if bias is None else _dl(bias), m, n, k,
+        DTYPE_TO_CODE[out_dtype],
+    ]
+    if _weight_tile_k:
+        gemm_args.extend((_weight_tile_k, _dual_m))
+    gemm_args.append(_stream(x))
+    gemm(*gemm_args)
     return out.reshape(*orig_shape[:-1], n)
+
+
+def int8_linear_gated_residual(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    residual: torch.Tensor,
+    gate: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    out_dtype: torch.dtype = torch.bfloat16,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+    input_act: str | None = None,
+    weight_tile_k: int = 0,
+    dual_m: bool = False,
+) -> torch.Tensor:
+    """INT8 linear followed by exact BF16 ``residual + gate * linear``."""
+    return int8_linear(
+        x, weight, weight_scale, bias, out_dtype, convrot,
+        convrot_groupsize, input_act, weight_tile_k, dual_m,
+        residual, gate,
+    )
+
+
+def int8_linear_tiled_b(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    out_dtype: torch.dtype = torch.bfloat16,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+    tile_k: int = 64,
+    dual_m: bool = True,
+) -> torch.Tensor:
+    """INT8 linear for a 128-by-``tile_k`` physically tiled weight."""
+    return int8_linear(
+        x, weight, weight_scale, bias, out_dtype, convrot,
+        convrot_groupsize, _weight_tile_k=tile_k, _dual_m=dual_m,
+    )
+
+
+def rms_gated_residual(
+    activation: torch.Tensor,
+    norm_weight: torch.Tensor,
+    residual: torch.Tensor,
+    gate: torch.Tensor,
+    eps: float = 1.0e-5,
+) -> torch.Tensor:
+    """Exact BF16 RMSNorm, gate multiplication, and residual add."""
+    use_fused = (
+        activation.dtype == torch.bfloat16
+        and norm_weight.dtype == torch.bfloat16
+        and residual.dtype == torch.bfloat16
+        and gate.dtype == torch.bfloat16
+        and activation.device == norm_weight.device == residual.device == gate.device
+        and activation.ndim == 3
+        and activation.shape[0] == 1
+        and activation.shape == residual.shape
+        and activation.shape[-1] > 0
+        and activation.shape[-1] % 4 == 0
+        and activation.shape[-1] <= _C.convrot_max_k(DTYPE_TO_CODE[activation.dtype])
+        and norm_weight.numel() == activation.shape[-1]
+        and gate.numel() == activation.shape[-1]
+    )
+    if not use_fused:
+        return _eager.rms_gated_residual(
+            activation, norm_weight, residual, gate, eps
+        )
+
+    shape = activation.shape
+    width = activation.shape[-1]
+    activation_2d = activation.reshape(-1, width).contiguous()
+    norm_weight_1d = norm_weight.reshape(-1).contiguous()
+    residual_2d = residual.reshape(-1, width).contiguous()
+    gate_1d = gate.reshape(-1).contiguous()
+    output = torch.empty_like(activation_2d)
+    _C.rms_gated_residual_bf16(
+        _dl(activation_2d), _dl(norm_weight_1d), _dl(residual_2d),
+        _dl(gate_1d), _dl(output), activation_2d.shape[0], width,
+        float(eps), _stream(activation),
+    )
+    return output.reshape(shape)
+
+
+def int8_linear_modulated(
+    x: torch.Tensor,
+    modulation_scale: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    out_dtype: torch.dtype = torch.bfloat16,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+    weight_tiled_b: bool = False,
+    modulation_shift: torch.Tensor | None = None,
+    weight_tile_k: int = 0,
+) -> torch.Tensor:
+    """INT8 projection with batch-one BF16 modulation in its ConvRot load."""
+    k = x.shape[-1]
+    if k != weight.shape[-1]:
+        raise ValueError(
+            f"Input and weight inner dimensions must match, got {k} and {weight.shape[-1]}"
+        )
+    if modulation_scale.numel() != k:
+        raise ValueError(
+            f"modulation_scale must contain one batch-one row of {k} values, "
+            f"got {modulation_scale.numel()}"
+        )
+
+    modulation_scale = modulation_scale.to(device=x.device).reshape(-1).contiguous()
+    if modulation_shift is not None:
+        if modulation_shift.numel() != k:
+            raise ValueError(
+                f"modulation_shift must contain one batch-one row of {k} values, "
+                f"got {modulation_shift.numel()}"
+            )
+        modulation_shift = (
+            modulation_shift.to(device=x.device).reshape(-1).contiguous()
+        )
+    orig_shape = x.shape
+    x2d = x.reshape(-1, k).contiguous()
+    m = x2d.shape[0]
+    n = weight.shape[0]
+    if weight_tiled_b and weight_tile_k:
+        raise ValueError("Only one tiled-B layout may be selected")
+    if weight_tile_k and not _tiled_b_supported(
+        x, m, n, k, out_dtype, weight_tile_k
+    ):
+        raise ValueError(
+            "tiled-B INT8 linear requires non-duplicated WMMA BF16, M>=96, "
+            "N divisible by 128, and K divisible by tile_k"
+        )
+    use_affine_fused = (
+        modulation_shift is not None
+        and x2d.dtype == torch.bfloat16
+        and modulation_scale.dtype == torch.bfloat16
+        and modulation_shift.dtype == torch.bfloat16
+        and out_dtype == torch.bfloat16
+        and convrot
+        and convrot_groupsize == 256
+        and not _C.convrot_int8_needs_spill(m, k, DTYPE_TO_CODE[x2d.dtype])
+    )
+    use_scale_fused = (
+        modulation_shift is None
+        and _has_nonduplicated_wmma(x.device)
+        and x2d.dtype == torch.bfloat16
+        and modulation_scale.dtype == torch.bfloat16
+        and out_dtype == torch.bfloat16
+        and convrot
+        and convrot_groupsize == 256
+        and k == 3840
+        and n == 11520
+    )
+    use_fused = use_affine_fused or use_scale_fused
+    if not use_fused:
+        if weight_tiled_b or weight_tile_k:
+            raise ValueError(
+                "WMMA-tiled weight is only valid for a fused modulation path"
+            )
+        scale_shape = (1,) * (x.ndim - 1) + (k,)
+        scale = modulation_scale.reshape(scale_shape)
+        if modulation_shift is None:
+            modulated = x * (1.0 + scale)
+        else:
+            modulated = torch.addcmul(
+                modulation_shift.reshape(scale_shape), x, 1.0 + scale
+            )
+        return int8_linear(
+            modulated, weight, weight_scale, bias, out_dtype,
+            convrot, convrot_groupsize,
+        )
+
+    weight = _aligned(weight.to(device=x.device).contiguous())
+    weight_scale = weight_scale.to(device=x.device, dtype=torch.float32).reshape(-1)
+    if weight_scale.numel() not in (1, n):
+        raise ValueError(
+            f"INT8 weight scale must be scalar or per-output-channel, got "
+            f"{tuple(weight_scale.shape)}"
+        )
+    if bias is not None:
+        bias = _bias_operand(bias, n, x.device)
+
+    if modulation_shift is None:
+        q, x_scale = _rotate_quant_int8_modulated(
+            x2d, modulation_scale, convrot_groupsize
+        )
+    else:
+        q, x_scale = _rotate_quant_int8_affine(
+            x2d, modulation_scale, modulation_shift, convrot_groupsize
+        )
+    out = torch.empty((m, n), dtype=out_dtype, device=x.device)
+    gemm_args = [
+        _dl(q), _dl(weight), _dl(out), _dl(x_scale), _dl(weight_scale),
+        0 if weight_scale.numel() == 1 else 1,
+        None if bias is None else _dl(bias),
+        m, n, k, DTYPE_TO_CODE[out_dtype],
+    ]
+    if weight_tile_k:
+        _C.int8_gemm_b_tiled(
+            *gemm_args, weight_tile_k, m >= 96, _stream(x)
+        )
+    elif weight_tiled_b:
+        _C.int8_gemm_b_tiled(*gemm_args, 64, True, _stream(x))
+    else:
+        _C.int8_gemm(*gemm_args, _stream(x))
+    return out.reshape(*orig_shape[:-1], n)
+
+
+def int8_linear_rms_modulated(
+    x: torch.Tensor,
+    norm_weight: torch.Tensor,
+    norm_eps: float,
+    modulation_scale: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    out_dtype: torch.dtype = torch.bfloat16,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+    weight_tiled_b: bool = False,
+) -> torch.Tensor:
+    """INT8 QKV projection with exact RMSNorm and modulation in ConvRot."""
+    k = x.shape[-1]
+    if k != weight.shape[-1]:
+        raise ValueError(
+            f"Input and weight inner dimensions must match, got {k} and {weight.shape[-1]}"
+        )
+    if norm_weight.numel() != k or modulation_scale.numel() != k:
+        raise ValueError(
+            f"norm_weight and modulation_scale must each contain {k} values"
+        )
+
+    norm_weight = norm_weight.to(device=x.device).reshape(-1).contiguous()
+    modulation_scale = modulation_scale.to(device=x.device).reshape(-1).contiguous()
+    orig_shape = x.shape
+    x2d = x.reshape(-1, k).contiguous()
+    m = x2d.shape[0]
+    n = weight.shape[0]
+    use_fused = (
+        _has_nonduplicated_wmma(x.device)
+        and x2d.dtype == torch.bfloat16
+        and norm_weight.dtype == torch.bfloat16
+        and modulation_scale.dtype == torch.bfloat16
+        and out_dtype == torch.bfloat16
+        and convrot
+        and convrot_groupsize == 256
+        and k == 3840
+        and n == 11520
+    )
+    if not use_fused:
+        if weight_tiled_b:
+            raise ValueError(
+                "WMMA-tiled QKV weight is only valid for its fused WMMA path"
+            )
+        normalized = torch.nn.functional.rms_norm(
+            x, (k,), norm_weight, norm_eps
+        )
+        return int8_linear_modulated(
+            normalized, modulation_scale, weight, weight_scale, bias,
+            out_dtype, convrot, convrot_groupsize, weight_tiled_b,
+        )
+
+    weight = _aligned(weight.to(device=x.device).contiguous())
+    weight_scale = weight_scale.to(
+        device=x.device, dtype=torch.float32
+    ).reshape(-1)
+    if weight_scale.numel() not in (1, n):
+        raise ValueError(
+            f"INT8 weight scale must be scalar or per-output-channel, got "
+            f"{tuple(weight_scale.shape)}"
+        )
+    if bias is not None:
+        bias = _bias_operand(bias, n, x.device)
+
+    q, x_scale = _rotate_quant_int8_rms_modulated(
+        x2d, norm_weight, norm_eps, modulation_scale, convrot_groupsize
+    )
+    out = torch.empty((m, n), dtype=out_dtype, device=x.device)
+    gemm_args = [
+        _dl(q), _dl(weight), _dl(out), _dl(x_scale), _dl(weight_scale),
+        0 if weight_scale.numel() == 1 else 1,
+        None if bias is None else _dl(bias),
+        m, n, k, DTYPE_TO_CODE[out_dtype],
+    ]
+    if weight_tiled_b:
+        _C.int8_gemm_b_tiled(*gemm_args, 64, True, _stream(x))
+    else:
+        _C.int8_gemm(*gemm_args, _stream(x))
+    return out.reshape(*orig_shape[:-1], n)
+
+
+def _int8_linear_pair_impl(
+    x: torch.Tensor,
+    weight0: torch.Tensor,
+    weight1: torch.Tensor,
+    weight_scale0: torch.Tensor,
+    weight_scale1: torch.Tensor,
+    bias0: torch.Tensor | None = None,
+    bias1: torch.Tensor | None = None,
+    out_dtype: torch.dtype = torch.bfloat16,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+    modulation_scale: torch.Tensor | None = None,
+    norm_weight: torch.Tensor | None = None,
+    norm_eps: float = 0.0,
+    weight_tile_k: int = 0,
+    modulation_shift: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Two INT8 linears sharing one row-wise activation quantization."""
+    if weight0.shape != weight1.shape or weight0.ndim != 2:
+        raise ValueError(
+            f"paired INT8 weights must have the same 2D shape, got "
+            f"{tuple(weight0.shape)} and {tuple(weight1.shape)}"
+        )
+    if x.shape[-1] != weight0.shape[-1]:
+        raise ValueError(
+            f"Input and weight inner dimensions must match, got {x.shape[-1]} "
+            f"and {weight0.shape[-1]}"
+        )
+    weight0 = _aligned(weight0.to(device=x.device).contiguous())
+    weight1 = _aligned(weight1.to(device=x.device).contiguous())
+    weight_scale0 = weight_scale0.to(device=x.device, dtype=torch.float32).reshape(-1)
+    weight_scale1 = weight_scale1.to(device=x.device, dtype=torch.float32).reshape(-1)
+    n, k = weight0.shape
+    for name, scale in (
+        ("weight_scale0", weight_scale0),
+        ("weight_scale1", weight_scale1),
+    ):
+        if scale.numel() not in (1, n):
+            raise ValueError(
+                f"{name} must be scalar or per-output-channel, got {tuple(scale.shape)}"
+            )
+
+    orig_shape = x.shape
+    x2d = x.reshape(-1, k).contiguous()
+    m = x2d.shape[0]
+    if k % 16 != 0:
+        raise ValueError(f"int8_linear_pair requires K divisible by 16, got {k}")
+    if weight_tile_k and not _tiled_b_supported(
+        x, m, n, k, out_dtype, weight_tile_k
+    ):
+        raise ValueError(
+            "tiled-B INT8 pair requires non-duplicated WMMA BF16, M>=96, "
+            "N divisible by 128, and K divisible by tile_k"
+        )
+
+    if convrot:
+        if convrot_groupsize not in (16, 64, 256):
+            raise ValueError(
+                f"ConvRot group size must be 16, 64 or 256, got {convrot_groupsize}"
+            )
+        if k % convrot_groupsize != 0:
+            raise ValueError(
+                f"ConvRot group size {convrot_groupsize} does not divide input features {k}"
+            )
+        if not _convrot_supported(k, convrot_groupsize, x.device, x.dtype):
+            return _eager.int8_linear_pair(
+                x, weight0, weight1, weight_scale0, weight_scale1,
+                bias0, bias1, out_dtype, convrot, convrot_groupsize,
+            )
+        if modulation_shift is not None:
+            if modulation_scale is None:
+                raise ValueError("Affine-modulated pair requires modulation_scale")
+            q, x_scale = _rotate_quant_int8_affine(
+                x2d, modulation_scale, modulation_shift,
+                convrot_groupsize,
+            )
+        elif norm_weight is not None:
+            if modulation_scale is None:
+                raise ValueError("RMS-modulated pair requires modulation_scale")
+            q, x_scale = _rotate_quant_int8_rms_modulated(
+                x2d, norm_weight, norm_eps, modulation_scale,
+                convrot_groupsize,
+            )
+        elif modulation_scale is None:
+            q, x_scale = _rotate_quant_int8(x2d, convrot_groupsize)
+        else:
+            q, x_scale = _rotate_quant_int8_modulated(
+                x2d, modulation_scale, convrot_groupsize
+            )
+    else:
+        q = torch.empty((m, k), dtype=torch.int8, device=x.device)
+        x_scale = torch.empty((m,), dtype=torch.float32, device=x.device)
+        _C.quantize_int8_rowwise(
+            _dl(x2d), _dl(q), _dl(x_scale), m, k, _stream(x)
+        )
+
+    x_scale = x_scale.reshape(-1).contiguous()
+    if bias0 is not None:
+        bias0 = _bias_operand(bias0, n, x.device)
+    if bias1 is not None:
+        bias1 = _bias_operand(bias1, n, x.device)
+
+    # Equal-width projections can share each activation tile once the output is
+    # large enough and N is not narrower than K.
+    output_tiles = ((m + 127) // 128) * ((n + 127) // 128)
+    use_paired_gemm = (
+        not weight_tile_k
+        and _has_nonduplicated_wmma(x.device)
+        and out_dtype == torch.bfloat16
+        and m >= 96
+        and n >= k
+        and k % 64 == 0
+        and output_tiles >= 96
+    )
+    if use_paired_gemm:
+        out0 = torch.empty((m, n), dtype=out_dtype, device=x.device)
+        out1 = torch.empty_like(out0)
+        _C.int8_gemm_pair(
+            _dl(q), _dl(weight0), _dl(weight1), _dl(out0), _dl(out1),
+            _dl(x_scale), _dl(weight_scale0),
+            0 if weight_scale0.numel() == 1 else 1,
+            _dl(weight_scale1), 0 if weight_scale1.numel() == 1 else 1,
+            None if bias0 is None else _dl(bias0),
+            None if bias1 is None else _dl(bias1),
+            m, n, k, DTYPE_TO_CODE[out_dtype], _stream(x),
+        )
+        return (
+            out0.reshape(*orig_shape[:-1], n),
+            out1.reshape(*orig_shape[:-1], n),
+        )
+
+    outputs = []
+    for weight, weight_scale, bias in (
+        (weight0, weight_scale0, bias0),
+        (weight1, weight_scale1, bias1),
+    ):
+        out = torch.empty((m, n), dtype=out_dtype, device=x.device)
+        gemm = _C.int8_gemm_b_tiled if weight_tile_k else _C.int8_gemm
+        gemm_args = [
+            _dl(q), _dl(weight), _dl(out), _dl(x_scale), _dl(weight_scale),
+            0 if weight_scale.numel() == 1 else 1,
+            None if bias is None else _dl(bias), m, n, k,
+            DTYPE_TO_CODE[out_dtype],
+        ]
+        if weight_tile_k:
+            gemm_args.extend((weight_tile_k, m >= 96))
+        gemm_args.append(_stream(x))
+        gemm(*gemm_args)
+        outputs.append(out.reshape(*orig_shape[:-1], n))
+    return outputs[0], outputs[1]
+
+
+def int8_linear_pair(
+    x: torch.Tensor,
+    weight0: torch.Tensor,
+    weight1: torch.Tensor,
+    weight_scale0: torch.Tensor,
+    weight_scale1: torch.Tensor,
+    bias0: torch.Tensor | None = None,
+    bias1: torch.Tensor | None = None,
+    out_dtype: torch.dtype = torch.bfloat16,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+    weight_tile_k: int = 0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    return _int8_linear_pair_impl(
+        x, weight0, weight1, weight_scale0, weight_scale1,
+        bias0, bias1, out_dtype, convrot, convrot_groupsize,
+        weight_tile_k=weight_tile_k,
+    )
+
+
+def int8_linear_pair_modulated(
+    x: torch.Tensor,
+    modulation_scale: torch.Tensor,
+    weight0: torch.Tensor,
+    weight1: torch.Tensor,
+    weight_scale0: torch.Tensor,
+    weight_scale1: torch.Tensor,
+    bias0: torch.Tensor | None = None,
+    bias1: torch.Tensor | None = None,
+    out_dtype: torch.dtype = torch.bfloat16,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+    modulation_shift: torch.Tensor | None = None,
+    weight_tile_k: int = 0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Paired INT8 projection sharing exact modulated quantization."""
+    k = x.shape[-1]
+    if modulation_scale.numel() != k:
+        raise ValueError(
+            f"modulation_scale must contain one batch-one row of {k} values, "
+            f"got {modulation_scale.numel()}"
+        )
+    modulation_scale = modulation_scale.to(device=x.device).reshape(-1).contiguous()
+    if modulation_shift is not None:
+        if modulation_shift.numel() != k:
+            raise ValueError(
+                f"modulation_shift must contain one batch-one row of {k} values, "
+                f"got {modulation_shift.numel()}"
+            )
+        modulation_shift = (
+            modulation_shift.to(device=x.device).reshape(-1).contiguous()
+        )
+    m = x.numel() // k
+    use_affine_fused = (
+        modulation_shift is not None
+        and x.dtype == torch.bfloat16
+        and modulation_scale.dtype == torch.bfloat16
+        and modulation_shift.dtype == torch.bfloat16
+        and out_dtype == torch.bfloat16
+        and convrot
+        and convrot_groupsize == 256
+        and not _C.convrot_int8_needs_spill(m, k, DTYPE_TO_CODE[x.dtype])
+    )
+    use_scale_fused = (
+        modulation_shift is None
+        and _has_nonduplicated_wmma(x.device)
+        and x.dtype == torch.bfloat16
+        and modulation_scale.dtype == torch.bfloat16
+        and out_dtype == torch.bfloat16
+        and convrot
+        and convrot_groupsize == 256
+        and m >= 96
+        and tuple(weight0.shape) == (10240, 3840)
+        and tuple(weight1.shape) == (10240, 3840)
+    )
+    use_fused = use_affine_fused or use_scale_fused
+    if not use_fused:
+        scale_shape = (1,) * (x.ndim - 1) + (k,)
+        scale = modulation_scale.reshape(scale_shape)
+        if modulation_shift is None:
+            modulated = x * (1.0 + scale)
+        else:
+            modulated = torch.addcmul(
+                modulation_shift.reshape(scale_shape), x, 1.0 + scale
+            )
+        return int8_linear_pair(
+            modulated, weight0, weight1, weight_scale0, weight_scale1,
+            bias0, bias1, out_dtype, convrot, convrot_groupsize,
+            weight_tile_k,
+        )
+    return _int8_linear_pair_impl(
+        x, weight0, weight1, weight_scale0, weight_scale1,
+        bias0, bias1, out_dtype, convrot, convrot_groupsize,
+        modulation_scale, weight_tile_k=weight_tile_k,
+        modulation_shift=modulation_shift,
+    )
+
+
+def int8_linear_triple_modulated(
+    x: torch.Tensor,
+    modulation_scale: torch.Tensor,
+    weight0: torch.Tensor,
+    weight1: torch.Tensor,
+    weight2: torch.Tensor,
+    weight_scale0: torch.Tensor,
+    weight_scale1: torch.Tensor,
+    weight_scale2: torch.Tensor,
+    bias0: torch.Tensor | None = None,
+    bias1: torch.Tensor | None = None,
+    bias2: torch.Tensor | None = None,
+    out_dtype: torch.dtype = torch.bfloat16,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+    modulation_shift: torch.Tensor | None = None,
+    weight_tile_k: int = 0,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Three projections sharing one exact affine ConvRot quantization."""
+    weights = (weight0, weight1, weight2)
+    weight_scales = (weight_scale0, weight_scale1, weight_scale2)
+    biases = (bias0, bias1, bias2)
+    if any(weight.ndim != 2 or weight.shape != weight0.shape for weight in weights):
+        raise ValueError(
+            "triple INT8 weights must have the same 2D shape, got "
+            + ", ".join(str(tuple(weight.shape)) for weight in weights)
+        )
+
+    n, k = weight0.shape
+    if x.shape[-1] != k:
+        raise ValueError(
+            f"Input and weight inner dimensions must match, got {x.shape[-1]} and {k}"
+        )
+    if modulation_scale.numel() != k:
+        raise ValueError(
+            f"modulation_scale must contain one batch-one row of {k} values, "
+            f"got {modulation_scale.numel()}"
+        )
+    if modulation_shift is not None and modulation_shift.numel() != k:
+        raise ValueError(
+            f"modulation_shift must contain one batch-one row of {k} values, "
+            f"got {modulation_shift.numel()}"
+        )
+
+    modulation_scale = (
+        modulation_scale.to(device=x.device).reshape(-1).contiguous()
+    )
+    if modulation_shift is not None:
+        modulation_shift = (
+            modulation_shift.to(device=x.device).reshape(-1).contiguous()
+        )
+    orig_shape = x.shape
+    x2d = x.reshape(-1, k).contiguous()
+    m = x2d.shape[0]
+
+    use_fused = (
+        modulation_shift is not None
+        and x2d.dtype == torch.bfloat16
+        and modulation_scale.dtype == torch.bfloat16
+        and modulation_shift.dtype == torch.bfloat16
+        and out_dtype == torch.bfloat16
+        and convrot
+        and convrot_groupsize == 256
+        and not _C.convrot_int8_needs_spill(m, k, DTYPE_TO_CODE[x2d.dtype])
+    )
+    if not use_fused:
+        if weight_tile_k:
+            raise ValueError(
+                "WMMA-tiled weights require fused affine triple quantization"
+            )
+        return _eager.int8_linear_triple_modulated(
+            x, modulation_scale, weight0, weight1, weight2,
+            weight_scale0, weight_scale1, weight_scale2,
+            bias0, bias1, bias2, out_dtype, convrot, convrot_groupsize,
+            modulation_shift,
+        )
+
+    if weight_tile_k and not _tiled_b_supported(
+        x, m, n, k, out_dtype, weight_tile_k
+    ):
+        raise ValueError(
+            "tiled-B INT8 triple requires non-duplicated WMMA BF16, M>=96, "
+            "N divisible by 128, and K divisible by tile_k"
+        )
+
+    prepared_weights = tuple(
+        _aligned(weight.to(device=x.device).contiguous()) for weight in weights
+    )
+    prepared_scales = tuple(
+        scale.to(device=x.device, dtype=torch.float32).reshape(-1)
+        for scale in weight_scales
+    )
+    for index, scale in enumerate(prepared_scales):
+        if scale.numel() not in (1, n):
+            raise ValueError(
+                f"weight_scale{index} must be scalar or per-output-channel, "
+                f"got {tuple(scale.shape)}"
+            )
+    prepared_biases = tuple(
+        None if bias is None else _bias_operand(bias, n, x.device)
+        for bias in biases
+    )
+
+    q, x_scale = _rotate_quant_int8_affine(
+        x2d, modulation_scale, modulation_shift, convrot_groupsize
+    )
+    outputs = []
+    for weight, weight_scale, bias in zip(
+        prepared_weights, prepared_scales, prepared_biases, strict=True
+    ):
+        output = torch.empty((m, n), dtype=out_dtype, device=x.device)
+        gemm_args = [
+            _dl(q), _dl(weight), _dl(output), _dl(x_scale), _dl(weight_scale),
+            0 if weight_scale.numel() == 1 else 1,
+            None if bias is None else _dl(bias), m, n, k,
+            DTYPE_TO_CODE[out_dtype],
+        ]
+        if weight_tile_k:
+            _C.int8_gemm_b_tiled(
+                *gemm_args, weight_tile_k, m >= 96, _stream(x)
+            )
+        else:
+            _C.int8_gemm(*gemm_args, _stream(x))
+        outputs.append(output.reshape(*orig_shape[:-1], n))
+    return outputs[0], outputs[1], outputs[2]
+
+
+def int8_linear_pair_rms_modulated(
+    x: torch.Tensor,
+    norm_weight: torch.Tensor,
+    norm_eps: float,
+    modulation_scale: torch.Tensor,
+    weight0: torch.Tensor,
+    weight1: torch.Tensor,
+    weight_scale0: torch.Tensor,
+    weight_scale1: torch.Tensor,
+    bias0: torch.Tensor | None = None,
+    bias1: torch.Tensor | None = None,
+    out_dtype: torch.dtype = torch.bfloat16,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Paired projections sharing exact fused RMS/modulation quantization."""
+    k = x.shape[-1]
+    if norm_weight.numel() != k or modulation_scale.numel() != k:
+        raise ValueError(
+            f"norm_weight and modulation_scale must each contain {k} values"
+        )
+    norm_weight = norm_weight.to(device=x.device).reshape(-1).contiguous()
+    modulation_scale = modulation_scale.to(device=x.device).reshape(-1).contiguous()
+    m = x.numel() // k
+    use_fused = (
+        _has_nonduplicated_wmma(x.device)
+        and x.dtype == torch.bfloat16
+        and norm_weight.dtype == torch.bfloat16
+        and modulation_scale.dtype == torch.bfloat16
+        and out_dtype == torch.bfloat16
+        and convrot
+        and convrot_groupsize == 256
+        and m >= 96
+        and tuple(weight0.shape) == (10240, 3840)
+        and tuple(weight1.shape) == (10240, 3840)
+    )
+    if not use_fused:
+        normalized = torch.nn.functional.rms_norm(
+            x, (k,), norm_weight, norm_eps
+        )
+        return int8_linear_pair_modulated(
+            normalized, modulation_scale, weight0, weight1,
+            weight_scale0, weight_scale1, bias0, bias1, out_dtype,
+            convrot, convrot_groupsize,
+        )
+    return _int8_linear_pair_impl(
+        x, weight0, weight1, weight_scale0, weight_scale1,
+        bias0, bias1, out_dtype, convrot, convrot_groupsize,
+        modulation_scale, norm_weight, norm_eps,
+    )
+
+
+def int8_linear_swiglu_split(
+    gate: torch.Tensor,
+    up: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    out_dtype: torch.dtype = torch.bfloat16,
+    convrot: bool = False,
+    convrot_groupsize: int = 256,
+    weight_tiled_b: bool = False,
+    weight_tile_k: int = 0,
+) -> torch.Tensor:
+    """Down projection with exact split-BF16 SwiGLU folded into ConvRot."""
+    if gate.shape != up.shape:
+        raise ValueError(
+            f"split SwiGLU inputs must have the same shape, got "
+            f"{tuple(gate.shape)} and {tuple(up.shape)}"
+        )
+    if gate.device != up.device:
+        raise ValueError(
+            f"split SwiGLU inputs must share a device, got {gate.device} and {up.device}"
+        )
+    if weight.ndim != 2 or gate.shape[-1] != weight.shape[-1]:
+        raise ValueError(
+            f"Input and weight inner dimensions must match, got "
+            f"{gate.shape[-1]} and {weight.shape[-1] if weight.ndim == 2 else tuple(weight.shape)}"
+        )
+
+    orig_shape = gate.shape
+    k = orig_shape[-1]
+    m = gate.numel() // k
+    n = weight.shape[0]
+    use_split_tiled = (
+        _has_nonduplicated_wmma(gate.device)
+        and gate.dtype == torch.bfloat16
+        and up.dtype == torch.bfloat16
+        and out_dtype == torch.bfloat16
+        and convrot
+        and convrot_groupsize == 256
+        and m >= 512
+        and n == 3840
+        and k == 10240
+    )
+    if not use_split_tiled:
+        if weight_tiled_b and not weight_tile_k:
+            raise ValueError(
+                "a generic WMMA-tiled down weight requires its physical K tile"
+            )
+        activated = torch.nn.functional.silu(gate) * up
+        return int8_linear(
+            activated, weight, weight_scale, bias, out_dtype,
+            convrot, convrot_groupsize, _weight_tile_k=weight_tile_k,
+            _dual_m=m >= 96,
+        )
+
+    if weight_tiled_b and weight_tile_k not in (0, 128):
+        raise ValueError("the fused tiled-A/B down path requires a 128-byte K tile")
+
+    weight = _aligned(weight.to(device=gate.device).contiguous())
+    weight_scale = weight_scale.to(
+        device=gate.device, dtype=torch.float32
+    ).reshape(-1)
+    if weight_scale.numel() not in (1, n):
+        raise ValueError(
+            f"INT8 weight scale must be scalar or per-output-channel, got "
+            f"{tuple(weight_scale.shape)}"
+        )
+    if bias is not None:
+        bias = _bias_operand(bias, n, gate.device)
+
+    gate2d = gate.reshape(m, k).contiguous()
+    up2d = up.reshape(m, k).contiguous()
+    q, x_scale = _rotate_quant_int8_swiglu_split_tiled128(
+        gate2d, up2d, convrot_groupsize
+    )
+    output = torch.empty((m, n), dtype=out_dtype, device=gate.device)
+    _C.int8_gemm_a_tiled128_down(
+        _dl(q), _dl(weight), _dl(output),
+        _dl(x_scale), _dl(weight_scale),
+        0 if weight_scale.numel() == 1 else 1,
+        None if bias is None else _dl(bias),
+        m, n, k, DTYPE_TO_CODE[out_dtype], weight_tiled_b, _stream(gate2d),
+    )
+    return output.reshape(*orig_shape[:-1], n)
 
 
 # ---------------------------------------------------------------------------
@@ -1374,6 +2366,138 @@ def na3d(
     return out
 
 
+def _attention_device_is_supported(tensor: torch.Tensor) -> bool:
+    return bool(tensor.is_cuda and _has_nonduplicated_wmma(tensor.device))
+
+
+def _attention_inputs_are_supported(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+) -> bool:
+    if not _attention_device_is_supported(q):
+        return False
+    if q.ndim != 4 or k.ndim != 4 or v.ndim != 4:
+        return False
+    q_shape, k_shape, v_shape = q.shape, k.shape, v.shape
+    dtype = q.dtype
+    if not (
+        dtype == k.dtype == v.dtype
+        and dtype in (torch.float16, torch.bfloat16)
+        and q.device == k.device == v.device
+        and q_shape[0] == k_shape[0] == v_shape[0] > 0
+        and q_shape[1] == k_shape[1] == v_shape[1] > 0
+        and q_shape[2] > 0
+        and k_shape[2] == v_shape[2] > 0
+        and q_shape[3] == k_shape[3] == v_shape[3] == 128
+        and q.stride(3) == k.stride(3) == v.stride(3) == 1
+        and q.stride(2) % 8 == k.stride(2) % 8 == v.stride(2) % 8 == 0
+        and q.data_ptr() % 16 == k.data_ptr() % 16 == v.data_ptr() % 16 == 0
+    ):
+        return False
+    long = q_shape[0] == 1 and q_shape[2] >= 1024
+    if dtype != torch.bfloat16 or q_shape[2] != k_shape[2]:
+        return long
+    # The batch-one native schedule wins once there are at least 128 queries. The
+    # compact native schedule covers many independent <=16-query batches. Both
+    # predicates are dimensional and come from paired production-shape gates.
+    batch_one_short = q_shape[0] == 1 and 128 <= q_shape[2] < 1024
+    batched_short = (
+        q_shape[0] > 1
+        and q_shape[2] <= 16
+        and q_shape[0] * q_shape[1] >= 1024
+    )
+    return long or batch_one_short or batched_short
+
+
+def hip_attention_is_supported(
+    q: torch.Tensor, k: torch.Tensor, v: torch.Tensor
+) -> bool:
+    if not _attention_inputs_are_supported(q, k, v):
+        return False
+    return q.dtype is torch.bfloat16
+
+
+def hip_int8_attention_is_supported(
+    q: torch.Tensor, k: torch.Tensor, v: torch.Tensor
+) -> bool:
+    if not _attention_inputs_are_supported(q, k, v):
+        return False
+    # Short and multi-batch INT8 calls reuse the BF16 HIP route.
+    if q.shape[0] > 1 or q.shape[2] < 1024:
+        return hip_attention_is_supported(q, k, v)
+    return True
+
+
+def hip_attention(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    scale: float | None = None,
+) -> torch.Tensor:
+    """HIP BF16 attention for supported unmasked D=128 calls.
+
+    Compact multi-batch and long batch-one calls use the native HIP schedule.
+    There is no Triton/Gluon runtime dependency.
+    """
+    if q.dtype is not torch.bfloat16:
+        raise RuntimeError("HIP native attention is BF16")
+    output = torch.empty(
+        (q.shape[0], q.shape[2], q.shape[1], q.shape[3]),
+        device=q.device,
+        dtype=q.dtype,
+    ).movedim(1, 2)
+    resolved_scale = float(scale if scale is not None else 1.0 / math.sqrt(q.shape[3]))
+    _C.bf16_sdpa_hip(
+        _dl(q), _dl(k), _dl(v), _dl(output), resolved_scale, _stream(q)
+    )
+    return output
+
+
+def _int8_attention_workspace(reference: torch.Tensor, q_len: int, kv_len: int):
+    heads = int(reference.shape[1])
+    padded_q = -(-q_len // 128) * 128
+    padded_k = -(-kv_len // 64) * 64
+    tiles = padded_k // 64
+    tensor = functools.partial(torch.empty, device=reference.device)
+    return (
+        tensor((1, heads, q_len, 128), dtype=torch.int8),
+        tensor((1, heads, padded_k, 128), dtype=torch.int8),
+        tensor((1, heads, tiles, 128, 64), dtype=torch.int8),
+        tensor((heads, padded_q), dtype=torch.float32),
+        tensor((heads, padded_k // 16), dtype=torch.float32),
+        tensor((heads, tiles, 128), dtype=torch.float32),
+        tensor((1, heads), dtype=torch.int32),
+    )
+
+
+def hip_int8_attention(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    scale: float,
+) -> torch.Tensor:
+    """Run INT8 attention, retaining BF16 for overhead-bound short calls."""
+    # Capability is checked by the public caller; any supported sub-1024 or
+    # multi-batch contract is one of the measured BF16 short routes.
+    if q.shape[0] > 1 or q.shape[2] < 1024:
+        return hip_attention(q, k, v, scale)
+    q_len = int(q.shape[2])
+    kv_len = int(k.shape[2])
+    output = torch.empty_strided(q.shape, q.stride(), device=q.device, dtype=q.dtype)
+    workspaces = _int8_attention_workspace(q, q_len, kv_len)
+    _C.hip_int8_attention(
+        _dl(q),
+        _dl(k),
+        _dl(v),
+        _dl(output),
+        *(_dl(tensor) for tensor in workspaces),
+        float(scale),
+        _stream(q),
+    )
+    return output
+
+
 def _adaln_impl(kernel, x, scale, shift, eps) -> torch.Tensor:
     """``kernel`` is _C.adaln (LayerNorm) or _C.rms_adaln (RMSNorm)."""
     from comfy_kitchen.backends._modulation import adaln_prep_modulation
@@ -1737,6 +2861,26 @@ def _build_constraints(has_wmma: bool = True) -> dict:
                 return ValidationResult.fail("q", "grid dims exceed HIP limits")
         return ValidationResult.ok()
 
+    bf16_param = ParamConstraint(dtypes=frozenset({torch.bfloat16}))
+    out_param = ParamConstraint(dtypes=out_floats)
+    int8_2d = ParamConstraint(
+        dtypes=frozenset({torch.int8}), shape_rules=(ExactDims(2),)
+    )
+    int_param = ParamConstraint(dtypes=frozenset({int}))
+    bool_param = ParamConstraint(dtypes=frozenset({bool}))
+    divisible_bf16 = ParamConstraint(
+        dtypes=frozenset({torch.bfloat16}), shape_rules=(DivisibleBy(-1, 16),)
+    )
+    divisible_float = ParamConstraint(
+        dtypes=floats, shape_rules=(DivisibleBy(-1, 16),)
+    )
+
+    def fusion(params):
+        return FunctionConstraints(params=params, default_devices=dev)
+
+    def projection_weights(count):
+        return {f"weight{index}": int8_2d for index in range(count)}
+
     constraints = {
         # fp32 has no 16-bit matrix path, so it goes to triton/eager.
         "na3d": FunctionConstraints(
@@ -1816,6 +2960,69 @@ def _build_constraints(has_wmma: bool = True) -> dict:
             },
             default_devices=dev,
         ),
+        "int8_linear_gated_residual": fusion({
+            "x": divisible_bf16, "weight": int8_2d,
+            "residual": bf16_param, "gate": bf16_param,
+            "out_dtype": bf16_param, "weight_tile_k": int_param,
+            "dual_m": bool_param,
+        }),
+        "int8_linear_tiled_b": FunctionConstraints(
+            params={
+                "x": ParamConstraint(
+                    dtypes=frozenset({torch.bfloat16}),
+                    shape_rules=(DivisibleBy(-1, 16),),
+                ),
+                "weight": ParamConstraint(
+                    dtypes=frozenset({torch.int8}), shape_rules=(ExactDims(2),)
+                ),
+                "out_dtype": ParamConstraint(dtypes=frozenset({torch.bfloat16})),
+                "convrot": ParamConstraint(dtypes=frozenset({bool})),
+                "convrot_groupsize": ParamConstraint(dtypes=frozenset({int})),
+                "tile_k": ParamConstraint(dtypes=frozenset({int})),
+                "dual_m": ParamConstraint(dtypes=frozenset({bool})),
+            },
+            default_devices=dev,
+        ),
+        "rms_gated_residual": fusion({
+            "activation": bf16_param, "norm_weight": bf16_param,
+            "residual": bf16_param, "gate": bf16_param,
+            "eps": ParamConstraint(dtypes=frozenset({float})),
+        }),
+        "int8_linear_modulated": fusion({
+            "x": divisible_bf16, "modulation_scale": bf16_param,
+            "modulation_shift": bf16_param, "weight": int8_2d,
+            "out_dtype": out_param, "weight_tiled_b": bool_param,
+            "weight_tile_k": int_param,
+        }),
+        "int8_linear_rms_modulated": fusion({
+            "x": divisible_bf16, "norm_weight": bf16_param,
+            "modulation_scale": bf16_param, "weight": int8_2d,
+            "out_dtype": out_param, "weight_tiled_b": bool_param,
+        }),
+        "int8_linear_pair": fusion(
+            {"x": divisible_float, "out_dtype": out_param,
+             "weight_tile_k": int_param} | projection_weights(2)
+        ),
+        "int8_linear_pair_modulated": fusion(
+            {"x": divisible_bf16, "modulation_scale": bf16_param,
+             "modulation_shift": bf16_param, "out_dtype": out_param,
+             "weight_tile_k": int_param} | projection_weights(2)
+        ),
+        "int8_linear_triple_modulated": fusion(
+            {"x": divisible_bf16, "modulation_scale": bf16_param,
+             "modulation_shift": bf16_param, "out_dtype": out_param,
+             "weight_tile_k": int_param} | projection_weights(3)
+        ),
+        "int8_linear_pair_rms_modulated": fusion(
+            {"x": divisible_bf16, "norm_weight": bf16_param,
+             "modulation_scale": bf16_param, "out_dtype": out_param}
+            | projection_weights(2)
+        ),
+        "int8_linear_swiglu_split": fusion({
+            "gate": divisible_bf16, "up": divisible_bf16,
+            "weight": int8_2d, "out_dtype": out_param,
+            "weight_tiled_b": bool_param, "weight_tile_k": int_param,
+        }),
         "quantize_w4a8_int8_weight": FunctionConstraints(
             params={
                 "weight": ParamConstraint(dtypes=floats, shape_rules=(ExactDims(2),)),
@@ -2045,21 +3252,8 @@ def _build_constraints(has_wmma: bool = True) -> dict:
 # Must match kCtaQ and the key tiles in sage_attention/int8_attn.hip.
 _SAGE_CTA_Q = 128
 _SAGE_CTA_K = 64
-_SAGE_LARGE_CTA_K = 128
 _SAGE_KEY_GROUP = 16
 _SAGE_HEAD_DIMS = (64, 128, 256)
-
-
-def _sage_cta_k(head_dim: int, kv_length: int, has_mask: bool) -> int:
-    """Keys per attention iteration.
-
-    Always 64. The CUDA backend widens this to 128 for long unmasked keys; the
-    wide tile is implemented here too and measures slower on RDNA, where V is
-    staged transposed and the tile doubles both LDS allocations at once. Kept as
-    a function because the choice belongs with the buffer padding it decides.
-    """
-    del head_dim, kv_length, has_mask
-    return _SAGE_CTA_K
 
 
 def int8_attention_is_available() -> bool:
@@ -2163,7 +3357,7 @@ def sage_int8_sdpa(
         batch, q_heads, q_length, head_dim, dtype=output_dtype, device=q.device
     )
 
-    cta_k = _sage_cta_k(head_dim, k.shape[2], attn_mask is not None)
+    cta_k = _SAGE_CTA_K
     buffers, anchor_indices = _sage_buffers(q, k, cta_k)
     _C.sage_sdpa(
         _dl(q),
@@ -2283,6 +3477,7 @@ def _register():
         ", ".join(sorted({a for a in arches if a})),
         "with WMMA" if has_wmma else "elementwise only, no matrix cores",
     )
+
 
 
 _register()

--- a/comfy_kitchen/backends/hip/dlpack_bindings.cpp
+++ b/comfy_kitchen/backends/hip/dlpack_bindings.cpp
@@ -167,6 +167,8 @@ static void require_dtype(const nb::ndarray<>& t, int lo, int hi, const char* fn
     }
 }
 
+static void require_packed_contiguous(const nb::ndarray<>& t, const char* fn, const char* name);
+
 // Mirrors kSvdGroup in ops/svdquant_w4a4.hip: one scale per 64-element group.
 constexpr int kSvdGroup = 64;
 
@@ -644,6 +646,9 @@ void quantize_int8_convrot(nb::ndarray<> x, nb::ndarray<> q, nb::ndarray<> scale
     require_len(x, static_cast<int64_t>(M) * K * in_width, kFn, "x");
     require_len(q, static_cast<int64_t>(M) * K, kFn, "q");
     require_scale_len(scales, static_cast<size_t>(M), kFn, "scales");
+    require_packed_contiguous(x, kFn, "x");
+    require_packed_contiguous(q, kFn, "q");
+    require_packed_contiguous(scales, kFn, "scales");
     const nb::ndarray<>* aligned_operands[] = {&x, &q, &scales};
     for (const nb::ndarray<>* operand : aligned_operands) {
         if (reinterpret_cast<uintptr_t>(operand->data()) % 8 != 0) {
@@ -660,11 +665,13 @@ void quantize_int8_convrot(nb::ndarray<> x, nb::ndarray<> q, nb::ndarray<> scale
         if (map_dtype_to_code(spill_rotated->dtype()) != map_dtype_to_code(x.dtype())) {
             throw std::runtime_error(std::string(kFn) + ": spill_rotated dtype must match x");
         }
+        require_packed_contiguous(*spill_rotated, kFn, "spill_rotated");
         spill_rotated_ptr = spill_rotated->data();
     }
     if (spill_partials.has_value()) {
         require_dtype(*spill_partials, 0, 0, kFn, "spill_partials");
         require_len(*spill_partials, static_cast<int64_t>(M) * (K / 256), kFn, "spill_partials");
+        require_packed_contiguous(*spill_partials, kFn, "spill_partials");
         spill_partials_ptr = spill_partials->data();
     }
 
@@ -692,6 +699,10 @@ void quantize_int8_convrot_swiglu_split_tiled128(
         (static_cast<int64_t>(M) + 127) / 128 * 128;
     require_len(q, padded_m * K, kFn, "q");
     require_scale_len(scales, static_cast<size_t>(M), kFn, "scales");
+    require_packed_contiguous(gate, kFn, "gate");
+    require_packed_contiguous(up, kFn, "up");
+    require_packed_contiguous(q, kFn, "q");
+    require_packed_contiguous(scales, kFn, "scales");
     const nb::ndarray<>* aligned_operands[] = {&gate, &up, &q, &scales};
     for (const nb::ndarray<>* operand : aligned_operands) {
         if (reinterpret_cast<uintptr_t>(operand->data()) % 8 != 0) {
@@ -721,6 +732,10 @@ void quantize_int8_convrot_modulated(
                 "modulation_scale");
     require_len(q, static_cast<int64_t>(M) * K, kFn, "q");
     require_scale_len(scales, static_cast<size_t>(M), kFn, "scales");
+    require_packed_contiguous(x, kFn, "x");
+    require_packed_contiguous(modulation_scale, kFn, "modulation_scale");
+    require_packed_contiguous(q, kFn, "q");
+    require_packed_contiguous(scales, kFn, "scales");
     const nb::ndarray<>* aligned_operands[] = {
         &x, &modulation_scale, &q, &scales};
     for (const nb::ndarray<>* operand : aligned_operands) {
@@ -755,6 +770,11 @@ void quantize_int8_convrot_affine(
                 "modulation_shift");
     require_len(q, static_cast<int64_t>(M) * K, kFn, "q");
     require_scale_len(scales, static_cast<size_t>(M), kFn, "scales");
+    require_packed_contiguous(x, kFn, "x");
+    require_packed_contiguous(modulation_scale, kFn, "modulation_scale");
+    require_packed_contiguous(modulation_shift, kFn, "modulation_shift");
+    require_packed_contiguous(q, kFn, "q");
+    require_packed_contiguous(scales, kFn, "scales");
     const nb::ndarray<>* aligned_operands[] = {
         &x, &modulation_scale, &modulation_shift, &q, &scales};
     for (const nb::ndarray<>* operand : aligned_operands) {

--- a/comfy_kitchen/backends/hip/dlpack_bindings.cpp
+++ b/comfy_kitchen/backends/hip/dlpack_bindings.cpp
@@ -1928,6 +1928,11 @@ void bf16_sdpa_hip(
     require_supported_layout(k, "k");
     require_supported_layout(v, "v");
     require_supported_layout(output, "output");
+    if (q_len > 1 && output.stride(2) < head_dim) {
+        throw std::runtime_error(
+            std::string(kFn) +
+            ": output row stride must be at least the head dimension");
+    }
     constexpr int kDeviceRocm = nb::device::rocm::value;
     const nb::ndarray<>* operands[] = {&q, &k, &v, &output};
     for (const nb::ndarray<>* operand : operands) {

--- a/comfy_kitchen/backends/hip/dlpack_bindings.cpp
+++ b/comfy_kitchen/backends/hip/dlpack_bindings.cpp
@@ -10,6 +10,7 @@
 #include <nanobind/nanobind.h>
 #include <nanobind/ndarray.h>
 #include <nanobind/stl/optional.h>
+#include <nanobind/stl/string.h>
 
 #include "launchers.h"
 
@@ -51,6 +52,16 @@ void launch_convrot_w4a4_gemm_kernel(const void*, const void*, void*, const void
 void launch_quantize_int8_rowwise_kernel(const void*, int, void*, void*, int, int, hipStream_t);
 void launch_quantize_int8_convrot_kernel(const void*, int, void*, void*, void*, void*, int, int,
                                          int, int, hipStream_t);
+void launch_quantize_int8_convrot_swiglu_split_tiled128_kernel(
+    const void*, const void*, void*, void*, int, int, int, hipStream_t);
+void launch_quantize_int8_convrot_modulated_kernel(
+    const void*, const void*, void*, void*, int, int, int, hipStream_t);
+void launch_quantize_int8_convrot_affine_kernel(
+    const void*, const void*, const void*, void*, void*, int, int, int,
+    hipStream_t);
+void launch_quantize_int8_convrot_rms_modulated_fused_stats_kernel(
+    const void*, const void*, const void*, void*, void*, int, int, int,
+    float, hipStream_t);
 void launch_quantize_int8_tensorwise_kernel(const void*, int, void*, void*, void*, int64_t,
                                             hipStream_t);
 void launch_dequantize_int8_simple_kernel(const void*, const void*, void*, int64_t, int64_t, int,
@@ -61,12 +72,6 @@ void launch_convrot_quant_int4_kernel(const void*, int, void*, void*, int, int, 
 void launch_unpack_int4_kernel(const void*, void*, int64_t, hipStream_t);
 int convrot_max_k_host(int);
 int convrot_int8_needs_spill_host(int, int, int);
-
-void launch_quantize_w4a8_convrot_kernel(const void*, const void*, void*, void*, void*, int64_t,
-                                         int64_t, int, bool, uint64_t, hipStream_t);
-int w4a8_requant_max_k_kernel();
-void launch_na3d_kernel(const void*, const void*, const void*, void*, int, int, int, int, int, int,
-                        int, int, int, int, int, int, float, int, hipStream_t);
 
 void launch_sage_quant_qk_int8(const void*, void*, void*, const void*, void*, void*, void*, int,
                                int, int, int, int, int, int, int, int64_t, int64_t, int64_t,
@@ -339,6 +344,220 @@ void int8_gemm(nb::ndarray<> a, nb::ndarray<> b, nb::ndarray<> c, nb::ndarray<> 
     check_hip_launch();
 }
 
+void int8_gemm_b_tiled(
+    nb::ndarray<> a, nb::ndarray<> b, nb::ndarray<> c,
+    nb::ndarray<> scale_a, nb::ndarray<> scale_b, int scale_b_stride,
+    OptArray bias, int M, int N, int K, int out_code, int tile_k,
+    bool dual_m, uintptr_t stream_ptr) {
+    constexpr const char* kFn = "int8_gemm_b_tiled";
+    if (scale_b_stride != 0 && scale_b_stride != 1) {
+        throw std::runtime_error(std::string(kFn) +
+                                 ": scale_b_stride must be 0 or 1");
+    }
+    require_nonneg(M, kFn, "M");
+    require_nonneg(N, kFn, "N");
+    require_nonneg(K, kFn, "K");
+    if (M != 0 && (M < 96 || N % 128 != 0 ||
+                   (tile_k != 64 && tile_k != 128) || K % tile_k != 0)) {
+        throw std::runtime_error(
+            std::string(kFn) +
+            ": requires M>=96, N divisible by 128, K divisible by "
+            "tile_k, and tile_k in {64,128}");
+    }
+    require_dtype(a, 4, 4, kFn, "a");
+    require_dtype(b, 4, 4, kFn, "b");
+    require_dtype(c, 0, 2, kFn, "c");
+    require_out_matches(c, out_code, kFn);
+    require_len(a, static_cast<int64_t>(M) * K, kFn, "a");
+    require_len(b, static_cast<int64_t>(N) * K, kFn, "b");
+    require_len(c, static_cast<int64_t>(M) * N, kFn, "c");
+    require_scale_len(scale_a, static_cast<size_t>(M), kFn, "scale_a");
+    require_scale_len(scale_b,
+                      scale_b_stride == 1 ? static_cast<size_t>(N) : 1,
+                      kFn, "scale_b");
+    require_bias(bias, N, kFn);
+
+    launch_int8_gemm_b_tiled_kernel(
+        a.data(), b.data(), c.data(), scale_a.data(), scale_b.data(),
+        scale_b_stride, opt_data(bias), opt_code(bias), M, N, K, N,
+        out_code, tile_k, dual_m,
+        reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+void int8_gemm_b_tiled_gated_residual(
+    nb::ndarray<> a, nb::ndarray<> b, nb::ndarray<> c,
+    nb::ndarray<> scale_a, nb::ndarray<> scale_b, int scale_b_stride,
+    OptArray bias, nb::ndarray<> residual, nb::ndarray<> gate,
+    int M, int N, int K, int tile_k, bool dual_m, uintptr_t stream_ptr) {
+    constexpr const char* kFn = "int8_gemm_b_tiled_gated_residual";
+    if (scale_b_stride != 0 && scale_b_stride != 1) {
+        throw std::runtime_error(std::string(kFn) +
+                                 ": scale_b_stride must be 0 or 1");
+    }
+    require_nonneg(M, kFn, "M");
+    require_nonneg(N, kFn, "N");
+    require_nonneg(K, kFn, "K");
+    if (M != 0 && (M < 96 || N % 128 != 0 ||
+                   (tile_k != 64 && tile_k != 128) || K % tile_k != 0)) {
+        throw std::runtime_error(
+            std::string(kFn) +
+            ": requires M>=96, N divisible by 128, K divisible by "
+            "tile_k, and tile_k in {64,128}");
+    }
+    require_dtype(a, 4, 4, kFn, "a");
+    require_dtype(b, 4, 4, kFn, "b");
+    require_dtype(c, 2, 2, kFn, "c");
+    require_dtype(residual, 2, 2, kFn, "residual");
+    require_dtype(gate, 2, 2, kFn, "gate");
+    require_len(a, static_cast<int64_t>(M) * K, kFn, "a");
+    require_len(b, static_cast<int64_t>(N) * K, kFn, "b");
+    require_len(c, static_cast<int64_t>(M) * N, kFn, "c");
+    require_len(residual, static_cast<int64_t>(M) * N, kFn, "residual");
+    require_len(gate, N, kFn, "gate");
+    require_scale_len(scale_a, static_cast<size_t>(M), kFn, "scale_a");
+    require_scale_len(scale_b,
+                      scale_b_stride == 1 ? static_cast<size_t>(N) : 1,
+                      kFn, "scale_b");
+    require_bias(bias, N, kFn);
+    if (residual.ndim() != 2 || residual.shape(0) != static_cast<size_t>(M) ||
+        residual.shape(1) != static_cast<size_t>(N) ||
+        residual.stride(0) != N || residual.stride(1) != 1 ||
+        gate.ndim() != 1 || gate.shape(0) != static_cast<size_t>(N) ||
+        gate.stride(0) != 1) {
+        throw std::runtime_error(
+            std::string(kFn) +
+            ": residual must be packed [M,N] and gate packed [N]");
+    }
+
+    launch_int8_gemm_b_tiled_gated_residual_kernel(
+        a.data(), b.data(), c.data(), scale_a.data(), scale_b.data(),
+        scale_b_stride, opt_data(bias), opt_code(bias), residual.data(),
+        gate.data(), M, N, K, N, tile_k, dual_m,
+        reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+void int8_gemm_pair(
+    nb::ndarray<> a, nb::ndarray<> b0, nb::ndarray<> b1,
+    nb::ndarray<> c0, nb::ndarray<> c1, nb::ndarray<> scale_a,
+    nb::ndarray<> scale_b0, int scale_b_stride0,
+    nb::ndarray<> scale_b1, int scale_b_stride1,
+    OptArray bias0, OptArray bias1, int M, int N, int K,
+    int out_code, uintptr_t stream_ptr) {
+    constexpr const char* kFn = "int8_gemm_pair";
+    if ((scale_b_stride0 != 0 && scale_b_stride0 != 1) ||
+        (scale_b_stride1 != 0 && scale_b_stride1 != 1)) {
+        throw std::runtime_error(
+            std::string(kFn) + ": scale strides must be 0 or 1");
+    }
+    require_nonneg(M, kFn, "M");
+    require_nonneg(N, kFn, "N");
+    require_nonneg(K, kFn, "K");
+    if (M != 0 && (M < 96 || N < 96 || K == 0 || K % 64 != 0)) {
+        throw std::runtime_error(
+            std::string(kFn) +
+            ": requires M,N>=96 and positive K divisible by 64");
+    }
+    require_dtype(a, 4, 4, kFn, "a");
+    require_dtype(b0, 4, 4, kFn, "b0");
+    require_dtype(b1, 4, 4, kFn, "b1");
+    require_dtype(c0, 0, 2, kFn, "c0");
+    require_dtype(c1, 0, 2, kFn, "c1");
+    require_out_matches(c0, out_code, kFn);
+    require_out_matches(c1, out_code, kFn);
+    require_len(a, static_cast<int64_t>(M) * K, kFn, "a");
+    require_len(b0, static_cast<int64_t>(N) * K, kFn, "b0");
+    require_len(b1, static_cast<int64_t>(N) * K, kFn, "b1");
+    require_len(c0, static_cast<int64_t>(M) * N, kFn, "c0");
+    require_len(c1, static_cast<int64_t>(M) * N, kFn, "c1");
+    require_scale_len(scale_a, static_cast<size_t>(M), kFn, "scale_a");
+    require_scale_len(
+        scale_b0, scale_b_stride0 == 1 ? static_cast<size_t>(N) : 1,
+        kFn, "scale_b0");
+    require_scale_len(
+        scale_b1, scale_b_stride1 == 1 ? static_cast<size_t>(N) : 1,
+        kFn, "scale_b1");
+    require_bias(bias0, N, kFn);
+    require_bias(bias1, N, kFn);
+
+    launch_int8_gemm_pair_kernel(
+        a.data(), b0.data(), b1.data(), c0.data(), c1.data(),
+        scale_a.data(), scale_b0.data(), scale_b_stride0,
+        scale_b1.data(), scale_b_stride1,
+        opt_data(bias0), opt_code(bias0), opt_data(bias1), opt_code(bias1),
+        M, N, K, N /*ldc*/, out_code,
+        reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+void rms_gated_residual_bf16(
+    nb::ndarray<> activation, nb::ndarray<> norm_weight,
+    nb::ndarray<> residual, nb::ndarray<> gate, nb::ndarray<> output,
+    int rows, int width, float eps, uintptr_t stream_ptr) {
+    constexpr const char* kFn = "rms_gated_residual_bf16";
+    require_nonneg(rows, kFn, "rows");
+    if (width <= 0 || width % 4 != 0) {
+        throw std::runtime_error(
+            std::string(kFn) + ": width must be positive and divisible by 4");
+    }
+    require_dtype(activation, 2, 2, kFn, "activation");
+    require_dtype(norm_weight, 2, 2, kFn, "norm_weight");
+    require_dtype(residual, 2, 2, kFn, "residual");
+    require_dtype(gate, 2, 2, kFn, "gate");
+    require_dtype(output, 2, 2, kFn, "output");
+    const int64_t numel = static_cast<int64_t>(rows) * width;
+    require_len(activation, numel, kFn, "activation");
+    require_len(norm_weight, width, kFn, "norm_weight");
+    require_len(residual, numel, kFn, "residual");
+    require_len(gate, width, kFn, "gate");
+    require_len(output, numel, kFn, "output");
+
+    launch_rms_gated_residual_bf16_kernel(
+        activation.data(), norm_weight.data(), residual.data(), gate.data(),
+        output.data(), rows, width, eps,
+        reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+void int8_gemm_a_tiled128_down(
+    nb::ndarray<> a, nb::ndarray<> b, nb::ndarray<> c,
+    nb::ndarray<> scale_a, nb::ndarray<> scale_b, int scale_b_stride,
+    OptArray bias, int M, int N, int K, int out_code, bool tiled_b,
+    uintptr_t stream_ptr) {
+    constexpr const char* kFn = "int8_gemm_a_tiled128_down";
+    if (scale_b_stride != 0 && scale_b_stride != 1) {
+        throw std::runtime_error(std::string(kFn) +
+                                 ": scale_b_stride must be 0 or 1");
+    }
+    require_nonneg(M, kFn, "M");
+    require_nonneg(N, kFn, "N");
+    require_nonneg(K, kFn, "K");
+    if (N <= 0 || K <= 0 || N % 128 != 0 || K % 128 != 0) {
+        throw std::runtime_error(
+            std::string(kFn) +
+            ": requires positive N and K divisible by 128");
+    }
+    require_dtype(a, 4, 4, kFn, "a");
+    require_dtype(b, 4, 4, kFn, "b");
+    require_dtype(c, 0, 2, kFn, "c");
+    require_out_matches(c, out_code, kFn);
+    const int64_t padded_m = (static_cast<int64_t>(M) + 127) / 128 * 128;
+    require_len(a, padded_m * K, kFn, "a");
+    require_len(b, static_cast<int64_t>(N) * K, kFn, "b");
+    require_len(c, static_cast<int64_t>(M) * N, kFn, "c");
+    require_scale_len(scale_a, static_cast<size_t>(M), kFn, "scale_a");
+    require_scale_len(scale_b, scale_b_stride == 1 ? static_cast<size_t>(N) : 1,
+                      kFn, "scale_b");
+    require_bias(bias, N, kFn);
+
+    launch_int8_gemm_a_tiled128_down_kernel(
+        a.data(), b.data(), c.data(), scale_a.data(), scale_b.data(),
+        scale_b_stride, opt_data(bias), opt_code(bias), M, N, K, N,
+        out_code, tiled_b, reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
 void convrot_w4a4_gemm(nb::ndarray<> a, nb::ndarray<> b, nb::ndarray<> c, nb::ndarray<> x_scale,
                        nb::ndarray<> w_scale, OptArray bias, int M, int N, int K, int out_code,
                        uintptr_t stream_ptr) {
@@ -438,6 +657,103 @@ void quantize_int8_convrot(nb::ndarray<> x, nb::ndarray<> q, nb::ndarray<> scale
                                         scales.data(), spill_rotated_ptr, spill_partials_ptr, M, K,
                                         group_size, act_code,
                                         reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+void quantize_int8_convrot_swiglu_split_tiled128(
+    nb::ndarray<> gate, nb::ndarray<> up, nb::ndarray<> q,
+    nb::ndarray<> scales, int M, int K, int group_size,
+    uintptr_t stream_ptr) {
+    constexpr const char* kFn =
+        "quantize_int8_convrot_swiglu_split_tiled128";
+    require_nonneg(M, kFn, "M");
+    require_convrot_group(K, group_size, kFn);
+    require_dtype(gate, 2, 2, kFn, "gate");
+    require_dtype(up, 2, 2, kFn, "up");
+    require_dtype(q, 4, 4, kFn, "q");
+    require_len(gate, static_cast<int64_t>(M) * K, kFn, "gate");
+    require_len(up, static_cast<int64_t>(M) * K, kFn, "up");
+    const int64_t padded_m =
+        (static_cast<int64_t>(M) + 127) / 128 * 128;
+    require_len(q, padded_m * K, kFn, "q");
+    require_scale_len(scales, static_cast<size_t>(M), kFn, "scales");
+
+    launch_quantize_int8_convrot_swiglu_split_tiled128_kernel(
+        gate.data(), up.data(), q.data(), scales.data(), M, K, group_size,
+        reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+void quantize_int8_convrot_modulated(
+    nb::ndarray<> x, nb::ndarray<> modulation_scale, nb::ndarray<> q,
+    nb::ndarray<> scales, int M, int K, int group_size,
+    uintptr_t stream_ptr) {
+    constexpr const char* kFn = "quantize_int8_convrot_modulated";
+    require_nonneg(M, kFn, "M");
+    require_convrot_group(K, group_size, kFn);
+    require_dtype(x, 2, 2, kFn, "x");
+    require_dtype(modulation_scale, 2, 2, kFn, "modulation_scale");
+    require_dtype(q, 4, 4, kFn, "q");
+    require_len(x, static_cast<int64_t>(M) * K, kFn, "x");
+    require_len(modulation_scale, static_cast<int64_t>(K), kFn,
+                "modulation_scale");
+    require_len(q, static_cast<int64_t>(M) * K, kFn, "q");
+    require_scale_len(scales, static_cast<size_t>(M), kFn, "scales");
+
+    launch_quantize_int8_convrot_modulated_kernel(
+        x.data(), modulation_scale.data(), q.data(), scales.data(),
+        M, K, group_size, reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+void quantize_int8_convrot_affine(
+    nb::ndarray<> x, nb::ndarray<> modulation_scale,
+    nb::ndarray<> modulation_shift, nb::ndarray<> q,
+    nb::ndarray<> scales, int M, int K, int group_size,
+    uintptr_t stream_ptr) {
+    constexpr const char* kFn = "quantize_int8_convrot_affine";
+    require_nonneg(M, kFn, "M");
+    require_convrot_group(K, group_size, kFn);
+    require_dtype(x, 2, 2, kFn, "x");
+    require_dtype(modulation_scale, 2, 2, kFn, "modulation_scale");
+    require_dtype(modulation_shift, 2, 2, kFn, "modulation_shift");
+    require_dtype(q, 4, 4, kFn, "q");
+    require_len(x, static_cast<int64_t>(M) * K, kFn, "x");
+    require_len(modulation_scale, static_cast<int64_t>(K), kFn,
+                "modulation_scale");
+    require_len(modulation_shift, static_cast<int64_t>(K), kFn,
+                "modulation_shift");
+    require_len(q, static_cast<int64_t>(M) * K, kFn, "q");
+    require_scale_len(scales, static_cast<size_t>(M), kFn, "scales");
+
+    launch_quantize_int8_convrot_affine_kernel(
+        x.data(), modulation_scale.data(), modulation_shift.data(),
+        q.data(), scales.data(), M, K, group_size,
+        reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+void quantize_int8_convrot_rms_modulated_fused_stats(
+    nb::ndarray<> x, nb::ndarray<> norm_weight,
+    nb::ndarray<> modulation_scale, nb::ndarray<> q, nb::ndarray<> scales,
+    int M, int K, int group_size, float eps, uintptr_t stream_ptr) {
+    constexpr const char* kFn =
+        "quantize_int8_convrot_rms_modulated_fused_stats";
+    require_nonneg(M, kFn, "M");
+    require_convrot_group(K, group_size, kFn);
+    require_dtype(x, 2, 2, kFn, "x");
+    require_dtype(norm_weight, 2, 2, kFn, "norm_weight");
+    require_dtype(modulation_scale, 2, 2, kFn, "modulation_scale");
+    require_dtype(q, 4, 4, kFn, "q");
+    require_len(x, static_cast<int64_t>(M) * K, kFn, "x");
+    require_len(norm_weight, K, kFn, "norm_weight");
+    require_len(modulation_scale, K, kFn, "modulation_scale");
+    require_len(q, static_cast<int64_t>(M) * K, kFn, "q");
+    require_scale_len(scales, static_cast<size_t>(M), kFn, "scales");
+    launch_quantize_int8_convrot_rms_modulated_fused_stats_kernel(
+        x.data(), norm_weight.data(), modulation_scale.data(), q.data(),
+        scales.data(), M, K, group_size, eps,
+        reinterpret_cast<hipStream_t>(stream_ptr));
     check_hip_launch();
 }
 
@@ -1366,7 +1682,6 @@ void sage_sdpa_prequantized(nb::ndarray<> q_int8, nb::ndarray<> k_int8, nb::ndar
                 reinterpret_cast<hipStream_t>(stream_ptr), kFn);
 }
 
-
 // BF16 decode attention. Every extent below is derived from the operands rather
 // than taken from the caller, and the kernel indexes with the strides passed
 // here, so a mismatch is an out-of-bounds device access. Mirrors the checks in
@@ -1494,6 +1809,164 @@ void flash_attention_decode(nb::ndarray<> q, nb::ndarray<> k, nb::ndarray<> v,
     check_hip_launch();
 }
 
+
+void bf16_sdpa_hip(
+    nb::ndarray<> q, nb::ndarray<> k, nb::ndarray<> v, nb::ndarray<> output,
+    float sm_scale, uintptr_t stream_ptr) {
+    constexpr const char* kFn = "bf16_sdpa_hip";
+    if (q.ndim() != 4 || k.ndim() != 4 || v.ndim() != 4 || output.ndim() != 4) {
+        throw std::runtime_error(std::string(kFn) + ": q, k, v and output must be 4D");
+    }
+    const int batch = static_cast<int>(q.shape(0));
+    const int q_heads = static_cast<int>(q.shape(1));
+    const int q_len = static_cast<int>(q.shape(2));
+    const int head_dim = static_cast<int>(q.shape(3));
+    const int kv_heads = static_cast<int>(k.shape(1));
+    const int kv_len = static_cast<int>(k.shape(2));
+    if (batch <= 0 || q_heads <= 0 || kv_heads <= 0 || q_heads % kv_heads != 0 ||
+        q_len <= 0 || kv_len <= 0 ||
+        (head_dim != 128) ||
+        k.shape(0) != q.shape(0) || k.shape(3) != q.shape(3) ||
+        v.shape(0) != q.shape(0) || v.shape(1) != k.shape(1) ||
+        v.shape(2) != k.shape(2) || v.shape(3) != q.shape(3) ||
+        output.shape(0) != q.shape(0) || output.shape(1) != q.shape(1) ||
+        output.shape(2) != q.shape(2) || output.shape(3) != q.shape(3)) {
+        throw std::runtime_error(
+            std::string(kFn) +
+            ": incompatible BF16 [B,H,N,D] tensors or unsupported head dimension");
+    }
+    require_dtype(q, 2, 2, kFn, "q");
+    require_dtype(k, 2, 2, kFn, "k");
+    require_dtype(v, 2, 2, kFn, "v");
+    require_dtype(output, 2, 2, kFn, "output");
+    auto require_supported_layout = [&](const nb::ndarray<>& tensor, const char* name) {
+        if (tensor.stride(3) != 1 || tensor.stride(2) % 8 != 0) {
+            throw std::runtime_error(
+                std::string(kFn) + ": " + name +
+                " must have a contiguous head dimension and 16-byte-aligned rows");
+        }
+        if (reinterpret_cast<uintptr_t>(tensor.data()) % 16 != 0) {
+            throw std::runtime_error(
+                std::string(kFn) + ": " + name + " must be 16-byte aligned");
+        }
+    };
+    require_supported_layout(q, "q");
+    require_supported_layout(k, "k");
+    require_supported_layout(v, "v");
+    require_supported_layout(output, "output");
+
+    launch_bf16_sdpa_hip(
+        q.data(), k.data(), v.data(), output.data(), batch, q_heads, kv_heads,
+        q_len, kv_len, head_dim,
+        q.stride(0), q.stride(1), q.stride(2),
+        k.stride(0), k.stride(1), k.stride(2),
+        v.stride(0), v.stride(1), v.stride(2),
+        output.stride(0), output.stride(1), output.stride(2), sm_scale,
+        reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+void hip_int8_attention(
+    nb::ndarray<> q, nb::ndarray<> k, nb::ndarray<> v, nb::ndarray<> output,
+    nb::ndarray<> q_int8, nb::ndarray<> k_int8, nb::ndarray<> v_int8,
+    nb::ndarray<> q_descale, nb::ndarray<> k_descale, nb::ndarray<> v_descale,
+    nb::ndarray<> anchor_indices, float sm_scale, uintptr_t stream_ptr) {
+    constexpr const char* kFn = "hip_int8_attention";
+    if (q.ndim() != 4 || k.ndim() != 4 || v.ndim() != 4 ||
+        q.shape(0) != 1 || q.shape(1) == 0 || q.shape(3) != 128 ||
+        k.shape(0) != 1 || k.shape(1) != q.shape(1) || k.shape(3) != 128 ||
+        v.shape(0) != 1 || v.shape(1) != q.shape(1) || v.shape(3) != 128 ||
+        k.shape(2) != v.shape(2)) {
+        throw std::runtime_error(
+            std::string(kFn) +
+            ": q must be [1, H, Q, 128] and k/v matching [1, H, K, 128]");
+    }
+    const int heads = static_cast<int>(q.shape(1));
+    const int q_len = static_cast<int>(q.shape(2));
+    const int kv_len = static_cast<int>(k.shape(2));
+    if (q_len <= 0 || kv_len <= 0) {
+        throw std::runtime_error(std::string(kFn) + ": Q and K/V lengths must be positive");
+    }
+    require_dtype(q, 1, 2, kFn, "q");
+    require_dtype(k, 1, 2, kFn, "k");
+    require_dtype(v, 1, 2, kFn, "v");
+    const int input_dtype_code = map_dtype_to_code(q.dtype());
+    if (map_dtype_to_code(k.dtype()) != input_dtype_code ||
+        map_dtype_to_code(v.dtype()) != input_dtype_code) {
+        throw std::runtime_error(std::string(kFn) + ": q, k, and v dtypes must match");
+    }
+    if (q.stride(3) != 1 || k.stride(3) != 1 || v.stride(3) != 1) {
+        throw std::runtime_error(std::string(kFn) + ": the head dimension must be contiguous");
+    }
+    const int padded_k = ((kv_len + 63) / 64) * 64;
+    const int padded_q = ((q_len + 127) / 128) * 128;
+    const int tiles = padded_k / 64;
+    const auto stream = reinterpret_cast<hipStream_t>(stream_ptr);
+
+    if (output.ndim() != 4 || output.shape(0) != 1 ||
+        output.shape(1) != static_cast<size_t>(heads) ||
+        output.shape(2) != static_cast<size_t>(q_len) || output.shape(3) != 128 ||
+        q_int8.ndim() != 4 || q_int8.shape(0) != 1 ||
+        q_int8.shape(1) != static_cast<size_t>(heads) ||
+        q_int8.shape(2) != static_cast<size_t>(q_len) || q_int8.shape(3) != 128 ||
+        k_int8.ndim() != 4 || k_int8.shape(0) != 1 ||
+        k_int8.shape(1) != static_cast<size_t>(heads) ||
+        k_int8.shape(2) != static_cast<size_t>(padded_k) || k_int8.shape(3) != 128 ||
+        v_int8.ndim() != 5 || v_int8.shape(0) != 1 ||
+        v_int8.shape(1) != static_cast<size_t>(heads) ||
+        v_int8.shape(2) != static_cast<size_t>(tiles) || v_int8.shape(3) != 128 ||
+        v_int8.shape(4) != 64) {
+        throw std::runtime_error(std::string(kFn) + ": incompatible packed workspace shapes");
+    }
+    require_dtype(output, 1, 2, kFn, "output");
+    if (map_dtype_to_code(output.dtype()) != input_dtype_code) {
+        throw std::runtime_error(std::string(kFn) + ": output dtype must match q");
+    }
+    require_dtype(q_int8, 4, 4, kFn, "q_int8");
+    require_dtype(k_int8, 4, 4, kFn, "k_int8");
+    require_dtype(v_int8, 4, 4, kFn, "v_int8");
+    require_scale_len(q_descale, static_cast<size_t>(heads) * padded_q,
+                      kFn, "q_descale");
+    require_scale_len(k_descale, static_cast<size_t>(heads) * (padded_k / 16),
+                      kFn, "k_descale");
+    require_scale_len(v_descale, static_cast<size_t>(heads) * tiles * 128,
+                      kFn, "v_descale");
+    if (output.stride(3) != 1) {
+        throw std::runtime_error(
+            std::string(kFn) + ": output head dimension must be contiguous");
+    }
+    require_packed_contiguous(q_int8, kFn, "q_int8");
+    require_packed_contiguous(k_int8, kFn, "k_int8");
+    require_packed_contiguous(v_int8, kFn, "v_int8");
+    require_packed_contiguous(q_descale, kFn, "q_descale");
+    require_packed_contiguous(k_descale, kFn, "k_descale");
+    require_packed_contiguous(v_descale, kFn, "v_descale");
+    if (anchor_indices.dtype().bits != 32 ||
+        anchor_indices.size() < static_cast<size_t>(heads)) {
+        throw std::runtime_error(
+            std::string(kFn) + ": anchor_indices must contain H int32s");
+    }
+
+    // Keeping all three producers and the consumer on this stream preserves
+    // the one-call API without host synchronization.
+    launch_gfx12_qk_quant(
+        q.data(), q_int8.data(), q_descale.data(),
+        k.data(), k_int8.data(), k_descale.data(), anchor_indices.data(),
+        heads, q_len, kv_len, padded_q, padded_k,
+        q.stride(0), q.stride(1), q.stride(2),
+        k.stride(0), k.stride(1), k.stride(2), input_dtype_code, stream);
+    launch_gfx12_tile_channel_v_quant(
+        v.data(), v_int8.data(), v_descale.data(), heads, kv_len, tiles,
+        v.stride(1), v.stride(2), input_dtype_code, stream);
+    launch_gfx12_int8_attention(
+        q_int8.data(), k_int8.data(), v_int8.data(), output.data(),
+        q_descale.data(), k_descale.data(), v_descale.data(), heads, q_len,
+        kv_len, padded_q, padded_k, padded_k / 16,
+        output.stride(1), output.stride(2),
+        sm_scale, input_dtype_code, stream);
+    check_hip_launch();
+}
+
 NB_MODULE(_C, m) {
     m.doc() = "ComfyKitchen HIP backend native operations (RDNA2-RDNA4, WMMA on gfx11/gfx12)";
     m.def("quantize_per_tensor_fp8", &quantize_per_tensor_fp8);
@@ -1501,9 +1974,25 @@ NB_MODULE(_C, m) {
     m.def("stochastic_round_fp8", &stochastic_round_fp8);
     m.def("scaled_mm_fp8", &scaled_mm_fp8);
     m.def("int8_gemm", &int8_gemm);
+    m.def("int8_gemm_b_tiled", &int8_gemm_b_tiled);
+    m.def("int8_gemm_b_tiled_gated_residual",
+          &int8_gemm_b_tiled_gated_residual);
+    m.def("int8_gemm_pair", &int8_gemm_pair);
+    m.def("rms_gated_residual_bf16", &rms_gated_residual_bf16);
+    m.def("int8_gemm_a_tiled128_down", &int8_gemm_a_tiled128_down);
     m.def("convrot_w4a4_gemm", &convrot_w4a4_gemm);
     m.def("quantize_int8_rowwise", &quantize_int8_rowwise);
-    m.def("quantize_int8_convrot", &quantize_int8_convrot);
+    m.def("quantize_int8_convrot", &quantize_int8_convrot,
+          nb::arg("x"), nb::arg("q"), nb::arg("scales"),
+          nb::arg("spill_rotated").none(), nb::arg("spill_partials").none(),
+          nb::arg("M"), nb::arg("K"), nb::arg("group_size"),
+          nb::arg("act_code"), nb::arg("stream_ptr"));
+    m.def("quantize_int8_convrot_swiglu_split_tiled128",
+          &quantize_int8_convrot_swiglu_split_tiled128);
+    m.def("quantize_int8_convrot_modulated", &quantize_int8_convrot_modulated);
+    m.def("quantize_int8_convrot_affine", &quantize_int8_convrot_affine);
+    m.def("quantize_int8_convrot_rms_modulated_fused_stats",
+          &quantize_int8_convrot_rms_modulated_fused_stats);
     m.def("quantize_int8_tensorwise", &quantize_int8_tensorwise);
     m.def("dequantize_int8_simple", &dequantize_int8_simple);
     m.def("dequantize_int8_convrot_weight", &dequantize_int8_convrot_weight);
@@ -1534,6 +2023,14 @@ NB_MODULE(_C, m) {
           nb::arg("v_int8"), nb::arg("o"), nb::arg("q_scale"), nb::arg("k_scale"),
           nb::arg("v_scale"), nb::arg("cta_k"), nb::arg("sm_scale"),
           nb::arg("output_dtype_code"), nb::arg("stream_ptr"), nb::arg("attn_mask") = nb::none());
+    m.def("bf16_sdpa_hip", &bf16_sdpa_hip,
+          nb::arg("q"), nb::arg("k"), nb::arg("v"), nb::arg("output"),
+          nb::arg("sm_scale"), nb::arg("stream_ptr"));
+    m.def("hip_int8_attention", &hip_int8_attention,
+          nb::arg("q"), nb::arg("k"), nb::arg("v"), nb::arg("output"),
+          nb::arg("q_int8"), nb::arg("k_int8"), nb::arg("v_int8"),
+          nb::arg("q_descale"), nb::arg("k_descale"), nb::arg("v_descale"),
+          nb::arg("anchor_indices"), nb::arg("sm_scale"), nb::arg("stream_ptr"));
     m.def("adaln", &adaln);
     m.def("rms_adaln", &rms_adaln);
     m.def("apply_rope", &apply_rope);

--- a/comfy_kitchen/backends/hip/dlpack_bindings.cpp
+++ b/comfy_kitchen/backends/hip/dlpack_bindings.cpp
@@ -808,6 +808,11 @@ void quantize_int8_convrot_rms_modulated_fused_stats(
     require_len(modulation_scale, K, kFn, "modulation_scale");
     require_len(q, static_cast<int64_t>(M) * K, kFn, "q");
     require_scale_len(scales, static_cast<size_t>(M), kFn, "scales");
+    require_packed_contiguous(x, kFn, "x");
+    require_packed_contiguous(norm_weight, kFn, "norm_weight");
+    require_packed_contiguous(modulation_scale, kFn, "modulation_scale");
+    require_packed_contiguous(q, kFn, "q");
+    require_packed_contiguous(scales, kFn, "scales");
     const nb::ndarray<>* aligned_operands[] = {
         &x, &norm_weight, &modulation_scale, &q, &scales};
     for (const nb::ndarray<>* operand : aligned_operands) {
@@ -2054,6 +2059,9 @@ void hip_int8_attention(
         kv_len, padded_q, padded_k, padded_k / 16,
         output.stride(1), output.stride(2),
         sm_scale, input_dtype_code, stream);
+    check_hip_launch();
+}
+
 // ---------------------------------------------------------------------------
 // Sol-Attn sparse attention
 // ---------------------------------------------------------------------------

--- a/comfy_kitchen/backends/hip/dlpack_bindings.cpp
+++ b/comfy_kitchen/backends/hip/dlpack_bindings.cpp
@@ -1911,10 +1911,13 @@ void bf16_sdpa_hip(
     require_dtype(v, 2, 2, kFn, "v");
     require_dtype(output, 2, 2, kFn, "output");
     auto require_supported_layout = [&](const nb::ndarray<>& tensor, const char* name) {
-        if (tensor.stride(3) != 1 || tensor.stride(2) % 8 != 0) {
+        if (tensor.stride(3) != 1 || tensor.stride(2) % 8 != 0 ||
+            (tensor.shape(0) > 1 && tensor.stride(0) % 8 != 0) ||
+            (tensor.shape(1) > 1 && tensor.stride(1) % 8 != 0)) {
             throw std::runtime_error(
                 std::string(kFn) + ": " + name +
-                " must have a contiguous head dimension and 16-byte-aligned rows");
+                " must have a contiguous head dimension and 16-byte-aligned rows "
+                "across every batch and head");
         }
         if (reinterpret_cast<uintptr_t>(tensor.data()) % 16 != 0) {
             throw std::runtime_error(

--- a/comfy_kitchen/backends/hip/dlpack_bindings.cpp
+++ b/comfy_kitchen/backends/hip/dlpack_bindings.cpp
@@ -512,6 +512,14 @@ void rms_gated_residual_bf16(
     require_len(residual, numel, kFn, "residual");
     require_len(gate, width, kFn, "gate");
     require_len(output, numel, kFn, "output");
+    const nb::ndarray<>* vector_operands[] = {
+        &activation, &norm_weight, &residual, &gate, &output};
+    for (const nb::ndarray<>* operand : vector_operands) {
+        if (reinterpret_cast<uintptr_t>(operand->data()) % 8 != 0) {
+            throw std::runtime_error(
+                std::string(kFn) + ": all operands must be 8-byte aligned");
+        }
+    }
 
     launch_rms_gated_residual_bf16_kernel(
         activation.data(), norm_weight.data(), residual.data(), gate.data(),
@@ -1854,6 +1862,16 @@ void bf16_sdpa_hip(
     require_supported_layout(k, "k");
     require_supported_layout(v, "v");
     require_supported_layout(output, "output");
+    constexpr int kDeviceRocm = nb::device::rocm::value;
+    const nb::ndarray<>* operands[] = {&q, &k, &v, &output};
+    for (const nb::ndarray<>* operand : operands) {
+        if (operand->device_type() != kDeviceRocm ||
+            operand->device_id() != q.device_id()) {
+            throw std::runtime_error(
+                std::string(kFn) +
+                ": every operand must be ROCm device memory on q's device");
+        }
+    }
 
     launch_bf16_sdpa_hip(
         q.data(), k.data(), v.data(), output.data(), batch, q_heads, kv_heads,
@@ -1945,6 +1963,20 @@ void hip_int8_attention(
         anchor_indices.size() < static_cast<size_t>(heads)) {
         throw std::runtime_error(
             std::string(kFn) + ": anchor_indices must contain H int32s");
+    }
+    constexpr int kDeviceRocm = nb::device::rocm::value;
+    const nb::ndarray<>* operands[] = {
+        &q,         &k,          &v,          &output,
+        &q_int8,    &k_int8,     &v_int8,     &q_descale,
+        &k_descale, &v_descale,  &anchor_indices,
+    };
+    for (const nb::ndarray<>* operand : operands) {
+        if (operand->device_type() != kDeviceRocm ||
+            operand->device_id() != q.device_id()) {
+            throw std::runtime_error(
+                std::string(kFn) +
+                ": every operand must be ROCm device memory on q's device");
+        }
     }
 
     // Keeping all three producers and the consumer on this stream preserves

--- a/comfy_kitchen/backends/hip/dlpack_bindings.cpp
+++ b/comfy_kitchen/backends/hip/dlpack_bindings.cpp
@@ -644,6 +644,13 @@ void quantize_int8_convrot(nb::ndarray<> x, nb::ndarray<> q, nb::ndarray<> scale
     require_len(x, static_cast<int64_t>(M) * K * in_width, kFn, "x");
     require_len(q, static_cast<int64_t>(M) * K, kFn, "q");
     require_scale_len(scales, static_cast<size_t>(M), kFn, "scales");
+    const nb::ndarray<>* aligned_operands[] = {&x, &q, &scales};
+    for (const nb::ndarray<>* operand : aligned_operands) {
+        if (reinterpret_cast<uintptr_t>(operand->data()) % 8 != 0) {
+            throw std::runtime_error(
+                std::string(kFn) + ": all operands must be 8-byte aligned");
+        }
+    }
 
     void* spill_rotated_ptr = nullptr;
     void* spill_partials_ptr = nullptr;
@@ -685,6 +692,13 @@ void quantize_int8_convrot_swiglu_split_tiled128(
         (static_cast<int64_t>(M) + 127) / 128 * 128;
     require_len(q, padded_m * K, kFn, "q");
     require_scale_len(scales, static_cast<size_t>(M), kFn, "scales");
+    const nb::ndarray<>* aligned_operands[] = {&gate, &up, &q, &scales};
+    for (const nb::ndarray<>* operand : aligned_operands) {
+        if (reinterpret_cast<uintptr_t>(operand->data()) % 8 != 0) {
+            throw std::runtime_error(
+                std::string(kFn) + ": all operands must be 8-byte aligned");
+        }
+    }
 
     launch_quantize_int8_convrot_swiglu_split_tiled128_kernel(
         gate.data(), up.data(), q.data(), scales.data(), M, K, group_size,
@@ -707,6 +721,14 @@ void quantize_int8_convrot_modulated(
                 "modulation_scale");
     require_len(q, static_cast<int64_t>(M) * K, kFn, "q");
     require_scale_len(scales, static_cast<size_t>(M), kFn, "scales");
+    const nb::ndarray<>* aligned_operands[] = {
+        &x, &modulation_scale, &q, &scales};
+    for (const nb::ndarray<>* operand : aligned_operands) {
+        if (reinterpret_cast<uintptr_t>(operand->data()) % 8 != 0) {
+            throw std::runtime_error(
+                std::string(kFn) + ": all operands must be 8-byte aligned");
+        }
+    }
 
     launch_quantize_int8_convrot_modulated_kernel(
         x.data(), modulation_scale.data(), q.data(), scales.data(),
@@ -733,6 +755,14 @@ void quantize_int8_convrot_affine(
                 "modulation_shift");
     require_len(q, static_cast<int64_t>(M) * K, kFn, "q");
     require_scale_len(scales, static_cast<size_t>(M), kFn, "scales");
+    const nb::ndarray<>* aligned_operands[] = {
+        &x, &modulation_scale, &modulation_shift, &q, &scales};
+    for (const nb::ndarray<>* operand : aligned_operands) {
+        if (reinterpret_cast<uintptr_t>(operand->data()) % 8 != 0) {
+            throw std::runtime_error(
+                std::string(kFn) + ": all operands must be 8-byte aligned");
+        }
+    }
 
     launch_quantize_int8_convrot_affine_kernel(
         x.data(), modulation_scale.data(), modulation_shift.data(),
@@ -758,6 +788,14 @@ void quantize_int8_convrot_rms_modulated_fused_stats(
     require_len(modulation_scale, K, kFn, "modulation_scale");
     require_len(q, static_cast<int64_t>(M) * K, kFn, "q");
     require_scale_len(scales, static_cast<size_t>(M), kFn, "scales");
+    const nb::ndarray<>* aligned_operands[] = {
+        &x, &norm_weight, &modulation_scale, &q, &scales};
+    for (const nb::ndarray<>* operand : aligned_operands) {
+        if (reinterpret_cast<uintptr_t>(operand->data()) % 8 != 0) {
+            throw std::runtime_error(
+                std::string(kFn) + ": all operands must be 8-byte aligned");
+        }
+    }
     launch_quantize_int8_convrot_rms_modulated_fused_stats_kernel(
         x.data(), norm_weight.data(), modulation_scale.data(), q.data(),
         scales.data(), M, K, group_size, eps,

--- a/comfy_kitchen/backends/hip/dlpack_bindings.cpp
+++ b/comfy_kitchen/backends/hip/dlpack_bindings.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #include <cstdint>
 #include <cstring>
+#include <limits>
 #include <optional>
 #include <stdexcept>
 #include <string>
@@ -1506,6 +1507,49 @@ static void require_packed_contiguous(const nb::ndarray<>& t, const char* fn, co
     }
 }
 
+static void require_non_overlapping_rows(
+    const nb::ndarray<>& output, int row_axis, uint64_t row_width,
+    const char* fn, const char* name) {
+    struct ActiveDimension {
+        uint64_t extent;
+        uint64_t stride;
+    };
+    ActiveDimension active_dimensions[3]{};
+    int active_count = 0;
+    for (int dim = 0; dim < row_axis; ++dim) {
+        if (output.shape(dim) <= 1) {
+            continue;
+        }
+        if (output.stride(dim) <= 0) {
+            throw std::runtime_error(
+                std::string(fn) + ": " + name + " must have a non-overlapping layout");
+        }
+        ActiveDimension current{
+            static_cast<uint64_t>(output.shape(dim)),
+            static_cast<uint64_t>(output.stride(dim))};
+        int insertion = active_count;
+        while (insertion > 0 &&
+               active_dimensions[insertion - 1].stride > current.stride) {
+            active_dimensions[insertion] = active_dimensions[insertion - 1];
+            --insertion;
+        }
+        active_dimensions[insertion] = current;
+        ++active_count;
+    }
+
+    uint64_t span = row_width;
+    for (int index = 0; index < active_count; ++index) {
+        const auto [extent, stride] = active_dimensions[index];
+        const uint64_t repeats = extent - 1;
+        if (stride < span ||
+            repeats > (std::numeric_limits<uint64_t>::max() - span) / stride) {
+            throw std::runtime_error(
+                std::string(fn) + ": " + name + " must have a non-overlapping layout");
+        }
+        span += repeats * stride;
+    }
+}
+
 static void sage_check_quantized(const nb::ndarray<>& q_int8, const nb::ndarray<>& q_scale,
                                  const nb::ndarray<>& k_int8, const nb::ndarray<>& k_scale,
                                  const nb::ndarray<>& v_int8, const nb::ndarray<>& v_scale,
@@ -1928,11 +1972,7 @@ void bf16_sdpa_hip(
     require_supported_layout(k, "k");
     require_supported_layout(v, "v");
     require_supported_layout(output, "output");
-    if (q_len > 1 && output.stride(2) < head_dim) {
-        throw std::runtime_error(
-            std::string(kFn) +
-            ": output row stride must be at least the head dimension");
-    }
+    require_non_overlapping_rows(output, 3, head_dim, kFn, "output");
     constexpr int kDeviceRocm = nb::device::rocm::value;
     const nb::ndarray<>* operands[] = {&q, &k, &v, &output};
     for (const nb::ndarray<>* operand : operands) {
@@ -2024,6 +2064,7 @@ void hip_int8_attention(
         throw std::runtime_error(
             std::string(kFn) + ": output head dimension must be contiguous");
     }
+    require_non_overlapping_rows(output, 3, 128, kFn, "output");
     require_packed_contiguous(q_int8, kFn, "q_int8");
     require_packed_contiguous(k_int8, kFn, "k_int8");
     require_packed_contiguous(v_int8, kFn, "v_int8");

--- a/comfy_kitchen/backends/hip/epilogue.h
+++ b/comfy_kitchen/backends/hip/epilogue.h
@@ -67,4 +67,49 @@ struct EpiRowwise {
     }
 };
 
+// out = residual + gate[col] * bf16(linear)
+//
+// The explicit BF16 conversion is observable: ComfyUI materializes the INT8
+// linear output before torch.addcmul consumes it.  Keeping that rounding point
+// makes this a traffic/dispatch fusion rather than a numerical approximation.
+struct EpiRowwiseGatedResidual {
+    const float* scale_a;
+    const float* scale_b;
+    int scale_b_stride;
+    const void* bias;
+    int bias_code;
+    const __bf16* residual;
+    const __bf16* gate;
+    int residual_stride;
+
+    __forceinline__ __device__ void init() {}
+
+    __forceinline__ __device__ float operator()(int row, int col, float acc) const {
+        #pragma clang fp contract(off)
+        #pragma clang fp reassociate(off)
+        float linear = acc * scale_a[row];
+        linear *= scale_b[col * scale_b_stride];
+        if (bias) linear += load_scalar(bias, bias_code, col);
+        const __bf16 rounded = static_cast<__bf16>(linear);
+        return fmaf(
+            static_cast<float>(gate[col]), static_cast<float>(rounded),
+            static_cast<float>(residual[static_cast<int64_t>(row) * residual_stride + col]));
+    }
+};
+
+// Pair-only specialization for the bias-free ConvRot FeedForward projections.
+// Keeping the same left-to-right scale expression preserves EpiRowwise's BF16
+// result while removing the runtime bias pointer/dtype branches from every
+// unrolled output element.
+struct EpiRowwiseNoBias {
+    const float* scale_a;
+    const float* scale_b;
+
+    __forceinline__ __device__ void init() {}
+
+    __forceinline__ __device__ float operator()(int row, int col, float acc) const {
+        return acc * scale_a[row] * scale_b[col];
+    }
+};
+
 }  // namespace comfy::hip_backend

--- a/comfy_kitchen/backends/hip/gemm_wmma.h
+++ b/comfy_kitchen/backends/hip/gemm_wmma.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <atomic>
+#include <type_traits>
 
 #include "mma.h"
 
@@ -35,7 +36,7 @@ constexpr int kLdsPad = 8;
 // kbytes is the source row length in bytes (K for 8-bit types, K/2 for int4) and
 // is a multiple of 16, so a 16-byte chunk starting inside a row also ends inside
 // it. Out-of-range rows and the K tail are zero-filled.
-template <int ROWS, int BKB, int THREADS>
+template <int ROWS, int BKB, int THREADS, bool COALESCED_STAGING = false>
 struct TileStager {
     static constexpr int kChunksPerRow = BKB / 16;
     static constexpr int kChunks = ROWS * kChunksPerRow;
@@ -48,19 +49,52 @@ struct TileStager {
 
     uint4 regs[kPerThread];
 
+    template <bool ASSUME_ROWS_FULL = false, bool ASSUME_K_FULL = false>
     __forceinline__ __device__ void load(const uint8_t* __restrict__ src, int row0, int rows_total,
                                          int kbyte0, int kbytes) {
         const int tid = threadIdx.x;
         #pragma unroll
         for (int i = 0; i < kPerThread; ++i) {
-            const int c = tid * kPerThread + i;
+            // A thread-strided assignment makes every load instruction cover
+            // consecutive 16-byte chunks across a wave. Keep the original
+            // thread-major order as the control until exact-shape profiling
+            // promotes this layout.
+            const int c = COALESCED_STAGING ? tid + i * THREADS
+                                             : tid * kPerThread + i;
             const int grow = row0 + c / kChunksPerRow;
             const int gk = kbyte0 + (c % kChunksPerRow) * 16;
 
-            regs[i] = (grow < rows_total && gk < kbytes)
-                          ? *reinterpret_cast<const uint4*>(
-                                src + static_cast<int64_t>(grow) * kbytes + gk)
-                          : make_uint4(0, 0, 0, 0);
+            if constexpr (ASSUME_ROWS_FULL && ASSUME_K_FULL) {
+                const uint8_t* const p =
+                    src + static_cast<int64_t>(grow) * kbytes + gk;
+                regs[i] = *reinterpret_cast<const uint4*>(p);
+            } else {
+                const bool valid_row = ASSUME_ROWS_FULL || grow < rows_total;
+                const bool valid_k = ASSUME_K_FULL || gk < kbytes;
+                if (valid_row && valid_k) {
+                    const uint8_t* const p =
+                        src + static_cast<int64_t>(grow) * kbytes + gk;
+                    regs[i] = *reinterpret_cast<const uint4*>(p);
+                } else {
+                    regs[i] = make_uint4(0, 0, 0, 0);
+                }
+            }
+        }
+    }
+
+    // Load one physically contiguous [ROWS, BKB] activation tile. The caller
+    // supplies A as [M_tile, K_tile, ROWS, BKB], so the wave-coalesced chunk
+    // assignment becomes a dense global-memory span instead of touching four
+    // K-strided rows per wave instruction.
+    __forceinline__ __device__ void load_contiguous(
+        const uint8_t* __restrict__ tile) {
+        const int tid = threadIdx.x;
+        #pragma unroll
+        for (int i = 0; i < kPerThread; ++i) {
+            const int c = COALESCED_STAGING ? tid + i * THREADS
+                                             : tid * kPerThread + i;
+            const uint8_t* const p = tile + static_cast<int64_t>(c) * 16;
+            regs[i] = *reinterpret_cast<const uint4*>(p);
         }
     }
 
@@ -68,7 +102,8 @@ struct TileStager {
         const int tid = threadIdx.x;
         #pragma unroll
         for (int i = 0; i < kPerThread; ++i) {
-            const int c = tid * kPerThread + i;
+            const int c = COALESCED_STAGING ? tid + i * THREADS
+                                             : tid * kPerThread + i;
             uint8_t* dst = lds + (c / kChunksPerRow) * kStride + (c % kChunksPerRow) * 16;
             // 8-byte stores: kLdsPad breaks 16-byte LDS alignment.
             *reinterpret_cast<uint2*>(dst) = make_uint2(regs[i].x, regs[i].y);
@@ -79,7 +114,9 @@ struct TileStager {
 
 // Epi is a functor: float operator()(int row, int col, float acc) const.
 template <typename Mma, typename Epi, typename OutT,
-          int BM, int BN, int BKB, int WARPS_M, int WARPS_N, int TM, int TN>
+          int BM, int BN, int BKB, int WARPS_M, int WARPS_N, int TM, int TN,
+          bool COALESCED_STAGING = false, bool TILED_A = false,
+          bool ASSUME_NK_FULL = false, bool TILED_B = false>
 __global__ __launch_bounds__(WARPS_M* WARPS_N* kWave) void gemm_wmma_kernel(
     const uint8_t* __restrict__ A, const uint8_t* __restrict__ B, OutT* __restrict__ C,
     int M, int N, int kbytes, int ldc, Epi epi) {
@@ -135,11 +172,22 @@ __global__ __launch_bounds__(WARPS_M* WARPS_N* kWave) void gemm_wmma_kernel(
 
     const int row = frag_row(lane);
 
-    TileStager<BM, BKB, kThreads> sa;
-    TileStager<BN, BKB, kThreads> sb;
+    TileStager<BM, BKB, kThreads, COALESCED_STAGING> sa;
+    TileStager<BN, BKB, kThreads, COALESCED_STAGING> sb;
 
-    sa.load(A, m0, M, 0, kbytes);
-    sb.load(B, n0, N, 0, kbytes);
+    if constexpr (TILED_A) {
+        const int64_t tile = static_cast<int64_t>(bm) * (kbytes / BKB);
+        sa.load_contiguous(A + tile * BM * BKB);
+    } else {
+        sa.template load<false, ASSUME_NK_FULL>(A, m0, M, 0, kbytes);
+    }
+    if constexpr (TILED_B) {
+        const int64_t tile = static_cast<int64_t>(bn) * (kbytes / BKB);
+        sb.load_contiguous(B + tile * BN * BKB);
+    } else {
+        sb.template load<ASSUME_NK_FULL, ASSUME_NK_FULL>(
+            B, n0, N, 0, kbytes);
+    }
     sa.store(As);
     sb.store(Bs);
     __syncthreads();
@@ -150,8 +198,23 @@ __global__ __launch_bounds__(WARPS_M* WARPS_N* kWave) void gemm_wmma_kernel(
 
         // Prefetch the next tile's global reads ahead of the current tile's math.
         if (has_next) {
-            sa.load(A, m0, M, knext, kbytes);
-            sb.load(B, n0, N, knext, kbytes);
+            if constexpr (TILED_A) {
+                const int64_t tile =
+                    static_cast<int64_t>(bm) * (kbytes / BKB) + knext / BKB;
+                sa.load_contiguous(A + tile * BM * BKB);
+            } else {
+                sa.template load<false, ASSUME_NK_FULL>(
+                    A, m0, M, knext, kbytes);
+            }
+            if constexpr (TILED_B) {
+                const int64_t tile =
+                    static_cast<int64_t>(bn) * (kbytes / BKB)
+                    + knext / BKB;
+                sb.load_contiguous(B + tile * BN * BKB);
+            } else {
+                sb.template load<ASSUME_NK_FULL, ASSUME_NK_FULL>(
+                    B, n0, N, knext, kbytes);
+            }
         }
 
         // Register-level pipeline over K-steps: the LDS reads for step kk+1 are
@@ -207,14 +270,609 @@ __global__ __launch_bounds__(WARPS_M* WARPS_N* kWave) void gemm_wmma_kernel(
     for (int i = 0; i < TM; ++i) {
         #pragma unroll
         for (int e = 0; e < 8; ++e) {
-            const int r = m0 + wm * (TM * 16) + i * 16 + acc_row(lane, e);
+            const int r =
+                m0 + wm * (TM * 16) + i * 16 + acc_row(lane, e);
             if (r >= M) continue;
             OutT* crow = C + static_cast<int64_t>(r) * ldc;
             #pragma unroll
             for (int j = 0; j < TN; ++j) {
-                const int col = n0 + wn * (TN * 16) + j * 16 + col_lane;
-                if (col >= N) continue;
-                crow[col] = static_cast<OutT>(epi(r, col, Mma::get(acc[i][j], e)));
+                const int col =
+                    n0 + wn * (TN * 16) + j * 16 + col_lane;
+                if constexpr (!ASSUME_NK_FULL) {
+                    if (col >= N) continue;
+                }
+                crow[col] = static_cast<OutT>(
+                    epi(r, col, Mma::get(acc[i][j], e)));
+            }
+        }
+    }
+}
+
+// Two equal-width projections over the same activation tile. Half of the
+// workgroup computes each projection, so each thread retains the same single
+// accumulator set as gemm_wmma_kernel while both halves share every global/LDS
+// load of A. The two outputs remain independent and keep the single-GEMM MMA and
+// epilogue order exactly.
+template <typename Mma, typename Epi, typename OutT,
+          int BM, int BN, int BKB, int WARPS_M, int WARPS_N, int TM, int TN,
+          bool TILED_B = false>
+__global__ __launch_bounds__(2 * WARPS_M * WARPS_N * kWave)
+void gemm_wmma_pair_kernel(
+    const uint8_t* __restrict__ A,
+    const uint8_t* __restrict__ B0,
+    const uint8_t* __restrict__ B1,
+    OutT* __restrict__ C0,
+    OutT* __restrict__ C1,
+    int M, int N, int kbytes, int ldc, Epi epi0, Epi epi1) {
+
+    constexpr int kProjectionWarps = WARPS_M * WARPS_N;
+    constexpr int kThreads = 2 * kProjectionWarps * kWave;
+    constexpr int kStride = BKB + kLdsPad;
+    constexpr int kStepBytes = Mma::kStepBytes;
+    constexpr int kSteps = BKB / kStepBytes;
+
+    static_assert(BM == WARPS_M * TM * 16,
+                  "the M warp grid must tile BM exactly");
+    static_assert(BN == WARPS_N * TN * 16,
+                  "the N warp grid must tile BN exactly");
+    static_assert(BKB % kStepBytes == 0,
+                  "BKB must be a whole number of MMA K-steps");
+
+    __shared__ __align__(16) uint8_t As[BM * kStride];
+    __shared__ __align__(16) uint8_t Bs[2][BN * kStride];
+
+    const int tid = threadIdx.x;
+    const int lane = tid % kWave;
+    const int warp = tid / kWave;
+    const int projection = warp / kProjectionWarps;
+    const int projection_warp = warp - projection * kProjectionWarps;
+    const int wm = projection_warp / WARPS_N;
+    const int wn = projection_warp % WARPS_N;
+
+    constexpr int kGroupM = 4;
+    const int blocks_n = gridDim.x;
+    const int blocks_m = gridDim.y;
+    const int bid = blockIdx.y * blocks_n + blockIdx.x;
+    const int per_group = kGroupM * blocks_n;
+    const int group = bid / per_group;
+    const int idx_in_group = bid - group * per_group;
+    const int group_rows = min(kGroupM, blocks_m - group * kGroupM);
+    const int bm = group * kGroupM + idx_in_group % group_rows;
+    const int bn = idx_in_group / group_rows;
+
+    const int m0 = bm * BM;
+    const int n0 = bn * BN;
+
+    typename Mma::Acc acc[TM][TN];
+    #pragma unroll
+    for (int i = 0; i < TM; ++i)
+        #pragma unroll
+        for (int j = 0; j < TN; ++j) acc[i][j] = Mma::zero();
+
+    const int row = frag_row(lane);
+    TileStager<BM, BKB, kThreads> sa;
+    TileStager<BN, BKB, kThreads> sb0;
+    TileStager<BN, BKB, kThreads> sb1;
+
+    sa.load(A, m0, M, 0, kbytes);
+    if constexpr (TILED_B) {
+        const int64_t tile = static_cast<int64_t>(bn) * (kbytes / BKB);
+        sb0.load_contiguous(B0 + tile * BN * BKB);
+        sb1.load_contiguous(B1 + tile * BN * BKB);
+    } else {
+        sb0.load(B0, n0, N, 0, kbytes);
+        sb1.load(B1, n0, N, 0, kbytes);
+    }
+    sa.store(As);
+    sb0.store(Bs[0]);
+    sb1.store(Bs[1]);
+    __syncthreads();
+
+    for (int kb0 = 0; kb0 < kbytes; kb0 += BKB) {
+        const int knext = kb0 + BKB;
+        const bool has_next = knext < kbytes;
+        if (has_next) {
+            sa.load(A, m0, M, knext, kbytes);
+            if constexpr (TILED_B) {
+                const int64_t tile =
+                    static_cast<int64_t>(bn) * (kbytes / BKB)
+                    + knext / BKB;
+                sb0.load_contiguous(B0 + tile * BN * BKB);
+                sb1.load_contiguous(B1 + tile * BN * BKB);
+            } else {
+                sb0.load(B0, n0, N, knext, kbytes);
+                sb1.load(B1, n0, N, knext, kbytes);
+            }
+        }
+
+        typename Mma::Frag af[2][TM];
+        typename Mma::Frag bf[2][TN];
+        #pragma unroll
+        for (int i = 0; i < TM; ++i)
+            af[0][i] = Mma::load(
+                As, wm * (TM * 16) + i * 16 + row, 0, kStride, lane);
+        #pragma unroll
+        for (int j = 0; j < TN; ++j)
+            bf[0][j] = Mma::load(
+                Bs[projection], wn * (TN * 16) + j * 16 + row,
+                0, kStride, lane);
+
+        #pragma unroll
+        for (int kk = 0; kk < kSteps; ++kk) {
+            const int cur = kk & 1;
+            const int nxt = cur ^ 1;
+            if (kk + 1 < kSteps) {
+                const int kbyte = (kk + 1) * kStepBytes;
+                #pragma unroll
+                for (int i = 0; i < TM; ++i)
+                    af[nxt][i] = Mma::load(
+                        As, wm * (TM * 16) + i * 16 + row,
+                        kbyte, kStride, lane);
+                #pragma unroll
+                for (int j = 0; j < TN; ++j)
+                    bf[nxt][j] = Mma::load(
+                        Bs[projection], wn * (TN * 16) + j * 16 + row,
+                        kbyte, kStride, lane);
+            }
+
+            #pragma unroll
+            for (int i = 0; i < TM; ++i)
+                #pragma unroll
+                for (int j = 0; j < TN; ++j)
+                    acc[i][j] = Mma::mma(
+                        af[cur][i], bf[cur][j], acc[i][j]);
+        }
+
+        if (has_next) {
+            __syncthreads();
+            sa.store(As);
+            sb0.store(Bs[0]);
+            sb1.store(Bs[1]);
+            __syncthreads();
+        }
+    }
+
+    constexpr bool kCacheRowwiseEpilogue =
+        std::is_same_v<Epi, EpiRowwiseNoBias> ||
+        std::is_same_v<Epi, EpiRowwise>;
+    float* scale_a_lds = nullptr;
+    float* scale_b_lds = nullptr;
+    float* bias_lds = nullptr;
+    if constexpr (kCacheRowwiseEpilogue) {
+        // The matrix loop is finished, so its A/B tiles can hold the much
+        // smaller epilogue operands. Synchronize before overwriting them, then
+        // load each unique row/channel scale and optional bias once per
+        // workgroup instead of once per unrolled accumulator element.
+        __syncthreads();
+        scale_a_lds = reinterpret_cast<float*>(As);
+        scale_b_lds = reinterpret_cast<float*>(&Bs[0][0]);
+        bias_lds = scale_b_lds + 2 * BN;
+        if (tid < BM) {
+            const int r = m0 + tid;
+            scale_a_lds[tid] = r < M ? epi0.scale_a[r] : 0.0f;
+        }
+        if (tid < BN) {
+            const int col = n0 + tid;
+            if (col < N) {
+                if constexpr (std::is_same_v<Epi, EpiRowwiseNoBias>) {
+                    scale_b_lds[tid] = epi0.scale_b[col];
+                } else {
+                    scale_b_lds[tid] =
+                        epi0.scale_b[col * epi0.scale_b_stride];
+                    bias_lds[tid] = epi0.bias
+                        ? load_scalar(epi0.bias, epi0.bias_code, col)
+                        : 0.0f;
+                }
+            } else {
+                scale_b_lds[tid] = 0.0f;
+                if constexpr (std::is_same_v<Epi, EpiRowwise>) {
+                    bias_lds[tid] = 0.0f;
+                }
+            }
+        } else if (tid < 2 * BN) {
+            const int local_col = tid - BN;
+            const int col = n0 + local_col;
+            if (col < N) {
+                if constexpr (std::is_same_v<Epi, EpiRowwiseNoBias>) {
+                    scale_b_lds[BN + local_col] = epi1.scale_b[col];
+                } else {
+                    scale_b_lds[BN + local_col] =
+                        epi1.scale_b[col * epi1.scale_b_stride];
+                    bias_lds[BN + local_col] = epi1.bias
+                        ? load_scalar(epi1.bias, epi1.bias_code, col)
+                        : 0.0f;
+                }
+            } else {
+                scale_b_lds[BN + local_col] = 0.0f;
+                if constexpr (std::is_same_v<Epi, EpiRowwise>) {
+                    bias_lds[BN + local_col] = 0.0f;
+                }
+            }
+        }
+        __syncthreads();
+    }
+
+    Epi epi = projection == 0 ? epi0 : epi1;
+    OutT* C = projection == 0 ? C0 : C1;
+    epi.init();
+    const int col_lane = acc_col(lane);
+    if constexpr (kCacheRowwiseEpilogue) {
+        // The accepted pair is row-major at writeback. Load its activation
+        // scale once for the four adjacent column fragments instead of letting
+        // the generic functor reload it for every fully unrolled output.
+        #pragma clang fp reassociate(off)
+        #pragma unroll
+        for (int i = 0; i < TM; ++i) {
+            #pragma unroll
+            for (int e = 0; e < 8; ++e) {
+                const int r =
+                    m0 + wm * (TM * 16) + i * 16 + acc_row(lane, e);
+                if (r >= M) continue;
+                OutT* crow = C + static_cast<int64_t>(r) * ldc;
+                const int local_row =
+                    wm * (TM * 16) + i * 16 + acc_row(lane, e);
+                const float row_scale = scale_a_lds[local_row];
+                #pragma unroll
+                for (int j = 0; j < TN; ++j) {
+                    const int col =
+                        n0 + wn * (TN * 16) + j * 16 + col_lane;
+                    if (col >= N) continue;
+                    const int local_col =
+                        wn * (TN * 16) + j * 16 + col_lane;
+                    float value = Mma::get(acc[i][j], e) * row_scale;
+                    value *= scale_b_lds[projection * BN + local_col];
+                    if constexpr (std::is_same_v<Epi, EpiRowwise>) {
+                        if (epi.bias) {
+                            value +=
+                                bias_lds[projection * BN + local_col];
+                        }
+                    }
+                    crow[col] = static_cast<OutT>(value);
+                }
+            }
+        }
+    } else {
+        #pragma unroll
+        for (int i = 0; i < TM; ++i) {
+            #pragma unroll
+            for (int e = 0; e < 8; ++e) {
+                const int r =
+                    m0 + wm * (TM * 16) + i * 16 + acc_row(lane, e);
+                if (r >= M) continue;
+                OutT* crow = C + static_cast<int64_t>(r) * ldc;
+                #pragma unroll
+                for (int j = 0; j < TN; ++j) {
+                    const int col =
+                        n0 + wn * (TN * 16) + j * 16 + col_lane;
+                    if (col >= N) continue;
+                    crow[col] = static_cast<OutT>(
+                        epi(r, col, Mma::get(acc[i][j], e)));
+                }
+            }
+        }
+    }
+}
+
+// Two adjacent M tiles over one weight tile. Half of the workgroup computes
+// each M tile, so every thread keeps the same accumulator shape and arithmetic
+// order as gemm_wmma_kernel while both halves share each global/LDS B stage.
+// gemm_wmma_pair_kernel shares A across two projections; this kernel instead
+// shares B across two row tiles.
+template <typename Mma, typename Epi, typename OutT,
+          int BM, int BN, int BKB, int WARPS_M, int WARPS_N, int TM, int TN,
+          bool VOPD_CROSS_E = false, bool TILED_B = false>
+__global__ __launch_bounds__(2 * WARPS_M * WARPS_N * kWave)
+void gemm_wmma_dual_m_kernel(
+    const uint8_t* __restrict__ A,
+    const uint8_t* __restrict__ B,
+    OutT* __restrict__ C,
+    int M, int N, int kbytes, int ldc, Epi epi) {
+
+    constexpr int kTileWarps = WARPS_M * WARPS_N;
+    constexpr int kThreads = 2 * kTileWarps * kWave;
+    constexpr int kStride = BKB + kLdsPad;
+    constexpr int kStepBytes = Mma::kStepBytes;
+    constexpr int kSteps = BKB / kStepBytes;
+
+    static_assert(BM == WARPS_M * TM * 16,
+                  "the M warp grid must tile BM exactly");
+    static_assert(BN == WARPS_N * TN * 16,
+                  "the N warp grid must tile BN exactly");
+    static_assert(BKB % kStepBytes == 0,
+                  "BKB must be a whole number of MMA K-steps");
+
+    __shared__ __align__(16) uint8_t As[2][BM * kStride];
+    __shared__ __align__(16) uint8_t Bs[BN * kStride];
+
+    const int tid = threadIdx.x;
+    const int lane = tid % kWave;
+    const int warp = tid / kWave;
+    const int mtile = warp / kTileWarps;
+    const int tile_warp = warp - mtile * kTileWarps;
+    const int wm = tile_warp / WARPS_N;
+    const int wn = tile_warp % WARPS_N;
+
+    // Each block covers two adjacent M tiles. Group two such blocks so the
+    // traversal retains the production kernel's four-M-tile B locality.
+    constexpr int kGroupM = 2;
+    const int blocks_n = gridDim.x;
+    const int blocks_m = gridDim.y;
+    const int bid = blockIdx.y * blocks_n + blockIdx.x;
+    const int per_group = kGroupM * blocks_n;
+    const int group = bid / per_group;
+    const int idx_in_group = bid - group * per_group;
+    const int group_rows = min(kGroupM, blocks_m - group * kGroupM);
+    const int bm_pair = group * kGroupM + idx_in_group % group_rows;
+    const int bn = idx_in_group / group_rows;
+
+    const int m0_pair = bm_pair * (2 * BM);
+    const int m0 = m0_pair + mtile * BM;
+    const int n0 = bn * BN;
+
+    typename Mma::Acc acc[TM][TN];
+    #pragma unroll
+    for (int i = 0; i < TM; ++i)
+        #pragma unroll
+        for (int j = 0; j < TN; ++j) acc[i][j] = Mma::zero();
+
+    const int row = frag_row(lane);
+    TileStager<BM, BKB, kThreads> sa0;
+    TileStager<BM, BKB, kThreads> sa1;
+    TileStager<BN, BKB, kThreads> sb;
+
+    sa0.load(A, m0_pair, M, 0, kbytes);
+    sa1.load(A, m0_pair + BM, M, 0, kbytes);
+    if constexpr (TILED_B) {
+        const int64_t tile = static_cast<int64_t>(bn) * (kbytes / BKB);
+        sb.load_contiguous(B + tile * BN * BKB);
+    } else {
+        sb.load(B, n0, N, 0, kbytes);
+    }
+    sa0.store(As[0]);
+    sa1.store(As[1]);
+    sb.store(Bs);
+    __syncthreads();
+
+    for (int kb0 = 0; kb0 < kbytes; kb0 += BKB) {
+        const int knext = kb0 + BKB;
+        const bool has_next = knext < kbytes;
+        if (has_next) {
+            sa0.load(A, m0_pair, M, knext, kbytes);
+            sa1.load(A, m0_pair + BM, M, knext, kbytes);
+            if constexpr (TILED_B) {
+                const int64_t tile =
+                    static_cast<int64_t>(bn) * (kbytes / BKB)
+                    + knext / BKB;
+                sb.load_contiguous(B + tile * BN * BKB);
+            } else {
+                sb.load(B, n0, N, knext, kbytes);
+            }
+        }
+
+        typename Mma::Frag af[2][TM];
+        typename Mma::Frag bf[2][TN];
+        #pragma unroll
+        for (int i = 0; i < TM; ++i)
+            af[0][i] = Mma::load(
+                As[mtile], wm * (TM * 16) + i * 16 + row,
+                0, kStride, lane);
+        #pragma unroll
+        for (int j = 0; j < TN; ++j)
+            bf[0][j] = Mma::load(
+                Bs, wn * (TN * 16) + j * 16 + row,
+                0, kStride, lane);
+
+        #pragma unroll
+        for (int kk = 0; kk < kSteps; ++kk) {
+            const int cur = kk & 1;
+            const int nxt = cur ^ 1;
+            if (kk + 1 < kSteps) {
+                const int kbyte = (kk + 1) * kStepBytes;
+                #pragma unroll
+                for (int i = 0; i < TM; ++i)
+                    af[nxt][i] = Mma::load(
+                        As[mtile], wm * (TM * 16) + i * 16 + row,
+                        kbyte, kStride, lane);
+                #pragma unroll
+                for (int j = 0; j < TN; ++j)
+                    bf[nxt][j] = Mma::load(
+                        Bs, wn * (TN * 16) + j * 16 + row,
+                        kbyte, kStride, lane);
+            }
+
+            #pragma unroll
+            for (int i = 0; i < TM; ++i)
+                #pragma unroll
+                for (int j = 0; j < TN; ++j)
+                    acc[i][j] = Mma::mma(
+                        af[cur][i], bf[cur][j], acc[i][j]);
+        }
+
+        if (has_next) {
+            __syncthreads();
+            sa0.store(As[0]);
+            sa1.store(As[1]);
+            sb.store(Bs);
+            __syncthreads();
+        }
+    }
+
+    epi.init();
+    const int col_lane = acc_col(lane);
+    if constexpr (std::is_same_v<Epi, EpiRowwiseNoBias>) {
+        #pragma clang fp reassociate(off)
+        // Cache the four channel scales owned by this lane directly in VGPRs.
+        // This avoids both the generic functor's fully-unrolled reloads and an
+        // LDS round trip/barrier after the matrix loop.
+        float col_scale[TN];
+        #pragma unroll
+        for (int j = 0; j < TN; ++j) {
+            const int col = n0 + wn * (TN * 16) + j * 16 + col_lane;
+            col_scale[j] = col < N ? epi.scale_b[col] : 0.0f;
+        }
+        #pragma unroll
+        for (int i = 0; i < TM; ++i) {
+            #pragma unroll
+            for (int e = 0; e < 8; ++e) {
+                const int r =
+                    m0 + wm * (TM * 16) + i * 16 + acc_row(lane, e);
+                if (r >= M) continue;
+                OutT* const crow = C + static_cast<int64_t>(r) * ldc;
+                const float row_scale = epi.scale_a[r];
+                #pragma unroll
+                for (int j = 0; j < TN; ++j) {
+                    const int col =
+                        n0 + wn * (TN * 16) + j * 16 + col_lane;
+                    if (col >= N) continue;
+                    float value = Mma::get(acc[i][j], e) * row_scale;
+                    value *= col_scale[j];
+                    crow[col] = static_cast<OutT>(value);
+                }
+            }
+        }
+    } else if constexpr (std::is_same_v<Epi, EpiRowwise>) {
+        #pragma clang fp contract(off)
+        #pragma clang fp reassociate(off)
+        // Bias-bearing checkpoints otherwise reload the same channel scale and
+        // bias for every accumulator element. Each lane owns TN columns, so
+        // retain those operands across all of its output rows just as the
+        // bias-free specialization does.
+        float col_scale[TN];
+        float col_bias[TN];
+        #pragma unroll
+        for (int j = 0; j < TN; ++j) {
+            const int col = n0 + wn * (TN * 16) + j * 16 + col_lane;
+            if (col < N) {
+                col_scale[j] = epi.scale_b[col * epi.scale_b_stride];
+                col_bias[j] = epi.bias
+                    ? load_scalar(epi.bias, epi.bias_code, col) : 0.0f;
+            } else {
+                col_scale[j] = 0.0f;
+                col_bias[j] = 0.0f;
+            }
+        }
+        #pragma unroll
+        for (int i = 0; i < TM; ++i) {
+            #pragma unroll
+            for (int e = 0; e < 8; ++e) {
+                const int r =
+                    m0 + wm * (TM * 16) + i * 16 + acc_row(lane, e);
+                if (r >= M) continue;
+                OutT* const crow = C + static_cast<int64_t>(r) * ldc;
+                const float row_scale = epi.scale_a[r];
+                #pragma unroll
+                for (int j = 0; j < TN; ++j) {
+                    const int col =
+                        n0 + wn * (TN * 16) + j * 16 + col_lane;
+                    if (col >= N) continue;
+                    float value = Mma::get(acc[i][j], e) * row_scale;
+                    value *= col_scale[j];
+                    value += col_bias[j];
+                    crow[col] = static_cast<OutT>(value);
+                }
+            }
+        }
+    } else if constexpr (std::is_same_v<Epi, EpiRowwiseGatedResidual>) {
+        #pragma clang fp contract(off)
+        #pragma clang fp reassociate(off)
+        // This is the same cached rowwise linear epilogue above, followed by
+        // the visible BF16 materialization and addcmul arithmetic.  Gate is a
+        // row-broadcast vector, so each lane retains its TN values while the
+        // residual is read once at the final output location.
+        float col_scale[TN];
+        float col_bias[TN];
+        float col_gate[TN];
+        #pragma unroll
+        for (int j = 0; j < TN; ++j) {
+            const int col = n0 + wn * (TN * 16) + j * 16 + col_lane;
+            if (col < N) {
+                col_scale[j] = epi.scale_b[col * epi.scale_b_stride];
+                col_bias[j] = epi.bias
+                    ? load_scalar(epi.bias, epi.bias_code, col) : 0.0f;
+                col_gate[j] = static_cast<float>(epi.gate[col]);
+            } else {
+                col_scale[j] = 0.0f;
+                col_bias[j] = 0.0f;
+                col_gate[j] = 0.0f;
+            }
+        }
+        #pragma unroll
+        for (int i = 0; i < TM; ++i) {
+            #pragma unroll
+            for (int e = 0; e < 8; ++e) {
+                const int r =
+                    m0 + wm * (TM * 16) + i * 16 + acc_row(lane, e);
+                if (r >= M) continue;
+                OutT* const crow = C + static_cast<int64_t>(r) * ldc;
+                const __bf16* const residual_row =
+                    epi.residual + static_cast<int64_t>(r) * epi.residual_stride;
+                const float row_scale = epi.scale_a[r];
+                #pragma unroll
+                for (int j = 0; j < TN; ++j) {
+                    const int col =
+                        n0 + wn * (TN * 16) + j * 16 + col_lane;
+                    if (col >= N) continue;
+                    float linear = Mma::get(acc[i][j], e) * row_scale;
+                    linear *= col_scale[j];
+                    linear += col_bias[j];
+                    const __bf16 rounded = static_cast<__bf16>(linear);
+                    const float value = fmaf(
+                        col_gate[j], static_cast<float>(rounded),
+                        static_cast<float>(residual_row[col]));
+                    crow[col] = static_cast<OutT>(value);
+                }
+            }
+        }
+    } else if constexpr (VOPD_CROSS_E) {
+        #pragma clang fp reassociate(off)
+        #pragma unroll
+        for (int i = 0; i < TM; ++i) {
+            #pragma unroll
+            for (int e = 0; e < 8; e += 2) {
+                const int r0 =
+                    m0 + wm * (TM * 16) + i * 16 + acc_row(lane, e);
+                const int r1 =
+                    m0 + wm * (TM * 16) + i * 16 + acc_row(lane, e + 1);
+                const bool valid0 = r0 < M;
+                const bool valid1 = r1 < M;
+                if (!valid0 && !valid1) continue;
+                #pragma unroll
+                for (int j = 0; j < TN; ++j) {
+                    const int col =
+                        n0 + wn * (TN * 16) + j * 16 + col_lane;
+                    if (col >= N) continue;
+                    if (valid0) {
+                        OutT* const crow0 =
+                            C + static_cast<int64_t>(r0) * ldc;
+                        crow0[col] = static_cast<OutT>(
+                            epi(r0, col, Mma::get(acc[i][j], e)));
+                    }
+                    if (valid1) {
+                        OutT* const crow1 =
+                            C + static_cast<int64_t>(r1) * ldc;
+                        crow1[col] = static_cast<OutT>(
+                            epi(r1, col, Mma::get(acc[i][j], e + 1)));
+                    }
+                }
+            }
+        }
+    } else {
+        #pragma unroll
+        for (int i = 0; i < TM; ++i) {
+            #pragma unroll
+            for (int e = 0; e < 8; ++e) {
+                const int r =
+                    m0 + wm * (TM * 16) + i * 16 + acc_row(lane, e);
+                if (r >= M) continue;
+                OutT* crow = C + static_cast<int64_t>(r) * ldc;
+                #pragma unroll
+                for (int j = 0; j < TN; ++j) {
+                    const int col =
+                        n0 + wn * (TN * 16) + j * 16 + col_lane;
+                    if (col >= N) continue;
+                    crow[col] = static_cast<OutT>(
+                        epi(r, col, Mma::get(acc[i][j], e)));
+                }
             }
         }
     }

--- a/comfy_kitchen/backends/hip/hadamard.h
+++ b/comfy_kitchen/backends/hip/hadamard.h
@@ -1350,7 +1350,7 @@ inline bool use_gfx12_convrot_packed_none() {
     auto select = [device] {
         hipDeviceProp_t properties{};
         return hipGetDeviceProperties(&properties, device) == hipSuccess &&
-            (std::strcmp(properties.gcnArchName, "gfx1170") == 0 ||
+            (std::strncmp(properties.gcnArchName, "gfx1170", 7) == 0 ||
              std::strncmp(properties.gcnArchName, "gfx12", 5) == 0) &&
             properties.warpSize == 32 && properties.maxThreadsPerBlock >= 512;
     };

--- a/comfy_kitchen/backends/hip/hadamard.h
+++ b/comfy_kitchen/backends/hip/hadamard.h
@@ -1350,7 +1350,8 @@ inline bool use_gfx12_convrot_packed_none() {
     auto select = [device] {
         hipDeviceProp_t properties{};
         return hipGetDeviceProperties(&properties, device) == hipSuccess &&
-            std::strncmp(properties.gcnArchName, "gfx12", 5) == 0 &&
+            (std::strcmp(properties.gcnArchName, "gfx1170") == 0 ||
+             std::strncmp(properties.gcnArchName, "gfx12", 5) == 0) &&
             properties.warpSize == 32 && properties.maxThreadsPerBlock >= 512;
     };
     if (device < 0 || device >= kMaxDevices) return select();

--- a/comfy_kitchen/backends/hip/hadamard.h
+++ b/comfy_kitchen/backends/hip/hadamard.h
@@ -13,6 +13,7 @@
 // even index), which is the layout the iu4 A-fragment consumes directly.
 #pragma once
 
+#include <atomic>
 #include <cstring>
 #include <stdexcept>
 #include <string>
@@ -28,31 +29,6 @@ namespace comfy::hip_backend {
 
 typedef __bf16 convrot_bf16x2 __attribute__((ext_vector_type(2)));
 typedef __bf16 convrot_bf16x4 __attribute__((ext_vector_type(4)));
-
-extern "C" __device__ float __ocml_rsqrt_f32(float);
-
-__forceinline__ __device__ float ieee_div_f32(
-    float numerator, float denominator) {
-    bool denominator_scale = false;
-    bool scale = false;
-    const float scaled_denominator = __builtin_amdgcn_div_scalef(
-        numerator, denominator, false, &denominator_scale);
-    const float scaled_numerator = __builtin_amdgcn_div_scalef(
-        numerator, denominator, true, &scale);
-    float reciprocal = __builtin_amdgcn_rcpf(scaled_denominator);
-    const float reciprocal_error =
-        fmaf(-scaled_denominator, reciprocal, 1.0f);
-    reciprocal = fmaf(reciprocal_error, reciprocal, reciprocal);
-    float quotient = scaled_numerator * reciprocal;
-    float remainder =
-        fmaf(-scaled_denominator, quotient, scaled_numerator);
-    quotient = fmaf(remainder, reciprocal, quotient);
-    remainder = fmaf(-scaled_denominator, quotient, scaled_numerator);
-    quotient = __builtin_amdgcn_div_fmasf(
-        remainder, reciprocal, quotient, scale);
-    return __builtin_amdgcn_div_fixupf(
-        quotient, denominator, numerator);
-}
 
 // convrot_quant_kernel handles 256/G groups per pass and rotates in log4(G)
 // stages, so a G outside this set either divides to a zero-width pass or is not
@@ -924,7 +900,9 @@ __global__ __launch_bounds__(512) void convrot_quant_512x2_bf16_kernel(
         {-1, 1, 1, 1},
     };
 
-    __shared__ float stage[2][kThreads * kGroupsPerThread];
+    __shared__ float stage_storage[2 * kThreads * kGroupsPerThread];
+    float (*stage)[kThreads * kGroupsPerThread] =
+        reinterpret_cast<float (*)[kThreads * kGroupsPerThread]>(stage_storage);
     __shared__ float wave_max[kThreads / 32];
     extern __shared__ unsigned char rowbuf_raw[];
     __bf16* rowbuf = reinterpret_cast<__bf16*>(rowbuf_raw);
@@ -1009,7 +987,7 @@ __global__ __launch_bounds__(512) void convrot_quant_512x2_bf16_kernel(
         constexpr int kPackedElements = 4;
         constexpr int kPackedThreadsPerGroup = kGroup / kPackedElements;
         constexpr int kPackedGroupsPerPass = kThreads / kPackedThreadsPerGroup;
-        float* packed_stage = &stage[0][0];
+        float* packed_stage = stage_storage;
         const int packed_local_group = t / kPackedThreadsPerGroup;
         const int packed_thread = t % kPackedThreadsPerGroup;
         const int element_base = packed_thread * kPackedElements;
@@ -1359,26 +1337,30 @@ inline bool convrot_512x2_supported(int K) {
         static_cast<size_t>(lds_bytes);
 }
 
-inline bool use_convrot_packed_quant() {
-    return convrot_wave32_512_supported();
-}
-
-inline bool use_convrot_packed_elements() {
+inline bool use_convrot_packed_schedule() {
     return convrot_wave32_512_supported();
 }
 
 inline bool use_gfx12_convrot_packed_none() {
-    static const bool selected = [] {
-        int device = 0;
+    constexpr int kMaxDevices = 16;
+    static std::atomic<int> cache[kMaxDevices] = {};
+    int device = 0;
+    if (hipGetDevice(&device) != hipSuccess) return false;
+
+    auto select = [device] {
         hipDeviceProp_t properties{};
-        if (hipGetDevice(&device) != hipSuccess ||
-            hipGetDeviceProperties(&properties, device) != hipSuccess ||
-            std::strncmp(properties.gcnArchName, "gfx12", 5) != 0) {
-            return false;
-        }
-        return use_convrot_packed_elements();
-    }();
-    return selected;
+        return hipGetDeviceProperties(&properties, device) == hipSuccess &&
+            std::strncmp(properties.gcnArchName, "gfx12", 5) == 0 &&
+            properties.warpSize == 32 && properties.maxThreadsPerBlock >= 512;
+    };
+    if (device < 0 || device >= kMaxDevices) return select();
+
+    int selected = cache[device].load(std::memory_order_relaxed);
+    if (selected == 0) {
+        selected = select() ? 2 : 1;
+        cache[device].store(selected, std::memory_order_relaxed);
+    }
+    return selected == 2;
 }
 
 template <int ACT>
@@ -1395,7 +1377,7 @@ inline void launch_convrot_quant_512x2_bf16(
             return;
         }
     }
-    if (use_convrot_packed_quant()) {
+    if (use_convrot_packed_schedule()) {
         convrot_quant_512x2_bf16_kernel<ACT, false, false, false, true>
             <<<M, 512, static_cast<size_t>(K) * sizeof(__bf16), stream>>>(
                 x, nullptr, in_dtype, qout, scaleout, M, K);
@@ -1409,7 +1391,7 @@ inline void launch_convrot_quant_512x2_bf16(
 inline void launch_convrot_quant_512x2_bf16_swiglu_split_tiled128(
     const void* gate, const void* up, int8_t* qout, float* scaleout,
     int M, int K, hipStream_t stream) {
-    if (use_convrot_packed_elements()) {
+    if (use_convrot_packed_schedule()) {
         convrot_quant_512x2_bf16_kernel<
             kActSwiGLU, true, true, false, true, false, false, true>
             <<<M, 512, static_cast<size_t>(K) * sizeof(__bf16), stream>>>(
@@ -1424,7 +1406,7 @@ inline void launch_convrot_quant_512x2_bf16_swiglu_split_tiled128(
 inline void launch_convrot_quant_512x2_bf16_modulated(
     const void* x, const void* modulation_scale,
     int8_t* qout, float* scaleout, int M, int K, hipStream_t stream) {
-    if (use_convrot_packed_quant()) {
+    if (use_convrot_packed_schedule()) {
         convrot_quant_512x2_bf16_kernel<kActNone, false, false, true, true>
             <<<M, 512, static_cast<size_t>(K) * sizeof(__bf16), stream>>>(
                 x, modulation_scale, 2, qout, scaleout, M, K);

--- a/comfy_kitchen/backends/hip/hadamard.h
+++ b/comfy_kitchen/backends/hip/hadamard.h
@@ -13,6 +13,7 @@
 // even index), which is the layout the iu4 A-fragment consumes directly.
 #pragma once
 
+#include <cstring>
 #include <stdexcept>
 #include <string>
 #include <type_traits>
@@ -20,7 +21,38 @@
 #include <hip/hip_fp16.h>
 #include <hip/hip_runtime.h>
 
+#include "rope_math.h"
+#include "swiglu_bf16.h"
+
 namespace comfy::hip_backend {
+
+typedef __bf16 convrot_bf16x2 __attribute__((ext_vector_type(2)));
+typedef __bf16 convrot_bf16x4 __attribute__((ext_vector_type(4)));
+
+extern "C" __device__ float __ocml_rsqrt_f32(float);
+
+__forceinline__ __device__ float ieee_div_f32(
+    float numerator, float denominator) {
+    bool denominator_scale = false;
+    bool scale = false;
+    const float scaled_denominator = __builtin_amdgcn_div_scalef(
+        numerator, denominator, false, &denominator_scale);
+    const float scaled_numerator = __builtin_amdgcn_div_scalef(
+        numerator, denominator, true, &scale);
+    float reciprocal = __builtin_amdgcn_rcpf(scaled_denominator);
+    const float reciprocal_error =
+        fmaf(-scaled_denominator, reciprocal, 1.0f);
+    reciprocal = fmaf(reciprocal_error, reciprocal, reciprocal);
+    float quotient = scaled_numerator * reciprocal;
+    float remainder =
+        fmaf(-scaled_denominator, quotient, scaled_numerator);
+    quotient = fmaf(remainder, reciprocal, quotient);
+    remainder = fmaf(-scaled_denominator, quotient, scaled_numerator);
+    quotient = __builtin_amdgcn_div_fmasf(
+        remainder, reciprocal, quotient, scale);
+    return __builtin_amdgcn_div_fixupf(
+        quotient, denominator, numerator);
+}
 
 // convrot_quant_kernel handles 256/G groups per pass and rotates in log4(G)
 // stages, so a G outside this set either divides to a zero-width pass or is not
@@ -132,6 +164,14 @@ inline int convrot_pick_fused_block_threads(int M, int K, int in_dtype) {
     }
     static constexpr int kFallbackBlocks[] = {768, 640, 512, 64};
     for (int block_threads : kFallbackBlocks) {
+        // Once a wide row can only fit the one-wave schedule, each workgroup
+        // serializes dozens of G=256 rotations. The cooperative
+        // two-pass path is the scalable fallback for these long inference
+        // rows; retain one-wave LDS for short-M calls where its launch and
+        // workspace savings still matter.
+        if (block_threads == 64 && M >= 96 && K >= 12288) {
+            continue;
+        }
         if (block_threads < preferred && convrot_fused_lds_fits(K, block_threads, in_dtype)) {
             return block_threads;
         }
@@ -374,7 +414,23 @@ __forceinline__ __device__ float finite_absmax_for_quant(float abs_max) {
     return abs_max;
 }
 
-constexpr int kConvrotGlobalGroupsPerBlock = 8;
+// Match ``torch.addcmul(shift, x, 1 + scale)`` when all operands and the
+// materialized result are BF16.  The add that forms the scale factor is a
+// separate PyTorch operation, while addcmul evaluates the multiply-add in
+// FP32 before rounding its output once to BF16.
+__forceinline__ __device__ float load_affine_modulated_bf16(
+    const void* __restrict__ x, const void* __restrict__ modulation_scale,
+    const void* __restrict__ modulation_shift, int64_t index, int column) {
+    const float factor = round_bf16(
+        1.0f + static_cast<float>(
+            static_cast<const __bf16*>(modulation_scale)[column]));
+    const float value = static_cast<float>(static_cast<const __bf16*>(x)[index]);
+    const float shift = static_cast<float>(
+        static_cast<const __bf16*>(modulation_shift)[column]);
+    return round_bf16(fmaf(value, factor, shift));
+}
+
+constexpr int kConvrotGlobalGroupsPerBlock = 4;
 constexpr int kConvrotGlobalBlockThreads = kConvrotGlobalGroupsPerBlock * 64;
 constexpr size_t kConvrotGlobalSmemBytes =
     static_cast<size_t>(kConvrotGlobalGroupsPerBlock) * 2 * kConvRotGroup256 * sizeof(float);
@@ -518,10 +574,15 @@ void launch_convrot_quant_global_managed(
 
 // Fused single-kernel path: FHT in LDS, vectorized loads, warp-shuffle absmax.
 // One block per row; the rotated row stays in shared memory as RowT.
-template <typename RowT, int BLOCK_THREADS, int ACT>
+template <typename RowT, int BLOCK_THREADS, int ACT, bool AFFINE_MODULATE = false>
 __global__ __launch_bounds__(BLOCK_THREADS) void convrot_quant_fused_kernel(
     const void* __restrict__ x, int in_dtype, int8_t* __restrict__ qout,
-    float* __restrict__ scaleout, int M, int K) {
+    float* __restrict__ scaleout, int M, int K,
+    const void* __restrict__ modulation_scale = nullptr,
+    const void* __restrict__ modulation_shift = nullptr) {
+
+    static_assert(!AFFINE_MODULATE || std::is_same_v<RowT, __bf16>);
+    static_assert(!AFFINE_MODULATE || ACT == kActNone);
 
     constexpr int kGroupThreads = 64;
     constexpr int kGroupsInFlight = BLOCK_THREADS / kGroupThreads;
@@ -560,7 +621,20 @@ __global__ __launch_bounds__(BLOCK_THREADS) void convrot_quant_fused_kernel(
         float xv2 = 0.0f;
         float xv3 = 0.0f;
         if (active) {
-            if constexpr (ACT == kActNone) {
+            if constexpr (AFFINE_MODULATE) {
+                xv0 = load_affine_modulated_bf16(
+                    x, modulation_scale, modulation_shift,
+                    in_row_offset + col, col);
+                xv1 = load_affine_modulated_bf16(
+                    x, modulation_scale, modulation_shift,
+                    in_row_offset + col + 1, col + 1);
+                xv2 = load_affine_modulated_bf16(
+                    x, modulation_scale, modulation_shift,
+                    in_row_offset + col + 2, col + 2);
+                xv3 = load_affine_modulated_bf16(
+                    x, modulation_scale, modulation_shift,
+                    in_row_offset + col + 3, col + 3);
+            } else if constexpr (ACT == kActNone) {
                 if (in_dtype == 2) {
                     load_input_act4_bf16(x, in_row_offset, col, xv0, xv1, xv2, xv3);
                 } else {
@@ -612,22 +686,26 @@ __global__ __launch_bounds__(BLOCK_THREADS) void convrot_quant_fused_kernel(
     }
 }
 
-template <typename RowT, int ACT, int BLOCK_THREADS>
+template <typename RowT, int ACT, int BLOCK_THREADS, bool AFFINE_MODULATE = false>
 inline bool launch_convrot_quant_fused_impl(
     const void* x, int in_dtype, int8_t* qout, float* scaleout, int M, int K,
-    hipStream_t stream) {
+    hipStream_t stream, const void* modulation_scale = nullptr,
+    const void* modulation_shift = nullptr) {
     const int groups_in_flight = BLOCK_THREADS / 64;
     const size_t shmem =
         static_cast<size_t>(K) * sizeof(RowT) +
         static_cast<size_t>(groups_in_flight) * 2 * kConvRotGroup256 * sizeof(float);
-    auto kernel = convrot_quant_fused_kernel<RowT, BLOCK_THREADS, ACT>;
+    auto kernel = convrot_quant_fused_kernel<
+        RowT, BLOCK_THREADS, ACT, AFFINE_MODULATE>;
     const hipError_t attr_err = hipFuncSetAttribute(
         reinterpret_cast<const void*>(kernel), hipFuncAttributeMaxDynamicSharedMemorySize,
         static_cast<int>(shmem));
     if (attr_err != hipSuccess) {
         return false;
     }
-    kernel<<<M, BLOCK_THREADS, shmem, stream>>>(x, in_dtype, qout, scaleout, M, K);
+    kernel<<<M, BLOCK_THREADS, shmem, stream>>>(
+        x, in_dtype, qout, scaleout, M, K,
+        modulation_scale, modulation_shift);
     return hipGetLastError() == hipSuccess;
 }
 
@@ -648,6 +726,53 @@ struct LaunchConvrotQuantFusedForBlock {
             x, in_dtype, qout, scaleout, M, K, stream);
     }
 };
+
+template <int BLOCK_THREADS>
+inline bool launch_convrot_quant_affine_fused_impl(
+    const void* x, const void* modulation_scale,
+    const void* modulation_shift, int8_t* qout, float* scaleout,
+    int M, int K, hipStream_t stream) {
+    return launch_convrot_quant_fused_impl<
+        __bf16, kActNone, BLOCK_THREADS, true>(
+            x, 2, qout, scaleout, M, K, stream,
+            modulation_scale, modulation_shift);
+}
+
+struct LaunchConvrotQuantAffineForBlock {
+    const void* x;
+    const void* modulation_scale;
+    const void* modulation_shift;
+    int8_t* qout;
+    float* scaleout;
+    int M;
+    int K;
+    hipStream_t stream;
+    bool* launched;
+
+    template <int BLOCK_THREADS>
+    void operator()() const {
+        *launched = launch_convrot_quant_affine_fused_impl<BLOCK_THREADS>(
+            x, modulation_scale, modulation_shift, qout, scaleout,
+            M, K, stream);
+    }
+};
+
+inline bool launch_convrot_quant_affine_bf16(
+    const void* x, const void* modulation_scale,
+    const void* modulation_shift, int8_t* qout, float* scaleout,
+    int M, int K, hipStream_t stream) {
+    const int block_threads = convrot_pick_fused_block_threads(M, K, /*bf16*/ 2);
+    if (block_threads == 0) {
+        return false;
+    }
+    bool launched = false;
+    dispatch_convrot_fused_block_threads(
+        block_threads,
+        LaunchConvrotQuantAffineForBlock{
+            x, modulation_scale, modulation_shift, qout, scaleout,
+            M, K, stream, &launched});
+    return launched;
+}
 
 template <int ACT>
 struct LaunchConvrotQuantFusedForRow {
@@ -757,6 +882,556 @@ __global__ __launch_bounds__(BLOCK_THREADS) void convrot_quant_kernel(
             q = q < -127 ? -127 : (q > 127 ? 127 : q);
             qout[static_cast<int64_t>(row) * K + j] = static_cast<int8_t>(q);
         }
+    }
+}
+
+// Wide-row ConvRot-256: four groups per pass. Wave32 shuffles cover the first
+// two radix-4 stages; the rest use ping-pong LDS (512 threads, two values each,
+// two barriers). Bank-aligned FP32 LDS. Not an arch-specific WMMA path; keep
+// separate from convrot_quant_kernel for other shapes and devices.
+template <int ACT, bool TILED_QOUT = false, bool SPLIT_SWIGLU = false,
+          bool MODULATE = false, bool PACK_QUANT = false,
+          bool RMSNORM = false, bool FUSED_RMS_STATS = false,
+          bool PACKED_ELEMENT_SCHEDULE = false>
+__global__ __launch_bounds__(512) void convrot_quant_512x2_bf16_kernel(
+    const void* __restrict__ x, const void* __restrict__ auxiliary, int in_dtype,
+    int8_t* __restrict__ qout, float* __restrict__ scaleout,
+    int M, int K, const void* __restrict__ norm_weight = nullptr,
+    float rms_eps = 0.0f) {
+
+    static_assert(!SPLIT_SWIGLU || ACT == kActSwiGLU);
+    static_assert(!MODULATE || ACT == kActNone);
+    static_assert(!MODULATE || !SPLIT_SWIGLU);
+    static_assert(!RMSNORM || MODULATE);
+    static_assert(RMSNORM == FUSED_RMS_STATS);
+    static_assert(!PACKED_ELEMENT_SCHEDULE ||
+                  ((ACT == kActSwiGLU && TILED_QOUT && SPLIT_SWIGLU &&
+                    PACK_QUANT && !MODULATE && !RMSNORM) ||
+                   (ACT == kActNone && !TILED_QOUT && !SPLIT_SWIGLU &&
+                    MODULATE && PACK_QUANT) ||
+                   (ACT == kActNone && !TILED_QOUT && !SPLIT_SWIGLU &&
+                    !MODULATE && PACK_QUANT && !RMSNORM)));
+
+    constexpr int kThreads = 512;
+    constexpr int kGroup = 256;
+    constexpr int kGroupsPerThread = 2;
+    constexpr int kGroupsPerSlot = kThreads / kGroup;
+    constexpr int kGroupsPerPass = kGroupsPerSlot * kGroupsPerThread;
+    const float h4[4][4] = {
+        {1, 1, 1, -1},
+        {1, 1, -1, 1},
+        {1, -1, 1, 1},
+        {-1, 1, 1, 1},
+    };
+
+    __shared__ float stage[2][kThreads * kGroupsPerThread];
+    __shared__ float wave_max[kThreads / 32];
+    extern __shared__ unsigned char rowbuf_raw[];
+    __bf16* rowbuf = reinterpret_cast<__bf16*>(rowbuf_raw);
+
+    const int row = blockIdx.x;
+    const int t = threadIdx.x;
+    const int lane = t & 31;
+    const int wave = t >> 5;
+    const int local_group = t / kGroup;
+    const int element = t % kGroup;
+    const int group_count = K / kGroup;
+    // Tile-major INT8 output is [M_tile, K_tile, row_in_tile, K_in_tile].
+    // This removes the hot down GEMM's K-strided activation loads.
+    const int64_t qout_row_base = TILED_QOUT
+        ? static_cast<int64_t>(row >> 7) * K * 128 + (row & 127) * 128
+        : static_cast<int64_t>(row) * K;
+    constexpr int kInputWidth =
+        ACT == kActSwiGLU && !SPLIT_SWIGLU ? 2 : 1;
+    const int64_t input_row = static_cast<int64_t>(row) * K * kInputWidth;
+    const float norm = rsqrtf(static_cast<float>(kGroup));
+
+    float row_rstd = 0.0f;
+    if constexpr (RMSNORM) {
+        if constexpr (FUSED_RMS_STATS) {
+            #pragma clang fp reassociate(off)
+            #pragma clang fp contract(on)
+            #pragma clang fp reciprocal(off)
+            // Match PyTorch's vectorized K=3840 RMSNorm statistics exactly.
+            // Only the first eight waves participate, reproducing its 32x8
+            // workgroup and four-BF16 vector ownership.  The same loads also
+            // seed the existing BF16 row buffer for the ConvRot pass.
+            float sum_sq = 0.0f;
+            if (t < 256) {
+                const auto* input_vectors =
+                    reinterpret_cast<const convrot_bf16x4*>(
+                        static_cast<const __bf16*>(x) + input_row);
+                auto* row_vectors =
+                    reinterpret_cast<convrot_bf16x4*>(rowbuf);
+                #pragma unroll
+                for (int vector = t; vector < 3840 / 4; vector += 256) {
+                    const convrot_bf16x4 values = input_vectors[vector];
+                    row_vectors[vector] = values;
+                    #pragma unroll
+                    for (int element4 = 0; element4 < 4; ++element4) {
+                        const float value =
+                            static_cast<float>(values[element4]);
+                        sum_sq += value * value;
+                    }
+                }
+                #pragma unroll
+                for (int offset = 16; offset > 0; offset >>= 1) {
+                    sum_sq += __shfl_down(sum_sq, offset, 32);
+                }
+            }
+
+            #pragma unroll
+            for (int offset = 4; offset > 0; offset >>= 1) {
+                if (lane == 0 && wave < 8 && wave >= offset &&
+                    wave < 2 * offset) {
+                    wave_max[wave - offset] = sum_sq;
+                }
+                __syncthreads();
+                if (lane == 0 && wave < offset) {
+                    sum_sq += wave_max[wave];
+                }
+                __syncthreads();
+            }
+            if (t == 0) {
+                const float mean_square =
+                    ieee_div_f32(sum_sq, static_cast<float>(K));
+                wave_max[0] = __ocml_rsqrt_f32(mean_square + rms_eps);
+            }
+            __syncthreads();
+            row_rstd = wave_max[0];
+        }
+    }
+    float local_max = 0.0f;
+    if constexpr (PACKED_ELEMENT_SCHEDULE) {
+        // Eight ConvRot-256 groups per pass: radix 0 is register-local, 1/2
+        // stay in-wave, only radix 3 uses LDS. Same 8-KiB ping-pong stage
+        // as the four-group schedule (one visibility + one reuse barrier).
+        constexpr int kPackedElements = 4;
+        constexpr int kPackedThreadsPerGroup = kGroup / kPackedElements;
+        constexpr int kPackedGroupsPerPass = kThreads / kPackedThreadsPerGroup;
+        float* packed_stage = &stage[0][0];
+        const int packed_local_group = t / kPackedThreadsPerGroup;
+        const int packed_thread = t % kPackedThreadsPerGroup;
+        const int element_base = packed_thread * kPackedElements;
+
+        for (int group_base = 0; group_base < group_count;
+             group_base += kPackedGroupsPerPass) {
+            const int group = group_base + packed_local_group;
+            const bool active = group < group_count;
+            float transformed[kPackedElements] = {0.0f, 0.0f, 0.0f, 0.0f};
+            if (active) {
+                const int64_t index = input_row + group * kGroup + element_base;
+                float input[kPackedElements];
+                if constexpr (SPLIT_SWIGLU) {
+                    const convrot_bf16x4 gates =
+                        *reinterpret_cast<const convrot_bf16x4*>(
+                            static_cast<const __bf16*>(x) + index);
+                    const convrot_bf16x4 ups =
+                        *reinterpret_cast<const convrot_bf16x4*>(
+                            static_cast<const __bf16*>(auxiliary) + index);
+                    #pragma unroll
+                    for (int element4 = 0; element4 < kPackedElements; ++element4) {
+                        input[element4] = static_cast<float>(
+                            swiglu_bf16_value(gates[element4], ups[element4]));
+                    }
+                } else if constexpr (MODULATE) {
+                    const int column = group * kGroup + element_base;
+                    const convrot_bf16x4 values =
+                        *reinterpret_cast<const convrot_bf16x4*>(
+                            (FUSED_RMS_STATS ? rowbuf : static_cast<const __bf16*>(x) + input_row)
+                            + column);
+                    const convrot_bf16x4 weights =
+                        *reinterpret_cast<const convrot_bf16x4*>(
+                            static_cast<const __bf16*>(norm_weight) + column);
+                    const convrot_bf16x4 modulation =
+                        *reinterpret_cast<const convrot_bf16x4*>(
+                            static_cast<const __bf16*>(auxiliary) + column);
+                    #pragma unroll
+                    for (int element4 = 0; element4 < kPackedElements; ++element4) {
+                        const float factor = round_bf16(
+                            1.0f + static_cast<float>(modulation[element4]));
+                        float normalized =
+                            row_rstd * static_cast<float>(values[element4]);
+                        asm volatile("" : "+v"(normalized));
+                        normalized *= static_cast<float>(weights[element4]);
+                        normalized = round_bf16(normalized);
+                        input[element4] = round_bf16(normalized * factor);
+                    }
+                } else {
+                    const convrot_bf16x4 values =
+                        *reinterpret_cast<const convrot_bf16x4*>(
+                            static_cast<const __bf16*>(x) + index);
+                    #pragma unroll
+                    for (int element4 = 0; element4 < kPackedElements; ++element4) {
+                        input[element4] = static_cast<float>(values[element4]);
+                    }
+                }
+                #pragma unroll
+                for (int digit = 0; digit < 4; ++digit) {
+                    transformed[digit] =
+                        h4[digit][0] * input[0] + h4[digit][1] * input[1] +
+                        h4[digit][2] * input[2] + h4[digit][3] * input[3];
+                }
+            }
+
+            // Radix 1: four adjacent physical threads own the four inputs.
+            const int digit1 = packed_thread & 3;
+            const int base1 = lane - digit1;
+            #pragma unroll
+            for (int element4 = 0; element4 < kPackedElements; ++element4) {
+                const float v0 = __shfl(transformed[element4], base1, 32);
+                const float v1 = __shfl(transformed[element4], base1 + 1, 32);
+                const float v2 = __shfl(transformed[element4], base1 + 2, 32);
+                const float v3 = __shfl(transformed[element4], base1 + 3, 32);
+                transformed[element4] =
+                    h4[digit1][0] * v0 + h4[digit1][1] * v1 +
+                    h4[digit1][2] * v2 + h4[digit1][3] * v3;
+            }
+
+            // Radix 2: the four source threads are still in one wave.
+            const int digit2 = (packed_thread >> 2) & 3;
+            const int base2 = lane - digit2 * 4;
+            #pragma unroll
+            for (int element4 = 0; element4 < kPackedElements; ++element4) {
+                const float v0 = __shfl(transformed[element4], base2, 32);
+                const float v1 = __shfl(transformed[element4], base2 + 4, 32);
+                const float v2 = __shfl(transformed[element4], base2 + 8, 32);
+                const float v3 = __shfl(transformed[element4], base2 + 12, 32);
+                transformed[element4] =
+                    h4[digit2][0] * v0 + h4[digit2][1] * v1 +
+                    h4[digit2][2] * v2 + h4[digit2][3] * v3;
+                packed_stage[packed_local_group * kGroup + element_base + element4] =
+                    transformed[element4];
+            }
+            __syncthreads();
+
+            // Radix 3 crosses the two waves assigned to this group.
+            const int digit3 = (packed_thread >> 4) & 3;
+            const int base3 = packed_local_group * kGroup + element_base - digit3 * 64;
+            #pragma unroll
+            for (int element4 = 0; element4 < kPackedElements; ++element4) {
+                const float v0 = packed_stage[base3 + element4];
+                const float v1 = packed_stage[base3 + 64 + element4];
+                const float v2 = packed_stage[base3 + 128 + element4];
+                const float v3 = packed_stage[base3 + 192 + element4];
+                transformed[element4] =
+                    h4[digit3][0] * v0 + h4[digit3][1] * v1 +
+                    h4[digit3][2] * v2 + h4[digit3][3] * v3;
+                if (active) {
+                    const __bf16 stored =
+                        static_cast<__bf16>(transformed[element4] * norm);
+                    rowbuf[static_cast<int64_t>(group) * kGroup + element_base + element4] =
+                        stored;
+                    local_max = fmaxf(
+                        local_max, fabsf(static_cast<float>(stored)));
+                }
+            }
+            if (group_base + kPackedGroupsPerPass < group_count) {
+                __syncthreads();
+            }
+        }
+    } else {
+    for (int group_base = 0; group_base < group_count;
+         group_base += kGroupsPerPass) {
+        float transformed[kGroupsPerThread];
+        bool active[kGroupsPerThread];
+
+        #pragma unroll
+        for (int slot = 0; slot < kGroupsPerThread; ++slot) {
+            const int group =
+                group_base + local_group + slot * kGroupsPerSlot;
+            active[slot] = group < group_count;
+            if (!active[slot]) {
+                transformed[slot] = 0.0f;
+            } else if constexpr (SPLIT_SWIGLU) {
+                const int64_t index =
+                    input_row + group * kGroup + element;
+                transformed[slot] = static_cast<float>(
+                    swiglu_bf16_value(
+                        static_cast<const __bf16*>(x)[index],
+                        static_cast<const __bf16*>(auxiliary)[index]));
+            } else if constexpr (MODULATE) {
+                const int column = group * kGroup + element;
+                const int64_t index = input_row + column;
+                // Match `x * (1 + scale)` as two BF16 elementwise kernels:
+                // round the add before the multiply, then round the product
+                // before the first ConvRot butterfly consumes it.
+                // `__bf16` casts carry excess precision under -ffast-math and
+                // clang otherwise contracts both observable rounding points
+                // into the final conversion.  Use the bitwise helper shared
+                // with fused RoPE so the add and multiply each materialize
+                // PyTorch's BF16 result without an intermediate tensor.
+                const float factor = round_bf16(
+                    1.0f + static_cast<float>(
+                        static_cast<const __bf16*>(auxiliary)[column]));
+                if constexpr (RMSNORM) {
+                    // Match PyTorch's BF16 RMSNorm materialization exactly:
+                    // gamma * (rstd * x), all in FP32, then one BF16 rounding.
+                    // The empty vector-asm boundary prevents Kitchen's global
+                    // -ffast-math from reassociating the two FP32 multiplies.
+                    float normalized =
+                        row_rstd * static_cast<float>(
+                            FUSED_RMS_STATS
+                                ? rowbuf[column]
+                                : static_cast<const __bf16*>(x)[index]);
+                    asm volatile("" : "+v"(normalized));
+                    normalized *= static_cast<float>(
+                        static_cast<const __bf16*>(norm_weight)[column]);
+                    normalized = round_bf16(normalized);
+                    transformed[slot] = round_bf16(normalized * factor);
+                } else {
+                    transformed[slot] = round_bf16(
+                        static_cast<float>(
+                            static_cast<const __bf16*>(x)[index]) * factor);
+                }
+            } else {
+                transformed[slot] = load_input_act<ACT>(
+                    x, input_row, group * kGroup + element, K, in_dtype);
+            }
+        }
+
+        // Radix stages 0 and 1 never leave their aligned 16-lane subgroup.
+        #pragma unroll
+        for (int radix_stage = 0; radix_stage < 2; ++radix_stage) {
+            const int stride = 1 << (2 * radix_stage);
+            const int digit = (element / stride) & 3;
+            const int base = (element & 15) - digit * stride;
+            #pragma unroll
+            for (int slot = 0; slot < kGroupsPerThread; ++slot) {
+                const float v0 = __shfl(transformed[slot], base, 16);
+                const float v1 = __shfl(transformed[slot], base + stride, 16);
+                const float v2 = __shfl(transformed[slot], base + 2 * stride, 16);
+                const float v3 = __shfl(transformed[slot], base + 3 * stride, 16);
+                transformed[slot] =
+                    h4[digit][0] * v0 + h4[digit][1] * v1 +
+                    h4[digit][2] * v2 + h4[digit][3] * v3;
+            }
+        }
+
+        #pragma unroll
+        for (int slot = 0; slot < kGroupsPerThread; ++slot) {
+            stage[0][t + slot * kThreads] = transformed[slot];
+        }
+        __syncthreads();
+
+        // Radix stage 2 reads FP32 LDS and publishes stage 3's input.  Each
+        // wave accesses one contiguous 32-float span per operand, so no two
+        // lanes address the same 4-byte bank.
+        {
+            constexpr int stride = 16;
+            const int digit = (element / stride) & 3;
+            #pragma unroll
+            for (int slot = 0; slot < kGroupsPerThread; ++slot) {
+                const int group_offset =
+                    (local_group + slot * kGroupsPerSlot) * kGroup;
+                const int base = group_offset + element - digit * stride;
+                const float v0 = stage[0][base];
+                const float v1 = stage[0][base + stride];
+                const float v2 = stage[0][base + 2 * stride];
+                const float v3 = stage[0][base + 3 * stride];
+                transformed[slot] =
+                    h4[digit][0] * v0 + h4[digit][1] * v1 +
+                    h4[digit][2] * v2 + h4[digit][3] * v3;
+                stage[1][t + slot * kThreads] = transformed[slot];
+            }
+        }
+        __syncthreads();
+
+        // Final radix stage only reads stage[1].  The next pass starts by
+        // writing stage[0], so no end-of-pass barrier is needed.
+        {
+            constexpr int stride = 64;
+            const int digit = (element / stride) & 3;
+            #pragma unroll
+            for (int slot = 0; slot < kGroupsPerThread; ++slot) {
+                const int group_offset =
+                    (local_group + slot * kGroupsPerSlot) * kGroup;
+                const int base = group_offset + element - digit * stride;
+                const float v0 = stage[1][base];
+                const float v1 = stage[1][base + stride];
+                const float v2 = stage[1][base + 2 * stride];
+                const float v3 = stage[1][base + 3 * stride];
+                transformed[slot] =
+                    h4[digit][0] * v0 + h4[digit][1] * v1 +
+                    h4[digit][2] * v2 + h4[digit][3] * v3;
+            }
+        }
+
+        #pragma unroll
+        for (int slot = 0; slot < kGroupsPerThread; ++slot) {
+            const int group =
+                group_base + local_group + slot * kGroupsPerSlot;
+            if (active[slot]) {
+                const __bf16 stored =
+                    static_cast<__bf16>(transformed[slot] * norm);
+                rowbuf[static_cast<int64_t>(group) * kGroup + element] = stored;
+                local_max = fmaxf(local_max, fabsf(static_cast<float>(stored)));
+            }
+        }
+    }
+    }
+
+    // Register/wave reduction replaces the stock 256-float LDS reduction and
+    // its eight workgroup barriers with two workgroup barriers total.
+    #pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1) {
+        local_max = fmaxf(local_max, __shfl_down(local_max, offset, 32));
+    }
+    if (lane == 0) wave_max[wave] = local_max;
+    __syncthreads();
+    if (wave == 0) {
+        float value = lane < kThreads / 32 ? wave_max[lane] : 0.0f;
+        #pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1) {
+            value = fmaxf(value, __shfl_down(value, offset, 32));
+        }
+        if (lane == 0) wave_max[0] = value;
+    }
+    __syncthreads();
+
+    const float row_max = fmaxf(wave_max[0], 1.0e-10f);
+    const float scale = row_max / 127.0f;
+    const float inverse_scale = 127.0f / row_max;
+    if (t == 0) scaleout[row] = scale;
+
+    if constexpr (PACK_QUANT) {
+        // One aligned dword LDS read covers two adjacent BF16
+        // values, avoiding the two-lanes-per-bank mapping of scalar BF16 reads.
+        // Even logical columns are also physically adjacent in the tiled128
+        // layout, so one aligned 16-bit store preserves both output layouts.
+        for (int pair = t; pair < K / 2; pair += kThreads) {
+            const int column = 2 * pair;
+            const convrot_bf16x2 values =
+                *reinterpret_cast<const convrot_bf16x2*>(rowbuf + column);
+            int q0 = static_cast<int>(
+                rintf(static_cast<float>(values[0]) * inverse_scale));
+            int q1 = static_cast<int>(
+                rintf(static_cast<float>(values[1]) * inverse_scale));
+            q0 = q0 < -127 ? -127 : (q0 > 127 ? 127 : q0);
+            q1 = q1 < -127 ? -127 : (q1 > 127 ? 127 : q1);
+            const int64_t qindex = TILED_QOUT
+                ? qout_row_base + static_cast<int64_t>(column >> 7) * 16384 +
+                      (column & 127)
+                : qout_row_base + column;
+            const uint16_t packed =
+                static_cast<uint8_t>(static_cast<int8_t>(q0)) |
+                (static_cast<uint16_t>(
+                     static_cast<uint8_t>(static_cast<int8_t>(q1))) << 8);
+            *reinterpret_cast<uint16_t*>(qout + qindex) = packed;
+        }
+    } else {
+        for (int column = t; column < K; column += kThreads) {
+            int quantized = static_cast<int>(
+                rintf(static_cast<float>(rowbuf[column]) * inverse_scale));
+            quantized = quantized < -127 ? -127 : (quantized > 127 ? 127 : quantized);
+            const int64_t qindex = TILED_QOUT
+                ? qout_row_base + static_cast<int64_t>(column >> 7) * 16384 +
+                      (column & 127)
+                : qout_row_base + column;
+            qout[qindex] = static_cast<int8_t>(quantized);
+        }
+    }
+}
+
+inline bool convrot_wave32_512_supported() {
+    int device = 0;
+    hipDeviceProp_t properties{};
+    return hipGetDevice(&device) == hipSuccess &&
+        hipGetDeviceProperties(&properties, device) == hipSuccess &&
+        properties.warpSize == 32 && properties.maxThreadsPerBlock >= 512;
+}
+
+inline bool convrot_512x2_supported(int K) {
+    if (!convrot_wave32_512_supported()) {
+        return false;
+    }
+    int device = 0;
+    int lds_bytes = 0;
+    if (hipGetDevice(&device) != hipSuccess ||
+        hipDeviceGetAttribute(
+            &lds_bytes, hipDeviceAttributeMaxSharedMemoryPerBlock, device) !=
+            hipSuccess) {
+        return false;
+    }
+    constexpr size_t kStaticBytes =
+        (2 * 512 * 2 + 512 / 32) * sizeof(float);
+    return static_cast<size_t>(K) * sizeof(__bf16) + kStaticBytes <=
+        static_cast<size_t>(lds_bytes);
+}
+
+inline bool use_convrot_packed_quant() {
+    return convrot_wave32_512_supported();
+}
+
+inline bool use_convrot_packed_elements() {
+    return convrot_wave32_512_supported();
+}
+
+inline bool use_gfx12_convrot_packed_none() {
+    static const bool selected = [] {
+        int device = 0;
+        hipDeviceProp_t properties{};
+        if (hipGetDevice(&device) != hipSuccess ||
+            hipGetDeviceProperties(&properties, device) != hipSuccess ||
+            std::strncmp(properties.gcnArchName, "gfx12", 5) != 0) {
+            return false;
+        }
+        return use_convrot_packed_elements();
+    }();
+    return selected;
+}
+
+template <int ACT>
+inline void launch_convrot_quant_512x2_bf16(
+    const void* x, int in_dtype, int8_t* qout, float* scaleout,
+    int M, int K, hipStream_t stream) {
+    // gfx12: eight-group packed schedule for plain activation ConvRot.
+    if constexpr (ACT == kActNone) {
+        if (use_gfx12_convrot_packed_none()) {
+            convrot_quant_512x2_bf16_kernel<
+                ACT, false, false, false, true, false, false, true>
+                <<<M, 512, static_cast<size_t>(K) * sizeof(__bf16), stream>>>(
+                    x, nullptr, in_dtype, qout, scaleout, M, K);
+            return;
+        }
+    }
+    if (use_convrot_packed_quant()) {
+        convrot_quant_512x2_bf16_kernel<ACT, false, false, false, true>
+            <<<M, 512, static_cast<size_t>(K) * sizeof(__bf16), stream>>>(
+                x, nullptr, in_dtype, qout, scaleout, M, K);
+    } else {
+        convrot_quant_512x2_bf16_kernel<ACT>
+            <<<M, 512, static_cast<size_t>(K) * sizeof(__bf16), stream>>>(
+                x, nullptr, in_dtype, qout, scaleout, M, K);
+    }
+}
+
+inline void launch_convrot_quant_512x2_bf16_swiglu_split_tiled128(
+    const void* gate, const void* up, int8_t* qout, float* scaleout,
+    int M, int K, hipStream_t stream) {
+    if (use_convrot_packed_elements()) {
+        convrot_quant_512x2_bf16_kernel<
+            kActSwiGLU, true, true, false, true, false, false, true>
+            <<<M, 512, static_cast<size_t>(K) * sizeof(__bf16), stream>>>(
+                gate, up, 2, qout, scaleout, M, K);
+    } else {
+        convrot_quant_512x2_bf16_kernel<kActSwiGLU, true, true>
+            <<<M, 512, static_cast<size_t>(K) * sizeof(__bf16), stream>>>(
+                gate, up, 2, qout, scaleout, M, K);
+    }
+}
+
+inline void launch_convrot_quant_512x2_bf16_modulated(
+    const void* x, const void* modulation_scale,
+    int8_t* qout, float* scaleout, int M, int K, hipStream_t stream) {
+    if (use_convrot_packed_quant()) {
+        convrot_quant_512x2_bf16_kernel<kActNone, false, false, true, true>
+            <<<M, 512, static_cast<size_t>(K) * sizeof(__bf16), stream>>>(
+                x, modulation_scale, 2, qout, scaleout, M, K);
+    } else {
+        convrot_quant_512x2_bf16_kernel<kActNone, false, false, true>
+            <<<M, 512, static_cast<size_t>(K) * sizeof(__bf16), stream>>>(
+                x, modulation_scale, 2, qout, scaleout, M, K);
     }
 }
 

--- a/comfy_kitchen/backends/hip/launchers.h
+++ b/comfy_kitchen/backends/hip/launchers.h
@@ -13,6 +13,16 @@
 
 extern "C" {
 
+// Native unmasked BF16 attention. This dimensional entry accepts B>1 and GQA.
+void launch_bf16_sdpa_hip(
+    const void* q, const void* k, const void* v, void* output,
+    int batch, int q_heads, int kv_heads, int q_len, int kv_len, int head_dim,
+    int64_t q_stride_b, int64_t q_stride_h, int64_t q_stride_n,
+    int64_t k_stride_b, int64_t k_stride_h, int64_t k_stride_n,
+    int64_t v_stride_b, int64_t v_stride_h, int64_t v_stride_n,
+    int64_t o_stride_b, int64_t o_stride_h, int64_t o_stride_n,
+    float sm_scale, hipStream_t stream);
+
 // Fused 3D neighborhood attention over contiguous (B, T, H, W, NH, HD) tensors.
 // dtype_code is a DTYPE_TO_CODE value: 1 float16, 2 bfloat16. See ops/na3d.hip.
 void launch_na3d_kernel(const void* q, const void* k, const void* v, void* out, int batch,
@@ -31,12 +41,73 @@ void launch_flash_decode(const void* q, const void* k, const void* v, const int*
                          int64_t k_batch_stride, int64_t k_row_stride, int64_t k_head_stride,
                          hipStream_t stream);
 
+// Quantized D=128 attention. Q uses a per-row scale, K a per-16-row scale,
+// and V is [head, tile64, D, 64].
+void launch_gfx12_int8_attention(
+    const void* q, const void* k, const void* v, void* o,
+    const void* q_descale, const void* k_descale, const void* v_descale,
+    int num_heads, int qo_len, int kv_len, int padded_q, int padded_k,
+    int k_groups_per_head,
+    int64_t output_stride_h, int64_t output_stride_n,
+    float sm_scale, int output_dtype_code, hipStream_t stream);
+void launch_gfx12_tile_channel_v_quant(
+    const void* v, void* output, void* descale, int num_heads,
+    int n_ctx, int tiles,
+    int64_t stride_h, int64_t stride_n, int input_dtype_code,
+    hipStream_t stream);
+void launch_gfx12_qk_quant(
+    const void* q, void* q_int8, void* q_scale,
+    const void* k, void* k_int8, void* k_scale, void* anchor_indices,
+    int num_heads, int q_len, int kv_len, int padded_q, int padded_k,
+    int64_t q_stride_b, int64_t q_stride_h, int64_t q_stride_n,
+    int64_t k_stride_b, int64_t k_stride_h, int64_t k_stride_n,
+    int input_dtype_code, hipStream_t stream);
+
 // ldc is c's row stride, so a caller writing an N-column slice of a wider output
 // passes that output's width; a whole GEMM passes N.
 void launch_int8_gemm_kernel(const void* a, const void* b, void* c, const void* scale_a,
                              const void* scale_b, int scale_b_stride, const void* bias,
                              int bias_code, int M, int N, int K, int ldc, int out_code,
                              hipStream_t stream);
+
+// B is physically [N / 128, K / tile_k, 128, tile_k]. The private entry is
+// generic over divisible M/N/K so exact-shape gates can select single- or
+// dual-M ownership without reintroducing row-stride partition camping.
+void launch_int8_gemm_b_tiled_kernel(
+    const void* a, const void* b, void* c, const void* scale_a,
+    const void* scale_b, int scale_b_stride, const void* bias,
+    int bias_code, int M, int N, int K, int ldc, int out_code,
+    int tile_k, bool dual_m, hipStream_t stream);
+
+// Same tiled-B GEMM with an exact BF16 materialization followed by
+// residual + gate * linear in the writeback epilogue. Gate is broadcast over M.
+void launch_int8_gemm_b_tiled_gated_residual_kernel(
+    const void* a, const void* b, void* c, const void* scale_a,
+    const void* scale_b, int scale_b_stride, const void* bias,
+    int bias_code, const void* residual, const void* gate,
+    int M, int N, int K, int ldc, int tile_k, bool dual_m,
+    hipStream_t stream);
+
+// Two equal-width row-major GEMMs sharing activation staging.
+void launch_int8_gemm_pair_kernel(
+    const void* a, const void* b0, const void* b1, void* c0, void* c1,
+    const void* scale_a, const void* scale_b0, int scale_b_stride0,
+    const void* scale_b1, int scale_b_stride1, const void* bias0,
+    int bias_code0, const void* bias1, int bias_code1, int M, int N, int K,
+    int ldc, int out_code, hipStream_t stream);
+
+// A is physically [M_tile, K_tile, 128, 128]; B is row-major unless tiled_b.
+void launch_int8_gemm_a_tiled128_down_kernel(
+    const void* a, const void* b, void* c, const void* scale_a,
+    const void* scale_b, int scale_b_stride, const void* bias,
+    int bias_code, int M, int N, int K, int ldc, int out_code,
+    bool tiled_b, hipStream_t stream);
+
+// Exact BF16 RMSNorm followed by gate multiplication and residual add.
+void launch_rms_gated_residual_bf16_kernel(
+    const void* activation, const void* norm_weight, const void* residual,
+    const void* gate, void* output, int rows, int width, float eps,
+    hipStream_t stream);
 
 // scale_code is a DTYPE_TO_CODE value: 0 float32, 5 e4m3 (passed as raw bytes).
 // codebook is 16 floats, or null for the uniform levels.

--- a/comfy_kitchen/backends/hip/mma.h
+++ b/comfy_kitchen/backends/hip/mma.h
@@ -18,7 +18,7 @@
 //          free. Fragment width is the K-step: 16B iu8, 8B iu4, 32B bf16 for fp8.
 //
 // Accumulators are v8f/v8i on both, column lane % 16, but the row differs:
-// gfx12 gives each half-wave a contiguous block, D[e + 8 * (lane / 16)]; gfx11
+// gfx12/gfx117 give each half-wave a contiguous block, D[e + 8 * (lane / 16)]; gfx11
 // interleaves the halves, D[2 * e + (lane / 16)]. See acc_row. rocWMMA's "padded
 // acc" gfx11 quirk applies to the 16-bit accumulators, not these.
 //
@@ -144,7 +144,7 @@ __forceinline__ __device__ typename Mma::Frag load_frag_16bit(const typename Mma
 // Policies
 // ---------------------------------------------------------------------------
 
-#if defined(COMFY_MMA_GFX12)
+#if defined(COMFY_MMA_GFX12) || defined(COMFY_MMA_GFX117)
 
 struct MmaFp8 {
     using Acc = v8f;

--- a/comfy_kitchen/backends/hip/mma.h
+++ b/comfy_kitchen/backends/hip/mma.h
@@ -1,17 +1,18 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
-// WMMA policies for RDNA3 (gfx11) and RDNA4 (gfx12), wave32.
+// WMMA policies for duplicated 256-bit operands (gfx11.0/11.5) and
+// non-duplicated 128-bit operands (gfx12), wave32.
 //
 // A policy holds the operand fragment type, the bytes of a K-row one MMA consumes
 // (kStepBytes), the LDS read, and the MMA. The tile kernels stay byte-addressed;
 // only the policy changes per architecture.
 //
 // Operand layout differs:
-//   gfx12: K is split across the half-waves. A lane holds 8 bytes at byte offset
+//   128b:  K is split across the half-waves. A lane holds 8 bytes at byte offset
 //          8 * (lane / 16) of its row. Every type is a v2i, which is what lets one
 //          kernel serve fp8, iu8 and iu4.
-//   gfx11: no K split. A lane holds the whole K-step of its row and both
+//   256b:  no K split. A lane holds the whole K-step of its row and both
 //          half-waves hold the same data (rocWMMA calls it input duplication),
 //          which reading at row = lane % 16 with no half-wave offset gives for
 //          free. Fragment width is the K-step: 16B iu8, 8B iu4, 32B bf16 for fp8.
@@ -380,10 +381,10 @@ struct MmaInt8 {
     using Frag = v2i;
     static constexpr int kStepBytes = 16;
     static __forceinline__ __device__ Frag load(const void*, int, int, int, int) { return Frag{}; }
-    static __forceinline__ __device__ Acc zero() { return Acc{0, 0, 0, 0, 0, 0, 0, 0}; }
     static __forceinline__ __device__ Frag load_aligned(const void*, int, int, int, int) {
         return Frag{};
     }
+    static __forceinline__ __device__ Acc zero() { return Acc{0, 0, 0, 0, 0, 0, 0, 0}; }
     static __forceinline__ __device__ Acc mma(Frag, Frag, Acc c) { COMFY_MMA_STUB_BODY }
     static __forceinline__ __device__ Acc mma_ua(Frag, Frag, Acc c) { COMFY_MMA_STUB_BODY }
     static __forceinline__ __device__ Acc mma_ub(Frag, Frag, Acc c) { COMFY_MMA_STUB_BODY }

--- a/comfy_kitchen/backends/hip/ops/attention_bf16.hip
+++ b/comfy_kitchen/backends/hip/ops/attention_bf16.hip
@@ -32,10 +32,22 @@ inline bool use_gfx12_attention_schedule() {
         hipDeviceProp_t properties{};
         if (hipGetDevice(&device) == hipSuccess &&
             hipGetDeviceProperties(&properties, device) == hipSuccess &&
-            std::strncmp(properties.gcnArchName, "gfx12", 5) == 0) {
+            (std::strcmp(properties.gcnArchName, "gfx1170") == 0 ||
+             std::strncmp(properties.gcnArchName, "gfx12", 5) == 0)) {
             return true;
         }
         return false;
+    }();
+    return selected;
+}
+
+inline bool use_gfx1170_attention_schedule() {
+    static const bool selected = [] {
+        int device = 0;
+        hipDeviceProp_t properties{};
+        return hipGetDevice(&device) == hipSuccess &&
+            hipGetDeviceProperties(&properties, device) == hipSuccess &&
+            std::strcmp(properties.gcnArchName, "gfx1170") == 0;
     }();
     return selected;
 }
@@ -50,7 +62,7 @@ struct Bf16AttentionShape {
     static constexpr int kDimTiles = HD / 16;
     static constexpr int kKeyTiles = BLOCK_N / 16;
     static constexpr int kKStride = HD + 4;
-    static constexpr int kVStride = BLOCK_N + 4;
+    static constexpr int kVStride = BLOCK_N + (BLOCK_M <= 64 ? 2 : 4);
 };
 
 template <typename T>
@@ -90,7 +102,7 @@ __forceinline__ __device__ void store_bf16_acc(
 }
 
 template <int HD, int BLOCK_M, int BLOCK_N, bool DIRECT_GLOBAL,
-          bool NO_KV_TAIL = false>
+          bool NO_KV_TAIL = false, bool STAGE_V = false>
 __global__ __launch_bounds__(BLOCK_M * 2)
 void bf16_attention_kernel(
     const __bf16* __restrict__ q, const __bf16* __restrict__ k,
@@ -107,7 +119,9 @@ void bf16_attention_kernel(
     constexpr int KT = Shape::kKeyTiles;
 
     __shared__ __align__(16) __bf16 staged_k[
-        DIRECT_GLOBAL ? 1 : 2 * BLOCK_N * Shape::kKStride];
+        DIRECT_GLOBAL ? 1 : (STAGE_V ? 1 : 2) * BLOCK_N * Shape::kKStride];
+    __shared__ __align__(16) __bf16 staged_v[
+        STAGE_V ? HD * Shape::kVStride : 1];
 
     const int tid = threadIdx.x;
     const int lane = tid & 31;
@@ -158,7 +172,7 @@ void bf16_attention_kernel(
     constexpr int kKStageItems = DIRECT_GLOBAL
         ? 1
         : (kPacksPerTile + Shape::kThreads - 1) / Shape::kThreads;
-    if constexpr (!DIRECT_GLOBAL) {
+    if constexpr (!DIRECT_GLOBAL && !STAGE_V) {
 #pragma unroll
         for (int item = 0; item < kKStageItems; ++item) {
             const int item_pack = tid + item * Shape::kThreads;
@@ -185,8 +199,46 @@ void bf16_attention_kernel(
         const bool has_next_tile = tile + 1 < key_tiles;
         const int next_buffer = (tile + 1) & 1;
 
+        if constexpr (STAGE_V) {
+            if (tile != 0) __syncthreads();
+#pragma unroll
+            for (int item = 0; item < kKStageItems; ++item) {
+                const int item_pack = tid + item * Shape::kThreads;
+                if (item_pack >= kPacksPerTile) continue;
+                const int item_key = item_pack / kPacksPerRow;
+                const int item_d =
+                    (item_pack - item_key * kPacksPerRow) * kPackElems;
+                const int key_index = key0 + item_key;
+                v8bf k_value{};
+                if constexpr (NO_KV_TAIL) {
+                    k_value = *reinterpret_cast<const v8bf*>(
+                        k_head + static_cast<int64_t>(key_index) * k_stride_n + item_d);
+                } else if (key_index < kv_len) {
+                    k_value = *reinterpret_cast<const v8bf*>(
+                        k_head + static_cast<int64_t>(key_index) * k_stride_n + item_d);
+                }
+                store_bf16x8_padded(
+                    staged_k + item_key * Shape::kKStride + item_d, k_value);
+
+                v8bf v_value{};
+                if constexpr (NO_KV_TAIL) {
+                    v_value = *reinterpret_cast<const v8bf*>(
+                        v_head + static_cast<int64_t>(key_index) * v_stride_n + item_d);
+                } else if (key_index < kv_len) {
+                    v_value = *reinterpret_cast<const v8bf*>(
+                        v_head + static_cast<int64_t>(key_index) * v_stride_n + item_d);
+                }
+#pragma unroll
+                for (int e = 0; e < kPackElems; ++e) {
+                    staged_v[(item_d + e) * Shape::kVStride + item_key] =
+                        v_value[e];
+                }
+            }
+            __syncthreads();
+        }
+
         const __bf16* const current_k = staged_k +
-            (tile & 1) * BLOCK_N * Shape::kKStride;
+            (STAGE_V ? 0 : (tile & 1) * BLOCK_N * Shape::kKStride);
 
         MmaBf16::Acc score[KT];
 #pragma unroll
@@ -217,7 +269,7 @@ void bf16_attention_kernel(
         // Prefetch the next K tile after score MMA so global latency hides
         // behind softmax prep instead of sitting in front of the MMA nest.
         v8bf next_k[kKStageItems]{};
-        if constexpr (!DIRECT_GLOBAL) {
+        if constexpr (!DIRECT_GLOBAL && !STAGE_V) {
 #pragma unroll
             for (int item = 0; item < kKStageItems; ++item) {
                 const int item_pack = tid + item * Shape::kThreads;
@@ -275,10 +327,15 @@ void bf16_attention_kernel(
 #pragma unroll
             for (int dt = 0; dt < DT; ++dt) {
                 MmaBf16::Frag v_fragment{};
-                if constexpr (!DIRECT_GLOBAL) {
+                if constexpr (STAGE_V) {
+                    v_fragment = load_frag_16bit<MmaBf16>(
+                        staged_v + (dt * 16 + frag_row(lane)) * Shape::kVStride +
+                        kt * 16,
+                        lane);
+                } else if constexpr (!DIRECT_GLOBAL) {
                     const int tile_key = key0 + kt * 16;
                     if (tile_key + 16 <= kv_len) {
-#if defined(__HIP_DEVICE_COMPILE__) && defined(COMFY_MMA_GFX12)
+#if defined(__HIP_DEVICE_COMPILE__) && defined(COMFY_MMA_GFX12) && defined(__GFX12__)
                         const int source_key = ((lane >> 4) << 3) + (lane & 7);
                         const int source_half = (lane >> 3) & 1;
                         const v8bf* const source = reinterpret_cast<const v8bf*>(
@@ -325,7 +382,7 @@ void bf16_attention_kernel(
         }
         row_sum += tile_sum;
 
-        if constexpr (!DIRECT_GLOBAL) {
+        if constexpr (!DIRECT_GLOBAL && !STAGE_V) {
 #pragma unroll
             for (int item = 0; item < kKStageItems; ++item) {
                 const int item_pack = tid + item * Shape::kThreads;
@@ -356,7 +413,7 @@ void bf16_attention_kernel(
 }
 
 template <int HD, int BLOCK_M, int BLOCK_N, bool DIRECT_GLOBAL,
-          bool NO_KV_TAIL = false>
+          bool NO_KV_TAIL = false, bool STAGE_V = false>
 void launch_bf16_attention_shape(
     const void* q, const void* k, const void* v, void* output,
     int batch, int q_heads, int kv_heads, int q_len, int kv_len,
@@ -366,7 +423,7 @@ void launch_bf16_attention_shape(
     int64_t o_stride_b, int64_t o_stride_h, int64_t o_stride_n,
     float sm_scale, hipStream_t stream) {
     const dim3 grid((q_len + BLOCK_M - 1) / BLOCK_M, q_heads, batch);
-    bf16_attention_kernel<HD, BLOCK_M, BLOCK_N, DIRECT_GLOBAL, NO_KV_TAIL>
+    bf16_attention_kernel<HD, BLOCK_M, BLOCK_N, DIRECT_GLOBAL, NO_KV_TAIL, STAGE_V>
         <<<grid, Bf16AttentionShape<HD, BLOCK_M, BLOCK_N>::kThreads, 0, stream>>>(
             static_cast<const __bf16*>(q), static_cast<const __bf16*>(k),
             static_cast<const __bf16*>(v), static_cast<__bf16*>(output),
@@ -393,14 +450,30 @@ void dispatch_bf16_attention(
             k_stride_n, v_stride_b, v_stride_h, v_stride_n, o_stride_b,
             o_stride_h, o_stride_n, sm_scale, stream);
     } else if (q_len <= 256) {
-        launch_bf16_attention_shape<HD, 32, 32, true>(
-            q, k, v, output, batch, q_heads, kv_heads, q_len, kv_len,
-            q_stride_b, q_stride_h, q_stride_n, k_stride_b, k_stride_h,
-            k_stride_n, v_stride_b, v_stride_h, v_stride_n, o_stride_b,
-            o_stride_h, o_stride_n, sm_scale, stream);
-    } else {
-        if (use_gfx12_attention_schedule() && kv_len >= 1024 &&
+        if (use_gfx1170_attention_schedule() && kv_len >= 128 &&
             kv_len % 32 == 0) {
+            launch_bf16_attention_shape<HD, 64, 32, false, true, true>(
+                q, k, v, output, batch, q_heads, kv_heads, q_len, kv_len,
+                q_stride_b, q_stride_h, q_stride_n, k_stride_b, k_stride_h,
+                k_stride_n, v_stride_b, v_stride_h, v_stride_n, o_stride_b,
+                o_stride_h, o_stride_n, sm_scale, stream);
+        } else {
+            launch_bf16_attention_shape<HD, 32, 32, true>(
+                q, k, v, output, batch, q_heads, kv_heads, q_len, kv_len,
+                q_stride_b, q_stride_h, q_stride_n, k_stride_b, k_stride_h,
+                k_stride_n, v_stride_b, v_stride_h, v_stride_n, o_stride_b,
+                o_stride_h, o_stride_n, sm_scale, stream);
+        }
+    } else {
+        if (use_gfx1170_attention_schedule() && kv_len >= 1024 &&
+            kv_len % 32 == 0) {
+            launch_bf16_attention_shape<HD, 512, 32, false, true, true>(
+                q, k, v, output, batch, q_heads, kv_heads, q_len, kv_len,
+                q_stride_b, q_stride_h, q_stride_n, k_stride_b, k_stride_h,
+                k_stride_n, v_stride_b, v_stride_h, v_stride_n, o_stride_b,
+                o_stride_h, o_stride_n, sm_scale, stream);
+        } else if (use_gfx12_attention_schedule() && kv_len >= 1024 &&
+                   kv_len % 32 == 0) {
             launch_bf16_attention_shape<HD, 128, 32, false, true>(
                 q, k, v, output, batch, q_heads, kv_heads, q_len, kv_len,
                 q_stride_b, q_stride_h, q_stride_n, k_stride_b, k_stride_h,

--- a/comfy_kitchen/backends/hip/ops/attention_bf16.hip
+++ b/comfy_kitchen/backends/hip/ops/attention_bf16.hip
@@ -12,6 +12,7 @@
 
 #include <hip/hip_runtime.h>
 
+#include <atomic>
 #include <cfloat>
 #include <cstdint>
 #include <cstring>
@@ -27,29 +28,46 @@ constexpr float kAttentionLog2e = 1.4426950408889634f;
 
 inline bool use_gfx12_attention_schedule() {
     // COMFY_MMA_GFX12 is device-pass only; query the runtime arch for host dispatch.
-    static const bool selected = [] {
-        int device = 0;
+    constexpr int kMaxDevices = 16;
+    static std::atomic<int> cache[kMaxDevices] = {};
+    int device = 0;
+    if (hipGetDevice(&device) != hipSuccess) return false;
+
+    auto select = [device] {
         hipDeviceProp_t properties{};
-        if (hipGetDevice(&device) == hipSuccess &&
-            hipGetDeviceProperties(&properties, device) == hipSuccess &&
+        return hipGetDeviceProperties(&properties, device) == hipSuccess &&
             (std::strncmp(properties.gcnArchName, "gfx1170", 7) == 0 ||
-             std::strncmp(properties.gcnArchName, "gfx12", 5) == 0)) {
-            return true;
-        }
-        return false;
-    }();
-    return selected;
+             std::strncmp(properties.gcnArchName, "gfx12", 5) == 0);
+    };
+    if (device < 0 || device >= kMaxDevices) return select();
+
+    int selected = cache[device].load(std::memory_order_relaxed);
+    if (selected == 0) {
+        selected = select() ? 2 : 1;
+        cache[device].store(selected, std::memory_order_relaxed);
+    }
+    return selected == 2;
 }
 
 inline bool use_gfx1170_attention_schedule() {
-    static const bool selected = [] {
-        int device = 0;
+    constexpr int kMaxDevices = 16;
+    static std::atomic<int> cache[kMaxDevices] = {};
+    int device = 0;
+    if (hipGetDevice(&device) != hipSuccess) return false;
+
+    auto select = [device] {
         hipDeviceProp_t properties{};
-        return hipGetDevice(&device) == hipSuccess &&
-            hipGetDeviceProperties(&properties, device) == hipSuccess &&
+        return hipGetDeviceProperties(&properties, device) == hipSuccess &&
             std::strncmp(properties.gcnArchName, "gfx1170", 7) == 0;
-    }();
-    return selected;
+    };
+    if (device < 0 || device >= kMaxDevices) return select();
+
+    int selected = cache[device].load(std::memory_order_relaxed);
+    if (selected == 0) {
+        selected = select() ? 2 : 1;
+        cache[device].store(selected, std::memory_order_relaxed);
+    }
+    return selected == 2;
 }
 
 template <int HD, int BLOCK_M, int BLOCK_N>

--- a/comfy_kitchen/backends/hip/ops/attention_bf16.hip
+++ b/comfy_kitchen/backends/hip/ops/attention_bf16.hip
@@ -32,7 +32,7 @@ inline bool use_gfx12_attention_schedule() {
         hipDeviceProp_t properties{};
         if (hipGetDevice(&device) == hipSuccess &&
             hipGetDeviceProperties(&properties, device) == hipSuccess &&
-            (std::strcmp(properties.gcnArchName, "gfx1170") == 0 ||
+            (std::strncmp(properties.gcnArchName, "gfx1170", 7) == 0 ||
              std::strncmp(properties.gcnArchName, "gfx12", 5) == 0)) {
             return true;
         }
@@ -47,7 +47,7 @@ inline bool use_gfx1170_attention_schedule() {
         hipDeviceProp_t properties{};
         return hipGetDevice(&device) == hipSuccess &&
             hipGetDeviceProperties(&properties, device) == hipSuccess &&
-            std::strcmp(properties.gcnArchName, "gfx1170") == 0;
+            std::strncmp(properties.gcnArchName, "gfx1170", 7) == 0;
     }();
     return selected;
 }

--- a/comfy_kitchen/backends/hip/ops/attention_bf16.hip
+++ b/comfy_kitchen/backends/hip/ops/attention_bf16.hip
@@ -66,6 +66,13 @@ __forceinline__ __device__ float sum8_balanced(const v8f& value) {
     return (sum01 + sum23) + (sum45 + sum67);
 }
 
+__forceinline__ __device__ void store_bf16x8_padded(
+    __bf16* __restrict__ destination, v8bf value) {
+    const uint4 words = __builtin_bit_cast(uint4, value);
+    *reinterpret_cast<uint2*>(destination) = make_uint2(words.x, words.y);
+    *reinterpret_cast<uint2*>(destination + 4) = make_uint2(words.z, words.w);
+}
+
 __forceinline__ __device__ void store_bf16_acc(
     __bf16* __restrict__ row, int d_base, const v8f& value, int lane) {
 #if defined(COMFY_MMA_GFX12)
@@ -167,8 +174,8 @@ void bf16_attention_kernel(
                 k_value = *reinterpret_cast<const v8bf*>(
                     k_head + static_cast<int64_t>(item_key) * k_stride_n + item_d);
             }
-            *reinterpret_cast<v8bf*>(
-                staged_k + item_key * Shape::kKStride + item_d) = k_value;
+            store_bf16x8_padded(
+                staged_k + item_key * Shape::kKStride + item_d, k_value);
         }
         __syncthreads();
     }
@@ -271,16 +278,23 @@ void bf16_attention_kernel(
                 if constexpr (!DIRECT_GLOBAL) {
                     const int tile_key = key0 + kt * 16;
                     if (tile_key + 16 <= kv_len) {
+#if defined(__HIP_DEVICE_COMPILE__) && defined(COMFY_MMA_GFX12)
                         const int source_key = ((lane >> 4) << 3) + (lane & 7);
                         const int source_half = (lane >> 3) & 1;
                         const v8bf* const source = reinterpret_cast<const v8bf*>(
                             v_head + static_cast<int64_t>(tile_key + source_key) * v_stride_n +
                             dt * 16 + source_half * 8);
-#if defined(__HIP_DEVICE_COMPILE__)
                         v_fragment = __builtin_amdgcn_global_load_tr_b128_v8bf16(
                             const_cast<v8bf*>(source));
 #else
-                        v_fragment = *source;
+                        const int d = dt * 16 + frag_row(lane);
+#pragma unroll
+                        for (int i = 0; i < MmaBf16::kFragElems; ++i) {
+                            const int key_index =
+                                tile_key + MmaBf16::frag_base(lane) + i;
+                            v_fragment[i] = v_head[
+                                static_cast<int64_t>(key_index) * v_stride_n + d];
+                        }
 #endif
                     } else if (tile_key < kv_len) {
                         const int d = dt * 16 + frag_row(lane);
@@ -319,9 +333,9 @@ void bf16_attention_kernel(
                 const int item_key = item_pack / kPacksPerRow;
                 const int item_d =
                     (item_pack - item_key * kPacksPerRow) * kPackElems;
-                *reinterpret_cast<v8bf*>(
+                store_bf16x8_padded(
                     staged_k + next_buffer * BLOCK_N * Shape::kKStride +
-                    item_key * Shape::kKStride + item_d) = next_k[item];
+                    item_key * Shape::kKStride + item_d, next_k[item]);
             }
             if (has_next_tile) __syncthreads();
         }

--- a/comfy_kitchen/backends/hip/ops/attention_bf16.hip
+++ b/comfy_kitchen/backends/hip/ops/attention_bf16.hip
@@ -1,0 +1,449 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Forward-only, unmasked BF16 scaled dot-product attention for RDNA wave32
+// matrix cores. The score and output products are both transposed:
+//
+//   S^T = K @ Q^T,  O^T = V^T @ P^T.
+//
+// One query column therefore stays on a lane through the online softmax, and
+// the BF16 probability fragment flows directly into the second WMMA. K and a
+// transposed V tile are shared by every 16-query wave in the workgroup.
+
+#include <hip/hip_runtime.h>
+
+#include <cfloat>
+#include <cstdint>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+
+#include "../mma.h"
+
+namespace comfy::hip_backend {
+namespace {
+
+constexpr float kAttentionLog2e = 1.4426950408889634f;
+
+inline bool use_gfx12_attention_schedule() {
+    // COMFY_MMA_GFX12 is device-pass only; query the runtime arch for host dispatch.
+    static const bool selected = [] {
+        int device = 0;
+        hipDeviceProp_t properties{};
+        if (hipGetDevice(&device) == hipSuccess &&
+            hipGetDeviceProperties(&properties, device) == hipSuccess &&
+            std::strncmp(properties.gcnArchName, "gfx12", 5) == 0) {
+            return true;
+        }
+        return false;
+    }();
+    return selected;
+}
+
+template <int HD, int BLOCK_M, int BLOCK_N>
+struct Bf16AttentionShape {
+    static_assert(HD % 16 == 0);
+    static_assert(BLOCK_M % 16 == 0);
+    static_assert(BLOCK_N % 16 == 0);
+    static constexpr int kWaves = BLOCK_M / 16;
+    static constexpr int kThreads = kWaves * 32;
+    static constexpr int kDimTiles = HD / 16;
+    static constexpr int kKeyTiles = BLOCK_N / 16;
+    static constexpr int kKStride = HD + 4;
+    static constexpr int kVStride = BLOCK_N + 4;
+};
+
+template <typename T>
+__forceinline__ __device__ T half_wave_swap(T value) {
+    return __shfl_xor(value, 16, 32);
+}
+
+__forceinline__ __device__ float sum8_balanced(const v8f& value) {
+    const float sum01 = value[0] + value[1];
+    const float sum23 = value[2] + value[3];
+    const float sum45 = value[4] + value[5];
+    const float sum67 = value[6] + value[7];
+    return (sum01 + sum23) + (sum45 + sum67);
+}
+
+__forceinline__ __device__ void store_bf16_acc(
+    __bf16* __restrict__ row, int d_base, const v8f& value, int lane) {
+#if defined(COMFY_MMA_GFX12)
+    __attribute__((aligned(16))) __bf16 packed[8];
+#pragma unroll
+    for (int e = 0; e < 8; ++e) packed[e] = static_cast<__bf16>(value[e]);
+    *reinterpret_cast<uint4*>(row + d_base + 8 * (lane / 16)) =
+        *reinterpret_cast<const uint4*>(packed);
+#else
+#pragma unroll
+    for (int e = 0; e < 8; ++e) {
+        row[d_base + acc_row(lane, e)] = static_cast<__bf16>(value[e]);
+    }
+#endif
+}
+
+template <int HD, int BLOCK_M, int BLOCK_N, bool DIRECT_GLOBAL,
+          bool NO_KV_TAIL = false>
+__global__ __launch_bounds__(BLOCK_M * 2)
+void bf16_attention_kernel(
+    const __bf16* __restrict__ q, const __bf16* __restrict__ k,
+    const __bf16* __restrict__ v, __bf16* __restrict__ output,
+    int q_heads, int kv_heads, int q_len, int kv_len,
+    int64_t q_stride_b, int64_t q_stride_h, int64_t q_stride_n,
+    int64_t k_stride_b, int64_t k_stride_h, int64_t k_stride_n,
+    int64_t v_stride_b, int64_t v_stride_h, int64_t v_stride_n,
+    int64_t o_stride_b, int64_t o_stride_h, int64_t o_stride_n,
+    float sm_scale) {
+
+    using Shape = Bf16AttentionShape<HD, BLOCK_M, BLOCK_N>;
+    constexpr int DT = Shape::kDimTiles;
+    constexpr int KT = Shape::kKeyTiles;
+
+    __shared__ __align__(16) __bf16 staged_k[
+        DIRECT_GLOBAL ? 1 : 2 * BLOCK_N * Shape::kKStride];
+
+    const int tid = threadIdx.x;
+    const int lane = tid & 31;
+    const int wave = tid >> 5;
+    const int head = blockIdx.y;
+    const int batch_index = blockIdx.z;
+    const int kv_head = head / (q_heads / kv_heads);
+    const int query_block = blockIdx.x * BLOCK_M;
+    const int query_row = query_block + wave * 16 + frag_row(lane);
+    const int query_column = query_block + wave * 16 + acc_col(lane);
+
+    const __bf16* const q_head =
+        q + static_cast<int64_t>(batch_index) * q_stride_b +
+        static_cast<int64_t>(head) * q_stride_h;
+    const __bf16* const k_head =
+        k + static_cast<int64_t>(batch_index) * k_stride_b +
+        static_cast<int64_t>(kv_head) * k_stride_h;
+    const __bf16* const v_head =
+        v + static_cast<int64_t>(batch_index) * v_stride_b +
+        static_cast<int64_t>(kv_head) * v_stride_h;
+    __bf16* const o_head =
+        output + static_cast<int64_t>(batch_index) * o_stride_b +
+        static_cast<int64_t>(head) * o_stride_h;
+
+    MmaBf16::Frag q_fragment[DT];
+    const int safe_query_row = query_row < q_len ? query_row : q_len - 1;
+#pragma unroll
+    for (int dt = 0; dt < DT; ++dt) {
+        q_fragment[dt] = load_frag_16bit<MmaBf16>(
+            q_head + static_cast<int64_t>(safe_query_row) * q_stride_n + dt * 16,
+            lane);
+    }
+
+    MmaBf16::Acc output_acc[DT];
+#pragma unroll
+    for (int dt = 0; dt < DT; ++dt) output_acc[dt] = MmaBf16::zero();
+
+    float row_max = -FLT_MAX;
+    float row_sum = 1.0f;
+    const float score_scale = sm_scale * kAttentionLog2e;
+    const int key_tiles = NO_KV_TAIL
+        ? kv_len / BLOCK_N
+        : (kv_len + BLOCK_N - 1) / BLOCK_N;
+
+    constexpr int kPackElems = 8;
+    constexpr int kPacksPerRow = HD / kPackElems;
+    constexpr int kPacksPerTile = BLOCK_N * kPacksPerRow;
+    constexpr int kKStageItems = DIRECT_GLOBAL
+        ? 1
+        : (kPacksPerTile + Shape::kThreads - 1) / Shape::kThreads;
+    if constexpr (!DIRECT_GLOBAL) {
+#pragma unroll
+        for (int item = 0; item < kKStageItems; ++item) {
+            const int item_pack = tid + item * Shape::kThreads;
+            if (item_pack >= kPacksPerTile) continue;
+            const int item_key = item_pack / kPacksPerRow;
+            const int item_d =
+                (item_pack - item_key * kPacksPerRow) * kPackElems;
+            v8bf k_value{};
+            if constexpr (NO_KV_TAIL) {
+                k_value = *reinterpret_cast<const v8bf*>(
+                    k_head + static_cast<int64_t>(item_key) * k_stride_n + item_d);
+            } else if (item_key < kv_len) {
+                k_value = *reinterpret_cast<const v8bf*>(
+                    k_head + static_cast<int64_t>(item_key) * k_stride_n + item_d);
+            }
+            *reinterpret_cast<v8bf*>(
+                staged_k + item_key * Shape::kKStride + item_d) = k_value;
+        }
+        __syncthreads();
+    }
+
+    for (int tile = 0; tile < key_tiles; ++tile) {
+        const int key0 = tile * BLOCK_N;
+        const bool has_next_tile = tile + 1 < key_tiles;
+        const int next_buffer = (tile + 1) & 1;
+
+        const __bf16* const current_k = staged_k +
+            (tile & 1) * BLOCK_N * Shape::kKStride;
+
+        MmaBf16::Acc score[KT];
+#pragma unroll
+        for (int kt = 0; kt < KT; ++kt) {
+            score[kt] = MmaBf16::zero();
+        }
+#pragma unroll
+        for (int dt = 0; dt < DT; ++dt) {
+#pragma unroll
+            for (int kt = 0; kt < KT; ++kt) {
+                MmaBf16::Frag k_fragment{};
+                if constexpr (DIRECT_GLOBAL) {
+                    const int key_index = key0 + kt * 16 + frag_row(lane);
+                    if (key_index < kv_len) {
+                        k_fragment = load_frag_16bit<MmaBf16>(
+                            k_head + static_cast<int64_t>(key_index) * k_stride_n + dt * 16,
+                            lane);
+                    }
+                } else {
+                    k_fragment = load_frag_16bit<MmaBf16>(
+                        current_k + (kt * 16 + frag_row(lane)) * Shape::kKStride + dt * 16,
+                        lane);
+                }
+                score[kt] = MmaBf16::mma(k_fragment, q_fragment[dt], score[kt]);
+            }
+        }
+
+        // Prefetch the next K tile after score MMA so global latency hides
+        // behind softmax prep instead of sitting in front of the MMA nest.
+        v8bf next_k[kKStageItems]{};
+        if constexpr (!DIRECT_GLOBAL) {
+#pragma unroll
+            for (int item = 0; item < kKStageItems; ++item) {
+                const int item_pack = tid + item * Shape::kThreads;
+                if (!has_next_tile || item_pack >= kPacksPerTile) continue;
+                const int item_key = item_pack / kPacksPerRow;
+                const int item_d =
+                    (item_pack - item_key * kPacksPerRow) * kPackElems;
+                const int next_key = key0 + BLOCK_N + item_key;
+                if constexpr (NO_KV_TAIL) {
+                    next_k[item] = *reinterpret_cast<const v8bf*>(
+                        k_head + static_cast<int64_t>(next_key) * k_stride_n + item_d);
+                } else if (next_key < kv_len) {
+                    next_k[item] = *reinterpret_cast<const v8bf*>(
+                        k_head + static_cast<int64_t>(next_key) * k_stride_n + item_d);
+                }
+            }
+        }
+
+        float local_max = -FLT_MAX;
+#pragma unroll
+        for (int kt = 0; kt < KT; ++kt) {
+#pragma unroll
+            for (int e = 0; e < 8; ++e) {
+                float value = score[kt][e] * score_scale;
+                const int key_index = key0 + kt * 16 + acc_row(lane, e);
+                if constexpr (!NO_KV_TAIL) {
+                    if (key_index >= kv_len) value = -FLT_MAX;
+                }
+                score[kt][e] = value;
+                local_max = fmaxf(local_max, value);
+            }
+        }
+        const float tile_max = fmaxf(local_max, half_wave_swap(local_max));
+        const float next_max = fmaxf(row_max, tile_max);
+        const float alpha = __builtin_amdgcn_exp2f(row_max - next_max);
+        row_max = next_max;
+        row_sum *= alpha;
+#pragma unroll
+        for (int dt = 0; dt < DT; ++dt) {
+#pragma unroll
+            for (int e = 0; e < 8; ++e) output_acc[dt][e] *= alpha;
+        }
+
+        float tile_sum = 0.0f;
+#pragma unroll
+        for (int kt = 0; kt < KT; ++kt) {
+            MmaBf16::Frag probability;
+            v8f p;
+#pragma unroll
+            for (int e = 0; e < 8; ++e) {
+                p[e] = __builtin_amdgcn_exp2f(score[kt][e] - next_max);
+                probability[e] = static_cast<__bf16>(p[e]);
+            }
+            tile_sum += sum8_balanced(p);
+#pragma unroll
+            for (int dt = 0; dt < DT; ++dt) {
+                MmaBf16::Frag v_fragment{};
+                if constexpr (!DIRECT_GLOBAL) {
+                    const int tile_key = key0 + kt * 16;
+                    if (tile_key + 16 <= kv_len) {
+                        const int source_key = ((lane >> 4) << 3) + (lane & 7);
+                        const int source_half = (lane >> 3) & 1;
+                        const v8bf* const source = reinterpret_cast<const v8bf*>(
+                            v_head + static_cast<int64_t>(tile_key + source_key) * v_stride_n +
+                            dt * 16 + source_half * 8);
+#if defined(__HIP_DEVICE_COMPILE__)
+                        v_fragment = __builtin_amdgcn_global_load_tr_b128_v8bf16(
+                            const_cast<v8bf*>(source));
+#else
+                        v_fragment = *source;
+#endif
+                    } else if (tile_key < kv_len) {
+                        const int d = dt * 16 + frag_row(lane);
+#pragma unroll
+                        for (int i = 0; i < MmaBf16::kFragElems; ++i) {
+                            const int key_index = tile_key + MmaBf16::frag_base(lane) + i;
+                            if (key_index < kv_len) {
+                                v_fragment[i] = v_head[
+                                    static_cast<int64_t>(key_index) * v_stride_n + d];
+                            }
+                        }
+                    }
+                } else {
+                    const int d = dt * 16 + frag_row(lane);
+#pragma unroll
+                    for (int i = 0; i < MmaBf16::kFragElems; ++i) {
+                        const int key_index =
+                            key0 + kt * 16 + MmaBf16::frag_base(lane) + i;
+                        if (key_index < kv_len) {
+                            v_fragment[i] = v_head[
+                                static_cast<int64_t>(key_index) * v_stride_n + d];
+                        }
+                    }
+                }
+                output_acc[dt] = MmaBf16::mma(
+                    v_fragment, probability, output_acc[dt]);
+            }
+        }
+        row_sum += tile_sum;
+
+        if constexpr (!DIRECT_GLOBAL) {
+#pragma unroll
+            for (int item = 0; item < kKStageItems; ++item) {
+                const int item_pack = tid + item * Shape::kThreads;
+                if (!has_next_tile || item_pack >= kPacksPerTile) continue;
+                const int item_key = item_pack / kPacksPerRow;
+                const int item_d =
+                    (item_pack - item_key * kPacksPerRow) * kPackElems;
+                *reinterpret_cast<v8bf*>(
+                    staged_k + next_buffer * BLOCK_N * Shape::kKStride +
+                    item_key * Shape::kKStride + item_d) = next_k[item];
+            }
+            if (has_next_tile) __syncthreads();
+        }
+    }
+
+    row_sum += half_wave_swap(row_sum);
+    if (query_column < q_len) {
+        const float reciprocal = 1.0f / row_sum;
+        __bf16* const row = o_head + static_cast<int64_t>(query_column) * o_stride_n;
+#pragma unroll
+        for (int dt = 0; dt < DT; ++dt) {
+            v8f normalized;
+#pragma unroll
+            for (int e = 0; e < 8; ++e) normalized[e] = output_acc[dt][e] * reciprocal;
+            store_bf16_acc(row, dt * 16, normalized, lane);
+        }
+    }
+}
+
+template <int HD, int BLOCK_M, int BLOCK_N, bool DIRECT_GLOBAL,
+          bool NO_KV_TAIL = false>
+void launch_bf16_attention_shape(
+    const void* q, const void* k, const void* v, void* output,
+    int batch, int q_heads, int kv_heads, int q_len, int kv_len,
+    int64_t q_stride_b, int64_t q_stride_h, int64_t q_stride_n,
+    int64_t k_stride_b, int64_t k_stride_h, int64_t k_stride_n,
+    int64_t v_stride_b, int64_t v_stride_h, int64_t v_stride_n,
+    int64_t o_stride_b, int64_t o_stride_h, int64_t o_stride_n,
+    float sm_scale, hipStream_t stream) {
+    const dim3 grid((q_len + BLOCK_M - 1) / BLOCK_M, q_heads, batch);
+    bf16_attention_kernel<HD, BLOCK_M, BLOCK_N, DIRECT_GLOBAL, NO_KV_TAIL>
+        <<<grid, Bf16AttentionShape<HD, BLOCK_M, BLOCK_N>::kThreads, 0, stream>>>(
+            static_cast<const __bf16*>(q), static_cast<const __bf16*>(k),
+            static_cast<const __bf16*>(v), static_cast<__bf16*>(output),
+            q_heads, kv_heads, q_len, kv_len,
+            q_stride_b, q_stride_h, q_stride_n,
+            k_stride_b, k_stride_h, k_stride_n,
+            v_stride_b, v_stride_h, v_stride_n,
+            o_stride_b, o_stride_h, o_stride_n, sm_scale);
+}
+
+template <int HD>
+void dispatch_bf16_attention(
+    const void* q, const void* k, const void* v, void* output,
+    int batch, int q_heads, int kv_heads, int q_len, int kv_len,
+    int64_t q_stride_b, int64_t q_stride_h, int64_t q_stride_n,
+    int64_t k_stride_b, int64_t k_stride_h, int64_t k_stride_n,
+    int64_t v_stride_b, int64_t v_stride_h, int64_t v_stride_n,
+    int64_t o_stride_b, int64_t o_stride_h, int64_t o_stride_n,
+    float sm_scale, hipStream_t stream) {
+    if (q_len <= 16 && kv_len <= 16) {
+        launch_bf16_attention_shape<HD, 16, 16, true>(
+            q, k, v, output, batch, q_heads, kv_heads, q_len, kv_len,
+            q_stride_b, q_stride_h, q_stride_n, k_stride_b, k_stride_h,
+            k_stride_n, v_stride_b, v_stride_h, v_stride_n, o_stride_b,
+            o_stride_h, o_stride_n, sm_scale, stream);
+    } else if (q_len <= 256) {
+        launch_bf16_attention_shape<HD, 32, 32, true>(
+            q, k, v, output, batch, q_heads, kv_heads, q_len, kv_len,
+            q_stride_b, q_stride_h, q_stride_n, k_stride_b, k_stride_h,
+            k_stride_n, v_stride_b, v_stride_h, v_stride_n, o_stride_b,
+            o_stride_h, o_stride_n, sm_scale, stream);
+    } else {
+        if (use_gfx12_attention_schedule() && kv_len >= 1024 &&
+            kv_len % 32 == 0) {
+            launch_bf16_attention_shape<HD, 128, 32, false, true>(
+                q, k, v, output, batch, q_heads, kv_heads, q_len, kv_len,
+                q_stride_b, q_stride_h, q_stride_n, k_stride_b, k_stride_h,
+                k_stride_n, v_stride_b, v_stride_h, v_stride_n, o_stride_b,
+                o_stride_h, o_stride_n, sm_scale, stream);
+        } else if (kv_len % 48 == 0) {
+            launch_bf16_attention_shape<HD, 192, 48, false, true>(
+                q, k, v, output, batch, q_heads, kv_heads, q_len, kv_len,
+                q_stride_b, q_stride_h, q_stride_n, k_stride_b, k_stride_h,
+                k_stride_n, v_stride_b, v_stride_h, v_stride_n, o_stride_b,
+                o_stride_h, o_stride_n, sm_scale, stream);
+        } else {
+            launch_bf16_attention_shape<HD, 192, 48, false, false>(
+                q, k, v, output, batch, q_heads, kv_heads, q_len, kv_len,
+                q_stride_b, q_stride_h, q_stride_n, k_stride_b, k_stride_h,
+                k_stride_n, v_stride_b, v_stride_h, v_stride_n, o_stride_b,
+                o_stride_h, o_stride_n, sm_scale, stream);
+        }
+    }
+}
+
+}  // namespace
+}  // namespace comfy::hip_backend
+
+extern "C" void launch_bf16_sdpa_hip(
+    const void* q, const void* k, const void* v, void* output,
+    int batch, int q_heads, int kv_heads, int q_len, int kv_len, int head_dim,
+    int64_t q_stride_b, int64_t q_stride_h, int64_t q_stride_n,
+    int64_t k_stride_b, int64_t k_stride_h, int64_t k_stride_n,
+    int64_t v_stride_b, int64_t v_stride_h, int64_t v_stride_n,
+    int64_t o_stride_b, int64_t o_stride_h, int64_t o_stride_n,
+    float sm_scale, hipStream_t stream) {
+    using namespace comfy::hip_backend;
+    if (batch <= 0 || q_heads <= 0 || kv_heads <= 0 || q_len <= 0 || kv_len <= 0 ||
+        q_heads % kv_heads != 0) {
+        throw std::runtime_error("BF16 HIP attention received invalid extents");
+    }
+
+#define COMFY_BF16_ATTN_CASE(HD)                                                        \
+    dispatch_bf16_attention<HD>(                                                       \
+        q, k, v, output, batch, q_heads, kv_heads, q_len, kv_len,                     \
+        q_stride_b, q_stride_h, q_stride_n, k_stride_b, k_stride_h, k_stride_n,       \
+        v_stride_b, v_stride_h, v_stride_n, o_stride_b, o_stride_h, o_stride_n,       \
+        sm_scale, stream)
+
+    switch (head_dim) {
+        case 128: COMFY_BF16_ATTN_CASE(128); break;
+        default:
+            throw std::runtime_error(
+                "BF16 HIP attention supports head dimension 128, got " +
+                std::to_string(head_dim));
+    }
+#undef COMFY_BF16_ATTN_CASE
+
+    const hipError_t error = hipGetLastError();
+    if (error != hipSuccess) {
+        throw std::runtime_error(
+            std::string("BF16 HIP attention launch failed: ") + hipGetErrorString(error));
+    }
+}

--- a/comfy_kitchen/backends/hip/ops/gemm_int8.hip
+++ b/comfy_kitchen/backends/hip/ops/gemm_int8.hip
@@ -25,7 +25,7 @@ inline bool use_nonduplicated_int8_schedule() {
     auto select = [device] {
         hipDeviceProp_t properties{};
         return hipGetDeviceProperties(&properties, device) == hipSuccess &&
-            (std::strcmp(properties.gcnArchName, "gfx1170") == 0 ||
+            (std::strncmp(properties.gcnArchName, "gfx1170", 7) == 0 ||
              std::strncmp(properties.gcnArchName, "gfx12", 5) == 0);
     };
     if (device < 0 || device >= kMaxDevices) return select();

--- a/comfy_kitchen/backends/hip/ops/gemm_int8.hip
+++ b/comfy_kitchen/backends/hip/ops/gemm_int8.hip
@@ -3,6 +3,7 @@
 //
 // INT8 GEMM on WMMA (v_wmma_i32_16x16x16_iu8), gfx11 and gfx12. See mma.h.
 // C[M, N] = (A[M, K] @ B[N, K]^T) * scale_a[row] * scale_b[col] + bias
+#include <atomic>
 #include <cstring>
 #include <stdexcept>
 #include <string>
@@ -16,17 +17,24 @@ namespace comfy::hip_backend {
 inline bool use_nonduplicated_int8_schedule() {
     // The launch contract stays dimensional. Only the hardware choice is
     // architecture-specific, and it remains private to this translation unit.
-    static const bool selected = [] {
-        int device = 0;
+    constexpr int kMaxDevices = 16;
+    static std::atomic<int> cache[kMaxDevices] = {};
+    int device = 0;
+    if (hipGetDevice(&device) != hipSuccess) return false;
+
+    auto select = [device] {
         hipDeviceProp_t properties{};
-        if (hipGetDevice(&device) == hipSuccess &&
-            hipGetDeviceProperties(&properties, device) == hipSuccess &&
-            std::strncmp(properties.gcnArchName, "gfx12", 5) == 0) {
-            return true;
-        }
-        return false;
-    }();
-    return selected;
+        return hipGetDeviceProperties(&properties, device) == hipSuccess &&
+            std::strncmp(properties.gcnArchName, "gfx12", 5) == 0;
+    };
+    if (device < 0 || device >= kMaxDevices) return select();
+
+    int selected = cache[device].load(std::memory_order_relaxed);
+    if (selected == 0) {
+        selected = select() ? 2 : 1;
+        cache[device].store(selected, std::memory_order_relaxed);
+    }
+    return selected == 2;
 }
 
 // Small-M path: reduce K across the wave, one wave per output column.
@@ -83,12 +91,12 @@ static void launch_int8(const int8_t* A, const int8_t* B, OutT* C, int M, int N,
             if (epi.bias == nullptr && epi.scale_b_stride == 1) {
                 EpiRowwiseNoBias no_bias{epi.scale_a, epi.scale_b};
                 gemm_wmma_dual_m_kernel<MmaInt8, EpiRowwiseNoBias, OutT,
-                                        BM, BN, BKB, 4, 2, 2, 4, true>
+                                        BM, BN, BKB, 4, 2, 2, 4>
                     <<<grid, 512, 0, stream>>>(
                         Au, Bu, C, M, N, K, ldc, no_bias);
             } else {
                 gemm_wmma_dual_m_kernel<MmaInt8, EpiRowwise, OutT,
-                                        BM, BN, BKB, 4, 2, 2, 4, true>
+                                        BM, BN, BKB, 4, 2, 2, 4>
                     <<<grid, 512, 0, stream>>>(Au, Bu, C, M, N, K, ldc, epi);
             }
         } else if (tuned && M >= 512 && N >= 128 && K > N) {
@@ -254,6 +262,10 @@ extern "C" void launch_int8_gemm_b_tiled_gated_residual_kernel(
         throw std::runtime_error(
             "int8_gemm_b_tiled_gated_residual: requires M>=96, N divisible "
             "by 128, K divisible by tile_k, tile_k in {64,128}, and ldc>=N");
+    }
+    if (residual == nullptr || gate == nullptr) {
+        throw std::runtime_error(
+            "int8_gemm_b_tiled_gated_residual: residual and gate are required");
     }
     EpiRowwiseGatedResidual epi{
         static_cast<const float*>(scale_a), static_cast<const float*>(scale_b),

--- a/comfy_kitchen/backends/hip/ops/gemm_int8.hip
+++ b/comfy_kitchen/backends/hip/ops/gemm_int8.hip
@@ -3,6 +3,7 @@
 //
 // INT8 GEMM on WMMA (v_wmma_i32_16x16x16_iu8), gfx11 and gfx12. See mma.h.
 // C[M, N] = (A[M, K] @ B[N, K]^T) * scale_a[row] * scale_b[col] + bias
+#include <cstring>
 #include <stdexcept>
 #include <string>
 
@@ -11,6 +12,22 @@
 #include "../launchers.h"
 
 namespace comfy::hip_backend {
+
+inline bool use_nonduplicated_int8_schedule() {
+    // The launch contract stays dimensional. Only the hardware choice is
+    // architecture-specific, and it remains private to this translation unit.
+    static const bool selected = [] {
+        int device = 0;
+        hipDeviceProp_t properties{};
+        if (hipGetDevice(&device) == hipSuccess &&
+            hipGetDeviceProperties(&properties, device) == hipSuccess &&
+            std::strncmp(properties.gcnArchName, "gfx12", 5) == 0) {
+            return true;
+        }
+        return false;
+    }();
+    return selected;
+}
 
 // Small-M path: reduce K across the wave, one wave per output column.
 template <typename OutT>
@@ -55,7 +72,51 @@ static void launch_int8(const int8_t* A, const int8_t* B, OutT* C, int M, int N,
         gemv_int8_kernel<OutT><<<grid, block, 0, stream>>>(A, B, C, M, N, K, ldc, epi);
         return;
     }
-    launch_gemm_wmma<MmaInt8, EpiRowwise, OutT>(Au, Bu, C, M, N, K, ldc, epi, stream);
+    const bool tuned = use_nonduplicated_int8_schedule();
+    if (M >= 96 && N >= 96) {
+        if (tuned && M >= 512 && K == 3840 &&
+            (N == 3840 || N == 10240 || N == 11520)) {
+            // Square, packed-QKV, and MLP projections all reuse one staged B
+            // tile across two adjacent M tiles.
+            constexpr int BM = 128, BN = 128, BKB = 64;
+            dim3 grid((N + BN - 1) / BN, (M + 2 * BM - 1) / (2 * BM));
+            if (epi.bias == nullptr && epi.scale_b_stride == 1) {
+                EpiRowwiseNoBias no_bias{epi.scale_a, epi.scale_b};
+                gemm_wmma_dual_m_kernel<MmaInt8, EpiRowwiseNoBias, OutT,
+                                        BM, BN, BKB, 4, 2, 2, 4, true>
+                    <<<grid, 512, 0, stream>>>(
+                        Au, Bu, C, M, N, K, ldc, no_bias);
+            } else {
+                gemm_wmma_dual_m_kernel<MmaInt8, EpiRowwise, OutT,
+                                        BM, BN, BKB, 4, 2, 2, 4, true>
+                    <<<grid, 512, 0, stream>>>(Au, Bu, C, M, N, K, ldc, epi);
+            }
+        } else if (tuned && M >= 512 && N >= 128 && K > N) {
+            constexpr int BM = 128, BN = 128, BKB = 64;
+            dim3 grid((N + BN - 1) / BN, (M + BM - 1) / BM);
+            gemm_wmma_kernel<MmaInt8, EpiRowwise, OutT, BM, BN, BKB,
+                             4, 2, 2, 4, true>
+                <<<grid, 256, 0, stream>>>(Au, Bu, C, M, N, K, ldc, epi);
+        } else if (tuned) {
+            // Non-duplicated WMMA operands favor the lower-LDS stage.
+            constexpr int BM = 128, BN = 128, BKB = 64;
+            dim3 grid((N + BN - 1) / BN, (M + BM - 1) / BM);
+            gemm_wmma_kernel<MmaInt8, EpiRowwise, OutT, BM, BN, BKB,
+                             4, 2, 2, 4>
+                <<<grid, 256, 0, stream>>>(Au, Bu, C, M, N, K, ldc, epi);
+        } else {
+            // Portable starting geometry for other WMMA targets.
+            constexpr int BM = 128, BN = 128, BKB = 128;
+            dim3 grid((N + BN - 1) / BN, (M + BM - 1) / BM);
+            gemm_wmma_kernel<MmaInt8, EpiRowwise, OutT, BM, BN, BKB, 4, 2, 2, 4>
+                <<<grid, 256, 0, stream>>>(Au, Bu, C, M, N, K, ldc, epi);
+        }
+    } else {
+        constexpr int BM = 64, BN = 64, BKB = 64;
+        dim3 grid((N + BN - 1) / BN, (M + BM - 1) / BM);
+        gemm_wmma_kernel<MmaInt8, EpiRowwise, OutT, BM, BN, BKB, 2, 2, 2, 2>
+            <<<grid, 128, 0, stream>>>(Au, Bu, C, M, N, K, ldc, epi);
+    }
 }
 
 }  // namespace comfy::hip_backend
@@ -98,5 +159,249 @@ extern "C" void launch_int8_gemm_kernel(
         launch_int8<float>(A, B, static_cast<float*>(c), M, N, K, ldc, epi, stream);
     } else {
         throw std::runtime_error("int8_gemm: unsupported output dtype");
+    }
+}
+
+template <typename OutT, int BKB, bool DUAL_M, typename Epi>
+static void launch_int8_b_tiled(
+    const uint8_t* A, const uint8_t* B, OutT* C,
+    int M, int N, int K, int ldc, Epi epi,
+    hipStream_t stream) {
+    using namespace comfy::hip_backend;
+    constexpr int BM = 128, BN = 128;
+    if constexpr (DUAL_M) {
+        dim3 grid((N + BN - 1) / BN, (M + 2 * BM - 1) / (2 * BM));
+        gemm_wmma_dual_m_kernel<MmaInt8, Epi, OutT,
+                                BM, BN, BKB, 4, 2, 2, 4,
+                                false, true>
+            <<<grid, 512, 0, stream>>>(A, B, C, M, N, K, ldc, epi);
+    } else {
+        dim3 grid((N + BN - 1) / BN, (M + BM - 1) / BM);
+        gemm_wmma_kernel<MmaInt8, Epi, OutT,
+                         BM, BN, BKB, 4, 2, 2, 4,
+                         true, false, true, true>
+            <<<grid, 256, 0, stream>>>(A, B, C, M, N, K, ldc, epi);
+    }
+}
+
+extern "C" void launch_int8_gemm_b_tiled_kernel(
+    const void* a, const void* b, void* c,
+    const void* scale_a, const void* scale_b, int scale_b_stride,
+    const void* bias, int bias_code, int M, int N, int K, int ldc,
+    int out_code, int tile_k, bool dual_m, hipStream_t stream) {
+    using namespace comfy::hip_backend;
+    if (M == 0 || N == 0) return;
+    if (M < 96 || N % 128 != 0 ||
+        (tile_k != 64 && tile_k != 128) || K % tile_k != 0 || ldc < N) {
+        throw std::runtime_error(
+            "int8_gemm_b_tiled: requires M>=96, N divisible by 128, "
+            "K divisible by tile_k, tile_k in {64,128}, and ldc>=N");
+    }
+    EpiRowwise epi{
+        static_cast<const float*>(scale_a), static_cast<const float*>(scale_b),
+        scale_b_stride, bias, bias_code};
+    const uint8_t* A = static_cast<const uint8_t*>(a);
+    const uint8_t* B = static_cast<const uint8_t*>(b);
+
+#define LAUNCH_TILED(OUT_T, EPI_ARG)                                            \
+    do {                                                                        \
+        if (tile_k == 64) {                                                     \
+            if (dual_m) launch_int8_b_tiled<OUT_T, 64, true>(                   \
+                A, B, static_cast<OUT_T*>(c), M, N, K, ldc, EPI_ARG, stream);   \
+            else launch_int8_b_tiled<OUT_T, 64, false>(                         \
+                A, B, static_cast<OUT_T*>(c), M, N, K, ldc, EPI_ARG, stream);   \
+        } else {                                                                \
+            if (dual_m) launch_int8_b_tiled<OUT_T, 128, true>(                  \
+                A, B, static_cast<OUT_T*>(c), M, N, K, ldc, EPI_ARG, stream);   \
+            else launch_int8_b_tiled<OUT_T, 128, false>(                        \
+                A, B, static_cast<OUT_T*>(c), M, N, K, ldc, EPI_ARG, stream);   \
+        }                                                                       \
+    } while (false)
+
+    if (epi.bias == nullptr && epi.scale_b_stride == 1) {
+        EpiRowwiseNoBias no_bias{epi.scale_a, epi.scale_b};
+        if (out_code == kBF16) {
+            LAUNCH_TILED(__bf16, no_bias);
+        } else if (out_code == kF16) {
+            LAUNCH_TILED(__half, no_bias);
+        } else if (out_code == kF32) {
+            LAUNCH_TILED(float, no_bias);
+        } else {
+            throw std::runtime_error("int8_gemm_b_tiled: unsupported output dtype");
+        }
+    } else if (out_code == kBF16) {
+        LAUNCH_TILED(__bf16, epi);
+    } else if (out_code == kF16) {
+        LAUNCH_TILED(__half, epi);
+    } else if (out_code == kF32) {
+        LAUNCH_TILED(float, epi);
+    } else {
+        throw std::runtime_error("int8_gemm_b_tiled: unsupported output dtype");
+    }
+#undef LAUNCH_TILED
+}
+
+extern "C" void launch_int8_gemm_b_tiled_gated_residual_kernel(
+    const void* a, const void* b, void* c,
+    const void* scale_a, const void* scale_b, int scale_b_stride,
+    const void* bias, int bias_code, const void* residual, const void* gate,
+    int M, int N, int K, int ldc, int tile_k, bool dual_m,
+    hipStream_t stream) {
+    using namespace comfy::hip_backend;
+    if (M == 0 || N == 0) return;
+    if (M < 96 || N % 128 != 0 ||
+        (tile_k != 64 && tile_k != 128) || K % tile_k != 0 || ldc < N) {
+        throw std::runtime_error(
+            "int8_gemm_b_tiled_gated_residual: requires M>=96, N divisible "
+            "by 128, K divisible by tile_k, tile_k in {64,128}, and ldc>=N");
+    }
+    EpiRowwiseGatedResidual epi{
+        static_cast<const float*>(scale_a), static_cast<const float*>(scale_b),
+        scale_b_stride, bias, bias_code,
+        static_cast<const __bf16*>(residual), static_cast<const __bf16*>(gate),
+        ldc};
+    const uint8_t* A = static_cast<const uint8_t*>(a);
+    const uint8_t* B = static_cast<const uint8_t*>(b);
+
+#define LAUNCH_TILED_GATED(TILE_K, DUAL_M)                                     \
+    launch_int8_b_tiled<__bf16, TILE_K, DUAL_M>(                              \
+        A, B, static_cast<__bf16*>(c), M, N, K, ldc, epi, stream)
+
+    if (tile_k == 64) {
+        if (dual_m) LAUNCH_TILED_GATED(64, true);
+        else LAUNCH_TILED_GATED(64, false);
+    } else {
+        if (dual_m) LAUNCH_TILED_GATED(128, true);
+        else LAUNCH_TILED_GATED(128, false);
+    }
+#undef LAUNCH_TILED_GATED
+}
+
+template <typename OutT>
+static void launch_int8_pair(
+    const uint8_t* A, const uint8_t* B0, const uint8_t* B1,
+    OutT* C0, OutT* C1, int M, int N, int K, int ldc,
+    comfy::hip_backend::EpiRowwise epi0,
+    comfy::hip_backend::EpiRowwise epi1, hipStream_t stream) {
+    using namespace comfy::hip_backend;
+    constexpr int BM = 128, BN = 128;
+    dim3 grid((N + BN - 1) / BN, (M + BM - 1) / BM);
+    if (use_nonduplicated_int8_schedule() &&
+        epi0.bias == nullptr && epi1.bias == nullptr &&
+        epi0.scale_b_stride == 1 && epi1.scale_b_stride == 1) {
+        constexpr int BKB = 128;
+        EpiRowwiseNoBias no_bias0{epi0.scale_a, epi0.scale_b};
+        EpiRowwiseNoBias no_bias1{epi1.scale_a, epi1.scale_b};
+        gemm_wmma_pair_kernel<MmaInt8, EpiRowwiseNoBias, OutT,
+                              BM, BN, BKB, 4, 2, 2, 4>
+            <<<grid, 512, 0, stream>>>(
+                A, B0, B1, C0, C1, M, N, K, ldc, no_bias0, no_bias1);
+    } else {
+        constexpr int BKB = 128;
+        gemm_wmma_pair_kernel<MmaInt8, EpiRowwise, OutT,
+                              BM, BN, BKB, 4, 2, 2, 4>
+            <<<grid, 512, 0, stream>>>(
+                A, B0, B1, C0, C1, M, N, K, ldc, epi0, epi1);
+    }
+}
+
+extern "C" void launch_int8_gemm_pair_kernel(
+    const void* a, const void* b0, const void* b1, void* c0, void* c1,
+    const void* scale_a, const void* scale_b0, int scale_b_stride0,
+    const void* scale_b1, int scale_b_stride1, const void* bias0,
+    int bias_code0, const void* bias1, int bias_code1, int M, int N, int K,
+    int ldc, int out_code, hipStream_t stream) {
+
+    using namespace comfy::hip_backend;
+    if (M == 0) return;
+    if (M < 96 || N < 96 || K <= 0 || K % 64 != 0 || ldc < N) {
+        throw std::runtime_error(
+            "int8_gemm_pair: requires M,N>=96, positive K divisible by 64, and ldc>=N");
+    }
+
+    EpiRowwise epi0{
+        static_cast<const float*>(scale_a),
+        static_cast<const float*>(scale_b0), scale_b_stride0,
+        bias0, bias_code0};
+    EpiRowwise epi1{
+        static_cast<const float*>(scale_a),
+        static_cast<const float*>(scale_b1), scale_b_stride1,
+        bias1, bias_code1};
+    const uint8_t* A = static_cast<const uint8_t*>(a);
+    const uint8_t* B0 = static_cast<const uint8_t*>(b0);
+    const uint8_t* B1 = static_cast<const uint8_t*>(b1);
+
+    if (out_code == kBF16) {
+        launch_int8_pair(
+            A, B0, B1, static_cast<__bf16*>(c0), static_cast<__bf16*>(c1),
+            M, N, K, ldc, epi0, epi1, stream);
+    } else if (out_code == kF16) {
+        launch_int8_pair(
+            A, B0, B1, static_cast<__half*>(c0), static_cast<__half*>(c1),
+            M, N, K, ldc, epi0, epi1, stream);
+    } else if (out_code == kF32) {
+        launch_int8_pair(
+            A, B0, B1, static_cast<float*>(c0), static_cast<float*>(c1),
+            M, N, K, ldc, epi0, epi1, stream);
+    } else {
+        throw std::runtime_error("int8_gemm_pair: unsupported output dtype");
+    }
+}
+
+template <typename OutT, typename Epi>
+static void launch_int8_tiled_a_down(
+    const uint8_t* A, const uint8_t* B, OutT* C,
+    int M, int N, int K, int ldc, Epi epi,
+    bool tiled_b, hipStream_t stream) {
+    using namespace comfy::hip_backend;
+    constexpr int BM = 128, BN = 128, BKB = 128;
+    dim3 grid((N + BN - 1) / BN, (M + BM - 1) / BM);
+    if (tiled_b) {
+        gemm_wmma_kernel<MmaInt8, Epi, OutT, BM, BN, BKB,
+                         4, 2, 2, 4, false, true, false, true>
+            <<<grid, 256, 0, stream>>>(A, B, C, M, N, K, ldc, epi);
+    } else {
+        gemm_wmma_kernel<MmaInt8, Epi, OutT, BM, BN, BKB,
+                         4, 2, 2, 4, true, true>
+            <<<grid, 256, 0, stream>>>(A, B, C, M, N, K, ldc, epi);
+    }
+}
+
+extern "C" void launch_int8_gemm_a_tiled128_down_kernel(
+    const void* a, const void* b, void* c,
+    const void* scale_a, const void* scale_b, int scale_b_stride,
+    const void* bias, int bias_code,
+    int M, int N, int K, int ldc, int out_code, bool tiled_b,
+    hipStream_t stream) {
+
+    using namespace comfy::hip_backend;
+    if (M == 0) return;
+    if (N <= 0 || K <= 0 || N % 128 != 0 || K % 128 != 0 || ldc < N) {
+        throw std::runtime_error(
+            "tiled-A int8 GEMM: requires positive N/K divisible by "
+            "128 and ldc>=N");
+    }
+    EpiRowwise epi{
+        static_cast<const float*>(scale_a), static_cast<const float*>(scale_b),
+        scale_b_stride, bias, bias_code};
+    const uint8_t* A = static_cast<const uint8_t*>(a);
+    const uint8_t* B = static_cast<const uint8_t*>(b);
+    if (out_code == kBF16) {
+        if (epi.bias == nullptr && epi.scale_b_stride == 1) {
+            EpiRowwiseNoBias no_bias{epi.scale_a, epi.scale_b};
+            launch_int8_tiled_a_down(
+                A, B, static_cast<__bf16*>(c), M, N, K, ldc, no_bias, tiled_b, stream);
+        } else {
+            launch_int8_tiled_a_down(
+                A, B, static_cast<__bf16*>(c), M, N, K, ldc, epi, tiled_b, stream);
+        }
+    } else if (out_code == kF16) {
+        launch_int8_tiled_a_down(
+            A, B, static_cast<__half*>(c), M, N, K, ldc, epi, tiled_b, stream);
+    } else if (out_code == kF32) {
+        launch_int8_tiled_a_down(
+            A, B, static_cast<float*>(c), M, N, K, ldc, epi, tiled_b, stream);
+    } else {
+        throw std::runtime_error("tiled-A int8 GEMM: unsupported output dtype");
     }
 }

--- a/comfy_kitchen/backends/hip/ops/gemm_int8.hip
+++ b/comfy_kitchen/backends/hip/ops/gemm_int8.hip
@@ -25,7 +25,8 @@ inline bool use_nonduplicated_int8_schedule() {
     auto select = [device] {
         hipDeviceProp_t properties{};
         return hipGetDeviceProperties(&properties, device) == hipSuccess &&
-            std::strncmp(properties.gcnArchName, "gfx12", 5) == 0;
+            (std::strcmp(properties.gcnArchName, "gfx1170") == 0 ||
+             std::strncmp(properties.gcnArchName, "gfx12", 5) == 0);
     };
     if (device < 0 || device >= kMaxDevices) return select();
 

--- a/comfy_kitchen/backends/hip/ops/quantize_int8.hip
+++ b/comfy_kitchen/backends/hip/ops/quantize_int8.hip
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // INT8 quantization kernels for the WMMA int8 GEMM.
+#include <cstring>
 #include <stdexcept>
 
 #include "../hadamard.h"
@@ -9,6 +10,25 @@
 namespace comfy::hip_backend {
 
 constexpr float kInt8Max = 127.0f;
+
+inline bool use_convrot_512x2_bf16(int in_code, int K, int group_size) {
+    if (in_code != 2 || group_size != 256) {
+        return false;
+    }
+
+    // The packed-element schedule is exact and faster at these two measured
+    // widths. K=3072, 5120, 5376, and 6144 are slower and do not preserve the
+    // generic producer's rounding, so they retain that path.
+    if (K != 3840 && K != 10240) {
+        return false;
+    }
+
+    // Portable wave32 RDNA schedule: requires a 512-thread workgroup and
+    // enough LDS, but no arch-specific instruction or layout. Validated on
+    // gfx12; other supported devices retain the same exact fallback when
+    // these launch capabilities are absent.
+    return convrot_512x2_supported(K);
+}
 
 __forceinline__ __device__ int8_t quant_round(float v, float inv) {
     // rintf is round-half-to-even, matching torch.round.
@@ -211,15 +231,8 @@ void launch_convrot_quant_global_managed(
     dispatch_convrot_row_type(
         in_dtype,
         LaunchConvrotQuantGlobalManaged<ACT>{
-            x,
-            in_dtype,
-            qout,
-            scaleout,
-            M,
-            K,
-            stream,
-            spill_rotated,
-            spill_partials});
+            x, in_dtype, qout, scaleout, M, K, stream,
+            spill_rotated, spill_partials});
 }
 
 template void launch_convrot_quant_global_managed<kActNone>(
@@ -255,22 +268,109 @@ extern "C" void launch_quantize_int8_convrot_kernel(
     if (M == 0) {
         return;  // a zero-block launch is hipErrorInvalidConfiguration
     }
+    const bool schedule_512x2 =
+        use_convrot_512x2_bf16(in_code, K, group_size);
     if (act_code == kActGeluTanh) {
-        launch_convrot_quant<false, kActGeluTanh>(
-            x, in_code, static_cast<int8_t*>(q), static_cast<float*>(scales),
-            M, K, group_size, stream, spill_rotated, spill_partials);
+        if (schedule_512x2) {
+            launch_convrot_quant_512x2_bf16<kActGeluTanh>(
+                x, in_code, static_cast<int8_t*>(q), static_cast<float*>(scales),
+                M, K, stream);
+        } else {
+            launch_convrot_quant<false, kActGeluTanh>(
+                x, in_code, static_cast<int8_t*>(q), static_cast<float*>(scales),
+                M, K, group_size, stream, spill_rotated, spill_partials);
+        }
     } else if (act_code == kActSwiGLU) {
-        launch_convrot_quant<false, kActSwiGLU>(
-            x, in_code, static_cast<int8_t*>(q), static_cast<float*>(scales),
-            M, K, group_size, stream, spill_rotated, spill_partials);
+        if (schedule_512x2) {
+            launch_convrot_quant_512x2_bf16<kActSwiGLU>(
+                x, in_code, static_cast<int8_t*>(q), static_cast<float*>(scales),
+                M, K, stream);
+        } else {
+            launch_convrot_quant<false, kActSwiGLU>(
+                x, in_code, static_cast<int8_t*>(q), static_cast<float*>(scales),
+                M, K, group_size, stream, spill_rotated, spill_partials);
+        }
     } else {
-        launch_convrot_quant<false, kActNone>(
-            x, in_code, static_cast<int8_t*>(q), static_cast<float*>(scales),
-            M, K, group_size, stream, spill_rotated, spill_partials);
+        if (schedule_512x2) {
+            launch_convrot_quant_512x2_bf16<kActNone>(
+                x, in_code, static_cast<int8_t*>(q), static_cast<float*>(scales),
+                M, K, stream);
+        } else {
+            launch_convrot_quant<false, kActNone>(
+                x, in_code, static_cast<int8_t*>(q), static_cast<float*>(scales),
+                M, K, group_size, stream, spill_rotated, spill_partials);
+        }
     }
 }
 
-// Returns 1 when INT8 G=256 must use the global spill path for (M, K, in_dtype).
+// Consume separate BF16 gate/up projections,
+// reproduce the exact standalone SwiGLU rounding contract, and emit the same
+// tile-major INT8 activation expected by the accepted down GEMM.
+extern "C" void launch_quantize_int8_convrot_swiglu_split_tiled128_kernel(
+    const void* gate, const void* up, void* q, void* scales,
+    int M, int K, int group_size, hipStream_t stream) {
+
+    using namespace comfy::hip_backend;
+    if (K <= 0 || K % 128 != 0 || group_size != 256 ||
+        !convrot_512x2_supported(K)) {
+        throw std::runtime_error(
+            "convrot split swiglu tiled128: requires K divisible by 128, "
+            "group_size=256, and sufficient wave32/LDS capacity");
+    }
+    check_convrot_k(K, group_size, 2);
+    if (M == 0) return;
+    launch_convrot_quant_512x2_bf16_swiglu_split_tiled128(
+        gate, up, static_cast<int8_t*>(q), static_cast<float*>(scales),
+        M, K, stream);
+}
+
+// Fold exact batch-one BF16 scale modulation into the row-major ConvRot
+// producer.
+extern "C" void launch_quantize_int8_convrot_modulated_kernel(
+    const void* x, const void* modulation_scale, void* q, void* scales,
+    int M, int K, int group_size, hipStream_t stream) {
+
+    using namespace comfy::hip_backend;
+    if (K <= 0 || group_size != 256 || !convrot_512x2_supported(K)) {
+        throw std::runtime_error(
+            "convrot modulated: requires positive K, group_size=256, and "
+            "sufficient wave32/LDS capacity");
+    }
+    check_convrot_k(K, group_size, 2);
+    if (M == 0) return;
+    launch_convrot_quant_512x2_bf16_modulated(
+        x, modulation_scale, static_cast<int8_t*>(q),
+        static_cast<float*>(scales), M, K, stream);
+}
+
+// Fold a materialized BF16 affine modulation into the generic fused
+// ConvRot producer.  The schedule is selected from dimensions and LDS
+// capacity, so the path applies to any compatible hidden width.
+extern "C" void launch_quantize_int8_convrot_affine_kernel(
+    const void* x, const void* modulation_scale,
+    const void* modulation_shift, void* q, void* scales,
+    int M, int K, int group_size, hipStream_t stream) {
+
+    using namespace comfy::hip_backend;
+    if (group_size != 256) {
+        throw std::runtime_error(
+            "convrot affine: requires group_size=256");
+    }
+    check_convrot_k(K, group_size, 2, /*int8_quant=*/true);
+    if (M == 0) return;
+    if (!launch_convrot_quant_affine_bf16(
+            x, modulation_scale, modulation_shift,
+            static_cast<int8_t*>(q), static_cast<float*>(scales),
+            M, K, stream)) {
+        throw std::runtime_error(
+            "convrot affine: row does not fit the fused LDS schedule");
+    }
+}
+
+// Returns 1 when INT8 G=256 must use the generic global-spill path for
+// this device. The specialized live shapes fit in LDS on capable wave32 RDNA
+// devices, so they do not allocate a workspace; generic and ultra-wide shapes
+// retain the generic capacity predicate.
 extern "C" int convrot_int8_needs_spill_host(int M, int K, int in_code) {
     using namespace comfy::hip_backend;
     return convrot_int8_needs_spill_buffers(M, K, in_code) ? 1 : 0;

--- a/comfy_kitchen/backends/hip/ops/rms_convrot_quant.hip
+++ b/comfy_kitchen/backends/hip/ops/rms_convrot_quant.hip
@@ -22,12 +22,15 @@ extern "C" void launch_quantize_int8_convrot_rms_modulated_fused_stats_kernel(
     if (M == 0) return;
 
     if (use_convrot_packed_schedule()) {
+        // <ACT, SWIGLU, PACK_QUANT, PACKED_ELEMENT_SCHEDULE, RMS, MODULATE, ...>
+        // This path enables both packed quantization and packed element loads.
         convrot_quant_512x2_bf16_kernel<
             kActNone, false, false, true, true, true, true, true>
             <<<M, 512, static_cast<size_t>(K) * sizeof(__bf16), stream>>>(
                 x, modulation_scale, 2, static_cast<int8_t*>(q),
                 static_cast<float*>(scales), M, K, norm_weight, eps);
     } else {
+        // The fallback keeps PACK_QUANT enabled but disables the packed element schedule.
         convrot_quant_512x2_bf16_kernel<
             kActNone, false, false, true, false, true, true>
             <<<M, 512, static_cast<size_t>(K) * sizeof(__bf16), stream>>>(

--- a/comfy_kitchen/backends/hip/ops/rms_convrot_quant.hip
+++ b/comfy_kitchen/backends/hip/ops/rms_convrot_quant.hip
@@ -21,7 +21,7 @@ extern "C" void launch_quantize_int8_convrot_rms_modulated_fused_stats_kernel(
     check_convrot_k(K, group_size, 2);
     if (M == 0) return;
 
-    if (use_convrot_packed_elements()) {
+    if (use_convrot_packed_schedule()) {
         convrot_quant_512x2_bf16_kernel<
             kActNone, false, false, true, true, true, true, true>
             <<<M, 512, static_cast<size_t>(K) * sizeof(__bf16), stream>>>(

--- a/comfy_kitchen/backends/hip/ops/rms_convrot_quant.hip
+++ b/comfy_kitchen/backends/hip/ops/rms_convrot_quant.hip
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Exact BF16 RMSNorm + BF16 modulation + ConvRot + INT8
+// rowwise quantization. The RMS statistic explicitly requests IEEE division
+// and OCML rsqrt while retaining the accepted fast-math ConvRot schedule.
+#include <stdexcept>
+
+#include "../hadamard.h"
+
+extern "C" void launch_quantize_int8_convrot_rms_modulated_fused_stats_kernel(
+    const void* x, const void* norm_weight, const void* modulation_scale,
+    void* q, void* scales, int M, int K, int group_size, float eps,
+    hipStream_t stream) {
+
+    using namespace comfy::hip_backend;
+    if (K != 3840 || group_size != 256) {
+        throw std::runtime_error(
+            "convrot fused rms modulated: requires BF16 K=3840 and group_size=256");
+    }
+    check_convrot_k(K, group_size, 2);
+    if (M == 0) return;
+
+    if (use_convrot_packed_elements()) {
+        convrot_quant_512x2_bf16_kernel<
+            kActNone, false, false, true, true, true, true, true>
+            <<<M, 512, static_cast<size_t>(K) * sizeof(__bf16), stream>>>(
+                x, modulation_scale, 2, static_cast<int8_t*>(q),
+                static_cast<float*>(scales), M, K, norm_weight, eps);
+    } else {
+        convrot_quant_512x2_bf16_kernel<
+            kActNone, false, false, true, false, true, true>
+            <<<M, 512, static_cast<size_t>(K) * sizeof(__bf16), stream>>>(
+                x, modulation_scale, 2, static_cast<int8_t*>(q),
+                static_cast<float*>(scales), M, K, norm_weight, eps);
+    }
+}

--- a/comfy_kitchen/backends/hip/ops/rms_gated_residual.hip
+++ b/comfy_kitchen/backends/hip/ops/rms_gated_residual.hip
@@ -1,0 +1,205 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Exact BF16 RMSNorm followed by the separately rounded BF16 gate product and
+// residual add. One workgroup owns one row.
+#include <cstdint>
+#include <stdexcept>
+
+#include <hip/hip_bfloat16.h>
+#include <hip/hip_fp16.h>
+#include <hip/hip_runtime.h>
+
+#include "../rope_math.h"
+
+namespace comfy::hip_backend {
+
+typedef __bf16 RmsResidualBf16x4 __attribute__((ext_vector_type(4)));
+
+extern "C" __device__ float __ocml_rsqrt_f32(float);
+
+__forceinline__ __device__ float rms_residual_ieee_div_f32(
+    float numerator, float denominator) {
+    bool denominator_scale = false;
+    bool scale = false;
+    const float scaled_denominator = __builtin_amdgcn_div_scalef(
+        numerator, denominator, false, &denominator_scale);
+    const float scaled_numerator = __builtin_amdgcn_div_scalef(
+        numerator, denominator, true, &scale);
+    float reciprocal = __builtin_amdgcn_rcpf(scaled_denominator);
+    const float reciprocal_error =
+        fmaf(-scaled_denominator, reciprocal, 1.0f);
+    reciprocal = fmaf(reciprocal_error, reciprocal, reciprocal);
+    float quotient = scaled_numerator * reciprocal;
+    float remainder =
+        fmaf(-scaled_denominator, quotient, scaled_numerator);
+    quotient = fmaf(remainder, reciprocal, quotient);
+    remainder = fmaf(-scaled_denominator, quotient, scaled_numerator);
+    quotient = __builtin_amdgcn_div_fmasf(
+        remainder, reciprocal, quotient, scale);
+    return __builtin_amdgcn_div_fixupf(
+        quotient, denominator, numerator);
+}
+
+__forceinline__ __device__ __bf16 rms_gated_residual_value(
+    __bf16 raw, __bf16 norm_weight, float rstd,
+    __bf16 residual, __bf16 gate) {
+    // PyTorch RMSNorm materializes gamma * (rstd * x) in BF16. Preserve the
+    // two FP32 multiplies and the single visible BF16 rounding point.
+    float normalized = rstd * static_cast<float>(raw);
+    asm volatile("" : "+v"(normalized));
+    normalized *= static_cast<float>(norm_weight);
+    normalized = round_bf16(normalized);
+
+    // The eager block exit is two more BF16 kernels: gate * normalized, then
+    // residual + product. Each therefore has its own BF16 rounding point.
+    const float product = round_bf16(
+        normalized * static_cast<float>(gate));
+    return static_cast<__bf16>(round_bf16(
+        static_cast<float>(residual) + product));
+}
+
+template <int STATIC_WIDTH = 0>
+__global__ __launch_bounds__(256) void rms_gated_residual_bf16_kernel(
+    const __bf16* __restrict__ activation,
+    const __bf16* __restrict__ norm_weight,
+    const __bf16* __restrict__ residual,
+    const __bf16* __restrict__ gate,
+    __bf16* __restrict__ output, int width,
+    float eps) {
+
+    const int kWidth = STATIC_WIDTH ? STATIC_WIDTH : width;
+    const int kVectors = kWidth / 4;
+    __shared__ float wave_sums[8];
+    extern __shared__ __bf16 row[];
+
+    const int thread = threadIdx.x;
+    const int lane = thread & 31;
+    const int wave = thread >> 5;
+    const int row_index = blockIdx.x;
+    const int64_t row_offset = static_cast<int64_t>(row_index) * kWidth;
+
+    const auto* input_vectors =
+        reinterpret_cast<const RmsResidualBf16x4*>(activation + row_offset);
+    auto* row_vectors = reinterpret_cast<RmsResidualBf16x4*>(row);
+
+    float rstd;
+    {
+    #pragma clang fp reassociate(off)
+    #pragma clang fp contract(on)
+    #pragma clang fp reciprocal(off)
+    float sum_sq = 0.0f;
+    for (int vector = thread; vector < kVectors; vector += 256) {
+        const RmsResidualBf16x4 values = input_vectors[vector];
+        row_vectors[vector] = values;
+        #pragma unroll
+        for (int element = 0; element < 4; ++element) {
+            const float value = static_cast<float>(values[element]);
+            sum_sq += value * value;
+        }
+    }
+
+    if constexpr (STATIC_WIDTH == 3840) {
+        #pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1) {
+            sum_sq += __shfl_down(sum_sq, offset, 32);
+        }
+        if (lane == 0) wave_sums[wave] = sum_sq;
+        __syncthreads();
+        if (wave == 0) {
+            float merged = lane < 8 ? wave_sums[lane] : 0.0f;
+            #pragma unroll
+            for (int offset = 4; offset > 0; offset >>= 1) {
+                merged += __shfl_down(merged, offset, 32);
+            }
+            if (lane == 0) {
+                const float mean_square = rms_residual_ieee_div_f32(
+                    merged, static_cast<float>(kWidth));
+                wave_sums[0] = __ocml_rsqrt_f32(mean_square + eps);
+            }
+        }
+        __syncthreads();
+    } else {
+        #pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1) {
+            sum_sq += __shfl_down(sum_sq, offset, 32);
+        }
+
+        // Match PyTorch's eight-wave pairwise compute_stats() merge order.
+        #pragma unroll
+        for (int offset = 4; offset > 0; offset >>= 1) {
+            if (lane == 0 && wave >= offset && wave < 2 * offset) {
+                wave_sums[wave - offset] = sum_sq;
+            }
+            __syncthreads();
+            if (lane == 0 && wave < offset) {
+                sum_sq += wave_sums[wave];
+            }
+            __syncthreads();
+        }
+
+        if (thread == 0) {
+            const float mean_square = rms_residual_ieee_div_f32(
+                sum_sq, static_cast<float>(kWidth));
+            wave_sums[0] = __ocml_rsqrt_f32(mean_square + eps);
+        }
+        __syncthreads();
+    }
+    rstd = wave_sums[0];
+    }
+
+    const auto* weight_vectors =
+        reinterpret_cast<const RmsResidualBf16x4*>(norm_weight);
+    const auto* residual_vectors =
+        reinterpret_cast<const RmsResidualBf16x4*>(residual + row_offset);
+    const auto* gate_vectors =
+        reinterpret_cast<const RmsResidualBf16x4*>(gate);
+    auto* output_vectors =
+        reinterpret_cast<RmsResidualBf16x4*>(output + row_offset);
+
+    for (int vector = thread; vector < kVectors; vector += 256) {
+        const RmsResidualBf16x4 raw_values = row_vectors[vector];
+        const RmsResidualBf16x4 weight_values = weight_vectors[vector];
+        const RmsResidualBf16x4 residual_values = residual_vectors[vector];
+        const RmsResidualBf16x4 gate_values = gate_vectors[vector];
+        RmsResidualBf16x4 result;
+        #pragma unroll
+        for (int element = 0; element < 4; ++element) {
+            result[element] = rms_gated_residual_value(
+                raw_values[element], weight_values[element], rstd,
+                residual_values[element], gate_values[element]);
+        }
+        output_vectors[vector] = result;
+    }
+}
+
+}  // namespace comfy::hip_backend
+
+extern "C" void launch_rms_gated_residual_bf16_kernel(
+    const void* activation, const void* norm_weight, const void* residual,
+    const void* gate, void* output, int rows, int width, float eps,
+    hipStream_t stream) {
+
+    using namespace comfy::hip_backend;
+    if (rows < 0 || width <= 0 || width % 4 != 0) {
+        throw std::runtime_error(
+            "rms_gated_residual_bf16: requires non-negative rows and positive "
+            "width divisible by 4");
+    }
+    if (rows == 0) return;
+    const size_t shared_bytes = static_cast<size_t>(width) * sizeof(__bf16);
+#define CK_LAUNCH_RMS_GATED(STATIC_WIDTH)                                      \
+    rms_gated_residual_bf16_kernel<STATIC_WIDTH>                               \
+        <<<rows, 256, shared_bytes, stream>>>(                                  \
+            static_cast<const __bf16*>(activation),                            \
+            static_cast<const __bf16*>(norm_weight),                           \
+            static_cast<const __bf16*>(residual),                              \
+            static_cast<const __bf16*>(gate), static_cast<__bf16*>(output),    \
+            width, eps)
+    if (width == 3840) {
+        CK_LAUNCH_RMS_GATED(3840);
+    } else {
+        CK_LAUNCH_RMS_GATED(0);
+    }
+#undef CK_LAUNCH_RMS_GATED
+}

--- a/comfy_kitchen/backends/hip/ops/rms_gated_residual.hip
+++ b/comfy_kitchen/backends/hip/ops/rms_gated_residual.hip
@@ -16,31 +16,6 @@ namespace comfy::hip_backend {
 
 typedef __bf16 RmsResidualBf16x4 __attribute__((ext_vector_type(4)));
 
-extern "C" __device__ float __ocml_rsqrt_f32(float);
-
-__forceinline__ __device__ float rms_residual_ieee_div_f32(
-    float numerator, float denominator) {
-    bool denominator_scale = false;
-    bool scale = false;
-    const float scaled_denominator = __builtin_amdgcn_div_scalef(
-        numerator, denominator, false, &denominator_scale);
-    const float scaled_numerator = __builtin_amdgcn_div_scalef(
-        numerator, denominator, true, &scale);
-    float reciprocal = __builtin_amdgcn_rcpf(scaled_denominator);
-    const float reciprocal_error =
-        fmaf(-scaled_denominator, reciprocal, 1.0f);
-    reciprocal = fmaf(reciprocal_error, reciprocal, reciprocal);
-    float quotient = scaled_numerator * reciprocal;
-    float remainder =
-        fmaf(-scaled_denominator, quotient, scaled_numerator);
-    quotient = fmaf(remainder, reciprocal, quotient);
-    remainder = fmaf(-scaled_denominator, quotient, scaled_numerator);
-    quotient = __builtin_amdgcn_div_fmasf(
-        remainder, reciprocal, quotient, scale);
-    return __builtin_amdgcn_div_fixupf(
-        quotient, denominator, numerator);
-}
-
 __forceinline__ __device__ __bf16 rms_gated_residual_value(
     __bf16 raw, __bf16 norm_weight, float rstd,
     __bf16 residual, __bf16 gate) {
@@ -113,7 +88,7 @@ __global__ __launch_bounds__(256) void rms_gated_residual_bf16_kernel(
                 merged += __shfl_down(merged, offset, 32);
             }
             if (lane == 0) {
-                const float mean_square = rms_residual_ieee_div_f32(
+                const float mean_square = ieee_div_f32(
                     merged, static_cast<float>(kWidth));
                 wave_sums[0] = __ocml_rsqrt_f32(mean_square + eps);
             }
@@ -139,7 +114,7 @@ __global__ __launch_bounds__(256) void rms_gated_residual_bf16_kernel(
         }
 
         if (thread == 0) {
-            const float mean_square = rms_residual_ieee_div_f32(
+            const float mean_square = ieee_div_f32(
                 sum_sq, static_cast<float>(kWidth));
             wave_sums[0] = __ocml_rsqrt_f32(mean_square + eps);
         }

--- a/comfy_kitchen/backends/hip/ops/rms_rope.hip
+++ b/comfy_kitchen/backends/hip/ops/rms_rope.hip
@@ -127,6 +127,190 @@ __global__ __launch_bounds__(kRmsRopeThreads) void rms_rope_kernel(
     }
 }
 
+// On wave32 RDNA, a 128-wide head fits one wave that reproduces the 64-thread
+// kernel's reduction tree while several independent
+// rows share a workgroup. This removes all workgroup barriers and reduction LDS.
+__device__ __forceinline__ float rms_rope_ordered_fmac(float accumulator, float value) {
+    asm volatile("v_fmac_f32_e32 %0, %1, %1" : "+v"(accumulator) : "v"(value));
+    return accumulator;
+}
+
+__device__ __forceinline__ float rms_rope_ordered_add(float lhs, float rhs) {
+    float result;
+    asm volatile("v_add_f32_e32 %0, %1, %2" : "=v"(result) : "v"(lhs), "v"(rhs));
+    return result;
+}
+
+// Specialize the common BF16 Q/K, FP32-frequency, BF16-scale, interleaved
+// contract so uniform runtime type branches disappear from the hot loop.
+template <bool STATIC_BF16_TYPES>
+__device__ __forceinline__ float rms_rope_load_x(
+    const void* ptr, int64_t index, int code) {
+    if constexpr (STATIC_BF16_TYPES) {
+        return static_cast<float>(static_cast<const __bf16*>(ptr)[index]);
+    }
+    return load_in(ptr, index, code);
+}
+
+template <bool STATIC_BF16_TYPES>
+__device__ __forceinline__ float rms_rope_load_freq(
+    const void* ptr, int64_t index, int code) {
+    if constexpr (STATIC_BF16_TYPES) {
+        return static_cast<const float*>(ptr)[index];
+    }
+    return load_in(ptr, index, code);
+}
+
+template <bool STATIC_BF16_TYPES>
+__device__ __forceinline__ float rms_rope_load_scale(
+    const void* ptr, int64_t index, int code) {
+    if constexpr (STATIC_BF16_TYPES) {
+        return static_cast<float>(static_cast<const __bf16*>(ptr)[index]);
+    }
+    return load_in(ptr, index, code);
+}
+
+template <typename T, int ROWS_PER_BLOCK, bool STATIC_BF16_TYPES = false>
+__global__ __launch_bounds__(ROWS_PER_BLOCK * 32) void rms_rope_wave32_128_kernel(
+    const void* __restrict__ q, const void* __restrict__ k,
+    const void* __restrict__ freqs, const void* __restrict__ q_scale,
+    const void* __restrict__ k_scale, T* __restrict__ q_out, T* __restrict__ k_out,
+    int64_t rows, int64_t dim1, int64_t dim2, int rot_dim,
+    int64_t fb, int64_t fd1, int64_t fd2,
+    int64_t sx_b, int64_t sx_d1, int64_t sx_d2, int64_t sx_d,
+    int64_t so_b, int64_t so_d1, int64_t so_d2, int64_t so_d,
+    int64_t sf_b, int64_t sf_d1, int64_t sf_d2, int64_t sf_d, int64_t sf_rot,
+    int64_t sf_pair,
+    int x_code, int f_code, int s_code, float epsilon, bool split_half) {
+
+    constexpr int kHeadDim = 128;
+    const int lane = threadIdx.x & 31;
+    const int wave = threadIdx.x >> 5;
+    const int64_t row = static_cast<int64_t>(blockIdx.x) * ROWS_PER_BLOCK + wave;
+    if (row >= rows) return;
+
+    const int64_t d2 = row % dim2;
+    const int64_t d1 = (row / dim2) % dim1;
+    const int64_t b = row / (dim2 * dim1);
+    const int64_t xoff = b * sx_b + d1 * sx_d1 + d2 * sx_d2;
+    const int64_t ooff = b * so_b + d1 * so_d1 + d2 * so_d2;
+    const bool has_k = k != nullptr;
+
+    // Match the original 64-thread reduction association exactly. Each old
+    // thread first sums d and d+64; its s=32 partner owns d+32 and d+96.
+    const int dims[4] = {lane, lane + 64, lane + 32, lane + 96};
+    float sq_q_lo = 0.0f;
+    float sq_q_hi = 0.0f;
+    float sq_k_lo = 0.0f;
+    float sq_k_hi = 0.0f;
+    #pragma unroll
+    for (int i = 0; i < 2; ++i) {
+        const float qv = rms_rope_load_x<STATIC_BF16_TYPES>(
+            q, xoff + static_cast<int64_t>(dims[i]) * sx_d, x_code);
+        sq_q_lo = rms_rope_ordered_fmac(sq_q_lo, qv);
+        if (has_k) {
+            const float kv = rms_rope_load_x<STATIC_BF16_TYPES>(
+                k, xoff + static_cast<int64_t>(dims[i]) * sx_d, x_code);
+            sq_k_lo = rms_rope_ordered_fmac(sq_k_lo, kv);
+        }
+    }
+    #pragma unroll
+    for (int i = 2; i < 4; ++i) {
+        const float qv = rms_rope_load_x<STATIC_BF16_TYPES>(
+            q, xoff + static_cast<int64_t>(dims[i]) * sx_d, x_code);
+        sq_q_hi = rms_rope_ordered_fmac(sq_q_hi, qv);
+        if (has_k) {
+            const float kv = rms_rope_load_x<STATIC_BF16_TYPES>(
+                k, xoff + static_cast<int64_t>(dims[i]) * sx_d, x_code);
+            sq_k_hi = rms_rope_ordered_fmac(sq_k_hi, kv);
+        }
+    }
+
+    float sq_q = rms_rope_ordered_add(sq_q_lo, sq_q_hi);
+    float sq_k = rms_rope_ordered_add(sq_k_lo, sq_k_hi);
+    #pragma unroll
+    for (int off = 16; off > 0; off >>= 1) {
+        sq_q = rms_rope_ordered_add(sq_q, __shfl_xor(sq_q, off, 32));
+        sq_k = rms_rope_ordered_add(sq_k, __shfl_xor(sq_k, off, 32));
+    }
+    // Only lane zero's butterfly association is identical to red_[qk][0] in
+    // the reference down-tree. Broadcast that result so compiler scheduling of
+    // the other lanes cannot create rare one-ULP normalization differences.
+    sq_q = __shfl(sq_q, 0, 32);
+    sq_k = __shfl(sq_k, 0, 32);
+
+    const float rrms_q = rsqrtf(sq_q * (1.0f / kHeadDim) + epsilon);
+    const float rrms_k = has_k ? rsqrtf(sq_k * (1.0f / kHeadDim) + epsilon) : 0.0f;
+    const int64_t foff_row = (fb == 1 ? 0 : b) * sf_b +
+                             (fd1 == 1 ? 0 : d1) * sf_d1 +
+                             (fd2 == 1 ? 0 : d2) * sf_d2;
+
+    const int n_pairs = rot_dim / 2;
+    for (int p = lane; p < n_pairs; p += 32) {
+        const int64_t ia = STATIC_BF16_TYPES ? 2 * p : (split_half ? p : 2 * p);
+        const int64_t ib = STATIC_BF16_TYPES ? 2 * p + 1
+                                               : (split_half ? p + n_pairs : 2 * p + 1);
+        const int64_t ia_in = xoff + ia * sx_d;
+        const int64_t ib_in = xoff + ib * sx_d;
+        const int64_t ia_out = ooff + ia * so_d;
+        const int64_t ib_out = ooff + ib * so_d;
+        const int64_t foff = foff_row + static_cast<int64_t>(p) * sf_d;
+        const float f00 = rms_rope_load_freq<STATIC_BF16_TYPES>(freqs, foff, f_code);
+        const float f01 = rms_rope_load_freq<STATIC_BF16_TYPES>(freqs, foff + sf_pair, f_code);
+        const float f10 = rms_rope_load_freq<STATIC_BF16_TYPES>(freqs, foff + sf_rot, f_code);
+        const float f11 = rms_rope_load_freq<STATIC_BF16_TYPES>(
+            freqs, foff + sf_rot + sf_pair, f_code);
+
+        const float sa = rms_rope_load_scale<STATIC_BF16_TYPES>(q_scale, ia, s_code);
+        const float sb = rms_rope_load_scale<STATIC_BF16_TYPES>(q_scale, ib, s_code);
+        const float qa = round_to<T>(
+            rms_rope_load_x<STATIC_BF16_TYPES>(q, ia_in, x_code) * rrms_q * sa);
+        const float qb = round_to<T>(
+            rms_rope_load_x<STATIC_BF16_TYPES>(q, ib_in, x_code) * rrms_q * sb);
+        rope_store<T>(q_out, ia_out,
+                      rope_combine(f00, qa, f01, qb, f_code, split_half));
+        rope_store<T>(q_out, ib_out,
+                      rope_combine(f10, qa, f11, qb, f_code, split_half));
+
+        if (has_k) {
+            const float ta = rms_rope_load_scale<STATIC_BF16_TYPES>(k_scale, ia, s_code);
+            const float tb = rms_rope_load_scale<STATIC_BF16_TYPES>(k_scale, ib, s_code);
+            const float ka = round_to<T>(
+                rms_rope_load_x<STATIC_BF16_TYPES>(k, ia_in, x_code) * rrms_k * ta);
+            const float kb = round_to<T>(
+                rms_rope_load_x<STATIC_BF16_TYPES>(k, ib_in, x_code) * rrms_k * tb);
+            rope_store<T>(k_out, ia_out,
+                          rope_combine(f00, ka, f01, kb, f_code, split_half));
+            rope_store<T>(k_out, ib_out,
+                          rope_combine(f10, ka, f11, kb, f_code, split_half));
+        }
+    }
+
+    for (int d = rot_dim + lane; d < kHeadDim; d += 32) {
+        const int64_t in = xoff + static_cast<int64_t>(d) * sx_d;
+        const int64_t out = ooff + static_cast<int64_t>(d) * so_d;
+        rope_store<T>(q_out, out,
+                      rms_rope_load_x<STATIC_BF16_TYPES>(q, in, x_code) * rrms_q *
+                          rms_rope_load_scale<STATIC_BF16_TYPES>(q_scale, d, s_code));
+        if (has_k) {
+            rope_store<T>(k_out, out,
+                          rms_rope_load_x<STATIC_BF16_TYPES>(k, in, x_code) * rrms_k *
+                              rms_rope_load_scale<STATIC_BF16_TYPES>(k_scale, d, s_code));
+        }
+    }
+}
+
+inline bool use_rms_rope_wave32_schedule() {
+    static const bool selected = [] {
+        int device = 0;
+        hipDeviceProp_t properties{};
+        return hipGetDevice(&device) == hipSuccess &&
+            hipGetDeviceProperties(&properties, device) == hipSuccess &&
+            properties.warpSize == 32;
+    }();
+    return selected;
+}
+
 }  // namespace comfy::hip_backend
 
 extern "C" void launch_rms_rope_kernel(
@@ -155,13 +339,37 @@ extern "C" void launch_rms_rope_kernel(
         throw std::runtime_error("rms_rope: rot_dim must be even and <= head_dim");
     }
 
+    const bool wave32_schedule = use_rms_rope_wave32_schedule();
+    const bool static_bf16_types = wave32_schedule &&
+        x_code == 2 && f_code == 0 && s_code == 2 && !split_half;
+
+#define CK_RMS_ROPE_WAVE32_LAUNCH(T, ROWS, STATIC_TYPES)                                       \
+    rms_rope_wave32_128_kernel<T, ROWS, STATIC_TYPES>                                          \
+        <<<static_cast<unsigned int>((rows + ROWS - 1) / ROWS), ROWS * 32, 0, stream>>>(       \
+            q, k, freqs, q_scale, k_scale, static_cast<T*>(q_out), static_cast<T*>(k_out),     \
+            rows, dim1, dim2, static_cast<int>(rot), fb, fd1, fd2, sx_b, sx_d1, sx_d2, sx_d,  \
+            so_b, so_d1, so_d2, so_d, sf_b, sf_d1, sf_d2, sf_d, sf_rot, sf_pair, x_code,      \
+            f_code, s_code, epsilon, split_half)
+
+    if (head_dim == 128 && static_bf16_types) {
+        CK_RMS_ROPE_WAVE32_LAUNCH(__bf16, 8, true);
+        return;
+    }
+
 #define CK_RMS_ROPE_LAUNCH(T)                                                                  \
-    rms_rope_kernel<T><<<static_cast<unsigned int>(rows), kRmsRopeThreads, 0, stream>>>(       \
-        q, k, freqs, q_scale, k_scale, static_cast<T*>(q_out), static_cast<T*>(k_out), dim1,   \
-        dim2, static_cast<int>(head_dim), static_cast<int>(rot), fb, fd1, fd2, sx_b, sx_d1,    \
-        sx_d2, sx_d, so_b, so_d1,                                                              \
-        so_d2, so_d, sf_b, sf_d1, sf_d2, sf_d, sf_rot, sf_pair, x_code, f_code, s_code,        \
-        epsilon, split_half)
+    do {                                                                                        \
+        if (head_dim == 128 && wave32_schedule) {                                              \
+            CK_RMS_ROPE_WAVE32_LAUNCH(T, 8, false);                                            \
+        } else {                                                                                \
+            rms_rope_kernel<T>                                                                  \
+                <<<static_cast<unsigned int>(rows), kRmsRopeThreads, 0, stream>>>(             \
+                    q, k, freqs, q_scale, k_scale, static_cast<T*>(q_out),                     \
+                    static_cast<T*>(k_out), dim1, dim2, static_cast<int>(head_dim),            \
+                    static_cast<int>(rot), fb, fd1, fd2, sx_b, sx_d1, sx_d2, sx_d, so_b,      \
+                    so_d1, so_d2, so_d, sf_b, sf_d1, sf_d2, sf_d, sf_rot, sf_pair, x_code,    \
+                    f_code, s_code, epsilon, split_half);                                      \
+        }                                                                                       \
+    } while (0)
 
     if (x_code == 0) {
         CK_RMS_ROPE_LAUNCH(float);
@@ -173,4 +381,5 @@ extern "C" void launch_rms_rope_kernel(
         throw std::runtime_error("rms_rope: unsupported input dtype");
     }
 #undef CK_RMS_ROPE_LAUNCH
+#undef CK_RMS_ROPE_WAVE32_LAUNCH
 }

--- a/comfy_kitchen/backends/hip/ops/rms_rope.hip
+++ b/comfy_kitchen/backends/hip/ops/rms_rope.hip
@@ -245,6 +245,9 @@ __global__ __launch_bounds__(ROWS_PER_BLOCK * 32) void rms_rope_wave32_128_kerne
                              (fd1 == 1 ? 0 : d1) * sf_d1 +
                              (fd2 == 1 ? 0 : d2) * sf_d2;
 
+    if constexpr (STATIC_BF16_TYPES) {
+        if (split_half) __builtin_trap();
+    }
     const int n_pairs = rot_dim / 2;
     for (int p = lane; p < n_pairs; p += 32) {
         const int64_t ia = STATIC_BF16_TYPES ? 2 * p : (split_half ? p : 2 * p);

--- a/comfy_kitchen/backends/hip/rope_math.h
+++ b/comfy_kitchen/backends/hip/rope_math.h
@@ -14,6 +14,31 @@
 
 namespace comfy::hip_backend {
 
+extern "C" __device__ float __ocml_rsqrt_f32(float);
+
+__forceinline__ __device__ float ieee_div_f32(
+    float numerator, float denominator) {
+    bool denominator_scale = false;
+    bool scale = false;
+    const float scaled_denominator = __builtin_amdgcn_div_scalef(
+        numerator, denominator, false, &denominator_scale);
+    const float scaled_numerator = __builtin_amdgcn_div_scalef(
+        numerator, denominator, true, &scale);
+    float reciprocal = __builtin_amdgcn_rcpf(scaled_denominator);
+    const float reciprocal_error =
+        fmaf(-scaled_denominator, reciprocal, 1.0f);
+    reciprocal = fmaf(reciprocal_error, reciprocal, reciprocal);
+    float quotient = scaled_numerator * reciprocal;
+    float remainder =
+        fmaf(-scaled_denominator, quotient, scaled_numerator);
+    quotient = fmaf(remainder, reciprocal, quotient);
+    remainder = fmaf(-scaled_denominator, quotient, scaled_numerator);
+    quotient = __builtin_amdgcn_div_fmasf(
+        remainder, reciprocal, quotient, scale);
+    return __builtin_amdgcn_div_fixupf(
+        quotient, denominator, numerator);
+}
+
 // Round fp32 to bf16 (round to nearest, ties to even) and widen back.
 // Both callers build with -ffast-math, under which the native __bf16 type carries
 // excess precision: casting fp32 -> __bf16 -> fp32 is folded away and the

--- a/comfy_kitchen/backends/hip/sage_attention/int8_attn.hip
+++ b/comfy_kitchen/backends/hip/sage_attention/int8_attn.hip
@@ -20,6 +20,7 @@
 // all tried and are all slower or spill. Do not re-try them blind.
 #include <hip/hip_runtime.h>
 
+#include <cfloat>
 #include <stdexcept>
 #include <string>
 
@@ -143,6 +144,376 @@ __forceinline__ __device__ void store_o_tile(OutT* __restrict__ row, int d_base,
         row[d_base + acc_row(lane, e)] = static_cast<OutT>(vals[e]);
     }
 #endif
+}
+
+// ---------------------------------------------------------------------------
+// gfx12 long-sequence specialization
+//
+// Keep the accepted schedule structural: BM128/BN64, eight wave32s, padded
+// single-stage Q/K/V LDS, synchronous global->VGPR->LDS prefetch, native
+// packed P, and FP32 output accumulation. The general kernel below retains its
+// original contract.
+// ---------------------------------------------------------------------------
+
+constexpr int kLongHeadDim = 128;
+constexpr int kLongBlockM = 128;
+constexpr int kLongBlockN = 64;
+constexpr int kLongWarps = 8;
+constexpr int kLongThreads = kLongWarps * 32;
+constexpr int kLongKStride = kLongHeadDim + 8;
+constexpr int kLongVStride = kLongBlockN + 8;
+
+__forceinline__ __device__ float long_fast_exp2(float x) {
+    return __builtin_amdgcn_exp2f(x);
+}
+
+__forceinline__ __device__ float long_balanced_sum8(v8f value) {
+    const float sum01 = value[0] + value[1];
+    const float sum23 = value[2] + value[3];
+    const float sum45 = value[4] + value[5];
+    const float sum67 = value[6] + value[7];
+    return (sum01 + sum23) + (sum45 + sum67);
+}
+
+__forceinline__ __device__ int long_fresh_lane_id() {
+    int lane;
+    // Rematerialize this after the long loop.  Carrying the prologue lane SSA
+    // value through the prefetched K/V state makes LLVM spill epilogue indices.
+    asm volatile("v_mbcnt_lo_u32_b32 %0, -1, 0" : "=v"(lane));
+    return lane;
+}
+
+__forceinline__ __device__ void long_store_b128_padded(int8_t* dst, uint4 value) {
+    // Eight-byte padding spreads consecutive WMMA fragment rows over banks.
+    *reinterpret_cast<uint2*>(dst) = make_uint2(value.x, value.y);
+    *reinterpret_cast<uint2*>(dst + 8) = make_uint2(value.z, value.w);
+}
+
+// The optimized packed contract pads K and transposed V to a whole BN64 tile.
+// Exactly 256 threads own the 512 sixteen-byte chunks in each operand, so the
+// bounds and loop trip count are compile-time facts.
+struct LongKVTileRegs {
+    uint4 k[2];
+    uint4 v[2];
+
+    __forceinline__ __device__ void load(const int8_t* __restrict__ k_head,
+                                         const int8_t* __restrict__ v_head,
+                                         int padded_k, int tile) {
+        const int tid = threadIdx.x;
+#pragma unroll
+        for (int i = 0; i < 2; ++i) {
+            const int chunk = tid + i * kLongThreads;
+            const int krow = chunk >> 3;
+            const int kd16 = (chunk & 7) << 4;
+            k[i] = *reinterpret_cast<const uint4*>(
+                k_head + static_cast<int64_t>(tile * kLongBlockN + krow) * kLongHeadDim + kd16);
+
+            const int vd = chunk >> 2;
+            const int vn16 = (chunk & 3) << 4;
+            v[i] = *reinterpret_cast<const uint4*>(
+                v_head + static_cast<int64_t>(tile) * kLongHeadDim * kLongBlockN +
+                vd * kLongBlockN + vn16);
+        }
+    }
+
+    __forceinline__ __device__ void store(int8_t* ks, int8_t* vs) const {
+        const int tid = threadIdx.x;
+#pragma unroll
+        for (int i = 0; i < 2; ++i) {
+            const int chunk = tid + i * kLongThreads;
+            const int krow = chunk >> 3;
+            const int kd16 = (chunk & 7) << 4;
+            long_store_b128_padded(ks + krow * kLongKStride + kd16, k[i]);
+
+            const int vd = chunk >> 2;
+            const int vn16 = (chunk & 3) << 4;
+            long_store_b128_padded(vs + vd * kLongVStride + vn16, v[i]);
+        }
+    }
+};
+
+template <bool NoQueryTail>
+__forceinline__ __device__ void long_stage_q_tile(
+    const int8_t* __restrict__ q_head, int8_t* __restrict__ qs,
+    int query_block0, int qo_len) {
+    const int tid = threadIdx.x;
+#pragma unroll
+    for (int i = 0; i < 4; ++i) {
+        const int chunk = tid + i * kLongThreads;
+        const int row = chunk >> 3;
+        const int d16 = (chunk & 7) << 4;
+        uint4 value = make_uint4(0, 0, 0, 0);
+        if constexpr (NoQueryTail) {
+            value = *reinterpret_cast<const uint4*>(
+                q_head + static_cast<int64_t>(query_block0 + row) * kLongHeadDim + d16);
+        } else if (query_block0 + row < qo_len) {
+            value = *reinterpret_cast<const uint4*>(
+                q_head + static_cast<int64_t>(query_block0 + row) * kLongHeadDim + d16);
+        }
+        long_store_b128_padded(qs + row * kLongKStride + d16, value);
+    }
+}
+
+template <typename OutT, bool NoQueryTail, bool FullScoreScale>
+__global__ __launch_bounds__(kLongThreads)
+__attribute__((amdgpu_waves_per_eu(1, 1)))
+void gfx12_int8_attention_kernel(
+    const int8_t* __restrict__ q,
+    const int8_t* __restrict__ k,
+    const int8_t* __restrict__ v,
+    OutT* __restrict__ output,
+    const float* __restrict__ q_descale,
+    const float* __restrict__ k_descale,
+    const float* __restrict__ v_descale,
+    int qo_len, int kv_len, int padded_q, int padded_k,
+    int k_groups_per_head, int query_block_offset,
+    int64_t output_stride_h, int64_t output_stride_n, float sm_scale) {
+
+    __shared__ __align__(16) int8_t ks[2][kLongBlockN * kLongKStride];
+    __shared__ __align__(16) int8_t vs[2][kLongHeadDim * kLongVStride];
+    __shared__ __align__(16) int8_t qs[kLongBlockM * kLongKStride];
+
+    const int lane = threadIdx.x & 31;
+    const int wave = threadIdx.x >> 5;
+    const int head = blockIdx.y;
+    const int query_block = blockIdx.x + query_block_offset;
+    const int query0 = query_block * kLongBlockM + wave * 16;
+    const bool active_query_wave = NoQueryTail || query0 < qo_len;
+    const int tiles = padded_k / kLongBlockN;
+    const int8_t* const q_head =
+        q + static_cast<int64_t>(head) * qo_len * kLongHeadDim;
+    const int8_t* const k_head =
+        k + static_cast<int64_t>(head) * padded_k * kLongHeadDim;
+    const int8_t* const v_head =
+        v + static_cast<int64_t>(head) * kLongHeadDim * padded_k;
+
+    const int query_lane = query0 + acc_col(lane);
+    const float q_scale = active_query_wave && query_lane < qo_len
+        ? q_descale[head * padded_q + query_lane]
+        : 0.0f;
+    const float qk_scale = sm_scale * kLog2e;
+    // Preserve the finite online-softmax state; this specialization changes
+    // schedule and data movement, not the probability quantization algorithm.
+    float row_max = kMaskedScore;
+    float row_sum = 1.0f;
+    v8f out_acc[8];
+#pragma unroll
+    for (int dt = 0; dt < 8; ++dt) {
+        out_acc[dt] = v8f{0, 0, 0, 0, 0, 0, 0, 0};
+    }
+
+    LongKVTileRegs next;
+    int kv_buf = 0;
+    long_stage_q_tile<NoQueryTail>(q_head, qs, query_block * kLongBlockM, qo_len);
+    next.load(k_head, v_head, padded_k, 0);
+    next.store(ks[kv_buf], vs[kv_buf]);
+    __syncthreads();
+
+    for (int tile = 0; tile < tiles; ++tile) {
+        const bool has_next = tile + 1 < tiles;
+        if (has_next) {
+            next.load(k_head, v_head, padded_k, tile + 1);
+        }
+
+        // Tail workgroups still need every wave for cooperative K/V staging
+        // and barriers.  Waves with no query rows can skip the matrix and
+        // softmax work between those barriers.
+        if (active_query_wave) {
+            float key_scale[4];
+#pragma unroll
+            for (int ct = 0; ct < 4; ++ct) {
+                key_scale[ct] =
+                    k_descale[head * k_groups_per_head + tile * 4 + ct];
+            }
+            float score_scale[4];
+#pragma unroll
+            for (int ct = 0; ct < 4; ++ct) {
+                // The full-scale variant hoists the query factor out of the
+                // score loop while preserving the quality-gated association.
+                if constexpr (FullScoreScale) {
+                    score_scale[ct] = (q_scale * key_scale[ct]) * qk_scale;
+                } else {
+                    score_scale[ct] = key_scale[ct] * qk_scale;
+                }
+            }
+
+            v8f score[4];
+            {
+                v8i score_i32[4];
+#pragma unroll
+                for (int ct = 0; ct < 4; ++ct) score_i32[ct] = MmaInt8::zero();
+#pragma unroll
+                for (int dt = 0; dt < 8; ++dt) {
+                    const MmaInt8::Frag q_frag = MmaInt8::load(
+                        qs, wave * 16 + frag_row(lane), dt * 16, kLongKStride, lane);
+#pragma unroll
+                    for (int ct = 0; ct < 4; ++ct) {
+                        const MmaInt8::Frag k_frag = MmaInt8::load(
+                            ks[kv_buf], ct * 16 + frag_row(lane), dt * 16,
+                            kLongKStride, lane);
+                        // K x Q^T leaves each score fragment in the native A
+                        // operand order consumed by P x V below.
+                        score_i32[ct] = MmaInt8::mma(k_frag, q_frag, score_i32[ct]);
+                    }
+                }
+#pragma unroll
+                for (int ct = 0; ct < 4; ++ct) {
+#pragma unroll
+                    for (int e = 0; e < 8; ++e) {
+                        float value;
+                        if constexpr (FullScoreScale) {
+                            value = static_cast<float>(score_i32[ct][e]) * score_scale[ct];
+                        } else {
+                            value = (static_cast<float>(score_i32[ct][e]) * q_scale) *
+                                    score_scale[ct];
+                        }
+                        const int key = tile * kLongBlockN + ct * 16 + acc_row(lane, e);
+                        if (key >= kv_len) value = kMaskedScore;
+                        score[ct][e] = value;
+                    }
+                }
+            }
+
+            float local_max = -FLT_MAX;
+#pragma unroll
+            for (int ct = 0; ct < 4; ++ct) {
+#pragma unroll
+                for (int e = 0; e < 8; ++e) local_max = fmaxf(local_max, score[ct][e]);
+            }
+            float tile_max = fmaxf(local_max, __shfl_xor(local_max, 16, 32));
+
+            // Shifting the tile maximum fills u8 [0, 255]; tile_scale carries
+            // its gap to the running maximum on the accumulator side.
+            tile_max -= kProbU8Offset;
+            const float previous_max = row_max;
+            const float smaller = long_fast_exp2(-fabsf(previous_max - tile_max));
+            const float output_scale = previous_max < tile_max ? smaller : 1.0f;
+            const float tile_scale = tile_max < previous_max ? smaller : 1.0f;
+            row_max = fmaxf(previous_max, tile_max);
+            row_sum *= output_scale;
+#pragma unroll
+            for (int dt = 0; dt < 8; ++dt) {
+#pragma unroll
+                for (int e = 0; e < 8; ++e) {
+                    out_acc[dt][e] *=
+                        __shfl(output_scale, acc_row(lane, e), 32);
+                }
+            }
+
+            MmaInt8::Frag direct_p_frag[4];
+#pragma unroll
+            for (int ct = 0; ct < 4; ++ct) {
+                uint32_t packed[8];
+#pragma unroll
+                for (int e = 0; e < 8; ++e) {
+                    const float probability = long_fast_exp2(score[ct][e] - tile_max);
+                    score[ct][e] = probability;
+                    packed[e] = prob_to_u8(probability);
+                }
+                direct_p_frag[ct] = pack_prob_frag(packed, lane);
+            }
+
+            // Each half-wave carries its part of the denominator through the
+            // loop.  A balanced native-fragment tree shortens the dependency
+            // chain while keeping the quality-gated cross-fragment ordering.
+            const float tile_sum =
+                (long_balanced_sum8(score[0]) + long_balanced_sum8(score[2])) +
+                (long_balanced_sum8(score[1]) + long_balanced_sum8(score[3]));
+            row_sum += tile_sum * tile_scale;
+
+#pragma unroll
+            for (int dt = 0; dt < 8; ++dt) {
+                v8i product = MmaInt8::zero();
+#pragma unroll
+                for (int ct = 0; ct < 4; ++ct) {
+                    const MmaInt8::Frag v_frag = MmaInt8::load(
+                        vs[kv_buf], dt * 16 + frag_row(lane), ct * 16,
+                        kLongVStride, lane);
+                    product = MmaInt8::mma_ua(direct_p_frag[ct], v_frag, product);
+                }
+                const int d = dt * 16 + acc_col(lane);
+                const float value_scale =
+                    v_descale[(head * tiles + tile) * kLongHeadDim + d];
+#pragma unroll
+                for (int e = 0; e < 8; ++e) {
+                    const float row_tile_scale =
+                        __shfl(tile_scale, acc_row(lane, e), 32);
+                    out_acc[dt][e] = fmaf(
+                        static_cast<float>(product[e]),
+                        value_scale * row_tile_scale, out_acc[dt][e]);
+                }
+            }
+        }
+
+        if (has_next) {
+            next.store(ks[kv_buf ^ 1], vs[kv_buf ^ 1]);
+            __syncthreads();
+            kv_buf ^= 1;
+        }
+    }
+
+    row_sum += __shfl_xor(row_sum, 16, 32);
+
+    if (active_query_wave) {
+        const int output_lane = long_fresh_lane_id();
+#pragma unroll
+        for (int dt = 0; dt < 8; ++dt) {
+            const int d = dt * 16 + acc_col(output_lane);
+#pragma unroll
+            for (int e = 0; e < 8; ++e) {
+                const int row = query0 + acc_row(output_lane, e);
+                if constexpr (NoQueryTail) {
+                    const float reciprocal = 1.0f / __shfl(
+                        row_sum, acc_row(output_lane, e), 32);
+                    output[static_cast<int64_t>(head) * output_stride_h +
+                           static_cast<int64_t>(row) * output_stride_n + d] =
+                        static_cast<OutT>(out_acc[dt][e] * reciprocal);
+                } else if (row < qo_len) {
+                    const float reciprocal = 1.0f / __shfl(
+                        row_sum, acc_row(output_lane, e), 32);
+                    output[static_cast<int64_t>(head) * output_stride_h +
+                           static_cast<int64_t>(row) * output_stride_n + d] =
+                        static_cast<OutT>(out_acc[dt][e] * reciprocal);
+                }
+            }
+        }
+    }
+}
+
+template <typename OutT>
+void launch_gfx12_int8_attention_typed(
+    const int8_t* q, const int8_t* k, const int8_t* v, OutT* output,
+    const float* q_descale, const float* k_descale, const float* v_descale,
+    int num_heads, int qo_len, int kv_len, int padded_q, int padded_k,
+    int k_groups_per_head,
+    int64_t output_stride_h, int64_t output_stride_n,
+    float sm_scale, hipStream_t stream) {
+    const int full_blocks = qo_len / kLongBlockM;
+    if (full_blocks) {
+        // Use one arithmetic association for an entirely full grid and the
+        // quality-gated association shared with the masked kernel whenever a
+        // query tail is present. This is a tile property, not a model shape.
+        if (qo_len % kLongBlockM != 0) {
+            gfx12_int8_attention_kernel<OutT, true, true>
+                <<<dim3(full_blocks, num_heads), kLongThreads, 0, stream>>>(
+                    q, k, v, output, q_descale, k_descale, v_descale,
+                    qo_len, kv_len, padded_q, padded_k, k_groups_per_head,
+                    0, output_stride_h, output_stride_n, sm_scale);
+        } else {
+            gfx12_int8_attention_kernel<OutT, true, false>
+                <<<dim3(full_blocks, num_heads), kLongThreads, 0, stream>>>(
+                    q, k, v, output, q_descale, k_descale, v_descale,
+                    qo_len, kv_len, padded_q, padded_k, k_groups_per_head,
+                    0, output_stride_h, output_stride_n, sm_scale);
+        }
+    }
+    if (full_blocks * kLongBlockM != qo_len) {
+        gfx12_int8_attention_kernel<OutT, false, true>
+            <<<dim3(1, num_heads), kLongThreads, 0, stream>>>(
+                q, k, v, output, q_descale, k_descale, v_descale,
+                qo_len, kv_len, padded_q, padded_k, k_groups_per_head,
+                full_blocks, output_stride_h, output_stride_n, sm_scale);
+    }
 }
 
 template <int HD, int CTA_K, MaskMode kMask, typename OutT>
@@ -504,6 +875,51 @@ void launch_one(const int8_t* q, const int8_t* k, const int8_t* v, OutT* o, cons
 }  // namespace comfy::hip_backend::sage
 
 using namespace comfy::hip_backend::sage;
+
+extern "C" void launch_gfx12_int8_attention(
+    const void* q, const void* k, const void* v, void* o,
+    const void* q_descale, const void* k_descale, const void* v_descale,
+    int num_heads, int qo_len, int kv_len, int padded_q, int padded_k,
+    int k_groups_per_head,
+    int64_t output_stride_h, int64_t output_stride_n,
+    float sm_scale, int output_dtype_code, hipStream_t stream) {
+    if (num_heads <= 0 || qo_len <= 0 || kv_len <= 0) {
+        throw std::runtime_error(
+            "gfx12 INT8 attention requires positive heads and lengths");
+    }
+    if (padded_q % 128 != 0 || padded_q < qo_len ||
+        padded_k % 64 != 0 || padded_k < kv_len) {
+        throw std::runtime_error(
+            "gfx12 INT8 attention received invalid Q or K/V padding");
+    }
+    if (reinterpret_cast<uintptr_t>(q) % 16 != 0 ||
+        reinterpret_cast<uintptr_t>(k) % 16 != 0 ||
+        reinterpret_cast<uintptr_t>(v) % 16 != 0 ||
+        reinterpret_cast<uintptr_t>(o) % 16 != 0) {
+        throw std::runtime_error(
+            "gfx12 INT8 attention buffers must be 16-byte aligned");
+    }
+    const auto* qi = static_cast<const int8_t*>(q);
+    const auto* ki = static_cast<const int8_t*>(k);
+    const auto* vi = static_cast<const int8_t*>(v);
+    const auto* qs = static_cast<const float*>(q_descale);
+    const auto* ks = static_cast<const float*>(k_descale);
+    const auto* vs = static_cast<const float*>(v_descale);
+    if (output_dtype_code == 1) {
+        launch_gfx12_int8_attention_typed(
+            qi, ki, vi, static_cast<__half*>(o), qs, ks, vs, num_heads,
+            qo_len, kv_len, padded_q, padded_k, k_groups_per_head,
+            output_stride_h, output_stride_n, sm_scale, stream);
+    } else if (output_dtype_code == 2) {
+        launch_gfx12_int8_attention_typed(
+            qi, ki, vi, static_cast<__bf16*>(o), qs, ks, vs, num_heads,
+            qo_len, kv_len, padded_q, padded_k, k_groups_per_head,
+            output_stride_h, output_stride_n, sm_scale, stream);
+    } else {
+        throw std::runtime_error(
+            "gfx12 INT8 attention supports float16 and bfloat16 output");
+    }
+}
 
 extern "C" void launch_sage_int8_attn(
     const void* q, const void* k, const void* v, void* o, const void* q_scale,

--- a/comfy_kitchen/backends/hip/sage_attention/int8_attn.hip
+++ b/comfy_kitchen/backends/hip/sage_attention/int8_attn.hip
@@ -892,6 +892,10 @@ extern "C" void launch_gfx12_int8_attention(
         throw std::runtime_error(
             "gfx12 INT8 attention received invalid Q or K/V padding");
     }
+    if (k_groups_per_head != padded_k / 16) {
+        throw std::runtime_error(
+            "gfx12 INT8 attention received invalid K scale grouping");
+    }
     if (reinterpret_cast<uintptr_t>(q) % 16 != 0 ||
         reinterpret_cast<uintptr_t>(k) % 16 != 0 ||
         reinterpret_cast<uintptr_t>(v) % 16 != 0 ||

--- a/comfy_kitchen/backends/hip/sage_attention/int8_attn.hip
+++ b/comfy_kitchen/backends/hip/sage_attention/int8_attn.hip
@@ -198,7 +198,7 @@ struct LongKVTileRegs {
 
     __forceinline__ __device__ void load(const int8_t* __restrict__ k_head,
                                          const int8_t* __restrict__ v_head,
-                                         int padded_k, int tile) {
+                                         int tile) {
         const int tid = threadIdx.x;
 #pragma unroll
         for (int i = 0; i < 2; ++i) {
@@ -305,14 +305,14 @@ void gfx12_int8_attention_kernel(
     LongKVTileRegs next;
     int kv_buf = 0;
     long_stage_q_tile<NoQueryTail>(q_head, qs, query_block * kLongBlockM, qo_len);
-    next.load(k_head, v_head, padded_k, 0);
+    next.load(k_head, v_head, 0);
     next.store(ks[kv_buf], vs[kv_buf]);
     __syncthreads();
 
     for (int tile = 0; tile < tiles; ++tile) {
         const bool has_next = tile + 1 < tiles;
         if (has_next) {
-            next.load(k_head, v_head, padded_k, tile + 1);
+            next.load(k_head, v_head, tile + 1);
         }
 
         // Tail workgroups still need every wave for cooperative K/V staging

--- a/comfy_kitchen/backends/hip/sage_attention/quant_qk_int8.hip
+++ b/comfy_kitchen/backends/hip/sage_attention/quant_qk_int8.hip
@@ -143,9 +143,9 @@ __global__ __launch_bounds__(kQuantWaves * 32) void quant_q_int8_kernel(
 // ---------------------------------------------------------------------------
 // K: one scale per 16 adjacent keys. A whole scale group lives in one wave, so
 // the reduction never leaves it and the kernel needs no barrier at all. The
-// group is read twice rather than held: 16 rows of registers is affordable at
-// D64 and D128 but not at D256, and the second read is cheaper than the
-// occupancy the widest case would lose.
+// D128 retains the 16-row group in registers so each key is read once. D256
+// keeps the two-pass path because retaining a group there is too register-heavy;
+// D64 stays on the existing path until its short-attention schedule is settled.
 // ---------------------------------------------------------------------------
 
 constexpr int kKeyGroupsPerBlock = kQuantWaves;
@@ -153,7 +153,8 @@ constexpr int kKeyGroupsPerBlock = kQuantWaves;
 template <typename T, int HD, int Rotation>
 __global__ __launch_bounds__(kQuantWaves * 32) void quant_k_int8_kernel(
     const T* __restrict__ k, int8_t* __restrict__ k_out, float* __restrict__ k_scale,
-    const int* __restrict__ anchor_indices, int Lk, int H_kv, int groups_per_head,
+    const int* __restrict__ anchor_indices, int Lk, int Lk_storage, int H_kv,
+    int groups_per_head,
     int64_t stride_b, int64_t stride_h, int64_t stride_n) {
 
     using Tile = RowTile<HD>;
@@ -185,33 +186,64 @@ __global__ __launch_bounds__(kQuantWaves * 32) void quant_k_int8_kernel(
         for (int i = 0; i < Tile::kValsPerLane; ++i) bias[i] = 0.0f;
     }
 
-    float vals[Tile::kValsPerLane];
-    float mx = 0.0f;
+    if constexpr (HD == 128) {
+        float rows[kRowPasses][Tile::kValsPerLane];
+        float mx = 0.0f;
 #pragma unroll
-    for (int pass = 0; pass < kRowPasses; ++pass) {
-        const int key = key0 + pass * Tile::kRowsPerWave + row_in_wave;
-        if (key < Lk) {
-            load_row<HD, T>(head + static_cast<int64_t>(key) * stride_n, lane_in_row, vals);
+        for (int pass = 0; pass < kRowPasses; ++pass) {
+            const int key = key0 + pass * Tile::kRowsPerWave + row_in_wave;
+            if (key < Lk) {
+                load_row<HD, T>(head + static_cast<int64_t>(key) * stride_n,
+                                lane_in_row, rows[pass]);
 #pragma unroll
-            for (int i = 0; i < Tile::kValsPerLane; ++i) vals[i] -= bias[i];
-            mx = fmaxf(mx, rotate_row<HD, Rotation>(vals));
+                for (int i = 0; i < Tile::kValsPerLane; ++i) rows[pass][i] -= bias[i];
+                mx = fmaxf(mx, rotate_row<HD, Rotation>(rows[pass]));
+            }
         }
-    }
 
-    mx = row_reduce_fmax<32>(mx);
-    const float scale = mx / kInt8Max + 1e-7f;
-    const float inv_scale = 1.0f / scale;
-    if (lane == 0) k_scale[bh * groups_per_head + group] = scale;
+        mx = row_reduce_fmax<32>(mx);
+        const float scale = mx / kInt8Max + 1e-7f;
+        const float inv_scale = 1.0f / scale;
+        if (lane == 0) k_scale[bh * groups_per_head + group] = scale;
 
 #pragma unroll
-    for (int pass = 0; pass < kRowPasses; ++pass) {
-        const int key = key0 + pass * Tile::kRowsPerWave + row_in_wave;
-        if (key < Lk) {
-            load_row<HD, T>(head + static_cast<int64_t>(key) * stride_n, lane_in_row, vals);
+        for (int pass = 0; pass < kRowPasses; ++pass) {
+            const int key = key0 + pass * Tile::kRowsPerWave + row_in_wave;
+            if (key < Lk) {
+                store_row<HD, T>(k_out + (bh * Lk_storage + key) * HD,
+                                 lane_in_row, rows[pass], inv_scale);
+            }
+        }
+    } else {
+        float vals[Tile::kValsPerLane];
+        float mx = 0.0f;
 #pragma unroll
-            for (int i = 0; i < Tile::kValsPerLane; ++i) vals[i] -= bias[i];
-            rotate_row<HD, Rotation>(vals);
-            store_row<HD, T>(k_out + (bh * Lk + key) * HD, lane_in_row, vals, inv_scale);
+        for (int pass = 0; pass < kRowPasses; ++pass) {
+            const int key = key0 + pass * Tile::kRowsPerWave + row_in_wave;
+            if (key < Lk) {
+                load_row<HD, T>(head + static_cast<int64_t>(key) * stride_n, lane_in_row, vals);
+#pragma unroll
+                for (int i = 0; i < Tile::kValsPerLane; ++i) vals[i] -= bias[i];
+                mx = fmaxf(mx, rotate_row<HD, Rotation>(vals));
+            }
+        }
+
+        mx = row_reduce_fmax<32>(mx);
+        const float scale = mx / kInt8Max + 1e-7f;
+        const float inv_scale = 1.0f / scale;
+        if (lane == 0) k_scale[bh * groups_per_head + group] = scale;
+
+#pragma unroll
+        for (int pass = 0; pass < kRowPasses; ++pass) {
+            const int key = key0 + pass * Tile::kRowsPerWave + row_in_wave;
+            if (key < Lk) {
+                load_row<HD, T>(head + static_cast<int64_t>(key) * stride_n, lane_in_row, vals);
+#pragma unroll
+                for (int i = 0; i < Tile::kValsPerLane; ++i) vals[i] -= bias[i];
+                rotate_row<HD, Rotation>(vals);
+                store_row<HD, T>(k_out + (bh * Lk_storage + key) * HD,
+                                 lane_in_row, vals, inv_scale);
+            }
         }
     }
 }
@@ -379,7 +411,8 @@ void launch_typed(const void* q, void* q_int8, void* q_scale, const void* k, voi
     const dim3 k_grid((groups_per_head + kKeyGroupsPerBlock - 1) / kKeyGroupsPerBlock, H_kv, B);
     quant_k_int8_kernel<T, HD, Rotation><<<k_grid, kQuantWaves * 32, 0, stream>>>(
         static_cast<const T*>(k), static_cast<int8_t*>(k_int8), static_cast<float*>(k_scale),
-        anchor_indices, Lk, H_kv, groups_per_head, k_stride_b, k_stride_h, k_stride_n);
+        anchor_indices, Lk, Lk, H_kv, groups_per_head,
+        k_stride_b, k_stride_h, k_stride_n);
 }
 
 // Only the rotations the caller can actually select are instantiated: short keys
@@ -435,10 +468,70 @@ void launch_anchor(const void* k, int* anchor_indices, int B, int H_kv, int Lk, 
         static_cast<const T*>(k), anchor_indices, Lk, C, H_kv, stride_b, stride_h, stride_n);
 }
 
+template <typename T>
+void launch_gfx12_qk_quant_typed(
+    const void* q, void* q_int8, void* q_scale,
+    const void* k, void* k_int8, void* k_scale, int* anchors,
+    int num_heads, int q_len, int kv_len, int padded_q, int padded_k,
+    int64_t q_stride_b, int64_t q_stride_h, int64_t q_stride_n,
+    int64_t k_stride_b, int64_t k_stride_h, int64_t k_stride_n,
+    hipStream_t stream) {
+    launch_anchor<T>(k, anchors, 1, num_heads, kv_len, 128,
+                     k_stride_b, k_stride_h, k_stride_n, stream);
+    constexpr int kRowsPerBlock =
+        kQuantWaves * RowTile<128>::kRowsPerWave * kRowIters;
+    const dim3 q_grid((padded_q + kRowsPerBlock - 1) / kRowsPerBlock,
+                      num_heads, 1);
+    quant_q_int8_kernel<T, 128, 128><<<q_grid, 256, 0, stream>>>(
+        static_cast<const T*>(q), static_cast<int8_t*>(q_int8),
+        static_cast<float*>(q_scale), q_len, padded_q, num_heads,
+        q_stride_b, q_stride_h, q_stride_n);
+    const int groups = padded_k / 16;
+    const dim3 k_grid((groups + kKeyGroupsPerBlock - 1) / kKeyGroupsPerBlock,
+                      num_heads, 1);
+    quant_k_int8_kernel<T, 128, 128><<<k_grid, 256, 0, stream>>>(
+        static_cast<const T*>(k), static_cast<int8_t*>(k_int8),
+        static_cast<float*>(k_scale), anchors, kv_len, padded_k, num_heads,
+        groups, k_stride_b, k_stride_h, k_stride_n);
+}
+
 }  // namespace
 }  // namespace comfy::hip_backend::sage
 
 using namespace comfy::hip_backend::sage;
+
+extern "C" void launch_gfx12_qk_quant(
+    const void* q, void* q_int8, void* q_scale,
+    const void* k, void* k_int8, void* k_scale, void* anchor_indices,
+    int num_heads, int q_len, int kv_len, int padded_q, int padded_k,
+    int64_t q_stride_b, int64_t q_stride_h, int64_t q_stride_n,
+    int64_t k_stride_b, int64_t k_stride_h, int64_t k_stride_n,
+    int input_dtype_code, hipStream_t stream) {
+    if (num_heads <= 0 || q_len <= 0 || kv_len <= 0) {
+        throw std::runtime_error(
+            "gfx12 Q/K quantization requires positive heads and lengths");
+    }
+    if (padded_q < q_len || padded_q % 128 != 0 ||
+        padded_k < kv_len || padded_k % 64 != 0) {
+        throw std::runtime_error(
+            "gfx12 Q/K workspaces have invalid padding");
+    }
+    auto* anchors = static_cast<int*>(anchor_indices);
+    if (input_dtype_code == 1) {
+        launch_gfx12_qk_quant_typed<__half>(
+            q, q_int8, q_scale, k, k_int8, k_scale, anchors, num_heads,
+            q_len, kv_len, padded_q, padded_k, q_stride_b, q_stride_h,
+            q_stride_n, k_stride_b, k_stride_h, k_stride_n, stream);
+    } else if (input_dtype_code == 2) {
+        launch_gfx12_qk_quant_typed<__bf16>(
+            q, q_int8, q_scale, k, k_int8, k_scale, anchors, num_heads,
+            q_len, kv_len, padded_q, padded_k, q_stride_b, q_stride_h,
+            q_stride_n, k_stride_b, k_stride_h, k_stride_n, stream);
+    } else {
+        throw std::runtime_error(
+            "gfx12 Q/K quantization supports float16 and bfloat16");
+    }
+}
 
 // rotation is 4, 64, 128 or 129; the caller picks it the same way the CUDA
 // backend does, and Q and K must agree or their dot products change.

--- a/comfy_kitchen/backends/hip/sage_attention/quant_qk_int8.hip
+++ b/comfy_kitchen/backends/hip/sage_attention/quant_qk_int8.hip
@@ -174,6 +174,8 @@ __global__ __launch_bounds__(kQuantWaves * 32) void quant_k_int8_kernel(
     const T* head = k + static_cast<int64_t>(b) * stride_b + static_cast<int64_t>(h) * stride_h;
     const int key0 = group * 16;
 
+    // Rows [Lk, Lk_storage) intentionally remain unwritten. The gfx12
+    // attention consumer masks their scores before the softmax.
     // A negative index means the detector found no anchor worth subtracting. The
     // subtraction stays unconditional either way, with a zero bias standing in,
     // so the anchor never has to be reached through a pointer.
@@ -515,6 +517,35 @@ extern "C" void launch_gfx12_qk_quant(
         padded_k < kv_len || padded_k % 64 != 0) {
         throw std::runtime_error(
             "gfx12 Q/K workspaces have invalid padding");
+    }
+    if (anchor_indices == nullptr) {
+        throw std::runtime_error(
+            "gfx12 Q/K quantization requires anchor_indices scratch");
+    }
+    const size_t element_size = sizeof(__half);
+    const size_t vector_size = 4 * element_size;
+    const auto stride_ok = [](int64_t stride, int extent) {
+        return extent < 2 || (stride > 0 && stride % 4 == 0);
+    };
+    const auto vector_aligned = [vector_size, &stride_ok](
+        const void* pointer, int64_t stride_b, int64_t stride_h,
+        int64_t stride_n, int batches, int heads, int length) {
+        return reinterpret_cast<uintptr_t>(pointer) % vector_size == 0 &&
+            stride_ok(stride_b, batches) && stride_ok(stride_h, heads) &&
+            stride_ok(stride_n, length);
+    };
+    if (!vector_aligned(
+            q, q_stride_b, q_stride_h, q_stride_n, 1, num_heads, q_len) ||
+        !vector_aligned(
+            k, k_stride_b, k_stride_h, k_stride_n, 1, num_heads, kv_len)) {
+        throw std::runtime_error(
+            "gfx12 Q/K base pointers and B/H/N strides must preserve "
+            "4-element alignment");
+    }
+    if (reinterpret_cast<uintptr_t>(q_int8) % 4 != 0 ||
+        reinterpret_cast<uintptr_t>(k_int8) % 4 != 0) {
+        throw std::runtime_error(
+            "gfx12 quantized Q/K base pointers must be 4-byte aligned");
     }
     auto* anchors = static_cast<int*>(anchor_indices);
     if (input_dtype_code == 1) {

--- a/comfy_kitchen/backends/hip/sage_attention/quant_v_int8.hip
+++ b/comfy_kitchen/backends/hip/sage_attention/quant_v_int8.hip
@@ -256,7 +256,9 @@ extern "C" void launch_gfx12_tile_channel_v_quant(
         return extent < 2 ||
             (stride > 0 && (static_cast<size_t>(stride) * sizeof(__half)) % 16 == 0);
     };
-    if (reinterpret_cast<uintptr_t>(v) % 16 != 0 ||
+    if (v == nullptr || output == nullptr ||
+        reinterpret_cast<uintptr_t>(v) % 16 != 0 ||
+        reinterpret_cast<uintptr_t>(output) % 16 != 0 ||
         !stride_ok(stride_h, num_heads) || !stride_ok(stride_n, n_ctx)) {
         throw std::runtime_error(
             "gfx12 V base pointer and H/N strides must be 16-byte aligned");

--- a/comfy_kitchen/backends/hip/sage_attention/quant_v_int8.hip
+++ b/comfy_kitchen/backends/hip/sage_attention/quant_v_int8.hip
@@ -252,6 +252,15 @@ extern "C" void launch_gfx12_tile_channel_v_quant(
         throw std::runtime_error(
             "gfx12 tile-channel V quantization received an invalid tile count");
     }
+    const auto stride_ok = [](int64_t stride, int extent) {
+        return extent < 2 ||
+            (stride > 0 && (static_cast<size_t>(stride) * sizeof(__half)) % 16 == 0);
+    };
+    if (reinterpret_cast<uintptr_t>(v) % 16 != 0 ||
+        !stride_ok(stride_h, num_heads) || !stride_ok(stride_n, n_ctx)) {
+        throw std::runtime_error(
+            "gfx12 V base pointer and H/N strides must be 16-byte aligned");
+    }
     if (input_dtype_code == 1) {
         launch_gfx12_tile_channel_v_quant(
             static_cast<const __half*>(v), static_cast<int8_t*>(output),

--- a/comfy_kitchen/backends/hip/sage_attention/quant_v_int8.hip
+++ b/comfy_kitchen/backends/hip/sage_attention/quant_v_int8.hip
@@ -24,6 +24,87 @@ namespace {
 
 constexpr int kDTile = 8;
 
+// Optimized producer: one scale per (head, 64-key tile, channel), with
+// the quantized bytes written directly as [head, tile, D, 64].  A synchronous
+// BF16 LDS tile keeps both the physical-NHD input loads and tile-major output
+// stores vectorized; this kernel family has no global-to-LDS async/direct path.
+template <typename T>
+__global__ __launch_bounds__(256) void gfx12_tile_channel_v_quant_kernel(
+    const T* __restrict__ v, int8_t* __restrict__ output,
+    float* __restrict__ descale, int n_ctx, int tiles,
+    int64_t stride_h, int64_t stride_n) {
+    constexpr int kTileN = 64;
+    constexpr int kD = 128;
+    constexpr int kStageStride = kD + 8;
+    __shared__ __align__(16) T staged[kTileN * kStageStride];
+    __shared__ float multiplier[kD];
+
+    const int tid = threadIdx.x;
+    const int tile = blockIdx.x;
+    const int head = blockIdx.y;
+    const int n0 = tile * kTileN;
+
+    // 64*128 BF16 values = 1024 aligned 16-byte chunks, four per thread.
+#pragma unroll
+    for (int i = 0; i < 4; ++i) {
+        const int chunk = tid + i * 256;
+        const int row = chunk >> 4;
+        const int d8 = (chunk & 15) << 3;
+        uint4 value = make_uint4(0, 0, 0, 0);
+        if (n0 + row < n_ctx) {
+            value = *reinterpret_cast<const uint4*>(
+                v + static_cast<int64_t>(head) * stride_h +
+                static_cast<int64_t>(n0 + row) * stride_n + d8);
+        }
+        *reinterpret_cast<uint4*>(staged + row * kStageStride + d8) = value;
+    }
+    __syncthreads();
+
+    if (tid < kD) {
+        float maximum = 0.0f;
+#pragma unroll
+        for (int row = 0; row < kTileN; ++row) {
+            maximum = fmaxf(maximum, fabsf(to_float(
+                staged[row * kStageStride + tid])));
+        }
+        if (maximum == 0.0f) maximum = 1.0e-8f;
+        descale[(static_cast<int64_t>(head) * tiles + tile) * kD + tid] =
+            maximum * (1.0f / 127.0f);
+        multiplier[tid] = __builtin_amdgcn_rcpf(maximum) * 127.0f;
+    }
+    __syncthreads();
+
+    // 128 rows of 64 output bytes = 512 uint4 chunks, two per thread.
+#pragma unroll
+    for (int i = 0; i < 2; ++i) {
+        const int chunk = tid + i * 256;
+        const int d = chunk >> 2;
+        const int n16 = (chunk & 3) << 4;
+        uint4 packed = make_uint4(0, 0, 0, 0);
+        uint32_t* words = reinterpret_cast<uint32_t*>(&packed);
+#pragma unroll
+        for (int j = 0; j < 16; ++j) {
+            const uint32_t code = static_cast<uint8_t>(float_to_int8_rn(
+                to_float(staged[(n16 + j) * kStageStride + d]) *
+                multiplier[d]));
+            words[j >> 2] |= code << (8 * (j & 3));
+        }
+        *reinterpret_cast<uint4*>(
+            output + static_cast<int64_t>(head) * tiles * kD * kTileN +
+            static_cast<int64_t>(tile) * kD * kTileN + d * kTileN + n16) = packed;
+    }
+}
+
+template <typename T>
+void launch_gfx12_tile_channel_v_quant(
+    const T* v, int8_t* output, float* descale,
+    int num_heads, int n_ctx, int tiles,
+    int64_t stride_h, int64_t stride_n,
+    hipStream_t stream) {
+    gfx12_tile_channel_v_quant_kernel<T><<<dim3(tiles, num_heads), 256, 0, stream>>>(
+        v, output, descale, n_ctx, tiles, stride_h, stride_n);
+}
+
 // Eight adjacent channels: 32 bytes for fp32, 16 for the 16-bit types.
 template <typename T>
 __forceinline__ __device__ void load8(const T* p, float* out) {
@@ -157,6 +238,35 @@ void launch_typed(const void* v, void* out, void* scale, int B, int H, int N, in
 }  // namespace comfy::hip_backend::sage
 
 using namespace comfy::hip_backend::sage;
+
+extern "C" void launch_gfx12_tile_channel_v_quant(
+    const void* v, void* output, void* descale, int num_heads,
+    int n_ctx, int tiles,
+    int64_t stride_h, int64_t stride_n, int input_dtype_code,
+    hipStream_t stream) {
+    if (num_heads <= 0 || n_ctx <= 0) {
+        throw std::runtime_error(
+            "gfx12 tile-channel V quantization requires positive heads and length");
+    }
+    if (tiles != (n_ctx + 63) / 64) {
+        throw std::runtime_error(
+            "gfx12 tile-channel V quantization received an invalid tile count");
+    }
+    if (input_dtype_code == 1) {
+        launch_gfx12_tile_channel_v_quant(
+            static_cast<const __half*>(v), static_cast<int8_t*>(output),
+            static_cast<float*>(descale), num_heads, n_ctx, tiles,
+            stride_h, stride_n, stream);
+    } else if (input_dtype_code == 2) {
+        launch_gfx12_tile_channel_v_quant(
+            static_cast<const __bf16*>(v), static_cast<int8_t*>(output),
+            static_cast<float*>(descale), num_heads, n_ctx, tiles,
+            stride_h, stride_n, stream);
+    } else {
+        throw std::runtime_error(
+            "gfx12 tile-channel V quantization supports float16 and bfloat16");
+    }
+}
 
 extern "C" void launch_sage_quant_v_int8(const void* v, void* out, void* scale, int B, int H,
                                          int N, int D, int padded_N, int64_t stride_b,

--- a/comfy_kitchen/backends/hip/sage_attention/sage_common.h
+++ b/comfy_kitchen/backends/hip/sage_attention/sage_common.h
@@ -22,7 +22,7 @@ namespace comfy::hip_backend::sage {
 // Every kernel here indexes lanes with & 31, reduces with a width of 32 and packs
 // fragments per half wave. RDNA defaults to wave32, but -mwavefrontsize64 would
 // compile all of that into silently wrong scales rather than an error.
-#if defined(__AMDGCN_WAVEFRONT_SIZE__)
+#if defined(__HIP_DEVICE_COMPILE__) && defined(__AMDGCN_WAVEFRONT_SIZE__)
 static_assert(__AMDGCN_WAVEFRONT_SIZE__ == 32,
               "the int8 attention kernels are wave32 only");
 #endif

--- a/comfy_kitchen/backends/hip/swiglu_bf16.h
+++ b/comfy_kitchen/backends/hip/swiglu_bf16.h
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <hip/hip_fp16.h>
+#include <hip/hip_runtime.h>
+
+namespace comfy::hip_backend {
+
+union Bf16Bits {
+    __bf16 value;
+    uint16_t bits;
+};
+
+__forceinline__ __device__ __bf16 bf16_from_bits(uint16_t bits) {
+    Bf16Bits result{};
+    result.bits = bits;
+    return result.value;
+}
+
+// Match torch.nn.functional.silu(gate) * up for BF16 operands: SiLU is rounded
+// to BF16 before the multiply and the product is rounded to BF16 on return.
+__forceinline__ __device__ __bf16 swiglu_bf16_value(
+    __bf16 gate, __bf16 up) {
+    Bf16Bits gate_storage{};
+    gate_storage.value = gate;
+    const float gate_f = static_cast<float>(gate);
+    __bf16 silu;
+    // PyTorch's current ROCm BF16 SiLU differs from the native float expf
+    // path at four finite BF16 inputs. Preserve those exact rounded values;
+    // every other finite BF16 input maps identically on gfx12.
+    switch (gate_storage.bits) {
+        case 0x40be: silu = bf16_from_bits(0x40bd); break;  //  5.9375
+        case 0xc2af: silu = bf16_from_bits(0x8395); break;  // -87.5
+        case 0xc2b0: silu = bf16_from_bits(0x8335); break;  // -88.0
+        case 0xc2b1: silu = bf16_from_bits(0x82dd); break;  // -88.5
+        default:
+            silu = static_cast<__bf16>(
+                gate_f / (1.0f + expf(-gate_f)));
+            break;
+    }
+    return static_cast<__bf16>(
+        static_cast<float>(silu) * static_cast<float>(up));
+}
+
+}  // namespace comfy::hip_backend

--- a/comfy_kitchen/backends/hip/swiglu_bf16.h
+++ b/comfy_kitchen/backends/hip/swiglu_bf16.h
@@ -7,29 +7,21 @@
 
 namespace comfy::hip_backend {
 
-union Bf16Bits {
-    __bf16 value;
-    uint16_t bits;
-};
-
 __forceinline__ __device__ __bf16 bf16_from_bits(uint16_t bits) {
-    Bf16Bits result{};
-    result.bits = bits;
-    return result.value;
+    return __builtin_bit_cast(__bf16, bits);
 }
 
 // Match torch.nn.functional.silu(gate) * up for BF16 operands: SiLU is rounded
 // to BF16 before the multiply and the product is rounded to BF16 on return.
 __forceinline__ __device__ __bf16 swiglu_bf16_value(
     __bf16 gate, __bf16 up) {
-    Bf16Bits gate_storage{};
-    gate_storage.value = gate;
+    const uint16_t gate_bits = __builtin_bit_cast(uint16_t, gate);
     const float gate_f = static_cast<float>(gate);
     __bf16 silu;
     // PyTorch's current ROCm BF16 SiLU differs from the native float expf
     // path at four finite BF16 inputs. Preserve those exact rounded values;
     // every other finite BF16 input maps identically on gfx12.
-    switch (gate_storage.bits) {
+    switch (gate_bits) {
         case 0x40be: silu = bf16_from_bits(0x40bd); break;  //  5.9375
         case 0xc2af: silu = bf16_from_bits(0x8395); break;  // -87.5
         case 0xc2b0: silu = bf16_from_bits(0x8335); break;  // -88.0

--- a/comfy_kitchen/sage_attention.py
+++ b/comfy_kitchen/sage_attention.py
@@ -301,11 +301,8 @@ def prequantize_int8_attention(
 
     if _hip_backend is not None:
         # The packed V row width follows this cta_k, so the value that packed the
-        # buffers is the one that has to come back to attend over them. Taking the
-        # CUDA-side constant here would only agree with the HIP choice by accident.
-        hip_cta_k = _hip_backend._sage_cta_k(
-            kernel_head_dim, k.shape[2], attn_mask is not None
-        )
+        # buffers is the one that has to come back to attend over them.
+        hip_cta_k = _hip_backend._SAGE_CTA_K
         packed = _hip_backend.sage_int8_quantize(q, k, v, cta_k=hip_cta_k)
         return PrequantizedInt8Attention(
             q=packed["q_int8"],

--- a/comfy_kitchen/sage_attention.py
+++ b/comfy_kitchen/sage_attention.py
@@ -32,6 +32,8 @@ def _validate_attention_scale(scale: object, default: float) -> float:
     if isinstance(scale, torch.Tensor):
         if scale.numel() != 1:
             raise ValueError(f"scale must be a scalar, got shape {tuple(scale.shape)}")
+        if scale.dtype == torch.bool:
+            raise TypeError(f"scale must be a real numeric scalar, got {scale.dtype}")
         if scale.is_complex():
             raise TypeError(f"scale must be a real numeric scalar, got {scale.dtype}")
         try:

--- a/comfy_kitchen/sage_attention.py
+++ b/comfy_kitchen/sage_attention.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import math
+import numbers
 from dataclasses import dataclass
 
 import torch
@@ -22,6 +23,28 @@ CTA_K = 64
 LARGE_CTA_K = 128
 _SUPPORTED_DTYPES = (torch.float32, torch.float16, torch.bfloat16)
 _NATIVE_MINIMUM_CAPABILITY = (7, 5)
+
+
+def _validate_attention_scale(scale: object, default: float) -> float:
+    """Normalize an attention scale while keeping kernel inputs unambiguous."""
+    if scale is None:
+        return default
+    if isinstance(scale, torch.Tensor):
+        if scale.numel() != 1:
+            raise ValueError(f"scale must be a scalar, got shape {tuple(scale.shape)}")
+        if scale.is_complex():
+            raise TypeError(f"scale must be a real numeric scalar, got {scale.dtype}")
+        try:
+            value = float(scale.item())
+        except (TypeError, ValueError, RuntimeError) as error:
+            raise TypeError(f"scale must be a real numeric scalar, got {scale.dtype}") from error
+    elif isinstance(scale, numbers.Real) and not isinstance(scale, bool):
+        value = float(scale)
+    else:
+        raise TypeError(f"scale must be a real numeric scalar, got {type(scale).__name__}")
+    if not math.isfinite(value):
+        raise ValueError(f"scale must be finite, got {value}")
+    return value
 
 
 @dataclass(frozen=True, slots=True)
@@ -156,9 +179,7 @@ def _int8_attention_cuda(
         k = functional.pad(k, padding)
         v = functional.pad(v, padding)
 
-    attention_scale = original_head_dim**-0.5 if scale is None else float(scale)
-    if not math.isfinite(attention_scale):
-        raise ValueError(f"scale must be finite, got {attention_scale}")
+    attention_scale = _validate_attention_scale(scale, original_head_dim**-0.5)
 
     if _hip_backend is not None:
         output = _hip_backend.sage_int8_sdpa(
@@ -295,9 +316,7 @@ def prequantize_int8_attention(
         k = functional.pad(k, padding)
         v = functional.pad(v, padding)
 
-    attention_scale = original_head_dim**-0.5 if scale is None else float(scale)
-    if not math.isfinite(attention_scale):
-        raise ValueError(f"scale must be finite, got {attention_scale}")
+    attention_scale = _validate_attention_scale(scale, original_head_dim**-0.5)
 
     if _hip_backend is not None:
         # The packed V row width follows this cta_k, so the value that packed the
@@ -558,6 +577,9 @@ def int8_attention(
     arithmetic is FP32. This path does not allocate FP8 tensors or execute FP8
     MMA instructions.
     """
+    # Validate before entering the custom op so every public path has the same
+    # scalar/type/finite-value contract (including CPU and fake dispatch).
+    scale = None if scale is None else _validate_attention_scale(scale, 0.0)
     if attn_mask is None:
         return torch.ops.comfy_kitchen.int8_attention(
             q,

--- a/comfy_kitchen/tensor/base.py
+++ b/comfy_kitchen/tensor/base.py
@@ -178,6 +178,9 @@ class QuantizedTensor(torch.Tensor):
         self._qdata = qdata
         self._layout_cls = layout_cls
         self._params = params
+        # Keep the physical storage and its metadata together.  WMMA packing
+        # replaces both references as one immutable operation snapshot.
+        self._wmma_state = (qdata, params)
 
     def __repr__(self) -> str:
         return (
@@ -226,6 +229,10 @@ class QuantizedTensor(torch.Tensor):
     @property
     def params(self) -> Any:
         return self._params
+
+    def _state_snapshot(self) -> tuple[torch.Tensor, Any]:
+        """Return matching quantized storage and metadata for one operation."""
+        return self._wmma_state
 
     # ==================== Factory Methods ====================
 
@@ -296,7 +303,8 @@ class QuantizedTensor(torch.Tensor):
         return full
 
     def state_dict(self, prefix: str = "") -> dict[str, torch.Tensor]:
-        tensors = self.layout_cls.state_dict_tensors(self._qdata, self._params)
+        qdata, params = self._state_snapshot()
+        tensors = self.layout_cls.state_dict_tensors(qdata, params)
         return {f"{prefix}{suffix}": tensor for suffix, tensor in tensors.items()}
 
     def requantize_from_float(self, tensor: torch.Tensor, **kwargs) -> QuantizedTensor:
@@ -311,12 +319,13 @@ class QuantizedTensor(torch.Tensor):
     # ==================== Flatten/Unflatten Protocol ====================
 
     def __tensor_flatten__(self):
+        _, params = self._state_snapshot()
         inner_tensors = ["_qdata"]
         tensor_fields = {}
         non_tensor_fields = {}
 
-        for field in dataclasses.fields(self._params):
-            value = getattr(self._params, field.name)
+        for field in dataclasses.fields(params):
+            value = getattr(params, field.name)
             if isinstance(value, torch.Tensor):
                 attr_name = f"_param_{field.name}"
                 object.__setattr__(self, attr_name, value)
@@ -463,6 +472,7 @@ def _handle_copy_(qt, args, kwargs):
     dst._qdata.copy_(src._qdata, non_blocking=non_blocking)
     dst._params.copy_from(src._params, non_blocking=non_blocking)
     dst._params = dataclasses.replace(dst._params, orig_dtype=dst_orig_dtype)
+    dst._wmma_state = (dst._qdata, dst._params)
     return dst
 
 

--- a/comfy_kitchen/tensor/base.py
+++ b/comfy_kitchen/tensor/base.py
@@ -182,24 +182,39 @@ class QuantizedTensor(torch.Tensor):
         # replaces both references as one immutable operation snapshot.
         self._wmma_state = (qdata, params)
 
+    def _state_snapshot(self) -> tuple[torch.Tensor, Any]:
+        """Return matching storage and metadata for one operation.
+
+        Older instances (including objects restored from older serialized
+        representations) may not have the WMMA state attribute.
+        """
+        return getattr(self, "_wmma_state", (self._qdata, self._params))
+
     def __repr__(self) -> str:
+        qdata, params = self._state_snapshot()
+        layout_cls = get_layout_class(self._layout_cls)
+        storage_shape = tuple(qdata.shape)
+        if hasattr(layout_cls, "get_logical_shape_from_storage"):
+            storage_shape = layout_cls.get_logical_shape_from_storage(storage_shape)
         return (
             f"QuantizedTensor(shape={tuple(self.shape)}, "
-            f"storage_shape={self.storage_shape}, "
+            f"storage_shape={storage_shape}, "
             f"layout={self._layout_cls}, "
-            f"dtype={self._params.orig_dtype})"
+            f"dtype={params.orig_dtype})"
         )
 
     # ==================== Properties ====================
 
     @property
     def storage_shape(self) -> tuple[int, ...]:
-        return tuple(self._qdata.shape)
+        qdata, _ = self._state_snapshot()
+        return tuple(qdata.shape)
 
     @property
     def storage_dtype(self) -> torch.dtype:
         """The dtype of the underlying quantized storage (e.g., float8_e4m3fn, uint8)."""
-        return self._qdata.dtype
+        qdata, _ = self._state_snapshot()
+        return qdata.dtype
 
     @property
     def nbytes(self) -> int:
@@ -209,7 +224,8 @@ class QuantizedTensor(torch.Tensor):
         not the logical size based on orig_dtype. For example, an FP8 quantized
         tensor with logical dtype bfloat16 returns the FP8 storage size.
         """
-        return self._qdata.nbytes
+        qdata, _ = self._state_snapshot()
+        return qdata.nbytes
 
     @property
     def padded_shape(self) -> tuple[int, ...]:
@@ -220,7 +236,12 @@ class QuantizedTensor(torch.Tensor):
 
     @property
     def is_padded(self) -> bool:
-        return self._params.orig_shape != self.padded_shape
+        qdata, params = self._state_snapshot()
+        layout_cls = get_layout_class(self._layout_cls)
+        storage_shape = tuple(qdata.shape)
+        if hasattr(layout_cls, "get_logical_shape_from_storage"):
+            storage_shape = layout_cls.get_logical_shape_from_storage(storage_shape)
+        return params.orig_shape != storage_shape
 
     @property
     def layout_cls(self) -> type[QuantizedLayout]:
@@ -228,11 +249,7 @@ class QuantizedTensor(torch.Tensor):
 
     @property
     def params(self) -> Any:
-        return self._params
-
-    def _state_snapshot(self) -> tuple[torch.Tensor, Any]:
-        """Return matching quantized storage and metadata for one operation."""
-        return self._wmma_state
+        return self._state_snapshot()[1]
 
     # ==================== Factory Methods ====================
 
@@ -260,10 +277,13 @@ class QuantizedTensor(torch.Tensor):
             clone_params: If True and params is None, clone self._params. Set to False
                 when you know params don't need cloning (e.g., they're already new).
         """
+        snapshot_qdata, snapshot_params = self._state_snapshot()
+        if qdata is None:
+            qdata = snapshot_qdata
         if params is None:
-            params = self._params.clone() if clone_params else self._params
+            params = snapshot_params.clone() if clone_params else snapshot_params
         return QuantizedTensor(
-            qdata if qdata is not None else self._qdata,
+            qdata,
             self._layout_cls,
             params,
         )
@@ -280,23 +300,24 @@ class QuantizedTensor(torch.Tensor):
         return self._qdata.storage()
 
     def dequantize(self) -> torch.Tensor:
+        qdata, params = self._state_snapshot()
         # Ensure qdata is contiguous - backends may not handle non-contiguous views
         # (e.g., after transpose/view operations)
-        qdata = self._qdata.contiguous() if not self._qdata.is_contiguous() else self._qdata
+        qdata = qdata.contiguous() if not qdata.is_contiguous() else qdata
 
         # Check if this is a logically transposed tensor (e.g., NVFP4 with deferred transpose)
-        is_transposed = getattr(self._params, "transposed", False)
+        is_transposed = getattr(params, "transposed", False)
 
         if is_transposed:
-            physical_shape = (self._params.orig_shape[1], self._params.orig_shape[0])
-            full = self.layout_cls.dequantize(qdata, self._params)
+            physical_shape = (params.orig_shape[1], params.orig_shape[0])
+            full = self.layout_cls.dequantize(qdata, params)
             if full.shape[:2] != physical_shape:
                 slices = tuple(slice(0, s) for s in physical_shape)
                 full = full[slices]
             return full.t()
 
-        full = self.layout_cls.dequantize(qdata, self._params)
-        orig = self._params.orig_shape
+        full = self.layout_cls.dequantize(qdata, params)
+        orig = params.orig_shape
         if full.shape != orig:
             slices = tuple(slice(0, s) for s in orig)
             return full[slices]
@@ -319,8 +340,9 @@ class QuantizedTensor(torch.Tensor):
     # ==================== Flatten/Unflatten Protocol ====================
 
     def __tensor_flatten__(self):
-        _, params = self._state_snapshot()
+        qdata, params = self._state_snapshot()
         inner_tensors = ["_qdata"]
+        object.__setattr__(self, "_qdata", qdata)
         tensor_fields = {}
         non_tensor_fields = {}
 
@@ -416,28 +438,31 @@ def _parse_to_args(args, kwargs):
 
 
 def _handle_detach(qt, args, kwargs):
-    return qt._copy_with(qdata=qt._qdata.detach())
+    qdata, params = qt._state_snapshot()
+    return qt._copy_with(qdata=qdata.detach(), params=params.clone())
 
 
 def _handle_clone(qt, args, kwargs):
-    return qt._copy_with(qdata=qt._qdata.clone())
+    qdata, params = qt._state_snapshot()
+    return qt._copy_with(qdata=qdata.clone(), params=params.clone(), clone_params=False)
 
 
 def _handle_to(qt, args, kwargs, force_copy=False):
     target_device, target_dtype = _parse_to_args(args, kwargs)
+    qdata, params = qt._state_snapshot()
 
-    needs_device = target_device is not None and target_device != qt._qdata.device
-    needs_dtype = target_dtype is not None and target_dtype != qt._params.orig_dtype
+    needs_device = target_device is not None and target_device != qdata.device
+    needs_dtype = target_dtype is not None and target_dtype != params.orig_dtype
 
     if not needs_device and not needs_dtype and not force_copy:
         return qt
 
     if needs_device:
-        new_qdata = qt._qdata.to(device=target_device)
-        new_params = qt._params.to_device(target_device)
+        new_qdata = qdata.to(device=target_device)
+        new_params = params.to_device(target_device)
     else:
-        new_qdata = qt._qdata.clone() if force_copy else qt._qdata
-        new_params = qt._params.clone()
+        new_qdata = qdata.clone() if force_copy else qdata
+        new_params = params.clone()
 
     if needs_dtype:
         new_params = dataclasses.replace(new_params, orig_dtype=target_dtype)
@@ -450,13 +475,14 @@ def _handle_to_copy(qt, args, kwargs):
 
 
 def _handle_contiguous(qt, args, kwargs):
-    if qt._qdata.is_contiguous():
+    qdata, params = qt._state_snapshot()
+    if qdata.is_contiguous():
         return qt
-    return qt._copy_with(qdata=qt._qdata.contiguous())
+    return qt._copy_with(qdata=qdata.contiguous(), params=params.clone(), clone_params=False)
 
 
 def _handle_is_contiguous(qt, args, kwargs):
-    return qt._qdata.is_contiguous()
+    return qt._state_snapshot()[0].is_contiguous()
 
 
 def _handle_copy_(qt, args, kwargs):
@@ -466,22 +492,27 @@ def _handle_copy_(qt, args, kwargs):
     if dst._layout_cls != src._layout_cls:
         raise TypeError(f"Layout mismatch: {dst._layout_cls} vs {src._layout_cls}")
 
-    dst_orig_dtype = dst._params.orig_dtype
+    dst_qdata, dst_params = dst._state_snapshot()
+    src_qdata, src_params = src._state_snapshot()
+    dst_orig_dtype = dst_params.orig_dtype
     non_blocking = kwargs.get("non_blocking", len(args) >= 3)
 
-    dst._qdata.copy_(src._qdata, non_blocking=non_blocking)
-    dst._params.copy_from(src._params, non_blocking=non_blocking)
-    dst._params = dataclasses.replace(dst._params, orig_dtype=dst_orig_dtype)
-    dst._wmma_state = (dst._qdata, dst._params)
+    dst_qdata.copy_(src_qdata, non_blocking=non_blocking)
+    dst_params.copy_from(src_params, non_blocking=non_blocking)
+    dst_params = dataclasses.replace(dst_params, orig_dtype=dst_orig_dtype)
+    dst._wmma_state = (dst_qdata, dst_params)
+    dst._qdata = dst_qdata
+    dst._params = dst_params
     return dst
 
 
 def _handle_empty_like(qt, args, kwargs):
     target_dtype = kwargs.pop("dtype", None)
     target_device = kwargs.get("device")
+    qdata, params = qt._state_snapshot()
 
-    new_qdata = torch.empty_like(qt._qdata, device=target_device)
-    new_params = qt._params.clone()
+    new_qdata = torch.empty_like(qdata, device=target_device)
+    new_params = params.clone()
 
     if target_device is not None:
         new_params = new_params.to_device(target_device)

--- a/comfy_kitchen/tensor/int8.py
+++ b/comfy_kitchen/tensor/int8.py
@@ -36,10 +36,7 @@ _WMMA_ROW_MAJOR_ONLY_SHAPES = frozenset({
 
 def _wmma_storage(qtensor: QuantizedTensor):
     """Atomically snapshot runtime WMMA storage and its matching parameters."""
-    state = getattr(qtensor, "_wmma_state", None)
-    if state is not None:
-        return state
-    return qtensor._qdata, qtensor._params
+    return qtensor._state_snapshot()
 
 _INT8_DEQUANT_DTYPE_TO_CODE = {
     torch.float32: 0,
@@ -145,7 +142,7 @@ class TensorWiseINT8Layout(QuantizedLayout):
         """
         if not isinstance(qtensor, QuantizedTensor) or qtensor._layout_cls != cls.__name__:
             raise TypeError("pack_wmma_weight_ requires a TensorWiseINT8Layout tensor")
-        params = qtensor._params
+        _, params = _wmma_storage(qtensor)
         if not getattr(params, "is_weight", True):
             raise ValueError("Only INT8 weights can use WMMA-tiled storage")
         if getattr(params, "transposed", False) or len(params.orig_shape) != 2:
@@ -203,7 +200,7 @@ class TensorWiseINT8Layout(QuantizedLayout):
         """
         if not isinstance(qtensor, QuantizedTensor) or qtensor._layout_cls != cls.__name__:
             return 0
-        params = qtensor._params
+        _, params = _wmma_storage(qtensor)
         existing = getattr(params, "wmma_tile_k", 0)
         if existing:
             return existing
@@ -218,8 +215,9 @@ class TensorWiseINT8Layout(QuantizedLayout):
                 return 0
         except (AttributeError, RuntimeError):
             return 0
+        qdata, _ = _wmma_storage(qtensor)
         if (not _uses_nonduplicated_wmma(input_tensor.device)
-                or qtensor._qdata.device != input_tensor.device):
+                or qdata.device != input_tensor.device):
             return 0
         if len(params.orig_shape) != 2 or input_tensor.ndim == 0:
             return 0
@@ -247,14 +245,15 @@ class TensorWiseINT8Layout(QuantizedLayout):
         """Whether this call can consume an already tiled physical weight."""
         if not isinstance(qtensor, QuantizedTensor) or qtensor._layout_cls != cls.__name__:
             return False
-        params = qtensor._params
+        _, params = _wmma_storage(qtensor)
         tile_n = getattr(params, "wmma_tile_n", 0)
         tile_k = getattr(params, "wmma_tile_k", 0)
         if tile_n != 128 or tile_k not in (64, 128):
             return False
         if input_tensor.dtype != torch.bfloat16 or input_tensor.device.type != "cuda":
             return False
-        if qtensor._qdata.device != input_tensor.device or input_tensor.ndim == 0:
+        qdata, _ = _wmma_storage(qtensor)
+        if qdata.device != input_tensor.device or input_tensor.ndim == 0:
             return False
         if (not _uses_nonduplicated_wmma(input_tensor.device)
                 or len(params.orig_shape) != 2):
@@ -389,7 +388,8 @@ class TensorWiseINT8Layout(QuantizedLayout):
         Returns:
             Tuple of (quantized_data, scale).
         """
-        return qtensor._qdata, qtensor._params.scale
+        qdata, params = _wmma_storage(qtensor)
+        return qdata, params.scale
 
     @classmethod
     def _fusion_operand(
@@ -402,16 +402,16 @@ class TensorWiseINT8Layout(QuantizedLayout):
         """Resolve private storage needed by compound INT8 operations."""
         if not isinstance(weight, QuantizedTensor) or weight._layout_cls != cls.__name__:
             return None
-        params = weight._params
+        qdata, params = _wmma_storage(weight)
         if getattr(params, "transposed", False):
             return None
         if prepare:
             cls.prepare_wmma_weight_(weight, x)
-            params = weight._params
+            qdata, params = _wmma_storage(weight)
         tile_k = int(getattr(params, "wmma_tile_k", 0))
         if tile_k and not cls.wmma_weight_is_supported(weight, x):
             return None
-        qdata, scale = cls.get_plain_tensors(weight)
+        scale = params.scale
         return (
             qdata.contiguous(),
             scale,
@@ -676,7 +676,7 @@ class TensorWiseINT8Layout(QuantizedLayout):
     @classmethod
     def requantize_kwargs(cls, qtensor: QuantizedTensor) -> dict[str, object]:
         """Return INT8 quantization options needed to preserve this layout."""
-        params = qtensor._params
+        _, params = _wmma_storage(qtensor)
         is_weight = getattr(params, "is_weight", True)
         convrot = getattr(params, "convrot", False)
         return {
@@ -780,20 +780,20 @@ def _handle_int8_mm_tensorwise(qt, args, kwargs):
     # Usually mm is called with weight as the second argument
     if not isinstance(weight, QuantizedTensor) or weight._layout_cls != "TensorWiseINT8Layout":
         return torch.mm(*dequantize_args(args), **dequantize_args(kwargs))
-    if getattr(weight._params, "wmma_tile_n", 0):
+    weight_qdata, weight_params = _wmma_storage(weight)
+    if getattr(weight_params, "wmma_tile_n", 0):
         return torch.mm(*dequantize_args(args), **dequantize_args(kwargs))
 
     if isinstance(input_tensor, QuantizedTensor):
         input_tensor = input_tensor.dequantize()
 
-    weight_qdata, weight_params = _wmma_storage(weight)
     weight_scale = weight_params.scale
     out_dtype = kwargs.get("out_dtype", input_tensor.dtype)
 
     convrot = getattr(weight_params, "convrot", False)
     convrot_groupsize = getattr(weight_params, "convrot_groupsize", 256)
 
-    if getattr(weight._params, "transposed", False):
+    if getattr(weight_params, "transposed", False):
         # Common decomposition: linear(x, W) -> mm(x, W.t()). Storage is still
         # W [N, K], and logical RHS is W.T [K, N].
         int8_weight = weight_qdata.contiguous()
@@ -826,20 +826,20 @@ def _handle_int8_addmm_tensorwise(qt, args, kwargs):
 
     if not isinstance(weight, QuantizedTensor) or weight._layout_cls != "TensorWiseINT8Layout":
         return torch.addmm(*dequantize_args(args), **dequantize_args(kwargs))
-    if getattr(weight._params, "wmma_tile_n", 0):
+    weight_qdata, weight_params = _wmma_storage(weight)
+    if getattr(weight_params, "wmma_tile_n", 0):
         return torch.addmm(*dequantize_args(args), **dequantize_args(kwargs))
 
     if isinstance(input_tensor, QuantizedTensor):
         input_tensor = input_tensor.dequantize()
 
-    weight_qdata, weight_params = _wmma_storage(weight)
     weight_scale = weight_params.scale
     out_dtype = kwargs.get("out_dtype", input_tensor.dtype)
 
-    convrot = getattr(weight._params, "convrot", False)
-    convrot_groupsize = getattr(weight._params, "convrot_groupsize", 256)
+    convrot = getattr(weight_params, "convrot", False)
+    convrot_groupsize = getattr(weight_params, "convrot_groupsize", 256)
 
-    if getattr(weight._params, "transposed", False):
+    if getattr(weight_params, "transposed", False):
         int8_weight = weight_qdata.contiguous()
     elif weight_scale.numel() == 1 and not convrot:
         int8_weight = weight_qdata.t().contiguous()

--- a/comfy_kitchen/tensor/int8.py
+++ b/comfy_kitchen/tensor/int8.py
@@ -442,10 +442,11 @@ class TensorWiseINT8Layout(QuantizedLayout):
     @classmethod
     def is_fusion_weight(cls, weight: torch.Tensor) -> bool:
         """Whether ``weight`` has the logical layout compound ops require."""
+        if not isinstance(weight, QuantizedTensor) or weight._layout_cls != cls.__name__:
+            return False
+        _, params = _wmma_storage(weight)
         return (
-            isinstance(weight, QuantizedTensor)
-            and weight._layout_cls == cls.__name__
-            and not getattr(weight._params, "transposed", False)
+            not getattr(params, "transposed", False)
         )
 
     @classmethod
@@ -707,16 +708,17 @@ def _handle_int8_transpose(qt, args, kwargs):
     if not isinstance(input_tensor, QuantizedTensor):
         return torch.ops.aten.t.default(*args, **kwargs)
 
-    if getattr(input_tensor._params, "wmma_tile_n", 0):
+    qdata, params = _wmma_storage(input_tensor)
+    if getattr(params, "wmma_tile_n", 0):
         return input_tensor.dequantize().t()
 
-    old = input_tensor._params
+    old = params
     new_params = dataclasses.replace(
         old,
         orig_shape=(old.orig_shape[1], old.orig_shape[0]),
         transposed=not old.transposed,
     )
-    return QuantizedTensor(input_tensor._qdata, "TensorWiseINT8Layout", new_params)
+    return QuantizedTensor(qdata, "TensorWiseINT8Layout", new_params)
 
 
 @register_layout_op(torch.ops.aten.linear.default, TensorWiseINT8Layout)

--- a/comfy_kitchen/tensor/int8.py
+++ b/comfy_kitchen/tensor/int8.py
@@ -28,6 +28,11 @@ from .base import (
 logger = logging.getLogger(__name__)
 
 _WMMA_WEIGHT_PACK_LOCK = threading.RLock()
+_WMMA_ROW_MAJOR_ONLY_SHAPES = frozenset({
+    (11520, 3840),
+    (3840, 10240),
+    (10240, 3840),
+})
 
 _INT8_DEQUANT_DTYPE_TO_CODE = {
     torch.float32: 0,
@@ -44,11 +49,11 @@ def _dtype_code(dtype: torch.dtype) -> int:
 
 
 def _uses_nonduplicated_wmma(device: torch.device) -> bool:
-    try:
-        arch = torch.cuda.get_device_properties(device).gcnArchName.split(":")[0]
-    except (AttributeError, RuntimeError):
+    if not getattr(torch.version, "hip", None):
         return False
-    return arch.startswith("gfx12")
+    from comfy_kitchen.backends import hip
+
+    return hip._has_nonduplicated_wmma(device)
 
 
 class TensorWiseINT8Layout(QuantizedLayout):
@@ -165,10 +170,7 @@ class TensorWiseINT8Layout(QuantizedLayout):
                 ready = torch.cuda.Event()
                 ready.record(torch.cuda.current_stream(packed.device))
                 ready.synchronize()
-            if qtensor._qdata.untyped_storage().resizable():
-                qtensor._qdata = packed
-            else:
-                qtensor._qdata.copy_(packed)
+            qtensor._qdata = packed
             qtensor._params = dataclasses.replace(
                 params, wmma_tile_n=tile_n, wmma_tile_k=tile_k
             )
@@ -215,7 +217,7 @@ class TensorWiseINT8Layout(QuantizedLayout):
             return 0
         m = input_tensor.numel() // k
         # Compound QKV and FFN operations consume row-major weights.
-        if (n, k) in ((11520, 3840), (3840, 10240), (10240, 3840)):
+        if (n, k) in _WMMA_ROW_MAJOR_ONLY_SHAPES:
             return 0
         if m < 512 or n % 128 or k % 256:
             return 0
@@ -250,7 +252,7 @@ class TensorWiseINT8Layout(QuantizedLayout):
         m = input_tensor.numel() // input_tensor.shape[-1]
         return (
             input_tensor.shape[-1] == k
-            and (n, k) not in ((11520, 3840), (3840, 10240), (10240, 3840))
+            and (n, k) not in _WMMA_ROW_MAJOR_ONLY_SHAPES
             and m >= 96
             and n % tile_n == 0
             and k % tile_k == 0
@@ -729,9 +731,12 @@ def _handle_int8_linear_tensorwise(qt, args, kwargs):
         weight, input_tensor
     )
     if tile_n and not tiled_supported:
-        return torch.nn.functional.linear(*dequantize_args(args), **dequantize_args(kwargs))
-
-    weight_qdata, weight_scale = TensorWiseINT8Layout.get_plain_tensors(weight)
+        weight_qdata = TensorWiseINT8Layout._unpack_wmma_weight(
+            weight._qdata, weight._params
+        )
+        weight_scale = weight._params.scale
+    else:
+        weight_qdata, weight_scale = TensorWiseINT8Layout.get_plain_tensors(weight)
     out_dtype = kwargs.get("out_dtype", input_tensor.dtype)
 
     convrot = getattr(weight._params, "convrot", False)

--- a/comfy_kitchen/tensor/int8.py
+++ b/comfy_kitchen/tensor/int8.py
@@ -34,6 +34,13 @@ _WMMA_ROW_MAJOR_ONLY_SHAPES = frozenset({
     (10240, 3840),
 })
 
+def _wmma_storage(qtensor: QuantizedTensor):
+    """Atomically snapshot runtime WMMA storage and its matching parameters."""
+    state = getattr(qtensor, "_wmma_state", None)
+    if state is not None:
+        return state
+    return qtensor._qdata, qtensor._params
+
 _INT8_DEQUANT_DTYPE_TO_CODE = {
     torch.float32: 0,
     torch.float16: 1,
@@ -151,17 +158,18 @@ class TensorWiseINT8Layout(QuantizedLayout):
         with _WMMA_WEIGHT_PACK_LOCK:
             # Another inference thread may have packed this wrapper while the
             # caller was checking eligibility.
-            params = qtensor._params
+            _, params = _wmma_storage(qtensor)
             old_tile_n = getattr(params, "wmma_tile_n", 0)
             old_tile_k = getattr(params, "wmma_tile_k", 0)
             if (old_tile_n, old_tile_k) == (tile_n, tile_k):
                 return qtensor
-            row_major = cls._unpack_wmma_weight(qtensor._qdata, params)
+            qdata, params = _wmma_storage(qtensor)
+            row_major = cls._unpack_wmma_weight(qdata, params)
             packed = (
                 row_major.reshape(n // tile_n, tile_n, k // tile_k, tile_k)
                 .permute(0, 2, 1, 3)
                 .contiguous()
-                .reshape_as(qtensor._qdata)
+                .reshape_as(qdata)
             )
             # Publish the new layout only after its asynchronous device copy is
             # complete. This makes first-use packing safe across inference
@@ -170,10 +178,13 @@ class TensorWiseINT8Layout(QuantizedLayout):
                 ready = torch.cuda.Event()
                 ready.record(torch.cuda.current_stream(packed.device))
                 ready.synchronize()
-            qtensor._qdata = packed
-            qtensor._params = dataclasses.replace(
+            new_params = dataclasses.replace(
                 params, wmma_tile_n=tile_n, wmma_tile_k=tile_k
             )
+            # A single reference publishes the matching data and metadata.
+            qtensor._wmma_state = (packed, new_params)
+            qtensor._qdata = packed
+            qtensor._params = new_params
         return qtensor
 
     @classmethod
@@ -584,6 +595,8 @@ class TensorWiseINT8Layout(QuantizedLayout):
         if operand is None:
             return NotImplemented
         qdata, scale, convrot, group_size, tile_k, _ = operand
+        if tile_k:
+            return NotImplemented
         from comfy_kitchen import int8_linear_rms_modulated
 
         return int8_linear_rms_modulated(
@@ -716,7 +729,8 @@ def _handle_int8_linear_tensorwise(qt, args, kwargs):
     # Fast path: weight is a TensorWiseINT8Layout QuantizedTensor
     if not isinstance(weight, QuantizedTensor) or weight._layout_cls != "TensorWiseINT8Layout":
         return torch.nn.functional.linear(*dequantize_args(args), **dequantize_args(kwargs))
-    if getattr(weight._params, "transposed", False):
+    weight_qdata, weight_params = _wmma_storage(weight)
+    if getattr(weight_params, "transposed", False):
         return torch.nn.functional.linear(*dequantize_args(args), **dequantize_args(kwargs))
 
     # If input is already quantized, dequantize it (TensorWise needs dynamic row-wise quant)
@@ -724,23 +738,24 @@ def _handle_int8_linear_tensorwise(qt, args, kwargs):
         input_tensor = input_tensor.dequantize()
 
     TensorWiseINT8Layout.prepare_wmma_weight_(weight, input_tensor)
-    tile_n = getattr(weight._params, "wmma_tile_n", 0)
-    tile_k = getattr(weight._params, "wmma_tile_k", 0)
+    weight_qdata, weight_params = _wmma_storage(weight)
+    tile_n = getattr(weight_params, "wmma_tile_n", 0)
+    tile_k = getattr(weight_params, "wmma_tile_k", 0)
     m = input_tensor.numel() // input_tensor.shape[-1]
     tiled_supported = TensorWiseINT8Layout.wmma_weight_is_supported(
         weight, input_tensor
     )
     if tile_n and not tiled_supported:
         weight_qdata = TensorWiseINT8Layout._unpack_wmma_weight(
-            weight._qdata, weight._params
+            weight_qdata, weight_params
         )
-        weight_scale = weight._params.scale
+        weight_scale = weight_params.scale
     else:
-        weight_qdata, weight_scale = TensorWiseINT8Layout.get_plain_tensors(weight)
+        weight_scale = weight_params.scale
     out_dtype = kwargs.get("out_dtype", input_tensor.dtype)
 
-    convrot = getattr(weight._params, "convrot", False)
-    convrot_groupsize = getattr(weight._params, "convrot_groupsize", 256)
+    convrot = getattr(weight_params, "convrot", False)
+    convrot_groupsize = getattr(weight_params, "convrot_groupsize", 256)
 
     op = (
         torch.ops.comfy_kitchen.int8_linear_tiled_b
@@ -771,11 +786,12 @@ def _handle_int8_mm_tensorwise(qt, args, kwargs):
     if isinstance(input_tensor, QuantizedTensor):
         input_tensor = input_tensor.dequantize()
 
-    weight_qdata, weight_scale = TensorWiseINT8Layout.get_plain_tensors(weight)
+    weight_qdata, weight_params = _wmma_storage(weight)
+    weight_scale = weight_params.scale
     out_dtype = kwargs.get("out_dtype", input_tensor.dtype)
 
-    convrot = getattr(weight._params, "convrot", False)
-    convrot_groupsize = getattr(weight._params, "convrot_groupsize", 256)
+    convrot = getattr(weight_params, "convrot", False)
+    convrot_groupsize = getattr(weight_params, "convrot_groupsize", 256)
 
     if getattr(weight._params, "transposed", False):
         # Common decomposition: linear(x, W) -> mm(x, W.t()). Storage is still
@@ -816,7 +832,8 @@ def _handle_int8_addmm_tensorwise(qt, args, kwargs):
     if isinstance(input_tensor, QuantizedTensor):
         input_tensor = input_tensor.dequantize()
 
-    weight_qdata, weight_scale = TensorWiseINT8Layout.get_plain_tensors(weight)
+    weight_qdata, weight_params = _wmma_storage(weight)
+    weight_scale = weight_params.scale
     out_dtype = kwargs.get("out_dtype", input_tensor.dtype)
 
     convrot = getattr(weight._params, "convrot", False)

--- a/comfy_kitchen/tensor/int8.py
+++ b/comfy_kitchen/tensor/int8.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import dataclasses
 import logging
+import threading
 from dataclasses import dataclass
 
 import torch
@@ -26,6 +27,8 @@ from .base import (
 
 logger = logging.getLogger(__name__)
 
+_WMMA_WEIGHT_PACK_LOCK = threading.RLock()
+
 _INT8_DEQUANT_DTYPE_TO_CODE = {
     torch.float32: 0,
     torch.float16: 1,
@@ -34,13 +37,18 @@ _INT8_DEQUANT_DTYPE_TO_CODE = {
 
 
 def _dtype_code(dtype: torch.dtype) -> int:
-    if dtype == torch.float32:
-        return 0
-    if dtype == torch.float16:
-        return 1
-    if dtype == torch.bfloat16:
-        return 2
-    raise ValueError(f"Unsupported INT8 output dtype: {dtype}")
+    try:
+        return _INT8_DEQUANT_DTYPE_TO_CODE[dtype]
+    except KeyError:
+        raise ValueError(f"Unsupported INT8 output dtype: {dtype}") from None
+
+
+def _uses_nonduplicated_wmma(device: torch.device) -> bool:
+    try:
+        arch = torch.cuda.get_device_properties(device).gcnArchName.split(":")[0]
+    except (AttributeError, RuntimeError):
+        return False
+    return arch.startswith("gfx12")
 
 
 class TensorWiseINT8Layout(QuantizedLayout):
@@ -75,12 +83,178 @@ class TensorWiseINT8Layout(QuantizedLayout):
         convrot: bool = False
         convrot_groupsize: int = 256
         transposed: bool = False
+        # Runtime-only physical storage layout. Zero means checkpoint-compatible
+        # row-major [N, K]. Nonzero values mean qdata is packed as
+        # [N / tile_n, K / tile_k, tile_n, tile_k] and then flattened back to
+        # the original 2-D storage shape. Serialization always unpacks it.
+        wmma_tile_n: int = 0
+        wmma_tile_k: int = 0
 
         def _tensor_fields(self) -> list[str]:
             return ["scale"]
 
         def _validate_tensor_fields(self):
-            pass
+            if (self.wmma_tile_n == 0) != (self.wmma_tile_k == 0):
+                raise ValueError(
+                    "wmma_tile_n and wmma_tile_k must both be zero or nonzero"
+                )
+
+    @staticmethod
+    def _unpack_wmma_weight(qdata: torch.Tensor, params: Params) -> torch.Tensor:
+        """Return a row-major view/copy of runtime-tiled weight storage."""
+        tile_n = getattr(params, "wmma_tile_n", 0)
+        tile_k = getattr(params, "wmma_tile_k", 0)
+        if tile_n == 0:
+            return qdata
+        if len(params.orig_shape) != 2 or getattr(params, "transposed", False):
+            raise ValueError("WMMA-tiled INT8 storage requires a non-transposed 2-D weight")
+        n, k = params.orig_shape
+        if n % tile_n or k % tile_k or qdata.numel() != n * k:
+            raise ValueError(
+                f"Invalid WMMA-tiled INT8 storage: shape={params.orig_shape}, "
+                f"tile=({tile_n}, {tile_k}), numel={qdata.numel()}"
+            )
+        return (
+            qdata.reshape(n // tile_n, k // tile_k, tile_n, tile_k)
+            .permute(0, 2, 1, 3)
+            .contiguous()
+            .reshape(n, k)
+        )
+
+    @classmethod
+    def pack_wmma_weight_(
+        cls, qtensor: QuantizedTensor, tile_k: int, tile_n: int = 128
+    ) -> QuantizedTensor:
+        """Pack one weight in place for static-tile GEMM loaders.
+
+        The wrapper and logical shape remain unchanged. Only its private INT8
+        storage is replaced, so the old row-major allocation can be released
+        rather than retaining a second multi-gigabyte model copy.
+        """
+        if not isinstance(qtensor, QuantizedTensor) or qtensor._layout_cls != cls.__name__:
+            raise TypeError("pack_wmma_weight_ requires a TensorWiseINT8Layout tensor")
+        params = qtensor._params
+        if not getattr(params, "is_weight", True):
+            raise ValueError("Only INT8 weights can use WMMA-tiled storage")
+        if getattr(params, "transposed", False) or len(params.orig_shape) != 2:
+            raise ValueError("WMMA-tiled storage requires a non-transposed 2-D weight")
+        n, k = params.orig_shape
+        if tile_n <= 0 or tile_k <= 0 or n % tile_n or k % tile_k:
+            raise ValueError(
+                f"Weight shape {(n, k)} is not divisible by tile {(tile_n, tile_k)}"
+            )
+        with _WMMA_WEIGHT_PACK_LOCK:
+            # Another inference thread may have packed this wrapper while the
+            # caller was checking eligibility.
+            params = qtensor._params
+            old_tile_n = getattr(params, "wmma_tile_n", 0)
+            old_tile_k = getattr(params, "wmma_tile_k", 0)
+            if (old_tile_n, old_tile_k) == (tile_n, tile_k):
+                return qtensor
+            row_major = cls._unpack_wmma_weight(qtensor._qdata, params)
+            packed = (
+                row_major.reshape(n // tile_n, tile_n, k // tile_k, tile_k)
+                .permute(0, 2, 1, 3)
+                .contiguous()
+                .reshape_as(qtensor._qdata)
+            )
+            # Publish the new layout only after its asynchronous device copy is
+            # complete. This makes first-use packing safe across inference
+            # threads and streams; subsequent calls do not synchronize.
+            if packed.device.type == "cuda":
+                ready = torch.cuda.Event()
+                ready.record(torch.cuda.current_stream(packed.device))
+                ready.synchronize()
+            if qtensor._qdata.untyped_storage().resizable():
+                qtensor._qdata = packed
+            else:
+                qtensor._qdata.copy_(packed)
+            qtensor._params = dataclasses.replace(
+                params, wmma_tile_n=tile_n, wmma_tile_k=tile_k
+            )
+        return qtensor
+
+    @classmethod
+    def prepare_wmma_weight_(
+        cls, qtensor: QuantizedTensor, input_tensor: torch.Tensor
+    ) -> int:
+        """Lazily select a measured tile layout for one inference weight.
+
+        The policy is deliberately dimensional. Wide, square, and very
+        deep-K projections use a 64-byte K tile; moderately deep-K
+        projections use a 128-byte tile. The native storage contract is
+        architecture-neutral; automatic selection requires the
+        non-duplicated gfx12 WMMA operand layout.
+
+        Returns the physical K tile, or zero when row-major storage is kept.
+        """
+        if not isinstance(qtensor, QuantizedTensor) or qtensor._layout_cls != cls.__name__:
+            return 0
+        params = qtensor._params
+        existing = getattr(params, "wmma_tile_k", 0)
+        if existing:
+            return existing
+        if getattr(params, "transposed", False) or not getattr(params, "is_weight", True):
+            return 0
+        if input_tensor.dtype != torch.bfloat16 or input_tensor.device.type != "cuda":
+            return 0
+        if input_tensor.requires_grad or torch.is_grad_enabled():
+            return 0
+        try:
+            if torch.compiler.is_compiling() or torch.cuda.is_current_stream_capturing():
+                return 0
+        except (AttributeError, RuntimeError):
+            return 0
+        if (not _uses_nonduplicated_wmma(input_tensor.device)
+                or qtensor._qdata.device != input_tensor.device):
+            return 0
+        if len(params.orig_shape) != 2 or input_tensor.ndim == 0:
+            return 0
+        n, k = params.orig_shape
+        if input_tensor.shape[-1] != k:
+            return 0
+        m = input_tensor.numel() // k
+        # Compound QKV and FFN operations consume row-major weights.
+        if (n, k) in ((11520, 3840), (3840, 10240), (10240, 3840)):
+            return 0
+        if m < 512 or n % 128 or k % 256:
+            return 0
+        tile_k = (
+            128
+            if (n, k) == (3840, 3840) or n < k < 4 * n
+            else 64
+        )
+        cls.pack_wmma_weight_(qtensor, tile_k=tile_k, tile_n=128)
+        return tile_k
+
+    @classmethod
+    def wmma_weight_is_supported(
+        cls, qtensor: QuantizedTensor, input_tensor: torch.Tensor
+    ) -> bool:
+        """Whether this call can consume an already tiled physical weight."""
+        if not isinstance(qtensor, QuantizedTensor) or qtensor._layout_cls != cls.__name__:
+            return False
+        params = qtensor._params
+        tile_n = getattr(params, "wmma_tile_n", 0)
+        tile_k = getattr(params, "wmma_tile_k", 0)
+        if tile_n != 128 or tile_k not in (64, 128):
+            return False
+        if input_tensor.dtype != torch.bfloat16 or input_tensor.device.type != "cuda":
+            return False
+        if qtensor._qdata.device != input_tensor.device or input_tensor.ndim == 0:
+            return False
+        if (not _uses_nonduplicated_wmma(input_tensor.device)
+                or len(params.orig_shape) != 2):
+            return False
+        n, k = params.orig_shape
+        m = input_tensor.numel() // input_tensor.shape[-1]
+        return (
+            input_tensor.shape[-1] == k
+            and (n, k) not in ((11520, 3840), (3840, 10240), (10240, 3840))
+            and m >= 96
+            and n % tile_n == 0
+            and k % tile_k == 0
+        )
 
     @classmethod
     def quantize(
@@ -167,6 +341,7 @@ class TensorWiseINT8Layout(QuantizedLayout):
         Returns:
             Dequantized tensor.
         """
+        qdata = cls._unpack_wmma_weight(qdata, params)
         output_dtype_code = _INT8_DEQUANT_DTYPE_TO_CODE.get(params.orig_dtype, 0)
         if getattr(params, "convrot", False):
             result = torch.ops.comfy_kitchen.dequantize_int8_convrot_weight_dtype(
@@ -183,6 +358,7 @@ class TensorWiseINT8Layout(QuantizedLayout):
         Embedding counterpart of ``dequantize``, which would materialize the whole ``[vocab, dim]``
         table to read a few rows. Un-rotates if ``params.convrot``. Returns ``[*indices.shape, dim]``.
         """
+        qdata = cls._unpack_wmma_weight(qdata, params)
         output_dtype_code = _INT8_DEQUANT_DTYPE_TO_CODE.get(params.orig_dtype, 0)
         group_size = params.convrot_groupsize if getattr(params, "convrot", False) else 0
         result = torch.ops.comfy_kitchen.dequantize_int8_embedding(
@@ -203,6 +379,270 @@ class TensorWiseINT8Layout(QuantizedLayout):
         return qtensor._qdata, qtensor._params.scale
 
     @classmethod
+    def _fusion_operand(
+        cls,
+        weight: QuantizedTensor,
+        x: torch.Tensor,
+        *,
+        prepare: bool = False,
+    ):
+        """Resolve private storage needed by compound INT8 operations."""
+        if not isinstance(weight, QuantizedTensor) or weight._layout_cls != cls.__name__:
+            return None
+        params = weight._params
+        if getattr(params, "transposed", False):
+            return None
+        if prepare:
+            cls.prepare_wmma_weight_(weight, x)
+            params = weight._params
+        tile_k = int(getattr(params, "wmma_tile_k", 0))
+        if tile_k and not cls.wmma_weight_is_supported(weight, x):
+            return None
+        qdata, scale = cls.get_plain_tensors(weight)
+        return (
+            qdata.contiguous(),
+            scale,
+            bool(getattr(params, "convrot", False)),
+            int(getattr(params, "convrot_groupsize", 256)),
+            tile_k,
+            weight,
+        )
+
+
+    @classmethod
+    def _fusion_operands(cls, weights, x: torch.Tensor):
+        """Resolve a compatible group of projections or return ``None``."""
+        operands = tuple(
+            cls._fusion_operand(weight, x, prepare=True) for weight in weights
+        )
+        if any(operand is None for operand in operands):
+            return None
+        qdata, _, convrot, group_size, tile_k, _ = operands[0]
+        if any(
+            operand[2:5] != (convrot, group_size, tile_k)
+            or operand[0].shape != qdata.shape
+            for operand in operands[1:]
+        ):
+            return None
+        return operands
+
+    @classmethod
+    def is_fusion_weight(cls, weight: torch.Tensor) -> bool:
+        """Whether ``weight`` has the logical layout compound ops require."""
+        return (
+            isinstance(weight, QuantizedTensor)
+            and weight._layout_cls == cls.__name__
+            and not getattr(weight._params, "transposed", False)
+        )
+
+    @classmethod
+    def fused_linear(
+        cls,
+        x: torch.Tensor,
+        weight: QuantizedTensor,
+        bias: torch.Tensor | None,
+        *,
+        input_act: str | None = None,
+        residual: torch.Tensor | None = None,
+        gate: torch.Tensor | None = None,
+    ):
+        """Run a compound linear when this layout can preserve its contract."""
+        operand = cls._fusion_operand(weight, x, prepare=True)
+        if operand is None:
+            return NotImplemented
+        qdata, scale, convrot, group_size, tile_k, packed_weight = operand
+        source = x
+        if input_act == "gelu_tanh":
+            source = torch.nn.functional.gelu(x, approximate="tanh")
+        elif input_act == "swiglu":
+            gate_source, up_source = x.chunk(2, dim=-1)
+            source = torch.nn.functional.silu(gate_source).mul_(up_source)
+        elif input_act is not None:
+            return NotImplemented
+
+        if tile_k:
+            if residual is None:
+                return torch.nn.functional.linear(source, packed_weight, bias)
+            if gate is None:
+                return NotImplemented
+            from comfy_kitchen import int8_linear_gated_residual
+
+            rows = source.numel() // source.shape[-1]
+            return int8_linear_gated_residual(
+                source, qdata, scale, residual, gate, bias, x.dtype,
+                convrot=convrot, convrot_groupsize=group_size,
+                weight_tile_k=tile_k, dual_m=rows >= 96,
+            )
+
+        from comfy_kitchen import int8_linear
+
+        output = int8_linear(
+            x, qdata, scale, bias, x.dtype, convrot=convrot,
+            convrot_groupsize=group_size, input_act=input_act,
+        )
+        if residual is not None:
+            if gate is None:
+                return NotImplemented
+            output = torch.addcmul(residual, gate, output)
+        return output
+
+    @classmethod
+    def fused_pair(
+        cls,
+        x: torch.Tensor,
+        weight0: QuantizedTensor,
+        weight1: QuantizedTensor,
+        bias0: torch.Tensor | None,
+        bias1: torch.Tensor | None,
+        *,
+        modulation_scale: torch.Tensor | None = None,
+        modulation_shift: torch.Tensor | None = None,
+    ):
+        operands = cls._fusion_operands((weight0, weight1), x)
+        if operands is None:
+            return NotImplemented
+        first, second = operands
+        qdata0, scale0, convrot, group_size, tile_k, _ = first
+        qdata1, scale1, _, _, _, _ = second
+        if modulation_scale is None:
+            from comfy_kitchen import int8_linear_pair
+
+            return int8_linear_pair(
+                x, qdata0, qdata1, scale0, scale1, bias0, bias1, x.dtype,
+                convrot=convrot, convrot_groupsize=group_size,
+                weight_tile_k=tile_k,
+            )
+        if modulation_shift is None:
+            return NotImplemented
+        from comfy_kitchen import int8_linear_pair_modulated
+
+        return int8_linear_pair_modulated(
+            x, modulation_scale, qdata0, qdata1, scale0, scale1,
+            bias0, bias1, x.dtype, convrot=convrot,
+            convrot_groupsize=group_size,
+            modulation_shift=modulation_shift, weight_tile_k=tile_k,
+        )
+
+    @classmethod
+    def fused_affine(
+        cls,
+        x: torch.Tensor,
+        weight: QuantizedTensor,
+        bias: torch.Tensor | None,
+        modulation_scale: torch.Tensor,
+        modulation_shift: torch.Tensor,
+    ):
+        operand = cls._fusion_operand(weight, x, prepare=True)
+        if operand is None:
+            return NotImplemented
+        qdata, scale, convrot, group_size, tile_k, _ = operand
+        from comfy_kitchen import int8_linear_modulated
+
+        return int8_linear_modulated(
+            x, modulation_scale, qdata, scale, bias, x.dtype,
+            convrot=convrot, convrot_groupsize=group_size,
+            modulation_shift=modulation_shift, weight_tile_k=tile_k,
+        )
+
+    @classmethod
+    def fused_triple_modulated(
+        cls,
+        x: torch.Tensor,
+        weights: tuple[QuantizedTensor, QuantizedTensor, QuantizedTensor],
+        biases: tuple[torch.Tensor | None, torch.Tensor | None, torch.Tensor | None],
+        modulation_scale: torch.Tensor,
+        modulation_shift: torch.Tensor,
+    ):
+        operands = cls._fusion_operands(weights, x)
+        if operands is None:
+            return NotImplemented
+        qdata0, scale0, convrot, group_size, tile_k, _ = operands[0]
+        from comfy_kitchen import int8_linear_triple_modulated
+
+        return int8_linear_triple_modulated(
+            x, modulation_scale,
+            qdata0, operands[1][0], operands[2][0],
+            scale0, operands[1][1], operands[2][1],
+            *biases, x.dtype, convrot=convrot,
+            convrot_groupsize=group_size,
+            modulation_shift=modulation_shift, weight_tile_k=tile_k,
+        )
+
+    @classmethod
+    def fused_rms_modulated(
+        cls,
+        x: torch.Tensor,
+        weight: QuantizedTensor,
+        bias: torch.Tensor | None,
+        norm_weight: torch.Tensor,
+        norm_eps: float,
+        modulation_scale: torch.Tensor,
+    ):
+        operand = cls._fusion_operand(weight, x, prepare=True)
+        if operand is None:
+            return NotImplemented
+        qdata, scale, convrot, group_size, tile_k, _ = operand
+        from comfy_kitchen import int8_linear_rms_modulated
+
+        return int8_linear_rms_modulated(
+            x, norm_weight, norm_eps, modulation_scale, qdata, scale,
+            bias, x.dtype, convrot=convrot,
+            convrot_groupsize=group_size, weight_tiled_b=bool(tile_k),
+        )
+
+    @classmethod
+    def fused_swiglu_ffn(
+        cls,
+        x: torch.Tensor,
+        gate_weight: QuantizedTensor,
+        up_weight: QuantizedTensor,
+        down_weight: QuantizedTensor,
+        gate_bias: torch.Tensor | None,
+        up_bias: torch.Tensor | None,
+        down_bias: torch.Tensor | None,
+        *,
+        norm_weight: torch.Tensor | None = None,
+        norm_eps: float = 0.0,
+        modulation_scale: torch.Tensor | None = None,
+    ):
+        pair = cls._fusion_operands((gate_weight, up_weight), x)
+        if pair is None:
+            return NotImplemented
+        first, second = pair
+        qgate, gate_scale, convrot, group_size, tile_k, _ = first
+        qup, up_scale, _, _, _, _ = second
+        if norm_weight is None:
+            from comfy_kitchen import int8_linear_pair
+
+            gate, up = int8_linear_pair(
+                x, qgate, qup, gate_scale, up_scale, gate_bias, up_bias,
+                x.dtype, convrot=convrot, convrot_groupsize=group_size,
+                weight_tile_k=tile_k,
+            )
+        else:
+            if modulation_scale is None or tile_k:
+                return NotImplemented
+            from comfy_kitchen import int8_linear_pair_rms_modulated
+
+            gate, up = int8_linear_pair_rms_modulated(
+                x, norm_weight, norm_eps, modulation_scale,
+                qgate, qup, gate_scale, up_scale, gate_bias, up_bias,
+                x.dtype, convrot=convrot, convrot_groupsize=group_size,
+            )
+
+        down = cls._fusion_operand(down_weight, gate, prepare=True)
+        if down is None:
+            return NotImplemented
+        qdown, down_scale, down_convrot, down_group, down_tile_k, _ = down
+        from comfy_kitchen import int8_linear_swiglu_split
+
+        return int8_linear_swiglu_split(
+            gate, up, qdown, down_scale, down_bias, gate.dtype,
+            convrot=down_convrot, convrot_groupsize=down_group,
+            weight_tiled_b=bool(down_tile_k), weight_tile_k=down_tile_k,
+        )
+
+    @classmethod
     def state_dict_tensors(cls, qdata: torch.Tensor, params: Params) -> dict[str, torch.Tensor]:
         """Return key suffix → tensor mapping for serialization.
 
@@ -214,7 +654,7 @@ class TensorWiseINT8Layout(QuantizedLayout):
             Dictionary mapping suffix to tensor.
         """
         return {
-            "": qdata,
+            "": cls._unpack_wmma_weight(qdata, params),
             "_scale": params.scale,
         }
 
@@ -252,6 +692,9 @@ def _handle_int8_transpose(qt, args, kwargs):
     if not isinstance(input_tensor, QuantizedTensor):
         return torch.ops.aten.t.default(*args, **kwargs)
 
+    if getattr(input_tensor._params, "wmma_tile_n", 0):
+        return input_tensor.dequantize().t()
+
     old = input_tensor._params
     new_params = dataclasses.replace(
         old,
@@ -278,21 +721,34 @@ def _handle_int8_linear_tensorwise(qt, args, kwargs):
     if isinstance(input_tensor, QuantizedTensor):
         input_tensor = input_tensor.dequantize()
 
+    TensorWiseINT8Layout.prepare_wmma_weight_(weight, input_tensor)
+    tile_n = getattr(weight._params, "wmma_tile_n", 0)
+    tile_k = getattr(weight._params, "wmma_tile_k", 0)
+    m = input_tensor.numel() // input_tensor.shape[-1]
+    tiled_supported = TensorWiseINT8Layout.wmma_weight_is_supported(
+        weight, input_tensor
+    )
+    if tile_n and not tiled_supported:
+        return torch.nn.functional.linear(*dequantize_args(args), **dequantize_args(kwargs))
+
     weight_qdata, weight_scale = TensorWiseINT8Layout.get_plain_tensors(weight)
     out_dtype = kwargs.get("out_dtype", input_tensor.dtype)
 
     convrot = getattr(weight._params, "convrot", False)
     convrot_groupsize = getattr(weight._params, "convrot_groupsize", 256)
 
-    return torch.ops.comfy_kitchen.int8_linear(
-        input_tensor.contiguous(),
-        weight_qdata.contiguous(),
-        weight_scale,
-        bias,
-        _dtype_code(out_dtype),
-        convrot,
-        convrot_groupsize,
+    op = (
+        torch.ops.comfy_kitchen.int8_linear_tiled_b
+        if tiled_supported
+        else torch.ops.comfy_kitchen.int8_linear
     )
+    op_args = [
+        input_tensor.contiguous(), weight_qdata.contiguous(), weight_scale,
+        bias, _dtype_code(out_dtype), convrot, convrot_groupsize,
+    ]
+    if tiled_supported:
+        op_args.extend((tile_k, m >= 96))
+    return op(*op_args)
 
 
 @register_layout_op(torch.ops.aten.mm.default, TensorWiseINT8Layout)
@@ -303,6 +759,8 @@ def _handle_int8_mm_tensorwise(qt, args, kwargs):
 
     # Usually mm is called with weight as the second argument
     if not isinstance(weight, QuantizedTensor) or weight._layout_cls != "TensorWiseINT8Layout":
+        return torch.mm(*dequantize_args(args), **dequantize_args(kwargs))
+    if getattr(weight._params, "wmma_tile_n", 0):
         return torch.mm(*dequantize_args(args), **dequantize_args(kwargs))
 
     if isinstance(input_tensor, QuantizedTensor):
@@ -346,6 +804,8 @@ def _handle_int8_addmm_tensorwise(qt, args, kwargs):
     weight = args[2]
 
     if not isinstance(weight, QuantizedTensor) or weight._layout_cls != "TensorWiseINT8Layout":
+        return torch.addmm(*dequantize_args(args), **dequantize_args(kwargs))
+    if getattr(weight._params, "wmma_tile_n", 0):
         return torch.addmm(*dequantize_args(args), **dequantize_args(kwargs))
 
     if isinstance(input_tensor, QuantizedTensor):

--- a/setup.py
+++ b/setup.py
@@ -310,7 +310,11 @@ def get_cuda_path() -> tuple[pathlib.Path, pathlib.Path] | None:
 # Keep build-time, CMake, and runtime architecture policy in one package resource.
 # Exact membership is intentional: accepting an unreviewed gfx11xx/gfx12xx target
 # can compile the no-WMMA trap stubs into an otherwise successful wheel.
-HIP_ARCH_GROUP_NAMES = ("elementwise_only", "wmma_gfx11", "wmma_gfx12")
+HIP_ARCH_GROUP_NAMES = (
+    "elementwise_only",
+    "wmma_gfx11",
+    "wmma_gfx12",
+)
 HIP_ARCH_MANIFEST_PATH = (
     pathlib.Path(__file__).resolve().parent
     / "comfy_kitchen"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,6 +41,8 @@ requires_cuda_backend = pytest.mark.skipif(
 def skip_unless_gfx12_wmma() -> None:
     if not getattr(torch.version, "hip", None):
         pytest.skip("requires HIP")
+    if not ck.list_backends().get("hip", {}).get("available", False):
+        pytest.skip("compiled HIP backend required")
     from comfy_kitchen.backends import hip
 
     if not hip._has_nonduplicated_wmma():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,6 +38,15 @@ requires_cuda_backend = pytest.mark.skipif(
 )
 
 
+def skip_unless_gfx12_wmma() -> None:
+    if not getattr(torch.version, "hip", None):
+        pytest.skip("requires HIP")
+    from comfy_kitchen.backends import hip
+
+    if not hip._has_nonduplicated_wmma():
+        pytest.skip("requires gfx12-class WMMA (gfx120x)")
+
+
 @pytest.fixture(scope="session")
 def cuda_available():
     return torch.cuda.is_available()

--- a/tests/test_hip_dispatch.py
+++ b/tests/test_hip_dispatch.py
@@ -39,7 +39,7 @@ def _manifest_archs() -> list[str]:
 
 
 @pytest.mark.parametrize("value", [False, True])
-def test_hip_attention_scale_rejects_boolean_tensor(value):
+def test_hip_int8_attention_scale_rejects_boolean_tensor(value):
     q = torch.empty(1, 1, 1, 128)
     with pytest.raises(TypeError, match="scale"):
         hip_backend.hip_int8_attention(q, None, None, torch.tensor(value))

--- a/tests/test_hip_dispatch.py
+++ b/tests/test_hip_dispatch.py
@@ -22,7 +22,11 @@ _ROOT = pathlib.Path(__file__).resolve().parents[1]
 _HIP_DIR = _ROOT / "comfy_kitchen" / "backends" / "hip"
 _HIP_CMAKE = _HIP_DIR / "CMakeLists.txt"
 _HIP_ARCH_MANIFEST = _HIP_DIR / "architectures.json"
-_HIP_ARCH_GROUP_NAMES = ("elementwise_only", "wmma_gfx11", "wmma_gfx12")
+_HIP_ARCH_GROUP_NAMES = (
+    "elementwise_only",
+    "wmma_gfx11",
+    "wmma_gfx12",
+)
 
 
 def _architecture_groups() -> dict[str, list[str]]:
@@ -273,6 +277,8 @@ def test_architecture_manifest_is_unique_and_shared_by_setup_and_runtime():
     assert set(groups["elementwise_only"]) == hip_backend._ARCH_ELEMENTWISE_ONLY
     assert set(groups["wmma_gfx11"]) == hip_backend._ARCH_WMMA_GFX11
     assert set(groups["wmma_gfx12"]) == hip_backend._ARCH_WMMA_GFX12
+    assert "gfx1200" in groups["wmma_gfx12"]
+    assert "gfx1201" in groups["wmma_gfx12"]
     assert set(manifest_archs) == hip_backend._ARCH_SUPPORTED
 
 
@@ -294,6 +300,19 @@ def test_cmake_reads_and_validates_the_shared_architecture_manifest():
     assert "configure_file(" in text
     assert not re.search(r'"gfx\d', text)
 
+    read_groups = re.findall(r"_ck_read_arch_group\(\w+ (\w+)\)", text)
+    assert tuple(read_groups) == _HIP_ARCH_GROUP_NAMES
+
+
+def test_cmake_uses_only_gfx12_group_for_gfx12_wmma_policy():
+    text = _HIP_CMAKE.read_text(encoding="utf-8")
+
+    gfx12_condition = re.search(
+        r"_ck_make_arch_condition\(COMFY_HIP_GFX12_CONDITION(.*?)\)", text, re.DOTALL
+    )
+    assert gfx12_condition is not None
+    assert "COMFY_HIP_WMMA_GFX12_ARCHS" in gfx12_condition.group(1)
+
 
 def test_mma_architecture_macros_are_generated_from_the_manifest():
     mma = (_HIP_DIR / "mma.h").read_text(encoding="utf-8")
@@ -312,7 +331,11 @@ def test_sdist_rules_include_every_hip_build_input():
     assert "include comfy_kitchen/backends/hip/CMakeLists.txt" in manifest
     assert "recursive-include comfy_kitchen/backends/hip *.cpp *.h *.hip *.in *.json" in manifest
     assert "include-package-data = false" in pyproject
-    assert '"comfy_kitchen.backends.hip" = ["architectures.json"]' in pyproject
+    assert (
+        '"comfy_kitchen.backends.hip" = '
+        '["architectures.json"]'
+        in pyproject
+    )
 
 
 def test_hip_kernels_are_independent_of_the_python_extension_target():

--- a/tests/test_hip_dispatch.py
+++ b/tests/test_hip_dispatch.py
@@ -38,6 +38,13 @@ def _manifest_archs() -> list[str]:
     return [arch for group_name in _HIP_ARCH_GROUP_NAMES for arch in groups[group_name]]
 
 
+@pytest.mark.parametrize("value", [False, True])
+def test_hip_attention_scale_rejects_boolean_tensor(value):
+    q = torch.empty(1, 1, 1, 128)
+    with pytest.raises(TypeError, match="scale"):
+        hip_backend.hip_int8_attention(q, None, None, torch.tensor(value))
+
+
 def test_non_rocm_runtime_does_not_import_hip_backend():
     """A combined wheel must not load the ROCm runtime in CUDA/CPU processes."""
     if getattr(torch.version, "hip", None):

--- a/tests/test_hip_wmma.py
+++ b/tests/test_hip_wmma.py
@@ -673,6 +673,25 @@ def test_int8_tiled_b_gated_residual_is_exact(
     assert torch.equal(candidate, reference)
 
 
+@pytest.mark.parametrize("gate_shape", [(128, 1), (2, 64)])
+def test_int8_linear_gated_residual_rejects_same_numel_non_channel_gate(
+    hip, gate_shape
+):
+    """Flattening a same-numel gate must not change its broadcast axis."""
+    torch.manual_seed(211)
+    m, n, k = 128, 128, 256
+    x = torch.randn(m, k, device=DEV, dtype=torch.bfloat16)
+    weight = torch.randint(-127, 128, (n, k), device=DEV, dtype=torch.int8)
+    weight_scale = torch.rand(n, device=DEV, dtype=torch.float32) + 0.25
+    residual = torch.randn(m, n, device=DEV, dtype=torch.bfloat16)
+    gate = torch.randn(gate_shape, device=DEV, dtype=torch.bfloat16)
+
+    with pytest.raises(ValueError, match="broadcastable row ending"):
+        hip.int8_linear_gated_residual(
+            x, weight, weight_scale, residual, gate
+        )
+
+
 def _offset_copy(t: torch.Tensor) -> torch.Tensor:
     """A contiguous copy of ``t`` deliberately based off a 16-byte boundary."""
     flat = t.reshape(-1)
@@ -2711,6 +2730,51 @@ def test_convrot_spill_rotated_must_match_input_dtype(hip):
         )
 
 
+@pytest.mark.parametrize(
+    "operand_name",
+    ["x", "norm_weight", "modulation_scale", "q", "scales"],
+)
+def test_rms_modulated_convrot_binding_rejects_noncontiguous_operand(
+    hip, operand_name
+):
+    """The raw-pointer kernel accepts only the packed layout it indexes."""
+    m, k = 2, 256
+    operands = {
+        "x": torch.empty(m, k, device=DEV, dtype=torch.bfloat16),
+        "norm_weight": torch.empty(k, device=DEV, dtype=torch.bfloat16),
+        "modulation_scale": torch.empty(k, device=DEV, dtype=torch.bfloat16),
+        "q": torch.empty(m, k, device=DEV, dtype=torch.int8),
+        "scales": torch.empty(m, device=DEV, dtype=torch.float32),
+    }
+    operand = operands[operand_name]
+    if operand.ndim == 1:
+        operand = torch.empty(
+            operand.numel() * 2, device=DEV, dtype=operand.dtype
+        )[::2]
+    else:
+        operand = torch.empty(
+            operand.shape[0], operand.shape[1] * 2,
+            device=DEV, dtype=operand.dtype,
+        )[:, ::2]
+    assert operand.shape == operands[operand_name].shape
+    assert not operand.is_contiguous()
+    operands[operand_name] = operand
+
+    with pytest.raises(RuntimeError, match=f"{operand_name} must be contiguous"):
+        hip._C.quantize_int8_convrot_rms_modulated_fused_stats(
+            hip._dl(operands["x"]),
+            hip._dl(operands["norm_weight"]),
+            hip._dl(operands["modulation_scale"]),
+            hip._dl(operands["q"]),
+            hip._dl(operands["scales"]),
+            m,
+            k,
+            256,
+            1.0e-5,
+            hip._stream(operands["x"]),
+        )
+
+
 @needs_wmma
 def test_convrot_int8_needs_spill_probe(hip):
     in_code = hip.DTYPE_TO_CODE[torch.bfloat16]
@@ -2774,6 +2838,28 @@ def test_convrot_wide_spill_chunks_are_exact(hip, monkeypatch):
 
     assert torch.equal(actual_q, expected_q)
     assert torch.equal(actual_scales, expected_scales)
+
+
+def test_convrot_spill_rebalancing_preserves_workspace_cap(hip, monkeypatch):
+    """A 96-row rebalance cannot merge two capacity-safe chunks into one."""
+    m, k = 96, 256
+    x = torch.empty(m, k, device=DEV, dtype=torch.bfloat16)
+    workspace_per_row = x.element_size() * k + 4 * (k // 256)
+    workspace_bytes = 95 * workspace_per_row
+    launched_rows = []
+
+    monkeypatch.setattr(hip, "_CONVROT_SPILL_WORKSPACE_BYTES", workspace_bytes)
+    monkeypatch.setattr(hip, "_convrot_int8_needs_spill", lambda *_: True)
+    monkeypatch.setattr(
+        hip._C,
+        "quantize_int8_convrot",
+        lambda *args: launched_rows.append(args[5]),
+    )
+
+    hip._rotate_quant_int8(x, 256)
+
+    assert sum(launched_rows) == m
+    assert max(launched_rows) * workspace_per_row <= workspace_bytes
 
 
 def test_convrot_lds_bound_accounts_for_row_dtype(hip):

--- a/tests/test_hip_wmma.py
+++ b/tests/test_hip_wmma.py
@@ -8,7 +8,6 @@ import pytest
 import torch
 
 import comfy_kitchen as ck
-from .conftest import skip_unless_gfx12_wmma
 from comfy_kitchen.backends.eager import w4a8_int8 as eager_w4a8
 from comfy_kitchen.backends.eager.convrot_w4a4 import _unpack_int4_row_major
 from comfy_kitchen.backends.eager.quantization import (
@@ -25,6 +24,8 @@ from comfy_kitchen.tensor import (
     TensorWiseINT8Layout,
 )
 from comfy_kitchen.tensor.int8_utils import _build_hadamard
+
+from .conftest import skip_unless_gfx12_wmma
 
 
 def _unavailable_reason() -> str | None:
@@ -210,7 +211,9 @@ def test_int8_linear_pair_reuses_exact_convrot_quantization():
                 x, weight_q, weight_scale.reshape(-1), bias,
                 torch.bfloat16, convrot=True, convrot_groupsize=256,
             )
-            for (weight_q, weight_scale), bias in zip(quantized, biases)
+            for (weight_q, weight_scale), bias in zip(
+                quantized, biases, strict=True
+            )
         )
         outputs = ck.int8_linear_pair(
             x,

--- a/tests/test_hip_wmma.py
+++ b/tests/test_hip_wmma.py
@@ -224,6 +224,20 @@ def test_int8_linear_pair_reuses_exact_convrot_quantization():
 
 
 @needs_wmma
+def test_gfx12_swiglu_silu_exceptions_match_torch():
+    skip_unless_gfx12_wmma()
+
+    values = torch.tensor(
+        [5.9375, -87.5, -88.0, -88.5],
+        device=DEV,
+        dtype=torch.bfloat16,
+    )
+    result_bits = torch.nn.functional.silu(values).view(torch.uint16).cpu().tolist()
+
+    assert result_bits == [0x40BD, 0x8395, 0x8335, 0x82DD]
+
+
+@needs_wmma
 def test_gfx12_split_swiglu_down_is_exact(hip):
     skip_unless_gfx12_wmma()
 
@@ -1752,6 +1766,26 @@ def test_rms_rope_matches_eager(split_half, freqs_dtype, shape, freqs_shape):
     torch.testing.assert_close(out_k.float(), ref_k.float(), rtol=2e-2, atol=2e-2)
     # The fused and single-tensor entries are the same launch with k dropped.
     assert torch.equal(out_one, out_q)
+
+
+def test_rms_rope_static_bf16_types_matches_eager(hip):
+    torch.manual_seed(1)
+    shape = (2, 8, 128, 128)
+    q = torch.randn(shape, device=DEV, dtype=torch.bfloat16)
+    k = torch.randn(shape, device=DEV, dtype=torch.bfloat16)
+    freqs = torch.randn(
+        (1, 1, 128, 64, 2, 2), device=DEV, dtype=torch.float32
+    )
+    q_scale = torch.randn(128, device=DEV, dtype=torch.bfloat16)
+    k_scale = torch.randn(128, device=DEV, dtype=torch.bfloat16)
+
+    with ck.use_backend("hip"):
+        out_q, out_k = ck.rms_rope(q, k, freqs, q_scale, k_scale)
+    with ck.use_backend("eager"):
+        ref_q, ref_k = ck.rms_rope(q, k, freqs, q_scale, k_scale)
+
+    torch.testing.assert_close(out_q.float(), ref_q.float(), rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(out_k.float(), ref_k.float(), rtol=2e-2, atol=2e-2)
 
 
 def _partial_rotary_reference(x, freqs, scale, epsilon, rot_dim):

--- a/tests/test_hip_wmma.py
+++ b/tests/test_hip_wmma.py
@@ -8,6 +8,7 @@ import pytest
 import torch
 
 import comfy_kitchen as ck
+from .conftest import skip_unless_gfx12_wmma
 from comfy_kitchen.backends.eager import w4a8_int8 as eager_w4a8
 from comfy_kitchen.backends.eager.convrot_w4a4 import _unpack_int4_row_major
 from comfy_kitchen.backends.eager.quantization import (
@@ -18,7 +19,11 @@ from comfy_kitchen.backends.eager.quantization import (
 )
 from comfy_kitchen.constraints import validate_function_call
 from comfy_kitchen.registry import registry
-from comfy_kitchen.tensor import AsymW4A8Int8Layout, QuantizedTensor
+from comfy_kitchen.tensor import (
+    AsymW4A8Int8Layout,
+    QuantizedTensor,
+    TensorWiseINT8Layout,
+)
 from comfy_kitchen.tensor.int8_utils import _build_hadamard
 
 
@@ -65,6 +70,15 @@ def hip():
     from comfy_kitchen.backends import hip as hip_backend
 
     return hip_backend
+
+
+def _tile_b(b: torch.Tensor, tile_k: int) -> torch.Tensor:
+    n, k = b.shape
+    return (
+        b.reshape(n // 128, 128, k // tile_k, tile_k)
+        .permute(0, 2, 1, 3)
+        .contiguous()
+    )
 
 
 # Covers each tile path on 16-48 WGP parts: GEMV (M <= 8), skinny (M or N <= 64),
@@ -173,6 +187,473 @@ def test_int8_linear_convrot_large_k_matches_eager(k):
 
     scale = ref.float().abs().max().item()
     assert (out.float() - ref.float()).abs().max().item() < 0.05 * scale
+
+
+@needs_wmma
+def test_int8_linear_pair_reuses_exact_convrot_quantization():
+    torch.manual_seed(0)
+    m, n, k = 256, 512, 512
+    x = torch.randn(m, k, device=DEV, dtype=torch.bfloat16)
+    weights = [
+        torch.randn(n, k, device=DEV, dtype=torch.bfloat16)
+        for _ in range(2)
+    ]
+    quantized = [ck.quantize_int8_rowwise(weight) for weight in weights]
+    biases = [
+        torch.randn(n, device=DEV, dtype=torch.bfloat16)
+        for _ in range(2)
+    ]
+
+    with ck.use_backend("hip"):
+        refs = tuple(
+            ck.int8_linear(
+                x, weight_q, weight_scale.reshape(-1), bias,
+                torch.bfloat16, convrot=True, convrot_groupsize=256,
+            )
+            for (weight_q, weight_scale), bias in zip(quantized, biases)
+        )
+        outputs = ck.int8_linear_pair(
+            x,
+            quantized[0][0], quantized[1][0],
+            quantized[0][1].reshape(-1), quantized[1][1].reshape(-1),
+            biases[0], biases[1], torch.bfloat16,
+            convrot=True, convrot_groupsize=256,
+        )
+    assert torch.equal(outputs[0], refs[0])
+    assert torch.equal(outputs[1], refs[1])
+
+
+@needs_wmma
+def test_gfx12_split_swiglu_down_is_exact(hip):
+    skip_unless_gfx12_wmma()
+
+    torch.manual_seed(2)
+    m, n, k = 512, 3840, 10240
+    gate = torch.randn(m, k, device=DEV, dtype=torch.bfloat16)
+    up = torch.randn_like(gate)
+    gate[0, :4] = torch.tensor(
+        [5.9375, -87.5, -88.0, -88.5], device=DEV,
+        dtype=torch.bfloat16,
+    )
+    weight = torch.randint(-127, 128, (n, k), device=DEV, dtype=torch.int8)
+    weight_scale = torch.rand(n, device=DEV, dtype=torch.float32) + 0.25
+
+    with ck.use_backend("hip"):
+        reference = ck.int8_linear(
+            torch.nn.functional.silu(gate) * up,
+            weight, weight_scale, None, torch.bfloat16,
+            convrot=True, convrot_groupsize=256,
+        )
+        output = ck.int8_linear_swiglu_split(
+            gate, up, weight, weight_scale, None, torch.bfloat16,
+            convrot=True, convrot_groupsize=256,
+        )
+
+    assert torch.equal(output, reference)
+
+
+@needs_wmma
+def test_gfx12_modulated_qkv_is_exact(hip):
+    skip_unless_gfx12_wmma()
+
+    torch.manual_seed(34)
+    m, n, k = 64, 11520, 3840
+    x = torch.randn((1, m, k), device=DEV, dtype=torch.bfloat16)
+    modulation_scale = (
+        torch.randn((1, k), device=DEV, dtype=torch.bfloat16) * 0.25
+    )
+    weight = torch.randint(-127, 128, (n, k), device=DEV, dtype=torch.int8)
+    weight_scale = torch.rand(n, device=DEV, dtype=torch.float32) + 0.25
+
+    with ck.use_backend("hip"):
+        reference = ck.int8_linear(
+            x * (1.0 + modulation_scale.unsqueeze(1)),
+            weight, weight_scale, None, torch.bfloat16,
+            convrot=True, convrot_groupsize=256,
+        )
+        candidate = ck.int8_linear_modulated(
+            x, modulation_scale, weight, weight_scale, None, torch.bfloat16,
+            convrot=True, convrot_groupsize=256,
+        )
+
+    assert torch.equal(candidate, reference)
+
+
+@needs_wmma
+def test_gfx12_modulated_pair_is_exact(hip):
+    skip_unless_gfx12_wmma()
+
+    torch.manual_seed(35)
+    m, n, k = 256, 10240, 3840
+    x = torch.randn((1, m, k), device=DEV, dtype=torch.bfloat16)
+    modulation_scale = (
+        torch.randn((1, k), device=DEV, dtype=torch.bfloat16) * 0.25
+    )
+    weights = tuple(
+        torch.randint(-127, 128, (n, k), device=DEV, dtype=torch.int8)
+        for _ in range(2)
+    )
+    scales = tuple(
+        torch.rand(n, device=DEV, dtype=torch.float32) + 0.25
+        for _ in range(2)
+    )
+
+    with ck.use_backend("hip"):
+        reference = ck.int8_linear_pair(
+            x * (1.0 + modulation_scale.unsqueeze(1)),
+            weights[0], weights[1], scales[0], scales[1],
+            None, None, torch.bfloat16,
+            convrot=True, convrot_groupsize=256,
+        )
+        candidate = ck.int8_linear_pair_modulated(
+            x, modulation_scale, weights[0], weights[1], scales[0], scales[1],
+            None, None, torch.bfloat16,
+            convrot=True, convrot_groupsize=256,
+        )
+
+    assert torch.equal(candidate[0], reference[0])
+    assert torch.equal(candidate[1], reference[1])
+
+
+@needs_wmma
+@pytest.mark.parametrize("k", [3072])
+def test_affine_modulated_convrot_is_exact(hip, k):
+    """Generic fused shift/scale producer must preserve the materialized path."""
+    torch.manual_seed(201 + k)
+    m, n = 129, 256
+    x = torch.randn((1, m, k), device=DEV, dtype=torch.bfloat16)
+    modulation_scale = (
+        torch.randn((1, k), device=DEV, dtype=torch.bfloat16) * 0.25
+    )
+    modulation_shift = (
+        torch.randn((1, k), device=DEV, dtype=torch.bfloat16) * 0.25
+    )
+    weights = tuple(
+        torch.randint(-127, 128, (n, k), device=DEV, dtype=torch.int8)
+        for _ in range(3)
+    )
+    scales = tuple(
+        torch.rand(n, device=DEV, dtype=torch.float32) + 0.25
+        for _ in range(3)
+    )
+    modulated = torch.addcmul(
+        modulation_shift.unsqueeze(1), x,
+        1.0 + modulation_scale.unsqueeze(1),
+    )
+
+    with ck.use_backend("hip"):
+        reference = ck.int8_linear_pair(
+            modulated, weights[0], weights[1], scales[0], scales[1],
+            None, None, torch.bfloat16,
+            convrot=True, convrot_groupsize=256,
+        )
+        candidate = ck.int8_linear_pair_modulated(
+            x, modulation_scale, weights[0], weights[1], scales[0], scales[1],
+            None, None, torch.bfloat16,
+            convrot=True, convrot_groupsize=256,
+            modulation_shift=modulation_shift,
+        )
+        single = ck.int8_linear_modulated(
+            x, modulation_scale, weights[0], scales[0], None,
+            torch.bfloat16, convrot=True, convrot_groupsize=256,
+            modulation_shift=modulation_shift,
+        )
+        triple = ck.int8_linear_triple_modulated(
+            x, modulation_scale, weights[0], weights[1], weights[2],
+            scales[0], scales[1], scales[2], None, None, None,
+            torch.bfloat16, convrot=True, convrot_groupsize=256,
+            modulation_shift=modulation_shift,
+        )
+        third_reference = ck.int8_linear(
+            modulated, weights[2], scales[2], None, torch.bfloat16,
+            convrot=True, convrot_groupsize=256,
+        )
+
+    assert torch.equal(candidate[0], reference[0])
+    assert torch.equal(candidate[1], reference[1])
+    assert torch.equal(single, reference[0])
+    assert torch.equal(triple[0], reference[0])
+    assert torch.equal(triple[1], reference[1])
+    assert torch.equal(triple[2], third_reference)
+
+
+@needs_wmma
+def test_tensorwise_layout_owns_compound_affine_execution(hip):
+    """Model integrations need no knowledge of packed INT8 storage."""
+    torch.manual_seed(211)
+    m, n, k = 129, 256, 3072
+    x = torch.randn((1, m, k), device=DEV, dtype=torch.bfloat16)
+    modulation_scale = (
+        torch.randn((1, k), device=DEV, dtype=torch.bfloat16) * 0.25
+    )
+    modulation_shift = (
+        torch.randn((1, k), device=DEV, dtype=torch.bfloat16) * 0.25
+    )
+    weights = tuple(
+        QuantizedTensor.from_float(
+            torch.randn(n, k, device=DEV, dtype=torch.bfloat16),
+            "TensorWiseINT8Layout", per_channel=True, convrot=True,
+            convrot_groupsize=256,
+        )
+        for _ in range(3)
+    )
+    biases = tuple(
+        torch.randn(n, device=DEV, dtype=torch.bfloat16) for _ in range(3)
+    )
+    modulated = torch.addcmul(
+        modulation_shift.unsqueeze(1), x,
+        1.0 + modulation_scale.unsqueeze(1),
+    )
+
+    with torch.inference_mode(), ck.use_backend("hip"):
+        reference = tuple(
+            torch.nn.functional.linear(modulated, weight, bias)
+            for weight, bias in zip(weights, biases, strict=True)
+        )
+        triple = TensorWiseINT8Layout.fused_triple_modulated(
+            x, weights, biases, modulation_scale, modulation_shift,
+        )
+        pair = TensorWiseINT8Layout.fused_pair(
+            x, weights[0], weights[1], biases[0], biases[1],
+            modulation_scale=modulation_scale,
+            modulation_shift=modulation_shift,
+        )
+        single = TensorWiseINT8Layout.fused_affine(
+            x, weights[2], biases[2], modulation_scale, modulation_shift,
+        )
+
+    assert triple is not NotImplemented
+    assert pair is not NotImplemented
+    assert single is not NotImplemented
+    assert all(
+        torch.equal(candidate, expected)
+        for candidate, expected in zip(triple, reference, strict=True)
+    )
+    assert torch.equal(pair[0], reference[0])
+    assert torch.equal(pair[1], reference[1])
+    assert torch.equal(single, reference[2])
+
+
+@pytest.mark.parametrize(
+    ("rows", "width"),
+    [(160, 3840), (4096, 3840), (97, 3072)],
+)
+def test_rms_gated_residual_is_exact(hip, rows, width):
+    torch.manual_seed(8404 + rows + width)
+    activation = torch.randn(
+        (1, rows, width), device=DEV, dtype=torch.bfloat16)
+    residual = torch.randn_like(activation)
+    norm_weight = torch.randn(width, device=DEV, dtype=torch.bfloat16)
+    gate = torch.tanh(torch.randn(
+        (1, 1, width), device=DEV, dtype=torch.bfloat16))
+    eps = 1.0e-5
+    reference = residual + gate * torch.nn.functional.rms_norm(
+        activation, (width,), norm_weight, eps)
+
+    with ck.use_backend("hip"):
+        candidate = ck.rms_gated_residual(
+            activation, norm_weight, residual, gate, eps)
+
+    assert torch.equal(candidate, reference)
+
+
+@needs_wmma
+def test_gfx12_int8_linear_pair_shared_a_is_exact(hip):
+    skip_unless_gfx12_wmma()
+
+    torch.manual_seed(1)
+    m, n, k = 256, 10240, 3840
+    x = torch.randn(m, k, device=DEV, dtype=torch.bfloat16)
+    weights = tuple(
+        torch.randint(-127, 128, (n, k), device=DEV, dtype=torch.int8)
+        for _ in range(2)
+    )
+    scales = tuple(
+        torch.rand(n, device=DEV, dtype=torch.float32) + 0.25
+        for _ in range(2)
+    )
+    biases = (
+        torch.randn(n, device=DEV, dtype=torch.bfloat16),
+        torch.randn(n, device=DEV, dtype=torch.bfloat16),
+    )
+
+    control = tuple(
+        hip.int8_linear(
+            x, weight, scale, bias, torch.bfloat16,
+        )
+        for weight, scale, bias in zip(weights, scales, biases, strict=True)
+    )
+    candidate = hip.int8_linear_pair(
+        x, weights[0], weights[1], scales[0], scales[1],
+        biases[0], biases[1], torch.bfloat16,
+    )
+
+    assert torch.equal(candidate[0], control[0])
+    assert torch.equal(candidate[1], control[1])
+
+
+@pytest.mark.parametrize(("m", "n"), [(160, 3840), (512, 3840), (512, 11520)])
+@needs_wmma
+def test_gfx12_int8_dual_m_shared_b_is_exact(hip, m, n):
+    skip_unless_gfx12_wmma()
+
+    torch.manual_seed(2)
+    k = 3840
+    a = torch.randint(-127, 128, (m, k), device=DEV, dtype=torch.int8)
+    b = torch.randint(-127, 128, (n, k), device=DEV, dtype=torch.int8)
+    scale_a = torch.rand(m, device=DEV, dtype=torch.float32) + 0.25
+    scale_b = torch.rand(n, device=DEV, dtype=torch.float32) + 0.25
+    candidate = torch.empty((m, n), device=DEV, dtype=torch.bfloat16)
+    stream = hip._stream(a)
+    hip._C.int8_gemm(
+        hip._dl(a), hip._dl(b), hip._dl(candidate), hip._dl(scale_a),
+        hip._dl(scale_b), 1, None, m, n, k,
+        hip.DTYPE_TO_CODE[torch.bfloat16], stream,
+    )
+    torch.cuda.synchronize()
+    reference = (
+        ck.mm_int8(a, b.t().contiguous()).float()
+        * scale_a[:, None]
+        * scale_b[None, :]
+    ).to(torch.bfloat16)
+    assert torch.equal(candidate, reference)
+
+    if m >= 512:
+        tiled_b = _tile_b(b, 64)
+        tiled_candidate = torch.empty_like(candidate)
+        hip._C.int8_gemm_b_tiled(
+            hip._dl(a), hip._dl(tiled_b), hip._dl(tiled_candidate),
+            hip._dl(scale_a), hip._dl(scale_b), 1, None, m, n, k,
+            hip.DTYPE_TO_CODE[torch.bfloat16], 64, True, stream,
+        )
+        torch.cuda.synchronize()
+        assert torch.equal(tiled_candidate, reference)
+
+
+@pytest.mark.parametrize("tile_k", [64, 128])
+@pytest.mark.parametrize("dual_m", [False, True])
+@pytest.mark.parametrize("with_bias", [False, True])
+@needs_wmma
+def test_int8_generic_tiled_b_is_exact(hip, tile_k, dual_m, with_bias):
+    """Physical B tiling preserves the mature row-major GEMM result."""
+    torch.manual_seed(21)
+    m, n, k = 513, 256, 1024
+    a = torch.randint(-127, 128, (m, k), device=DEV, dtype=torch.int8)
+    b = torch.randint(-127, 128, (n, k), device=DEV, dtype=torch.int8)
+    tiled_b = _tile_b(b, tile_k)
+    scale_a = torch.rand(m, device=DEV, dtype=torch.float32) + 0.25
+    scale_b = torch.rand(n, device=DEV, dtype=torch.float32) + 0.25
+    bias = (
+        torch.rand(n, device=DEV, dtype=torch.bfloat16)
+        if with_bias else None
+    )
+    control = torch.empty((m, n), device=DEV, dtype=torch.bfloat16)
+    candidate = torch.empty_like(control)
+    stream = hip._stream(a)
+    hip._C.int8_gemm(
+        hip._dl(a), hip._dl(b), hip._dl(control), hip._dl(scale_a),
+        hip._dl(scale_b), 1, None if bias is None else hip._dl(bias),
+        m, n, k, hip.DTYPE_TO_CODE[torch.bfloat16], stream,
+    )
+    hip._C.int8_gemm_b_tiled(
+        hip._dl(a), hip._dl(tiled_b), hip._dl(candidate),
+        hip._dl(scale_a), hip._dl(scale_b), 1,
+        None if bias is None else hip._dl(bias), m, n, k,
+        hip.DTYPE_TO_CODE[torch.bfloat16], tile_k, dual_m, stream,
+    )
+    torch.cuda.synchronize()
+    assert torch.equal(candidate, control)
+
+
+@needs_wmma
+def test_int8_generic_tiled_a_is_exact(hip):
+    """Physical A tiling is a dimensional contract, not a model shape."""
+    torch.manual_seed(211)
+    m, n, k = 257, 256, 1024
+    x = torch.randn((m, k), device=DEV, dtype=torch.bfloat16)
+    b = torch.randint(-127, 128, (n, k), device=DEV, dtype=torch.int8)
+    tiled_b = _tile_b(b, 128)
+    scale_b = torch.rand(n, device=DEV, dtype=torch.float32) + 0.25
+    padded_m = (m + 127) // 128 * 128
+    padded_x = torch.nn.functional.pad(x, (0, 0, 0, padded_m - m))
+    row_a, padded_scale_a = hip._rotate_quant_int8(padded_x, 256)
+    tiled_scale_a = padded_scale_a[:m]
+    tiled_a = (
+        row_a.reshape(padded_m // 128, 128, k // 128, 128)
+        .permute(0, 2, 1, 3)
+        .contiguous()
+    )
+    row_a = (
+        tiled_a.reshape(padded_m // 128, k // 128, 128, 128)
+        .permute(0, 2, 1, 3)
+        .reshape(padded_m, k)[:m]
+        .contiguous()
+    )
+
+    reference = torch.empty((m, n), device=DEV, dtype=torch.bfloat16)
+    row_major = torch.empty_like(reference)
+    tiled = torch.empty_like(reference)
+    stream = hip._stream(x)
+    hip._C.int8_gemm(
+        hip._dl(row_a), hip._dl(b), hip._dl(reference), hip._dl(tiled_scale_a),
+        hip._dl(scale_b), 1, None, m, n, k,
+        hip.DTYPE_TO_CODE[torch.bfloat16], stream,
+    )
+    hip._C.int8_gemm_a_tiled128_down(
+        hip._dl(tiled_a), hip._dl(b), hip._dl(row_major),
+        hip._dl(tiled_scale_a), hip._dl(scale_b), 1, None, m, n, k,
+        hip.DTYPE_TO_CODE[torch.bfloat16], False, stream,
+    )
+    hip._C.int8_gemm_a_tiled128_down(
+        hip._dl(tiled_a), hip._dl(tiled_b), hip._dl(tiled),
+        hip._dl(tiled_scale_a), hip._dl(scale_b), 1, None, m, n, k,
+        hip.DTYPE_TO_CODE[torch.bfloat16], True, stream,
+    )
+    torch.cuda.synchronize()
+
+    assert torch.equal(row_major, reference)
+    assert torch.equal(tiled, reference)
+
+
+@pytest.mark.parametrize("tile_k", [64, 128])
+@pytest.mark.parametrize("dual_m", [False, True])
+@pytest.mark.parametrize("with_bias", [False, True])
+@needs_wmma
+def test_int8_tiled_b_gated_residual_is_exact(
+    hip, tile_k, dual_m, with_bias
+):
+    """The fused epilogue preserves both visible BF16 rounding points."""
+    torch.manual_seed(210)
+    m, n, k = 513, 256, 1024
+    a = torch.randint(-127, 128, (m, k), device=DEV, dtype=torch.int8)
+    b = torch.randint(-127, 128, (n, k), device=DEV, dtype=torch.int8)
+    tiled_b = _tile_b(b, tile_k)
+    scale_a = torch.rand(m, device=DEV, dtype=torch.float32) + 0.25
+    scale_b = torch.rand(n, device=DEV, dtype=torch.float32) + 0.25
+    bias = (
+        torch.rand(n, device=DEV, dtype=torch.bfloat16)
+        if with_bias else None
+    )
+    residual = torch.randn((m, n), device=DEV, dtype=torch.bfloat16)
+    gate = torch.randn(n, device=DEV, dtype=torch.bfloat16)
+    linear = torch.empty_like(residual)
+    candidate = torch.empty_like(residual)
+    stream = hip._stream(a)
+    hip._C.int8_gemm_b_tiled(
+        hip._dl(a), hip._dl(tiled_b), hip._dl(linear),
+        hip._dl(scale_a), hip._dl(scale_b), 1,
+        None if bias is None else hip._dl(bias), m, n, k,
+        hip.DTYPE_TO_CODE[torch.bfloat16], tile_k, dual_m, stream,
+    )
+    reference = torch.addcmul(residual, gate, linear)
+    hip._C.int8_gemm_b_tiled_gated_residual(
+        hip._dl(a), hip._dl(tiled_b), hip._dl(candidate),
+        hip._dl(scale_a), hip._dl(scale_b), 1,
+        None if bias is None else hip._dl(bias),
+        hip._dl(residual), hip._dl(gate), m, n, k, tile_k, dual_m, stream,
+    )
+    torch.cuda.synchronize()
+    assert torch.equal(candidate, reference)
 
 
 def _offset_copy(t: torch.Tensor) -> torch.Tensor:
@@ -2170,15 +2651,15 @@ def test_convrot_falls_back_to_eager_past_the_lds_bound(hip, dtype):
         )
 
 
-def test_convrot_spill_rotated_dtype_must_match_x(hip):
-    """spill_rotated is written as RowT derived from x; dtype must match."""
+def test_convrot_spill_rotated_must_match_input_dtype(hip):
+    """The two-pass path preserves the fused row-buffer rounding contract."""
     m, k = 2, 256
-    x = torch.randn(m, k, device=DEV, dtype=torch.float32)
+    x = torch.randn(m, k, device=DEV, dtype=torch.bfloat16)
     q = torch.zeros(m, k, dtype=torch.int8, device=DEV)
     scales = torch.zeros(m, dtype=torch.float32, device=DEV)
-    spill_rotated = torch.empty(m, k, dtype=torch.bfloat16, device=DEV)
+    spill_rotated = torch.empty(m, k, dtype=torch.float32, device=DEV)
     spill_partials = torch.empty(m, k // 256, dtype=torch.float32, device=DEV)
-    with pytest.raises(RuntimeError, match="spill_rotated dtype must match x"):
+    with pytest.raises(RuntimeError, match="spill_rotated"):
         hip._C.quantize_int8_convrot(
             hip._dl(x),
             hip._dl(q),
@@ -2199,6 +2680,63 @@ def test_convrot_int8_needs_spill_probe(hip):
     with torch.cuda.device(DEV):
         assert not hip._C.convrot_int8_needs_spill(4128, 10240, in_code)
         assert hip._C.convrot_int8_needs_spill(4128, 32768, in_code)
+
+
+@needs_wmma
+def test_convrot_wide_global_is_exact_to_fused_lds(hip):
+    """The scalable global fallback preserves the mature fused INT8 result."""
+    torch.manual_seed(37)
+    m, k = 96, 12288
+    x = torch.randn(m, k, device=DEV, dtype=torch.bfloat16)
+    global_q = torch.empty(m, k, device=DEV, dtype=torch.int8)
+    global_scales = torch.empty(m, device=DEV, dtype=torch.float32)
+    fused_q = torch.empty_like(global_q)
+    fused_scales = torch.empty_like(global_scales)
+    spill_rotated = torch.empty(m, k, device=DEV, dtype=x.dtype)
+    spill_partials = torch.empty(m, k // 256, device=DEV, dtype=torch.float32)
+
+    hip._C.quantize_int8_convrot(
+        hip._dl(x), hip._dl(global_q), hip._dl(global_scales),
+        hip._dl(spill_rotated), hip._dl(spill_partials), m, k, 256, 0,
+        hip._stream(x),
+    )
+    # M<96 selects the mature fused-LDS schedule. ConvRot is row-independent,
+    # so two bounded launches form an exact reference for the same 96 rows.
+    for start, end in ((0, 64), (64, m)):
+        hip._C.quantize_int8_convrot(
+            hip._dl(x[start:end]), hip._dl(fused_q[start:end]),
+            hip._dl(fused_scales[start:end]), hip._dl(spill_rotated),
+            hip._dl(spill_partials), end - start, k, 256, 0,
+            hip._stream(x),
+        )
+    torch.cuda.synchronize()
+
+    assert torch.equal(global_q, fused_q)
+    assert torch.equal(global_scales, fused_scales)
+
+
+@needs_wmma
+def test_convrot_wide_spill_chunks_are_exact(hip, monkeypatch):
+    """Bounded row chunks preserve the global fallback's per-row arithmetic."""
+    torch.manual_seed(41)
+    m, k = 257, 12288
+    x = torch.randn(m, k, device=DEV, dtype=torch.bfloat16)
+    expected_q = torch.empty(m, k, device=DEV, dtype=torch.int8)
+    expected_scales = torch.empty(m, device=DEV, dtype=torch.float32)
+    spill_rotated = torch.empty(m, k, device=DEV, dtype=x.dtype)
+    spill_partials = torch.empty(m, k // 256, device=DEV, dtype=torch.float32)
+
+    hip._C.quantize_int8_convrot(
+        hip._dl(x), hip._dl(expected_q), hip._dl(expected_scales),
+        hip._dl(spill_rotated), hip._dl(spill_partials), m, k, 256, 1,
+        hip._stream(x),
+    )
+    monkeypatch.setattr(hip, "_CONVROT_SPILL_WORKSPACE_BYTES", 6 << 20)
+    actual_q, actual_scales = hip._rotate_quant_int8(x, 256, "gelu_tanh")
+    torch.cuda.synchronize()
+
+    assert torch.equal(actual_q, expected_q)
+    assert torch.equal(actual_scales, expected_scales)
 
 
 def test_convrot_lds_bound_accounts_for_row_dtype(hip):

--- a/tests/test_int8.py
+++ b/tests/test_int8.py
@@ -13,6 +13,7 @@ from .conftest import (
     assert_values_close,
     cuda_backend_available,
     get_capable_backends,
+    skip_unless_gfx12_wmma,
 )
 
 COMFYUI_NVIDIA_16_SERIES = (
@@ -367,6 +368,65 @@ class TestTensorWiseINT8Layout:
         assert set(sd.keys()) == {"", "_scale"}
         assert sd[""].dtype == torch.int8
         assert sd["_scale"].numel() == 1
+
+    @pytest.mark.parametrize("tile_k", [64, 128])
+    def test_wmma_weight_pack_is_lossless_and_serializes_row_major(
+        self, seed, tile_k
+    ):
+        """Runtime tiling must not leak into a checkpoint or dequantization."""
+        from comfy_kitchen.tensor import QuantizedTensor, TensorWiseINT8Layout
+
+        w = torch.randn(128, 1024, device="cuda", dtype=torch.bfloat16)
+        qt = QuantizedTensor.from_float(
+            w, "TensorWiseINT8Layout", per_channel=True
+        )
+        row_major = qt._qdata.clone()
+        dequantized = qt.dequantize()
+
+        TensorWiseINT8Layout.pack_wmma_weight_(qt, tile_k=tile_k)
+
+        assert qt._params.wmma_tile_n == 128
+        assert qt._params.wmma_tile_k == tile_k
+        assert torch.equal(qt.dequantize(), dequantized)
+        assert torch.equal(qt.state_dict()[""], row_major)
+
+    @pytest.mark.parametrize(
+        ("n", "k", "expected_tile_k"),
+        [(128, 1024, 64), (512, 1024, 128), (1024, 1024, 64), (11520, 3840, 0)],
+    )
+    def test_linear_lazily_uses_dimensional_tiled_weight_exactly(
+        self, seed, n, k, expected_tile_k
+    ):
+        """The ordinary TensorWise linear owns dimensional packing exactly."""
+        import comfy_kitchen as ck
+        from comfy_kitchen.tensor import QuantizedTensor, TensorWiseINT8Layout
+
+        skip_unless_gfx12_wmma()
+        x = torch.randn(512, k, device="cuda", dtype=torch.bfloat16)
+        w = torch.randn(n, k, device="cuda", dtype=torch.bfloat16)
+        qt = QuantizedTensor.from_float(
+            w, "TensorWiseINT8Layout", per_channel=True
+        )
+        row_major, scale = TensorWiseINT8Layout.get_plain_tensors(qt)
+
+        with torch.inference_mode():
+            reference = ck.int8_linear(
+                x, row_major.clone(), scale, out_dtype=x.dtype
+            )
+            candidate = torch.nn.functional.linear(x, qt)
+
+        assert qt._params.wmma_tile_k == expected_tile_k
+        assert torch.equal(candidate, reference)
+
+        # A later short call cannot use the tiled native contract. Its
+        # dequantized fallback remains correct rather than reading packed bytes
+        # as a row-major matrix.
+        if expected_tile_k:
+            short = x[:32]
+            with torch.inference_mode():
+                short_out = torch.nn.functional.linear(short, qt)
+                short_reference = torch.nn.functional.linear(short, qt.dequantize())
+            assert torch.equal(short_out, short_reference)
 
     def test_supports_fast_matmul(self):
         """supports_fast_matmul returns True on CUDA SM >= 7.5."""
@@ -869,6 +929,27 @@ class TestTensorWisePublicAPI:
 
         assert out.shape == (4, 64)
         assert out.dtype == torch.bfloat16
+
+    def test_public_api_int8_linear_gated_residual(self, seed, device):
+        """The portable API exposes the original linear/addcmul semantics."""
+        import comfy_kitchen as ck
+        from comfy_kitchen.backends.eager.quantization import quantize_int8_tensorwise
+
+        x = torch.randn(4, 128, device=device, dtype=torch.bfloat16)
+        w = torch.randn(64, 128, device=device, dtype=torch.bfloat16)
+        w_int8, w_scale = quantize_int8_tensorwise(w)
+        bias = torch.randn(64, device=device, dtype=torch.bfloat16)
+        residual = torch.randn(4, 64, device=device, dtype=torch.bfloat16)
+        gate = torch.randn(64, device=device, dtype=torch.bfloat16)
+
+        with ck.registry.use_backend("eager"):
+            projected = ck.int8_linear(x, w_int8, w_scale, bias)
+            reference = torch.addcmul(residual, gate, projected)
+            candidate = ck.int8_linear_gated_residual(
+                x, w_int8, w_scale, residual, gate, bias
+            )
+
+        assert torch.equal(candidate, reference)
 
     def test_eager_int8_linear_single_row(self, seed, device):
         """Eager int8_linear supports single-row batches."""

--- a/tests/test_int8.py
+++ b/tests/test_int8.py
@@ -390,6 +390,32 @@ class TestTensorWiseINT8Layout:
         assert torch.equal(qt.dequantize(), dequantized)
         assert torch.equal(qt.state_dict()[""], row_major)
 
+    def test_wmma_weight_pack_replaces_non_resizable_storage(self):
+        from comfy_kitchen.tensor import QuantizedTensor, TensorWiseINT8Layout
+
+        n, k = 256, 128
+        qdata = torch.frombuffer(bytearray(n * k), dtype=torch.int8).reshape(n, k)
+        qdata.copy_(
+            (torch.arange(n * k, dtype=torch.int16) % 251 - 125)
+            .to(torch.int8)
+            .reshape(n, k)
+        )
+        params = TensorWiseINT8Layout.Params(
+            scale=torch.ones(1, dtype=torch.float32),
+            orig_dtype=torch.bfloat16,
+            orig_shape=(n, k),
+        )
+        qt = QuantizedTensor(qdata, "TensorWiseINT8Layout", params)
+        original_storage = qt._qdata
+        row_major = original_storage.clone()
+        assert not original_storage.untyped_storage().resizable()
+
+        TensorWiseINT8Layout.pack_wmma_weight_(qt, tile_k=64)
+
+        assert qt._qdata.data_ptr() != original_storage.data_ptr()
+        assert torch.equal(original_storage, row_major)
+        assert torch.equal(qt.state_dict()[""], row_major)
+
     @pytest.mark.parametrize(
         ("n", "k", "expected_tile_k"),
         [(128, 1024, 64), (512, 1024, 128), (1024, 1024, 64), (11520, 3840, 0)],
@@ -418,14 +444,15 @@ class TestTensorWiseINT8Layout:
         assert qt._params.wmma_tile_k == expected_tile_k
         assert torch.equal(candidate, reference)
 
-        # A later short call cannot use the tiled native contract. Its
-        # dequantized fallback remains correct rather than reading packed bytes
-        # as a row-major matrix.
+        # A later short call cannot use the tiled native contract. Unpack to the
+        # ordinary INT8 path rather than dequantizing the full weight.
         if expected_tile_k:
             short = x[:32]
             with torch.inference_mode():
                 short_out = torch.nn.functional.linear(short, qt)
-                short_reference = torch.nn.functional.linear(short, qt.dequantize())
+                short_reference = ck.int8_linear(
+                    short, row_major, scale, out_dtype=short.dtype
+                )
             assert torch.equal(short_out, short_reference)
 
     def test_supports_fast_matmul(self):

--- a/tests/test_int8_attention.py
+++ b/tests/test_int8_attention.py
@@ -62,6 +62,8 @@ def test_attention_scale_accepts_numeric_scalars(scale, expected):
         (torch.ones(2), ValueError),
         ("0.5", TypeError),
         (True, TypeError),
+        (torch.tensor(False), TypeError),
+        (torch.tensor(True), TypeError),
         (float("nan"), ValueError),
         (torch.tensor(float("inf")), ValueError),
     ],
@@ -69,6 +71,12 @@ def test_attention_scale_accepts_numeric_scalars(scale, expected):
 def test_attention_scale_rejects_invalid_values(scale, error):
     with pytest.raises(error, match="scale"):
         sage_attention_module._validate_attention_scale(scale, 1.0)
+
+
+@pytest.mark.parametrize("value", [False, True])
+def test_int8_attention_rejects_boolean_tensor_scale(value):
+    with pytest.raises(TypeError, match="scale"):
+        ck.int8_attention(None, None, None, scale=torch.tensor(value))
 
 
 def test_prequantized_attention_rejects_cpu_tensors():

--- a/tests/test_int8_attention.py
+++ b/tests/test_int8_attention.py
@@ -394,6 +394,33 @@ def test_gfx12_short_attention_capability_is_dimensional():
 
 
 @requires_int8_attention
+def test_gfx12_bf16_attention_rejects_misaligned_head_stride():
+    skip_unless_gfx12_wmma()
+
+    heads, length, head_dim = 4, 128, 128
+    head_stride = length * head_dim + 1
+    storage = torch.empty(
+        heads * head_stride, device="cuda", dtype=torch.bfloat16
+    )
+    k = torch.as_strided(
+        storage,
+        (1, heads, length, head_dim),
+        (heads * head_stride, head_stride, head_dim, 1),
+    )
+    q = torch.randn(
+        1, heads, length, head_dim, device="cuda", dtype=torch.bfloat16
+    )
+    v = torch.randn_like(q)
+
+    assert k.data_ptr() % 16 == 0
+    assert k.stride(2) % 8 == 0
+    assert k.stride(1) % 8 != 0
+    assert not ck.hip_attention_is_supported(q, k, v)
+    with pytest.raises(RuntimeError, match="16-byte-aligned rows"):
+        ck.hip_attention(q, k, v)
+
+
+@requires_int8_attention
 def test_gfx12_compact_batched_attention_matches_sdpa():
     skip_unless_gfx12_wmma()
 

--- a/tests/test_int8_attention.py
+++ b/tests/test_int8_attention.py
@@ -8,6 +8,7 @@ import torch
 
 import comfy_kitchen as ck
 import comfy_kitchen.sage_attention as sage_attention_module
+
 from .conftest import (
     skip_unless_gfx12_wmma,
 )

--- a/tests/test_int8_attention.py
+++ b/tests/test_int8_attention.py
@@ -419,29 +419,41 @@ def test_gfx12_bf16_attention_rejects_misaligned_head_stride():
         ck.hip_attention(q, k, v)
 
 
-@pytest.mark.parametrize("row_stride", [0, 64])
-def test_gfx12_bf16_attention_rejects_overlapping_output_rows(row_stride):
+@pytest.mark.parametrize(
+    ("dimension", "bad_stride"),
+    [
+        ("batch", 0),
+        ("batch", 64),
+        ("head", 0),
+        ("head", 64),
+        ("row", 0),
+        ("row", 64),
+    ],
+)
+def test_gfx12_bf16_attention_rejects_overlapping_output_spans(
+    dimension, bad_stride
+):
     skip_unless_gfx12_wmma()
     from comfy_kitchen.backends import hip
 
-    heads, length, head_dim = 4, 128, 128
-    head_stride = length * head_dim
-    storage = torch.empty(
-        heads * head_stride, device="cuda", dtype=torch.bfloat16
-    )
+    batch, heads, length, head_dim = 2, 4, 128, 128
+    shape = (batch, heads, length, head_dim)
+    strides = [length * heads * head_dim, head_dim, heads * head_dim, 1]
+    strides[{"batch": 0, "head": 1, "row": 2}[dimension]] = bad_stride
+    storage = torch.empty(shape, device="cuda", dtype=torch.bfloat16)
     output = torch.as_strided(
         storage,
-        (1, heads, length, head_dim),
-        (heads * head_stride, head_stride, row_stride, 1),
+        shape,
+        strides,
     )
     q, k, v = (
         torch.randn(
-            1, heads, length, head_dim, device="cuda", dtype=torch.bfloat16
+            shape, device="cuda", dtype=torch.bfloat16
         )
         for _ in range(3)
     )
 
-    with pytest.raises(RuntimeError, match="output row stride"):
+    with pytest.raises(RuntimeError, match="non-overlapping layout"):
         hip._C.bf16_sdpa_hip(
             hip._dl(q), hip._dl(k), hip._dl(v), hip._dl(output),
             head_dim**-0.5, hip._stream(q),
@@ -465,6 +477,35 @@ def test_gfx12_compact_batched_attention_matches_sdpa():
     assert ck.hip_int8_attention_is_supported(q, k, v)
     assert torch.equal(int8_mode, bf16)
     assert (bf16.float() - expected.float()).abs().max() <= 0.00390625
+
+
+@requires_int8_attention
+def test_gfx12_int8_attention_does_not_inherit_overlapping_q_strides():
+    skip_unless_gfx12_wmma()
+
+    torch.manual_seed(43)
+    heads, length, head_dim = 2, 1024, 128
+    q_storage = torch.randn(
+        length * heads * head_dim, device="cuda", dtype=torch.bfloat16
+    )
+    q = torch.as_strided(
+        q_storage,
+        (1, heads, length, head_dim),
+        (length * heads * head_dim, 64, heads * head_dim, 1),
+    )
+    k, v = (
+        torch.randn(
+            1, heads, length, head_dim, device="cuda", dtype=torch.bfloat16
+        )
+        for _ in range(2)
+    )
+    expected = torch.nn.functional.scaled_dot_product_attention(q, k, v)
+
+    actual = ck.hip_int8_attention(q, k, v)
+
+    assert 0 < q.stride(1) < head_dim
+    assert actual.stride(1) > 0
+    assert _nrmse(actual, expected) < 0.03
 
 
 @requires_int8_attention

--- a/tests/test_int8_attention.py
+++ b/tests/test_int8_attention.py
@@ -47,6 +47,29 @@ def test_int8_attention_cta_k_selection():
     assert select(128, 1025, has_mask=True) == 64
 
 
+@pytest.mark.parametrize(
+    ("scale", "expected"),
+    [(0.5, 0.5), (2, 2.0), (torch.tensor(0.5), 0.5), (torch.tensor([0.5]), 0.5)],
+)
+def test_attention_scale_accepts_numeric_scalars(scale, expected):
+    assert sage_attention_module._validate_attention_scale(scale, 1.0) == expected
+
+
+@pytest.mark.parametrize(
+    ("scale", "error"),
+    [
+        (torch.ones(2), ValueError),
+        ("0.5", TypeError),
+        (True, TypeError),
+        (float("nan"), ValueError),
+        (torch.tensor(float("inf")), ValueError),
+    ],
+)
+def test_attention_scale_rejects_invalid_values(scale, error):
+    with pytest.raises(error, match="scale"):
+        sage_attention_module._validate_attention_scale(scale, 1.0)
+
+
 def test_prequantized_attention_rejects_cpu_tensors():
     packed = sage_attention_module.PrequantizedInt8Attention(
         q=torch.empty(1, 1, 1, 64, dtype=torch.int8),

--- a/tests/test_int8_attention.py
+++ b/tests/test_int8_attention.py
@@ -8,6 +8,9 @@ import torch
 
 import comfy_kitchen as ck
 import comfy_kitchen.sage_attention as sage_attention_module
+from .conftest import (
+    skip_unless_gfx12_wmma,
+)
 
 _CUDA_READY = torch.cuda.is_available() and ck.int8_attention_is_available()
 requires_int8_attention = pytest.mark.skipif(
@@ -288,6 +291,101 @@ def test_int8_attention_stabilization_is_deterministic():
     second = ck.int8_attention(q, k, v)
 
     assert torch.equal(first, second)
+
+
+@requires_int8_attention
+def test_gfx12_bf16_attention_handles_long_rectangular_lengths():
+    skip_unless_gfx12_wmma()
+
+    torch.manual_seed(37)
+    q = torch.randn(1, 1025, 4, 128, device="cuda", dtype=torch.bfloat16).transpose(1, 2)
+    k = torch.randn(1, 1033, 4, 128, device="cuda", dtype=torch.bfloat16).transpose(1, 2)
+    v = torch.randn(1, 1033, 4, 128, device="cuda", dtype=torch.bfloat16).transpose(1, 2)
+    expected = torch.nn.functional.scaled_dot_product_attention(q, k, v)
+
+    actual = ck.hip_attention(q, k, v)
+
+    assert ck.hip_attention_is_supported(q, k, v)
+    assert ck.hip_int8_attention_is_supported(q, k, v)
+    assert actual.dtype is torch.bfloat16
+    assert actual.shape == q.shape
+    assert (actual.float() - expected.float()).abs().max() <= 0.00390625
+
+
+@requires_int8_attention
+def test_gfx12_bf16_full_k_tile_route_is_shape_generic():
+    skip_unless_gfx12_wmma()
+
+    torch.manual_seed(39)
+    # Deliberately differs from every captured model contract: seven heads,
+    # rectangular attention, and a one-row query tail. K/V is the only exact
+    # tile requirement of this schedule.
+    q = torch.randn(1, 7, 1025, 128, device="cuda", dtype=torch.bfloat16)
+    k = torch.randn(1, 7, 1056, 128, device="cuda", dtype=torch.bfloat16)
+    v = torch.randn(1, 7, 1056, 128, device="cuda", dtype=torch.bfloat16)
+    expected = torch.nn.functional.scaled_dot_product_attention(q, k, v)
+
+    actual = ck.hip_attention(q, k, v)
+
+    assert ck.hip_attention_is_supported(q, k, v)
+    assert ck.hip_int8_attention_is_supported(q, k, v)
+    assert (actual.float() - expected.float()).abs().max() <= 0.00390625
+
+
+@requires_int8_attention
+def test_gfx12_short_attention_capability_is_dimensional():
+    skip_unless_gfx12_wmma()
+
+    def supported(batch, heads, length, *, dtype=torch.bfloat16):
+        tensors = tuple(
+            torch.empty(batch, heads, length, 128, device="cuda", dtype=dtype)
+            for _ in range(3)
+        )
+        return ck.hip_attention_is_supported(*tensors)
+
+    assert not supported(1, 4, 127)
+    assert supported(1, 4, 128)
+    assert supported(1, 56, 388)
+    assert supported(1, 17, 1024)
+    assert ck.hip_int8_attention_is_supported(
+        *(
+            torch.empty(1, 17, 1024, 128, device="cuda", dtype=torch.bfloat16)
+            for _ in range(3)
+        )
+    )
+    assert not supported(2, 4, 16)
+    assert supported(64, 16, 16)
+    assert not supported(1, 4, 160, dtype=torch.float16)
+    unaligned = tuple(
+        torch.empty(1, 4, 128, 129, device="cuda", dtype=torch.bfloat16)[..., 1:]
+        for _ in range(3)
+    )
+    assert not ck.hip_attention_is_supported(*unaligned)
+    long_fp16 = tuple(
+        torch.empty(1, 4, 1024, 128, device="cuda", dtype=torch.float16)
+        for _ in range(3)
+    )
+    assert ck.hip_int8_attention_is_supported(*long_fp16)
+    assert not ck.hip_attention_is_supported(*long_fp16)
+
+
+@requires_int8_attention
+def test_gfx12_compact_batched_attention_matches_sdpa():
+    skip_unless_gfx12_wmma()
+
+    torch.manual_seed(41)
+    q, k, v = (
+        torch.randn(64, 16, 12, 128, device="cuda", dtype=torch.bfloat16)
+        for _ in range(3)
+    )
+    expected = torch.nn.functional.scaled_dot_product_attention(q, k, v)
+    bf16 = ck.hip_attention(q, k, v)
+    int8_mode = ck.hip_int8_attention(q, k, v)
+
+    assert ck.hip_attention_is_supported(q, k, v)
+    assert ck.hip_int8_attention_is_supported(q, k, v)
+    assert torch.equal(int8_mode, bf16)
+    assert (bf16.float() - expected.float()).abs().max() <= 0.00390625
 
 
 @requires_int8_attention

--- a/tests/test_int8_attention.py
+++ b/tests/test_int8_attention.py
@@ -393,7 +393,6 @@ def test_gfx12_short_attention_capability_is_dimensional():
     assert not ck.hip_attention_is_supported(*long_fp16)
 
 
-@requires_int8_attention
 def test_gfx12_bf16_attention_rejects_misaligned_head_stride():
     skip_unless_gfx12_wmma()
 
@@ -418,6 +417,35 @@ def test_gfx12_bf16_attention_rejects_misaligned_head_stride():
     assert not ck.hip_attention_is_supported(q, k, v)
     with pytest.raises(RuntimeError, match="16-byte-aligned rows"):
         ck.hip_attention(q, k, v)
+
+
+@pytest.mark.parametrize("row_stride", [0, 64])
+def test_gfx12_bf16_attention_rejects_overlapping_output_rows(row_stride):
+    skip_unless_gfx12_wmma()
+    from comfy_kitchen.backends import hip
+
+    heads, length, head_dim = 4, 128, 128
+    head_stride = length * head_dim
+    storage = torch.empty(
+        heads * head_stride, device="cuda", dtype=torch.bfloat16
+    )
+    output = torch.as_strided(
+        storage,
+        (1, heads, length, head_dim),
+        (heads * head_stride, head_stride, row_stride, 1),
+    )
+    q, k, v = (
+        torch.randn(
+            1, heads, length, head_dim, device="cuda", dtype=torch.bfloat16
+        )
+        for _ in range(3)
+    )
+
+    with pytest.raises(RuntimeError, match="output row stride"):
+        hip._C.bf16_sdpa_hip(
+            hip._dl(q), hip._dl(k), hip._dl(v), hip._dl(output),
+            head_dim**-0.5, hip._stream(q),
+        )
 
 
 @requires_int8_attention


### PR DESCRIPTION
## Summary

Adds native gfx12 HIP BF16/INT8 attention and the INT8 fusion primitives required for accelerated Z-Image Turbo inference.

BF16 and INT8 modes remain explicit: `hip_attention` handles supported BF16 routes, while `hip_int8_attention` uses INT8 for long sequences and retains BF16 for overhead-bound short or batched calls.

## Key changes

- Adds public HIP BF16/INT8 attention APIs and capability checks.
- Implements native BF16 and INT8 attention kernels.
- Adds fused INT8 QKV, projection, modulation, SwiGLU, RMSNorm, RoPE, and gated-residual operations.
- Adds runtime WMMA weight packing while preserving checkpoint serialization.
- Optimizes gfx12 WMMA GEMM and ConvRot quantization.
- Preserves gfx11, eager, and unsupported-device fallbacks.
- Removes unreachable kernel and dispatch paths.
- Adds correctness, routing, layout, serialization, and fallback tests.

## Required ComfyUI integration

This work requires the corresponding [ComfyUI integration PR #15928](https://github.com/Comfy-Org/ComfyUI/pull/15928).

The ComfyUI changes provide the command-line options, attention routing, Z-Image fusion integration, and Dynamic VRAM handling needed to activate these kernels. Both PRs must be used together to reproduce the benchmarked performance.

## Testing

Tested on **AMD Radeon RX 9070 XT (Navi 48, gfx1201, 16 GB)** running **Ubuntu 24.04.2 LTS**.

~~~bash
  python -m pytest \
  tests/test_hip_dispatch.py \
  tests/test_hip_wmma.py \
  tests/test_int8.py \
  tests/test_int8_attention.py \
  -q
~~~

Result:

~~~text
616 passed, 46 skipped
~~~

## Z-Image Turbo benchmark

Protocol: 1024×1024, 8 steps, batch size 1, one warmup and five timed runs per cell. Values are median sampler throughput.

| Dynamic VRAM | Configuration | Median | Min–max | vs BF16 |
|---|---|---:|---:|---:|
| On | BF16 + AOTriton | 1.61 it/s | 1.60–1.62 it/s | 1.000× |
| On | INT8 + AOTriton | 2.17 it/s | 2.16–2.18 it/s | 1.348× |
| On | INT8 + Kitchen BF16 | 2.30 it/s | 2.29–2.31 it/s | 1.429× |
| On | INT8 + Kitchen INT8 | 2.36 it/s | 2.36–2.37 it/s | 1.466× |
| Off | BF16 + AOTriton | 1.58 it/s | 1.58–1.59 it/s | 1.000× |
| Off | INT8 + AOTriton | 2.16 it/s | 2.15–2.16 it/s | 1.367× |
| Off | INT8 + Kitchen BF16 | 2.30 it/s | 2.30–2.30 it/s | 1.456× |
| Off | INT8 + Kitchen INT8 | 2.36 it/s | 2.35–2.37 it/s | 1.494× |

## Compatibility

Native kernels are selected only when their capability and input checks pass. Existing gfx11, eager, and unsupported-shape fallback behavior is preserved.

Big thanks to @jammm for contribution!