### PR TITLE
HIP port of #117: int8 Sol-Attn sparse attention

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Fast kernel library for Diffusion inference with multiple compute backends.
 | `rms_adaln`                 | ✓     | ✓    | ✓      | ✓   |
 | `na3d`                      | ✓     | ✓    | ✓      | ✓   |
 | `na2d`                      | ✓     | ✓    | ✓      | ✓   |
-| `sol_attn`                  | ✓     | ✓    |        |     |
+| `sol_attn`                  | ✓     | ✓    |        | ✓   |
 | `int8_attention`            |       | ✓    |        | ✓   |
 | `apply_rope`                | ✓     | ✓    | ✓      | ✓   |
 | `apply_rope1`               | ✓     | ✓    | ✓      | ✓   |

--- a/comfy_kitchen/backends/hip/CMakeLists.txt
+++ b/comfy_kitchen/backends/hip/CMakeLists.txt
@@ -163,6 +163,12 @@ set(HIP_SOURCES
     sage_attention/quant_qk_int8.hip
     sage_attention/quant_v_int8.hip
     sage_attention/int8_attn.hip
+    sage_attention/sol_attn.hip
+    sage_attention/sol_attn_preprocess.hip
+    sage_attention/sol_attn_vtranspose.hip
+    sage_attention/sol_attn_producer.hip
+    sage_attention/sol_attn_route.hip
+    sage_attention/sol_attn_exact.hip
     ops/apply_rope.hip
     ops/flash_decode.hip
     ops/rms_rope.hip

--- a/comfy_kitchen/backends/hip/__init__.py
+++ b/comfy_kitchen/backends/hip/__init__.py
@@ -31,6 +31,16 @@ from comfy_kitchen.backends._activations import input_act_code as _input_act_cod
 from comfy_kitchen.backends._activations import input_act_width as _input_act_width
 from comfy_kitchen.backends.eager import rope as _eager_rope
 from comfy_kitchen.backends.eager.quantization import DTYPE_CODE_TO_DTYPE, DTYPE_TO_CODE
+from comfy_kitchen.backends.eager.sol_attn import (
+    _LOG2E,
+    _block_lengths,
+    _normalize_key_bias,
+    _sink_count,
+    _topk_count,
+    _valid_rows,
+    add_coarse_,
+    coarse_output,
+)
 from comfy_kitchen.backends.eager.w4a8_int8 import (
     _QUANT_ROW_ELEM_BUDGET,
     _decide_codebook,
@@ -88,6 +98,8 @@ __all__ = [
     "rms_rope_split_half1",
     "rms_rope_split_half1_",
     "scaled_mm_fp8",
+    "sol_attn",
+    "sol_attn_chunked",
     "stochastic_rounding_fp8",
     "w4a8_int8_linear",
 ]
@@ -169,6 +181,7 @@ _ARCH_SUPPORTED = _ARCH_ELEMENTWISE_ONLY | _ARCH_WMMA
 _WMMA_ONLY_OPS = frozenset({
     "int8_linear",
     "na3d",
+    "sol_attn",
     "convrot_w4a4_linear",
     "scaled_mm_svdquant_w4a4",
     "w4a8_int8_linear",
@@ -1701,6 +1714,355 @@ def rms_rope_split_half_(
                           rot_dim=rot_dim)
 
 
+
+# ---------------------------------------------------------------------------
+# Sol-Attn sparse attention
+#
+# The kernels are in sage_attention/sol_attn*.hip. Everything below mirrors the
+# CUDA backend's entry points, including the workspace plan, which both backends
+# read from their own C++ Plan. The one place they diverge is what the carriers
+# hold: the CUDA layout permutes the contraction and key axes for its m16n8k32
+# fragments and this one does not, so the top-k threshold reads cen8 in channel
+# order rather than un-permuting it.
+# ---------------------------------------------------------------------------
+
+_SOL_HD = 128
+_SOL_VSCALE_MARGIN = 1.1   # clip headroom on last step's V absmax
+
+
+def _topk_from_pooled(c8, csc, kc, topk_ratio, log2s, sinks):
+    """Per-query-block top-k as a threshold: the k-th largest pooled score (the
+    kernel keeps score >= threshold, so ties over-select). ``c8``/``csc`` are the
+    quantized centroids ``[BH, N, D]``/``[BH, N]``, ``kc`` the centred pooled keys.
+    Scores are computed through the route kernel's own int8 quantization and
+    operation order; an fp32 threshold against int8 kernel scores inflates the kept
+    budget ~15%. Sink blocks are always kept, so they neither count toward nor
+    consume the budget."""
+    n = kc.shape[1]
+    ksc = (kc.abs().amax(-1, True) / 127.0).clamp_min(1e-12)     # prep_pooled_quant
+    k8 = torch.round(kc / ksc).clamp_(-127, 127)
+    s = torch.bmm(c8, k8.transpose(1, 2))     # integer dot, exact in fp32
+    s = s * (csc * log2s).unsqueeze(-1) * ksc.squeeze(-1).unsqueeze(-2)
+    s0, s1 = sinks
+    if s1 > s0:
+        s[..., s0:s1] = float("-inf")
+    kk = _topk_count(n - _sink_count(n, s0, s1), topk_ratio)
+    if kk == 0:   # nothing beyond the forced blocks: a threshold no finite score clears
+        return torch.full(s.shape[:-1], float("inf"), device=s.device, dtype=s.dtype)
+    kth = s.topk(kk, dim=-1, sorted=False).values.min(-1).values
+    # backed off a few ulps: this replica of the kernel's scores is not bit-exact
+    return (kth - kth.abs() * 1e-5).contiguous()
+
+
+def _block_means(x, lengths=None, valid=None):
+    """(B, T, H, D) -> [BH, N, D] fp32 means over each 64-block's live rows, with
+    fp32 accumulation but no fp32 copy of x. ``lengths``/``valid`` only for
+    zero-padded tiles; the default divides by Python floats so the routing
+    threshold stays bit-identical run to run."""
+    b, t, h, d = x.shape
+    full = (t // 64) * 64
+    if lengths is None:
+        m = x[:, :full].view(b, -1, 64, h, d).sum(2, dtype=torch.float32) / 64.0
+        if full != t:
+            tail = x[:, full:].sum(1, keepdim=True, dtype=torch.float32) / (t - full)
+            m = torch.cat([m, tail], dim=1)
+    else:
+        if valid is not None:
+            x = x * valid.view(1, -1, 1, 1).to(x.dtype)
+        m = x[:, :full].view(b, -1, 64, h, d).sum(2, dtype=torch.float32)
+        if full != t:
+            m = torch.cat([m, x[:, full:].sum(1, keepdim=True, dtype=torch.float32)], dim=1)
+        m = m / lengths.view(1, -1, 1, 1)
+    return m.permute(0, 2, 1, 3).reshape(b * h, -1, d)
+
+
+def _check_block_len(block_len, t, device):
+    n = (t + 63) // 64
+    if block_len.dtype != torch.int32 or block_len.dim() != 1 or block_len.numel() != n:
+        raise ValueError(
+            f"sol_attn: block_len must be int32 of shape ({n},), got {block_len.dtype} "
+            f"{tuple(block_len.shape)}")
+    if block_len.device != device:
+        raise ValueError(f"sol_attn: block_len must be on {device}, got {block_len.device}")
+    return block_len.contiguous()
+
+
+def _check_coarse_gate(coarse_gate, shape, device):
+    if tuple(coarse_gate.shape) != tuple(shape) or coarse_gate.device != device:
+        raise ValueError(
+            f"sol_attn: coarse_gate must be {tuple(shape)} on {device}, got "
+            f"{tuple(coarse_gate.shape)} on {coarse_gate.device}")
+    return coarse_gate
+
+
+def _topk_threshold(q, k, topk_ratio, scale, lengths, valid, sinks):
+    """Top-k threshold from post-rope q/k, pooled and quantized like prep_q."""
+    cen = _block_means(q, lengths, valid)
+    kc = _block_means(k, lengths, valid)
+    kc = kc - kc.mean(dim=1, keepdim=True)
+    csc = (cen.abs().amax(-1, True) / 127.0).clamp_min(1e-8)      # prep_q
+    c8 = torch.round(cen / csc).clamp_(-127, 127)
+    return _topk_from_pooled(c8, csc.squeeze(-1), kc, topk_ratio, scale * _LOG2E, sinks)
+
+
+_ROPE_FAB_CACHE = {}
+
+
+def _packed_rope_fab(freqs, t, rot):
+    """[..., T, 1, rot/2, 2, 2] -> [T, rot, 2] per-channel (self, partner)
+    coefficients. Cached per freqs tensor (one attention step reuses one across
+    layers); keyed on id() with a strong ref, since data_ptr can be reused after
+    free and inference tensors have no _version."""
+    key = (id(freqs), t, rot)
+    hit = _ROPE_FAB_CACHE.get(key)
+    if hit is not None:
+        return hit[1]
+    f = freqs.reshape(-1, rot // 2, 2, 2)
+    if f.shape[0] != t:
+        raise ValueError(f"sol_attn: rope_freqs covers {f.shape[0]} tokens, T={t}")
+    f = f.float()
+    fab = torch.empty(t, rot, 2, device=freqs.device, dtype=torch.float32)
+    fab[:, :rot // 2, 0] = f[:, :, 0, 0]
+    fab[:, :rot // 2, 1] = f[:, :, 0, 1]
+    fab[:, rot // 2:, 0] = f[:, :, 1, 1]
+    fab[:, rot // 2:, 1] = f[:, :, 1, 0]
+    _ROPE_FAB_CACHE.clear()   # one live entry
+    _ROPE_FAB_CACHE[key] = (freqs, fab)
+    return fab
+
+
+def _sink_pair(value):
+    return [0, 0] if value is None else [int(value[0]), int(value[1])]
+
+
+def _check_sol_args(sink_blocks, sink_q, topk_ratio, **tensors):
+    """Shared by both HIP entries, since a caller may bypass the registry: the
+    registry rule plus a matrix-core check.
+
+    No device argument, unlike the CUDA entry's per-device compute-capability
+    test. has_wmma() is the intersection over every visible device, so it is
+    already the conservative answer for whichever one the tensors are on.
+    """
+    from comfy_kitchen.constraints import sol_attn_common_call_rule
+
+    if not has_wmma():
+        raise RuntimeError(
+            "sol_attn: requires RDNA3 or newer matrix cores (WMMA); this device has none")
+    check = sol_attn_common_call_rule(
+        {"sink_blocks": sink_blocks, "sink_q": sink_q, "topk_ratio": topk_ratio, **tensors})
+    if not check.success:
+        raise ValueError(f"sol_attn: {check.failed_param}: {check.failure_reason}")
+
+
+def sol_attn(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    tau: float = 1.0,
+    scale: float | None = None,
+    sink_blocks: list[int] | None = None,
+    sink_q: list[int] | None = None,
+    key_bias: torch.Tensor | None = None,
+    topk_ratio: float = 0.0,
+    tail: bool = True,
+    block_len: torch.Tensor | None = None,
+    coarse_gate: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Sol-Attn sparse attention over ``(B, T, H, 128)`` bf16 tensors.
+    See sage_attention/sol_attn.hip and the public docstring for ``tail``,
+    ``block_len`` and ``coarse_gate``.
+
+    ``topk_ratio`` > 0 switches selection from the tau threshold to SLA-style
+    per-query-block top-k: keep that fraction of key blocks per query block (sinks
+    and the diagonal still ride on top). tau is ignored then.
+    """
+    batch, t, h, d = q.shape
+    if q.dtype != torch.bfloat16:
+        raise ValueError(f"sol_attn: q/k/v must be bfloat16, got {q.dtype}")
+    _check_sol_args(sink_blocks, sink_q, topk_ratio, q=q, k=k, v=v,
+                    block_len=block_len, coarse_gate=coarse_gate)
+    if scale is None:
+        scale = d ** -0.5
+    if block_len is not None:
+        block_len = block_len.contiguous()
+    lengths = _block_lengths(t, (t + 63) // 64, q.device, block_len)
+    valid = _valid_rows(t, lengths) if block_len is not None else None
+    mean_lengths = lengths if block_len is not None else None   # exact default arithmetic
+    # Only the last dim must be contiguous (16-byte staging loads), so a BHND view
+    # goes in as-is. A misaligned load faults asynchronously and poisons the
+    # context, so base pointer and leading strides are checked here.
+    for name, x in (("q", q), ("k", k), ("v", v)):
+        if x.stride(-1) != 1:
+            raise ValueError(f"sol_attn: {name} must have a contiguous last dim")
+        if x.data_ptr() % 16:
+            raise ValueError(
+                f"sol_attn: {name} must be 16-byte aligned (storage_offset "
+                f"{x.storage_offset()} leaves it at +{x.data_ptr() % 16}); "
+                f"call .contiguous() on it")
+        for dim in range(3):
+            if x.shape[dim] > 1 and x.stride(dim) % 8:
+                raise ValueError(
+                    f"sol_attn: {name} stride({dim}) = {x.stride(dim)} elements "
+                    f"is not a multiple of 8, so the 16-byte staging loads would "
+                    f"be misaligned; call .contiguous() on it")
+    sb, sq = _sink_pair(sink_blocks), _sink_pair(sink_q)
+    thr = (_topk_threshold(q, k, topk_ratio, scale, mean_lengths, valid, sb)
+           if topk_ratio else None)
+    kb = None
+    if key_bias is not None:
+        # exact branch only, in log2 units; biased blocks must be sink-covered
+        kb = _normalize_key_bias(key_bias, batch, t, q.device)
+        kb = (kb * _LOG2E).expand(batch, t).contiguous()
+    out = torch.empty(q.shape, dtype=q.dtype, device=q.device)
+    p = _C.sol_attn_plan(batch, t, h)
+    workspace = torch.empty(p["total"], dtype=torch.uint8, device=q.device)
+    _C.sol_attn(
+        _dl(q), _dl(k), _dl(v), _dl(out), _dl(workspace),
+        batch, t, h, d,
+        float(tau), float(scale),
+        sb[0], sb[1], sq[0], sq[1],
+        _stream(q),
+        key_bias=None if kb is None else _dl(kb),
+        threshold=None if thr is None else _dl(thr),
+        block_len=None if block_len is None else _dl(block_len),
+        tail=bool(tail),
+    )
+    if coarse_gate is not None:
+        add_coarse_(out, coarse_output(*_ws_block_means(workspace, p, batch * h, lengths), scale),
+                    coarse_gate)
+    return out
+
+
+def sol_attn_chunked(
+    qkv_chunks,
+    t: int,
+    h: int,
+    rope_freqs: torch.Tensor,
+    qk_norm_weights: tuple[torch.Tensor, torch.Tensor],
+    kmean: torch.Tensor | None = None,
+    vscale: torch.Tensor | None = None,
+    tau: float = 1.0,
+    topk_ratio: float = 0.0,
+    scale: float | None = None,
+    sink_blocks: list[int] | None = None,
+    sink_q: list[int] | None = None,
+    rope_eps: float = 1e-6,
+    tail: bool = True,
+    block_len: torch.Tensor | None = None,
+    coarse_gate: torch.Tensor | None = None,
+):
+    """Chunked-producer Sol-Attn over fused qkv projection chunks ([M, 3*H*128]
+    bf16, 64-aligned starts, B=1); full Q/K/V are never materialised.
+    ``tail`` / ``block_len`` / ``coarse_gate`` as in ``sol_attn``.
+
+    ``qkv_chunks``: an iterable of chunks or a zero-arg callable returning one.
+    ``kmean``/``vscale`` are LAST step's statistics ([H,128] f32); when None the
+    producer runs twice (measure, then quantize), so pass a callable to stream on
+    the first call. Returns ``(out[1,T,H,128] bf16, kmean_next, vscale_next)``."""
+    d = _SOL_HD
+    rot = rope_freqs.shape[-3] * 2
+    # the fused rope pairs channels across lanes of 4: rot/2 must be lane-aligned
+    if rot % 8 or not 0 < rot <= d:
+        raise ValueError(f"sol_attn_chunked: rot_dim must be a multiple of 8 in (0, {d}], got {rot}")
+    fab = _packed_rope_fab(rope_freqs, t, rot)
+    dev = fab.device
+    _check_sol_args(sink_blocks, sink_q, topk_ratio)
+    if scale is None:
+        scale = d ** -0.5
+    if block_len is not None:
+        block_len = _check_block_len(block_len, t, dev)
+    if coarse_gate is not None:
+        coarse_gate = _check_coarse_gate(coarse_gate, (1, t, h, d), dev)
+    lengths = _block_lengths(t, (t + 63) // 64, dev, block_len)
+    qw, kw = (w.to(device=dev, dtype=torch.bfloat16).contiguous() for w in qk_norm_weights)
+    factory = qkv_chunks if callable(qkv_chunks) else None
+    if factory is None and (kmean is None or vscale is None):
+        qkv_chunks = list(qkv_chunks)          # need two passes over it
+        factory = lambda: iter(qkv_chunks)     # noqa: E731
+    p = _C.sol_attn_plan(1, t, h)
+    ws = torch.empty(p["total"], dtype=torch.uint8, device=dev)
+    stream = torch.cuda.current_stream(dev).cuda_stream
+    width = 3 * h * d
+
+    def produce(km, vsc):
+        _C.sol_producer_begin(_dl(ws), 1, t, h, stream)
+        t0 = 0
+        for chunk in (factory() if factory is not None else qkv_chunks):
+            m = chunk.shape[-2]
+            if t0 % 64 and m:
+                raise ValueError("sol_attn_chunked: chunk starts must be 64-aligned")
+            # bare pointers below: a wrong width reads OOB, a host tensor poisons the context
+            if chunk.shape[-1] != width or chunk.dtype != torch.bfloat16 or chunk.device != dev:
+                raise ValueError(
+                    f"sol_attn_chunked: chunks must be [M, {width}] bfloat16 on {dev}, "
+                    f"got {tuple(chunk.shape)} {chunk.dtype} on {chunk.device}")
+            _C.sol_producer_chunk(
+                _dl(ws), _dl(chunk.contiguous()), _dl(fab), _dl(qw), _dl(kw), _dl(km), _dl(vsc),
+                float(rope_eps), rot, t0, m, 1, t, h, stream,
+                block_len=None if block_len is None else _dl(block_len))
+            t0 += m
+        if t0 != t:
+            raise ValueError(f"sol_attn_chunked: chunks cover {t0} tokens, T={t}")
+
+    def vscale_of(vamax):
+        return (vamax / 127.0 * _SOL_VSCALE_MARGIN).clamp_min(1e-8)
+
+    if kmean is None or vscale is None:
+        # bootstrap: harvest the scale-independent statistics (post-rope K sums, V
+        # absmax) with dummy scales, then produce for real
+        produce(torch.zeros(h, d, device=dev), torch.ones(h, d, device=dev))
+        kmean = _ws_ksums(ws, p, h).sum(1) / lengths.sum()   # live tokens, like prep_sums_to_means
+        vscale = vscale_of(ws[p["statsV"]:p["statsV"] + h * d * 4].view(torch.float32))
+    kmean = kmean.to(device=dev, dtype=torch.float32).contiguous()
+    # a zero scale is 1/0 in the producer and 255/0 in route: clamp like vscale_of
+    vscale = vscale.to(device=dev, dtype=torch.float32).clamp_min(1e-8).contiguous()
+    produce(kmean, vscale)
+    sb, sq = _sink_pair(sink_blocks), _sink_pair(sink_q)
+    threshold = (_topk_threshold_from_workspace(ws, p, h, topk_ratio, scale, lengths, sb)
+                 if topk_ratio else None)
+    out = torch.empty(1, t, h, d, dtype=torch.bfloat16, device=dev)
+    kmean_next = torch.empty(h, d, device=dev, dtype=torch.float32)
+    vamax = torch.empty(h, d, device=dev, dtype=torch.float32)
+    _C.sol_attn_core(
+        _dl(ws), _dl(out), _dl(vscale), _dl(kmean_next), _dl(vamax),
+        1, t, h, float(tau), float(scale), sb[0], sb[1], sq[0], sq[1], stream,
+        threshold=None if threshold is None else _dl(threshold),
+        block_len=None if block_len is None else _dl(block_len), tail=bool(tail))
+    if coarse_gate is not None:
+        add_coarse_(out, coarse_output(*_ws_block_means(ws, p, h, lengths), scale), coarse_gate)
+    return out, kmean_next, vscale_of(vamax)
+
+
+def _ws_ksums(ws, p, bh):
+    """The producer's post-rope block K sums, [BH, NTB, 128] f32 view into scratch
+    (block MEANS on the direct path, and once sol_attn_core has run)."""
+    d = _SOL_HD
+    return ws[p["scratch"]:p["scratch"] + bh * p["NPAD"] * d * 4] \
+        .view(torch.float32).view(bh, p["NPAD"], d)[:, :p["NTB"]]
+
+
+def _ws_block_means(ws, p, bh, lengths):
+    """(qm, km, vm) ``[BH, NTB, 128]`` fp32 block means over live rows, read from
+    what the kernels already left in the workspace: the qmean slot, K means in
+    scratch, V sums in vcT (bf16)."""
+    ntb, npad, d = p["NTB"], p["NPAD"], _SOL_HD
+    qm = ws[p["qmean"]:p["qmean"] + bh * npad * d * 4].view(torch.float32).view(bh, npad, d)[:, :ntb]
+    vm = ws[p["vcT"]:p["vcT"] + bh * d * npad * 2].view(torch.bfloat16).view(bh, d, npad)[:, :, :ntb]
+    return qm, _ws_ksums(ws, p, bh), vm.transpose(1, 2).float() / lengths.view(1, -1, 1)
+
+
+def _topk_threshold_from_workspace(ws, p, h, topk_ratio, scale, lengths, sinks):
+    """Producer-path top-k threshold from the workspace's own pooled outputs. The
+    HIP carriers are in channel order, so cen8 is read as stored -- the CUDA entry
+    has to gather it at perm_d first."""
+    ntb, d = p["NTB"], _SOL_HD
+    cen8 = ws[p["cen8"]:p["cen8"] + h * ntb * d].view(torch.int8).view(h, ntb, d).float()
+    cens = ws[p["cens"]:p["cens"] + h * ntb * 4].view(torch.float32).view(h, ntb)
+    kc = _ws_ksums(ws, p, h) / lengths.view(1, -1, 1)
+    kc = kc - kc.mean(dim=1, keepdim=True)
+    return _topk_from_pooled(cen8, cens, kc, topk_ratio, scale * _LOG2E, sinks)
+
+
 # ---------------------------------------------------------------------------
 # Registration
 # ---------------------------------------------------------------------------
@@ -1713,6 +2075,7 @@ def _build_constraints(has_wmma: bool = True) -> dict:
         ParamConstraint,
         ValidationResult,
         na3d_common_call_rule,
+        sol_attn_common_call_rule,
     )
 
     # PyTorch exposes ROCm tensors with device type "cuda".
@@ -1738,6 +2101,24 @@ def _build_constraints(has_wmma: bool = True) -> dict:
         return ValidationResult.ok()
 
     constraints = {
+        "sol_attn": FunctionConstraints(
+            params={
+                "q": ParamConstraint(
+                    dtypes=frozenset({torch.bfloat16}),
+                    shape_rules=(ExactDims(4),),
+                ),
+                "k": ParamConstraint(
+                    dtypes=frozenset({torch.bfloat16}),
+                    shape_rules=(ExactDims(4),),
+                ),
+                "v": ParamConstraint(
+                    dtypes=frozenset({torch.bfloat16}),
+                    shape_rules=(ExactDims(4),),
+                ),
+            },
+            default_devices=dev,
+            call_rules=(sol_attn_common_call_rule,),
+        ),
         # fp32 has no 16-bit matrix path, so it goes to triton/eager.
         "na3d": FunctionConstraints(
             params={

--- a/comfy_kitchen/backends/hip/dlpack_bindings.cpp
+++ b/comfy_kitchen/backends/hip/dlpack_bindings.cpp
@@ -1494,8 +1494,266 @@ void flash_attention_decode(nb::ndarray<> q, nb::ndarray<> k, nb::ndarray<> v,
     check_hip_launch();
 }
 
+
+// ---------------------------------------------------------------------------
+// Sol-Attn sparse attention
+// ---------------------------------------------------------------------------
+//
+// _C is importable, so none of this can assume the Python layer put it together.
+// The kernels reach q/k/v and the workspace as bare pointers sized from (B, T, H),
+// so a short buffer, or a layout the 16-byte staging loads cannot use, is an
+// out-of-bounds device access rather than an exception.
+
+// The kernels read these as packed arrays of one dtype, so an element count on
+// its own is not enough: a narrower dtype makes the buffer shorter in bytes than
+// the kernel reads, and a strided view of the right count is accessed as though
+// it were packed. `code` is a DTYPE_TO_CODE value.
+static void sol_need_elems(const nb::ndarray<>& a, int64_t n, int code, const char* fn,
+                           const char* what) {
+    if (static_cast<int64_t>(a.size()) != n) {
+        throw std::runtime_error(std::string(fn) + ": " + what + " must have " +
+                                 std::to_string(n) + " elements, got " + std::to_string(a.size()));
+    }
+    if (map_dtype_to_code(a.dtype()) != code) {
+        throw std::runtime_error(std::string(fn) + ": " + what + " has an unsupported dtype");
+    }
+    int64_t expect = 1;
+    for (int i = static_cast<int>(a.ndim()) - 1; i >= 0; --i) {
+        if (a.shape(i) > 1 && a.stride(i) != expect) {
+            throw std::runtime_error(std::string(fn) + ": " + what + " must be contiguous");
+        }
+        expect *= static_cast<int64_t>(a.shape(i));
+    }
+}
+
+// Extents size every workspace slot and every grid, and they reach the kernels as
+// plain ints. A non-positive one plans a workspace nothing checks again.
+static void sol_need_extents(int64_t batch, int64_t seq_len, int64_t num_heads, const char* fn) {
+    if (batch <= 0 || seq_len <= 0 || num_heads <= 0) {
+        throw std::runtime_error(std::string(fn) +
+                                 ": batch, seq_len and num_heads must all be positive");
+    }
+}
+
+// Both sinks are half-open [start, end) block ranges, mirroring
+// sol_attn_common_call_rule on the Python side. A negative start would make the
+// routing kernel emit that many extra list entries, wrapped to huge uint16 block
+// ids, and overrun the per-query row.
+static void sol_need_sinks(int64_t start, int64_t end, const char* fn, const char* what) {
+    if (start < 0 || end < 0 || end < start) {
+        throw std::runtime_error(std::string(fn) + ": " + what +
+                                 " must be a [start, end) range with 0 <= start <= end");
+    }
+}
+
+static void sol_check_block_len(const nb::ndarray<>& b, int64_t seq_len, const char* fn) {
+    if (b.dtype().code != static_cast<uint8_t>(nb::dlpack::dtype_code::Int) ||
+        b.dtype().bits != 32 || b.ndim() != 1 || b.stride(0) != 1 ||
+        static_cast<int64_t>(b.size()) != (seq_len + 63) / 64) {
+        throw std::runtime_error(std::string(fn) +
+                                 ": block_len must be a contiguous 1-D int32 array of "
+                                 "ceil(T/64) elements");
+    }
+}
+
+static void sol_need_workspace(const nb::ndarray<>& ws, int64_t batch, int64_t seq_len,
+                               int64_t num_heads, const char* fn) {
+    int64_t v[32];
+    const int n = sol_attn_plan(static_cast<int>(batch), static_cast<int>(seq_len),
+                                static_cast<int>(num_heads), v, 32);
+    if (n > 32 || static_cast<int64_t>(ws.size()) < v[n - 1]) {  // last slot is "total"
+        throw std::runtime_error(std::string(fn) + ": workspace too small for this shape");
+    }
+    // sol_attn_plan reports byte offsets and the Python layer slices the workspace
+    // with them to read the block means back out, so a workspace of anything but
+    // bytes reads the wrong slots. The size check above already bounds the
+    // allocation, since no element is narrower than a byte; this pins the units.
+    if (map_dtype_to_code(ws.dtype()) != 3) {
+        throw std::runtime_error(std::string(fn) + ": workspace must be a uint8 array");
+    }
+}
+
+static void sol_need_bthd(const nb::ndarray<>& a, int64_t b, int64_t t, int64_t h, int64_t d,
+                          const char* fn, const char* what) {
+    if (a.ndim() != 4 || map_dtype_to_code(a.dtype()) != 2 ||
+        a.shape(0) != static_cast<size_t>(b) || a.shape(1) != static_cast<size_t>(t) ||
+        a.shape(2) != static_cast<size_t>(h) || a.shape(3) != static_cast<size_t>(d)) {
+        throw std::runtime_error(std::string(fn) + ": " + what +
+                                 " must be a (B, T, H, D) bfloat16 array");
+    }
+}
+
+// The kernels stage rows with 16-byte loads: unit last stride, 16-byte base, and
+// leading strides (of non-singleton dims) that keep every row 16-byte aligned.
+static void sol_need_staging_layout(const nb::ndarray<>& a, const char* fn, const char* what) {
+    bool ok = a.stride(3) == 1 && reinterpret_cast<uintptr_t>(a.data()) % 16 == 0;
+    for (int i = 0; i < 3; ++i) ok = ok && (a.shape(i) <= 1 || a.stride(i) % 8 == 0);
+    if (!ok) {
+        throw std::runtime_error(
+            std::string(fn) + ": " + what +
+            " must have a contiguous last dim, a 16-byte aligned base and leading strides that "
+            "are multiples of 8");
+    }
+}
+
+static void sol_need_contiguous(const nb::ndarray<>& a, const char* fn, const char* what) {
+    int64_t expect = 1;
+    for (int i = static_cast<int>(a.ndim()) - 1; i >= 0; --i) {
+        if (a.shape(i) > 1 && a.stride(i) != expect) {
+            throw std::runtime_error(std::string(fn) + ": " + what + " must be contiguous");
+        }
+        expect *= static_cast<int64_t>(a.shape(i));
+    }
+}
+
+// Workspace dims and slot byte offsets, from the C++ Plan (the one definition).
+nb::dict sol_attn_plan_py(int64_t batch, int64_t seq_len, int64_t num_heads) {
+    int64_t v[32];
+    const int n = sol_attn_plan(static_cast<int>(batch), static_cast<int>(seq_len),
+                                static_cast<int>(num_heads), v, 32);
+    if (n > 32) throw std::runtime_error("sol_attn_plan: Plan grew past the binding's buffer");
+    nb::dict d;
+    for (int i = 0; i < n && sol_attn_plan_names[i]; ++i) d[sol_attn_plan_names[i]] = v[i];
+    return d;
+}
+
+void sol_attn(nb::ndarray<> q, nb::ndarray<> k, nb::ndarray<> v, nb::ndarray<> out,
+              nb::ndarray<> workspace, int64_t batch, int64_t seq_len, int64_t num_heads,
+              int64_t head_dim, float tau, float scale, int64_t sink_start, int64_t sink_end,
+              int64_t sink_q_start, int64_t sink_q_end, uintptr_t stream_ptr,
+              OptArray key_bias = std::nullopt, OptArray threshold = std::nullopt,
+              OptArray block_len = std::nullopt, bool tail = true) {
+    constexpr const char* kFn = "sol_attn";
+    auto stream = reinterpret_cast<hipStream_t>(stream_ptr);
+    sol_need_extents(batch, seq_len, num_heads, kFn);
+    sol_need_sinks(sink_start, sink_end, kFn, "sink_blocks");
+    sol_need_sinks(sink_q_start, sink_q_end, kFn, "sink_q");
+    if (threshold) {
+        sol_need_elems(*threshold, batch * num_heads * ((seq_len + 63) / 64), 0, kFn, "threshold");
+    }
+    if (block_len) sol_check_block_len(*block_len, seq_len, kFn);
+    sol_need_bthd(q, batch, seq_len, num_heads, head_dim, kFn, "q");
+    sol_need_bthd(k, batch, seq_len, num_heads, head_dim, kFn, "k");
+    sol_need_bthd(v, batch, seq_len, num_heads, head_dim, kFn, "v");
+    sol_need_bthd(out, batch, seq_len, num_heads, head_dim, kFn, "out");
+    sol_need_staging_layout(q, kFn, "q");
+    sol_need_staging_layout(k, kFn, "k");
+    sol_need_staging_layout(v, kFn, "v");
+    sol_need_contiguous(out, kFn, "out");
+    sol_need_workspace(workspace, batch, seq_len, num_heads, kFn);
+    if (key_bias) sol_need_elems(*key_bias, batch * seq_len, 0, kFn, "key_bias");
+    // Explicit strides: only the last dim must be contiguous (BHND views go in as-is).
+    launch_sol_attn(q.data(), k.data(), v.data(), out.data(), workspace.data(),
+                    static_cast<int>(batch), static_cast<int>(seq_len),
+                    static_cast<int>(num_heads), static_cast<int>(head_dim), tau, scale,
+                    opt_data(key_bias), opt_data(threshold), opt_data(block_len), tail ? 1 : 0,
+                    static_cast<int>(sink_start), static_cast<int>(sink_end),
+                    static_cast<int>(sink_q_start), static_cast<int>(sink_q_end), q.stride(0),
+                    q.stride(1), q.stride(2), k.stride(0), k.stride(1), k.stride(2), v.stride(0),
+                    v.stride(1), v.stride(2), stream);
+    check_hip_launch();
+}
+
+void sol_producer_begin_py(nb::ndarray<> workspace, int64_t batch, int64_t seq_len,
+                           int64_t num_heads, uintptr_t stream_ptr) {
+    sol_need_extents(batch, seq_len, num_heads, "sol_producer_begin");
+    sol_need_workspace(workspace, batch, seq_len, num_heads, "sol_producer_begin");
+    sol_producer_begin(workspace.data(), static_cast<int>(batch), static_cast<int>(seq_len),
+                       static_cast<int>(num_heads), reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+void sol_producer_chunk_py(nb::ndarray<> workspace, nb::ndarray<> qkv, nb::ndarray<> fab,
+                           nb::ndarray<> qw, nb::ndarray<> kw, nb::ndarray<> kmean,
+                           nb::ndarray<> vscale, float rope_eps, int64_t rot_dim, int64_t t0,
+                           int64_t m, int64_t batch, int64_t seq_len, int64_t num_heads,
+                           uintptr_t stream_ptr, OptArray block_len = std::nullopt) {
+    constexpr const char* kFn = "sol_producer_chunk";
+    sol_need_extents(batch, seq_len, num_heads, kFn);
+    if (batch != 1) throw std::runtime_error(std::string(kFn) + ": the producer path is B=1 only");
+    if (rot_dim <= 0 || rot_dim > 128 || rot_dim % 8) {
+        throw std::runtime_error(std::string(kFn) +
+                                 ": rot_dim must be a multiple of 8 in (0, 128]");
+    }
+    if (t0 < 0 || m < 0 || t0 + m > seq_len || (m && t0 % 64)) {
+        throw std::runtime_error(
+            std::string(kFn) +
+            ": chunk [t0, t0 + m) must lie in [0, seq_len] with a 64-aligned start");
+    }
+    if (block_len) sol_check_block_len(*block_len, seq_len, kFn);
+    sol_need_workspace(workspace, batch, seq_len, num_heads, kFn);
+    sol_need_elems(qkv, m * 3 * num_heads * 128, 2, kFn, "qkv");
+    sol_need_elems(fab, seq_len * rot_dim * 2, 0, kFn, "fab");
+    sol_need_elems(qw, 128, 2, kFn, "qw");
+    sol_need_elems(kw, 128, 2, kFn, "kw");
+    sol_need_elems(kmean, batch * num_heads * 128, 0, kFn, "kmean");
+    sol_need_elems(vscale, batch * num_heads * 128, 0, kFn, "vscale");
+    sol_producer_chunk(workspace.data(), qkv.data(), fab.data(), qw.data(), kw.data(),
+                       kmean.data(), vscale.data(), opt_data(block_len), rope_eps,
+                       static_cast<int>(rot_dim), static_cast<int>(t0), static_cast<int>(m),
+                       static_cast<int>(batch), static_cast<int>(seq_len),
+                       static_cast<int>(num_heads), reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
+void sol_attn_core_py(nb::ndarray<> workspace, nb::ndarray<> out, nb::ndarray<> vscale,
+                      nb::ndarray<> kmean_next, nb::ndarray<> vamax_out, int64_t batch,
+                      int64_t seq_len, int64_t num_heads, float tau, float scale,
+                      int64_t sink_start, int64_t sink_end, int64_t sink_q_start,
+                      int64_t sink_q_end, uintptr_t stream_ptr, OptArray threshold = std::nullopt,
+                      OptArray block_len = std::nullopt, bool tail = true) {
+    constexpr const char* kFn = "sol_attn_core";
+    sol_need_extents(batch, seq_len, num_heads, kFn);
+    sol_need_sinks(sink_start, sink_end, kFn, "sink_blocks");
+    sol_need_sinks(sink_q_start, sink_q_end, kFn, "sink_q");
+    const int64_t stats = batch * num_heads * 128;
+    sol_need_elems(vscale, stats, 0, kFn, "vscale");
+    sol_need_elems(kmean_next, stats, 0, kFn, "kmean_next");
+    sol_need_elems(vamax_out, stats, 0, kFn, "vamax_out");
+    if (threshold) {
+        sol_need_elems(*threshold, batch * num_heads * ((seq_len + 63) / 64), 0, kFn, "threshold");
+    }
+    if (block_len) sol_check_block_len(*block_len, seq_len, kFn);
+    sol_need_workspace(workspace, batch, seq_len, num_heads, kFn);
+    sol_need_elems(out, batch * seq_len * num_heads * 128, 2, kFn, "out");
+    launch_sol_attn_core(workspace.data(), out.data(), vscale.data(), kmean_next.data(),
+                         vamax_out.data(), opt_data(block_len), tail ? 1 : 0,
+                         static_cast<int>(batch), static_cast<int>(seq_len),
+                         static_cast<int>(num_heads), tau, scale, opt_data(threshold),
+                         static_cast<int>(sink_start), static_cast<int>(sink_end),
+                         static_cast<int>(sink_q_start), static_cast<int>(sink_q_end),
+                         reinterpret_cast<hipStream_t>(stream_ptr));
+    check_hip_launch();
+}
+
 NB_MODULE(_C, m) {
     m.doc() = "ComfyKitchen HIP backend native operations (RDNA2-RDNA4, WMMA on gfx11/gfx12)";
+    m.def("sol_attn_plan", &sol_attn_plan_py,
+          "Workspace dims, slot byte offsets and total bytes for this shape",
+          nb::arg("batch"), nb::arg("seq_len"), nb::arg("num_heads"));
+    m.def("sol_attn", &sol_attn,
+          "Sol-Attn training-free sparse attention (BF16 in/out, head_dim 128)",
+          nb::arg("q"), nb::arg("k"), nb::arg("v"), nb::arg("out"), nb::arg("workspace"),
+          nb::arg("batch"), nb::arg("seq_len"), nb::arg("num_heads"), nb::arg("head_dim"),
+          nb::arg("tau"), nb::arg("scale"), nb::arg("sink_start"), nb::arg("sink_end"),
+          nb::arg("sink_q_start"), nb::arg("sink_q_end"), nb::arg("stream_ptr"),
+          nb::arg("key_bias") = nb::none(), nb::arg("threshold") = nb::none(),
+          nb::arg("block_len") = nb::none(), nb::arg("tail") = true);
+    m.def("sol_producer_begin", &sol_producer_begin_py,
+          nb::arg("workspace"), nb::arg("batch"), nb::arg("seq_len"), nb::arg("num_heads"),
+          nb::arg("stream_ptr"));
+    m.def("sol_producer_chunk", &sol_producer_chunk_py,
+          nb::arg("workspace"), nb::arg("qkv"), nb::arg("fab"), nb::arg("qw"), nb::arg("kw"),
+          nb::arg("kmean"), nb::arg("vscale"), nb::arg("rope_eps"), nb::arg("rot_dim"),
+          nb::arg("t0"), nb::arg("m"), nb::arg("batch"), nb::arg("seq_len"), nb::arg("num_heads"),
+          nb::arg("stream_ptr"), nb::arg("block_len") = nb::none());
+    m.def("sol_attn_core", &sol_attn_core_py,
+          nb::arg("workspace"), nb::arg("out"), nb::arg("vscale"), nb::arg("kmean_next"),
+          nb::arg("vamax_out"), nb::arg("batch"), nb::arg("seq_len"), nb::arg("num_heads"),
+          nb::arg("tau"), nb::arg("scale"), nb::arg("sink_start"), nb::arg("sink_end"),
+          nb::arg("sink_q_start"), nb::arg("sink_q_end"), nb::arg("stream_ptr"),
+          nb::arg("threshold") = nb::none(), nb::arg("block_len") = nb::none(),
+          nb::arg("tail") = true);
     m.def("quantize_per_tensor_fp8", &quantize_per_tensor_fp8);
     m.def("dequantize_per_tensor_fp8", &dequantize_per_tensor_fp8);
     m.def("stochastic_round_fp8", &stochastic_round_fp8);

--- a/comfy_kitchen/backends/hip/launchers.h
+++ b/comfy_kitchen/backends/hip/launchers.h
@@ -61,4 +61,26 @@ void launch_w4a8_int8_gemm_chunked_kernel(const void* xq, const void* qw, const 
                                           int K, int group_size, int chunk_cols, int out_code,
                                           hipStream_t stream);
 
+// Sol-Attn sparse attention -- see sage_attention/sol_attn.hip. The whole pipeline
+// runs over one caller-allocated workspace whose carve-up sol_attn_plan reports.
+extern const char* const sol_attn_plan_names[];  // null-terminated
+int sol_attn_plan(int batch, int seq_len, int num_heads, int64_t* out, int cap);
+void sol_producer_begin(void* workspace, int batch, int seq_len, int num_heads,
+                        hipStream_t stream);
+void sol_producer_chunk(void* workspace, const void* qkv, const void* fab, const void* qw,
+                        const void* kw, const void* kmean, const void* vscale, const void* blen,
+                        float rope_eps, int rot_dim, int t0, int M, int batch, int seq_len,
+                        int num_heads, hipStream_t stream);
+void launch_sol_attn_core(void* workspace, void* out, const void* vscale, void* kmean_next,
+                          void* vamax_out, const void* blen, int tail, int batch, int seq_len,
+                          int num_heads, float tau, float scale, const void* ext_threshold,
+                          int sink_start, int sink_end, int sink_q_start, int sink_q_end,
+                          hipStream_t stream);
+void launch_sol_attn(const void* q, const void* k, const void* v, void* out, void* workspace,
+                     int batch, int seq_len, int num_heads, int head_dim, float tau, float scale,
+                     const void* key_bias, const void* ext_threshold, const void* blen, int tail,
+                     int sink_start, int sink_end, int sink_q_start, int sink_q_end, int64_t qs_b,
+                     int64_t qs_t, int64_t qs_h, int64_t ks_b, int64_t ks_t, int64_t ks_h,
+                     int64_t vs_b, int64_t vs_t, int64_t vs_h, hipStream_t stream);
+
 }  // extern "C"

--- a/comfy_kitchen/backends/hip/sage_attention/int8_attn.hip
+++ b/comfy_kitchen/backends/hip/sage_attention/int8_attn.hip
@@ -60,43 +60,6 @@ struct Shape {
     static constexpr int kDimTiles = HD / 16;
 };
 
-// Round to nearest even and saturate, matching cvt.rni.sat.u8.f32 in the CUDA
-// backend's pack_u8x4.
-__forceinline__ __device__ uint32_t prob_to_u8(float p) {
-    return static_cast<uint32_t>(fminf(255.0f, fmaxf(0.0f, rintf(p))));
-}
-
-// The eight probabilities a lane holds, packed into the P operand of the PV
-// matmul. gfx12 element e is key 8 * (lane / 16) + e, which is already the
-// fragment's K slice. gfx11 element e is key 2e + lane / 16, so a lane holds
-// every other key and trades with its partner to rebuild the whole 16-key step.
-__forceinline__ __device__ MmaInt8::Frag pack_prob_frag(const uint32_t p[8], int lane) {
-    const uint32_t lo = p[0] | (p[1] << 8) | (p[2] << 16) | (p[3] << 24);
-    const uint32_t hi = p[4] | (p[5] << 8) | (p[6] << 16) | (p[7] << 24);
-#if defined(COMFY_MMA_GFX12)
-    (void)lane;
-    MmaInt8::Frag f;
-    f[0] = static_cast<int>(lo);
-    f[1] = static_cast<int>(hi);
-    return f;
-#else
-    const uint32_t partner_lo = swap_half_wave_b32(lo);
-    const uint32_t partner_hi = swap_half_wave_b32(hi);
-    const bool even_half = lane < 16;
-    const uint32_t even0 = even_half ? lo : partner_lo;  // keys 0, 2, 4, 6
-    const uint32_t odd0 = even_half ? partner_lo : lo;   // keys 1, 3, 5, 7
-    const uint32_t even1 = even_half ? hi : partner_hi;  // keys 8, 10, 12, 14
-    const uint32_t odd1 = even_half ? partner_hi : hi;   // keys 9, 11, 13, 15
-    // v_perm_b32 selector bytes index {src0, src1} with src1 in bytes 0..3.
-    MmaInt8::Frag f;
-    f[0] = static_cast<int>(__builtin_amdgcn_perm(odd0, even0, 0x05010400u));
-    f[1] = static_cast<int>(__builtin_amdgcn_perm(odd0, even0, 0x07030602u));
-    f[2] = static_cast<int>(__builtin_amdgcn_perm(odd1, even1, 0x05010400u));
-    f[3] = static_cast<int>(__builtin_amdgcn_perm(odd1, even1, 0x07030602u));
-    return f;
-#endif
-}
-
 // Reads one mask element as raw bits. -ffast-math folds isfinite() away, so the
 // non-finite test that decides whether an additive bias means "drop this key"
 // has to be an exponent bit test on the value as loaded, never a float compare.
@@ -122,27 +85,6 @@ __forceinline__ __device__ bool mask_keep(const void* mask, int64_t offset, int 
     if ((bits & 0x7F80u) == 0x7F80u) return false;
     bias = static_cast<float>(*reinterpret_cast<const __bf16*>(&bits));
     return true;
-}
-
-// vals[e] belongs to channel d_base + acc_row(lane, e). gfx12 makes those eight
-// channels contiguous, so the row goes out in one 16-byte store; gfx11
-// interleaves them with the partner lane's and needs eight.
-template <typename OutT>
-__forceinline__ __device__ void store_o_tile(OutT* __restrict__ row, int d_base,
-                                             const float* vals, int lane) {
-#if defined(COMFY_MMA_GFX12)
-    // Aligned because the 16-byte store below reinterprets it.
-    __attribute__((aligned(16))) OutT packed[8];
-#pragma unroll
-    for (int e = 0; e < 8; ++e) packed[e] = static_cast<OutT>(vals[e]);
-    *reinterpret_cast<uint4*>(row + d_base + 8 * (lane / 16)) =
-        *reinterpret_cast<const uint4*>(packed);
-#else
-#pragma unroll
-    for (int e = 0; e < 8; ++e) {
-        row[d_base + acc_row(lane, e)] = static_cast<OutT>(vals[e]);
-    }
-#endif
 }
 
 template <int HD, int CTA_K, MaskMode kMask, typename OutT>

--- a/comfy_kitchen/backends/hip/sage_attention/sage_common.h
+++ b/comfy_kitchen/backends/hip/sage_attention/sage_common.h
@@ -15,6 +15,7 @@
 #include <string>
 #include <type_traits>
 
+#include "../mma.h"
 #include "architecture_config.h"
 
 namespace comfy::hip_backend::sage {
@@ -226,6 +227,116 @@ __forceinline__ __device__ void convrot(float* v) {
     } else if constexpr (Rotation == 4) {
         convrot4(v);
     }
+}
+
+// ---------------------------------------------------------------------------
+// WMMA fragment plumbing shared by the int8 attention kernels
+// ---------------------------------------------------------------------------
+
+// Round to nearest even and saturate, matching cvt.rni.sat.u8.f32 in the CUDA
+// backend's pack_u8x4.
+__forceinline__ __device__ uint32_t prob_to_u8(float p) {
+    return static_cast<uint32_t>(fminf(255.0f, fmaxf(0.0f, rintf(p))));
+}
+
+// The eight probabilities a lane holds, packed into the P operand of the PV
+// matmul. gfx12 element e is key 8 * (lane / 16) + e, which is already the
+// fragment's K slice. gfx11 element e is key 2e + lane / 16, so a lane holds
+// every other key and trades with its partner to rebuild the whole 16-key step.
+__forceinline__ __device__ MmaInt8::Frag pack_prob_frag(const uint32_t p[8], int lane) {
+    const uint32_t lo = p[0] | (p[1] << 8) | (p[2] << 16) | (p[3] << 24);
+    const uint32_t hi = p[4] | (p[5] << 8) | (p[6] << 16) | (p[7] << 24);
+#if !defined(COMFY_MMA_GFX11)
+    // gfx12, and the no-matrix-core stub, whose Frag is this narrow too.
+    (void)lane;
+    MmaInt8::Frag f;
+    f[0] = static_cast<int>(lo);
+    f[1] = static_cast<int>(hi);
+    return f;
+#else
+    const uint32_t partner_lo = swap_half_wave_b32(lo);
+    const uint32_t partner_hi = swap_half_wave_b32(hi);
+    const bool even_half = lane < 16;
+    const uint32_t even0 = even_half ? lo : partner_lo;  // keys 0, 2, 4, 6
+    const uint32_t odd0 = even_half ? partner_lo : lo;   // keys 1, 3, 5, 7
+    const uint32_t even1 = even_half ? hi : partner_hi;  // keys 8, 10, 12, 14
+    const uint32_t odd1 = even_half ? partner_hi : hi;   // keys 9, 11, 13, 15
+    // v_perm_b32 selector bytes index {src0, src1} with src1 in bytes 0..3.
+    MmaInt8::Frag f;
+    f[0] = static_cast<int>(__builtin_amdgcn_perm(odd0, even0, 0x05010400u));
+    f[1] = static_cast<int>(__builtin_amdgcn_perm(odd0, even0, 0x07030602u));
+    f[2] = static_cast<int>(__builtin_amdgcn_perm(odd1, even1, 0x05010400u));
+    f[3] = static_cast<int>(__builtin_amdgcn_perm(odd1, even1, 0x07030602u));
+    return f;
+#endif
+}
+
+// The same repack for a BF16 P operand, which the Sol-Attn routing kernel needs
+// for its pooled PV. gfx12's K slice is the accumulator order again; gfx11 rebuilds
+// the 16-key step from the two half-waves, exchanging four packed dwords instead of
+// eight floats.
+__forceinline__ __device__ MmaBf16::Frag pack_prob_frag_bf16(const float p[8], int lane) {
+    MmaBf16::Frag f;
+#if !defined(COMFY_MMA_GFX11)
+    (void)lane;
+#pragma unroll
+    for (int e = 0; e < 8; ++e) f[e] = static_cast<__bf16>(p[e]);
+#else
+    union {
+        uint32_t w[4];
+        __bf16 e[8];
+    } own, partner;
+#pragma unroll
+    for (int e = 0; e < 8; ++e) own.e[e] = static_cast<__bf16>(p[e]);
+#pragma unroll
+    for (int i = 0; i < 4; ++i) partner.w[i] = swap_half_wave_b32(own.w[i]);
+    const bool even_half = lane < 16;
+#pragma unroll
+    for (int e = 0; e < 8; ++e) {
+        f[2 * e] = even_half ? own.e[e] : partner.e[e];
+        f[2 * e + 1] = even_half ? partner.e[e] : own.e[e];
+    }
+#endif
+    return f;
+}
+
+// vals[e] belongs to channel d_base + acc_row(lane, e). gfx12 makes those eight
+// channels contiguous, so the row goes out in one 16-byte store; gfx11
+// interleaves them with the partner lane's and needs eight.
+template <typename OutT>
+__forceinline__ __device__ void store_o_tile(OutT* __restrict__ row, int d_base,
+                                             const float* vals, int lane) {
+#if defined(COMFY_MMA_GFX12)
+    // Aligned because the 16-byte store below reinterprets it.
+    __attribute__((aligned(16))) OutT packed[8];
+#pragma unroll
+    for (int e = 0; e < 8; ++e) packed[e] = static_cast<OutT>(vals[e]);
+    *reinterpret_cast<uint4*>(row + d_base + 8 * (lane / 16)) =
+        *reinterpret_cast<const uint4*>(packed);
+#else
+#pragma unroll
+    for (int e = 0; e < 8; ++e) {
+        row[d_base + acc_row(lane, e)] = static_cast<OutT>(vals[e]);
+    }
+#endif
+}
+
+// The read side of store_o_tile, for a handover the next kernel resumes from.
+template <typename InT>
+__forceinline__ __device__ void load_o_tile(const InT* __restrict__ row, int d_base, float* vals,
+                                            int lane) {
+#if defined(COMFY_MMA_GFX12)
+    __attribute__((aligned(16))) InT packed[8];
+    *reinterpret_cast<uint4*>(packed) =
+        *reinterpret_cast<const uint4*>(row + d_base + 8 * (lane / 16));
+#pragma unroll
+    for (int e = 0; e < 8; ++e) vals[e] = static_cast<float>(packed[e]);
+#else
+#pragma unroll
+    for (int e = 0; e < 8; ++e) {
+        vals[e] = static_cast<float>(row[d_base + acc_row(lane, e)]);
+    }
+#endif
 }
 
 }  // namespace comfy::hip_backend::sage

--- a/comfy_kitchen/backends/hip/sage_attention/sol_attn.hip
+++ b/comfy_kitchen/backends/hip/sage_attention/sol_attn.hip
@@ -1,0 +1,234 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Sol-Attn (arXiv 2607.24027) orchestration over one caller-allocated workspace:
+//   preprocess  quantize Q/K/V, pool K/V per block, routing threshold
+//   vtranspose  INT8 V^T for the exact stage's PV operand
+//   route       choose the routed blocks; approximate tail from the centroids
+//   exact       walk each routed list, resuming route's online softmax
+// Entry paths: `launch_sol_attn` (post-rope q/k/v) or the chunked producer
+// (`sol_producer_begin/chunk`, then `launch_sol_attn_core`). Tensors are
+// (B, T, H, 128) bf16 and the kernels need WMMA, so gfx11 and gfx12 only.
+//
+// The workspace carve-up matches the CUDA backend's sol_attn.cu slot for slot, so
+// the Python layer reads the same plan. What the slots CONTAIN differs by the two
+// permutations the CUDA layout applies and this one does not; see sol_common.h.
+#include <hip/hip_runtime.h>
+
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+
+#include "../launchers.h"
+#include "sol_common.h"
+
+// Sibling-TU launchers. C++ linkage on purpose: a drifted prototype fails to link
+// instead of corrupting at runtime.
+void launch_sol_preprocess(const void*, const void*, const void*, void*, void*, void*, void*,
+                           void*, void*, void*, void*, void*, void*, void*, void*, void*,
+                           const void*, const void*, int, int, int, int, int, int, int, int64_t,
+                           int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t,
+                           float, float, hipStream_t);
+size_t sol_preprocess_scratch_bytes(int, int, int);
+void launch_sol_producer(const void*, const void*, const void*, const void*, const void*,
+                         const void*, void*, void*, void*, void*, void*, void*, void*, void*,
+                         void*, void*, void*, const void*, float, int, int, int, int, int, int,
+                         int, int, hipStream_t);
+void launch_sol_finish(void*, void*, void*, void*, const void*, const void*, void*, const void*,
+                       int, int, int, int, int, int, float, float, hipStream_t);
+void launch_sol_vtranspose(const void*, const void*, void*, int, int, int, int, int64_t, int64_t,
+                           int64_t, hipStream_t);
+void launch_sol_route(const void*, const void*, const void*, const void*, const void*, const void*,
+                      const void*, void*, void*, void*, void*, void*, const void*, int, int, int,
+                      int, int, int, int, int, int, int, int, float, hipStream_t);
+void launch_sol_exact(const void*, const void*, const void*, const void*, const void*,
+                      const void*, const void*, const void*, const void*, const void*,
+                      const void*, void*, int, int, int, int, int, int, float, hipStream_t);
+
+namespace {
+
+constexpr int HD = comfy::hip_backend::sol::kHeadDim;
+constexpr int BLK = comfy::hip_backend::sol::kBlock;
+
+inline size_t align16(size_t n) { return (n + 15u) & ~static_cast<size_t>(15u); }
+
+// Workspace carve-up, a pure function of the shape; exported by sol_attn_plan.
+struct Plan {
+    int Tp, NTB, NPAD, NQ;
+    size_t qiP, qs, kiP, ksb, vTi, vsc, kciP, kcs, vcT, thr, cen8, cens;
+    size_t idx, cnt, oPart, mPart, lPart, statsV, qmean, scratch, total;
+
+    Plan(int B, int T, int H) {
+        NTB = (T + BLK - 1) / BLK;
+        Tp = NTB * BLK;
+        NPAD = ((NTB + 63) / 64) * 64;  // route reads pooled keys in 64-block groups
+        NQ = NTB;
+        const size_t bh = static_cast<size_t>(B) * H, tok = static_cast<size_t>(B) * T * H;
+        size_t o = 0;
+        auto take = [&](size_t bytes) {
+            const size_t s = o;
+            o = align16(o + bytes);
+            return s;
+        };
+        qiP = take(tok * HD);
+        qs = take(tok * sizeof(float));
+        kiP = take(bh * Tp * HD);
+        ksb = take(bh * Tp * 2 * sizeof(float));
+        vTi = take(bh * HD * Tp);
+        vsc = take(bh * HD * sizeof(float));
+        kciP = take(bh * NPAD * HD);
+        kcs = take(bh * NPAD * sizeof(float));
+        vcT = take(bh * HD * NPAD * sizeof(uint16_t));
+        thr = take(bh * NQ * sizeof(float));
+        idx = take(bh * NQ * NTB * sizeof(uint16_t));  // the only T^2 term
+        cnt = take(bh * NQ * sizeof(int32_t));
+        cen8 = take(bh * NQ * HD);
+        cens = take(bh * NQ * sizeof(float));
+        // route -> exact handover: one (o, m, l) per (b, h, query block)
+        oPart = take(bh * NQ * HD * sizeof(uint16_t));
+        mPart = take(bh * NQ * sizeof(float));
+        lPart = take(bh * NQ * sizeof(float));
+        statsV = take(bh * HD * sizeof(float));         // producer vamax accumulator
+        qmean = take(bh * NPAD * HD * sizeof(float));   // f32 query-block means (coarse branch)
+        scratch = take(sol_preprocess_scratch_bytes(B, H, NPAD));
+        total = o;
+    }
+};
+
+void validate_shape(int batch, int seq_len, int num_heads) {
+    if ((seq_len + BLK - 1) / BLK > 65535)
+        throw std::runtime_error("sol_attn: seq_len too long for 16-bit block ids");
+    // gridDim.y for every stage.
+    if (static_cast<int64_t>(batch) * num_heads > 65535)
+        throw std::runtime_error("sol_attn: batch * num_heads exceeds the 65535 grid limit");
+}
+
+// route + exact over a populated workspace. The hipGetLastError covers every stage
+// launched before it; without it a rejected launch leaves route's handover values
+// in `out`.
+void run_route_exact(const Plan& p, char* w, const void* ext_threshold, void* out,
+                     const void* blen, int tail, int batch, int seq_len, int num_heads,
+                     int sink_start, int sink_end, int sink_q_start, int sink_q_end,
+                     float scale_log2, hipStream_t stream) {
+    // top-k mode: the caller supplies the per-query-block threshold
+    const void* thr = ext_threshold ? ext_threshold : static_cast<const void*>(w + p.thr);
+    launch_sol_route(w + p.cen8, w + p.cens, w + p.kciP, w + p.kcs, w + p.vcT, w + p.vsc, thr,
+                     w + p.idx, w + p.cnt, w + p.oPart, w + p.mPart, w + p.lPart, blen, tail,
+                     batch, seq_len, num_heads, p.NTB, p.NPAD, p.NQ, sink_start, sink_end,
+                     sink_q_start, sink_q_end, scale_log2, stream);
+    launch_sol_exact(w + p.qiP, w + p.qs, w + p.kiP, w + p.ksb, w + p.vTi, w + p.vsc, w + p.idx,
+                     w + p.cnt, w + p.oPart, w + p.mPart, w + p.lPart, out, batch, seq_len, p.Tp,
+                     num_heads, p.NQ, p.NTB, scale_log2, stream);
+    const hipError_t err = hipGetLastError();
+    if (err != hipSuccess)
+        throw std::runtime_error(std::string("sol_attn: kernel launch failed: ") +
+                                 hipGetErrorString(err));
+}
+
+}  // namespace
+
+using comfy::hip_backend::sol::sol_check;
+
+// Plan dims and slot offsets, in the order sol_attn_plan_names lists them.
+extern "C" const char* const sol_attn_plan_names[] = {
+    "Tp",   "NTB",  "NPAD", "NQ",     "qiP",   "qs",    "kiP",     "ksb",   "vTi",
+    "vsc",  "kciP", "kcs",  "vcT",    "thr",   "cen8",  "cens",    "idx",   "cnt",
+    "oPart", "mPart", "lPart", "statsV", "qmean", "scratch", "total", nullptr,
+};
+
+// Writes the values into out[0..count) and returns count; writes nothing if
+// cap < count, so a caller with a fixed buffer can detect a grown Plan.
+extern "C" int sol_attn_plan(int batch, int seq_len, int num_heads, int64_t* out, int cap) {
+    const Plan p(batch, seq_len, num_heads);
+    const int64_t v[] = {
+        p.Tp, p.NTB, p.NPAD, p.NQ,
+        static_cast<int64_t>(p.qiP), static_cast<int64_t>(p.qs), static_cast<int64_t>(p.kiP),
+        static_cast<int64_t>(p.ksb), static_cast<int64_t>(p.vTi), static_cast<int64_t>(p.vsc),
+        static_cast<int64_t>(p.kciP), static_cast<int64_t>(p.kcs), static_cast<int64_t>(p.vcT),
+        static_cast<int64_t>(p.thr), static_cast<int64_t>(p.cen8), static_cast<int64_t>(p.cens),
+        static_cast<int64_t>(p.idx), static_cast<int64_t>(p.cnt), static_cast<int64_t>(p.oPart),
+        static_cast<int64_t>(p.mPart), static_cast<int64_t>(p.lPart),
+        static_cast<int64_t>(p.statsV), static_cast<int64_t>(p.qmean),
+        static_cast<int64_t>(p.scratch), static_cast<int64_t>(p.total),
+    };
+    const int count = static_cast<int>(sizeof(v) / sizeof(v[0]));
+    if (cap >= count)
+        for (int i = 0; i < count; ++i) out[i] = v[i];
+    return count;
+}
+
+// ---- chunked producer path ----
+extern "C" void sol_producer_begin(void* workspace, int batch, int seq_len, int num_heads,
+                                   hipStream_t stream) {
+    validate_shape(batch, seq_len, num_heads);
+    const Plan p(batch, seq_len, num_heads);
+    char* w = reinterpret_cast<char*>(workspace);
+    const size_t bh = static_cast<size_t>(batch) * num_heads;
+    // route reads vcT's pad columns; statsV is an atomicMax accumulator
+    sol_check(hipMemsetAsync(w + p.vcT, 0, bh * HD * p.NPAD * sizeof(uint16_t), stream),
+              "clearing the pooled V slot");
+    sol_check(hipMemsetAsync(w + p.statsV, 0, bh * HD * sizeof(float), stream),
+              "clearing the V absmax accumulator");
+}
+
+extern "C" void sol_producer_chunk(void* workspace, const void* qkv, const void* fab,
+                                   const void* qw, const void* kw, const void* kmean,
+                                   const void* vscale, const void* blen, float rope_eps,
+                                   int rot_dim, int t0, int M, int batch, int seq_len,
+                                   int num_heads, hipStream_t stream) {
+    const Plan p(batch, seq_len, num_heads);
+    char* w = reinterpret_cast<char*>(workspace);
+    launch_sol_producer(qkv, fab, qw, kw, kmean, vscale, w + p.qiP, w + p.qs, w + p.kiP,
+                        w + p.ksb, w + p.vTi, w + p.vcT, w + p.scratch, w + p.cen8, w + p.cens,
+                        w + p.qmean, w + p.statsV, blen, rope_eps, rot_dim, t0, M, seq_len, p.Tp,
+                        num_heads, p.NPAD, p.NQ, stream);
+}
+
+// vscale: the [B*H, HD] f32 scale the producer quantized V with.
+// kmean_next / vamax_out ([B*H, HD] f32) receive this step's statistics.
+extern "C" void launch_sol_attn_core(void* workspace, void* out, const void* vscale,
+                                     void* kmean_next, void* vamax_out, const void* blen, int tail,
+                                     int batch, int seq_len, int num_heads, float tau, float scale,
+                                     const void* ext_threshold, int sink_start, int sink_end,
+                                     int sink_q_start, int sink_q_end, hipStream_t stream) {
+    validate_shape(batch, seq_len, num_heads);
+    const Plan p(batch, seq_len, num_heads);
+    char* w = reinterpret_cast<char*>(workspace);
+    const float scale_log2 = scale * 1.4426950408889634f;
+    const size_t stats_bytes = static_cast<size_t>(batch) * num_heads * HD * sizeof(float);
+    sol_check(hipMemcpyAsync(w + p.vsc, vscale, stats_bytes, hipMemcpyDeviceToDevice, stream),
+              "staging the V scale");
+    launch_sol_finish(w + p.scratch, w + p.kciP, w + p.kcs, w + p.thr, w + p.cen8, w + p.cens,
+                      kmean_next, blen, batch, seq_len, num_heads, p.NTB, p.NPAD, p.NQ, tau,
+                      scale_log2, stream);
+    run_route_exact(p, w, ext_threshold, out, blen, tail, batch, seq_len, num_heads, sink_start,
+                    sink_end, sink_q_start, sink_q_end, scale_log2, stream);
+    sol_check(hipMemcpyAsync(vamax_out, w + p.statsV, stats_bytes, hipMemcpyDeviceToDevice, stream),
+              "reading back the V absmax");
+}
+
+extern "C" void launch_sol_attn(const void* q, const void* k, const void* v, void* out,
+                                void* workspace, int batch, int seq_len, int num_heads,
+                                int head_dim, float tau, float scale, const void* key_bias,
+                                const void* ext_threshold, const void* blen, int tail,
+                                int sink_start, int sink_end, int sink_q_start, int sink_q_end,
+                                int64_t qs_b, int64_t qs_t, int64_t qs_h, int64_t ks_b,
+                                int64_t ks_t, int64_t ks_h, int64_t vs_b, int64_t vs_t,
+                                int64_t vs_h, hipStream_t stream) {
+    if (head_dim != HD)
+        throw std::runtime_error("sol_attn supports head_dim 128, got " + std::to_string(head_dim));
+    validate_shape(batch, seq_len, num_heads);
+
+    const Plan p(batch, seq_len, num_heads);
+    char* w = reinterpret_cast<char*>(workspace);
+    const float scale_log2 = scale * 1.4426950408889634f;
+    launch_sol_preprocess(q, k, v, w + p.qiP, w + p.qs, w + p.kiP, w + p.ksb, w + p.kciP,
+                          w + p.kcs, w + p.vcT, w + p.thr, w + p.cen8, w + p.cens, w + p.vsc,
+                          w + p.qmean, w + p.scratch, key_bias, blen, batch, seq_len, p.Tp,
+                          num_heads, p.NTB, p.NPAD, p.NQ, qs_b, qs_t, qs_h, ks_b, ks_t, ks_h,
+                          vs_b, vs_t, vs_h, tau, scale_log2, stream);
+    launch_sol_vtranspose(v, w + p.vsc, w + p.vTi, batch, seq_len, p.Tp, num_heads, vs_b, vs_t,
+                          vs_h, stream);
+    run_route_exact(p, w, ext_threshold, out, blen, tail, batch, seq_len, num_heads, sink_start,
+                    sink_end, sink_q_start, sink_q_end, scale_log2, stream);
+}

--- a/comfy_kitchen/backends/hip/sage_attention/sol_attn_exact.hip
+++ b/comfy_kitchen/backends/hip/sage_attention/sol_attn_exact.hip
@@ -1,0 +1,203 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Sol-Attn exact branch: each query block walks its routed key-block list,
+// resuming the online softmax (o / m / l) from route's handover.
+//
+// All-INT8, and transposed like int8_attn.hip: S^T = K @ Q^T puts one query on a
+// lane with eight keys in its accumulator, so the softmax is scalar per lane and
+// P^T is already the u8 A operand of O^T = V^T @ P^T. That is what the CUDA source
+// buys with sol::perm_key instead; neither the keys nor the channels are permuted
+// here. K's (scale, bias) pairs are staged alongside the tile because the key index
+// is half-wave uniform, so every lane of a half reads the same pair.
+//
+// The u8 P scale and the per-channel V scale are constant across key blocks and
+// fold into the epilogue; l sums the packed bytes so numerator and denominator
+// quantize identically.
+#include <hip/hip_runtime.h>
+
+#include <cstdint>
+
+#include "sol_common.h"
+
+namespace comfy::hip_backend::sol {
+namespace {
+
+constexpr int HD = kHeadDim;
+constexpr int BQ = kBlock;  // queries per workgroup: one query block
+constexpr int BK = kBlock;  // keys per routed block
+constexpr int NWAVE = BQ / 16, kThreads = NWAVE * 32;
+constexpr int DT = HD / 16;  // contraction tiles for S = K Q^T
+constexpr int KT = BK / 16;  // score key tiles
+constexpr int NT = HD / 16;  // output channel tiles
+
+#if defined(COMFY_MMA_GFX11)
+constexpr int kLdsPad = 16;
+#else
+constexpr int kLdsPad = 8;
+#endif
+constexpr int kStrideK = HD + kLdsPad;
+constexpr int kStrideV = BK + kLdsPad;
+
+// qi:  [B,T,H,D] int8                  qs:  [B,T,H] f32
+// ki:  [B*H,Tp,D] int8                 ksb: [B*H,Tp] float2 = (ks, bias)
+// vT:  [B*H,D,Tp] int8 (transposed)    vsc: [B*H,D] f32
+__global__ __launch_bounds__(kThreads) void sol_exact_kernel(
+    const int8_t* __restrict__ qi, const float* __restrict__ qs, const int8_t* __restrict__ ki,
+    const float2* __restrict__ ksb, const int8_t* __restrict__ vT, const float* __restrict__ vsc,
+    const uint16_t* __restrict__ blk_idx, const int32_t* __restrict__ blk_cnt,
+    const __bf16* __restrict__ o_part, const float* __restrict__ m_part,
+    const float* __restrict__ l_part, __bf16* __restrict__ out, int T, int Tp, int H, int NTB,
+    float scale_log2) {
+    __shared__ __attribute__((aligned(16))) int8_t sK[BK * kStrideK];
+    __shared__ __attribute__((aligned(16))) int8_t sVt[HD * kStrideV];
+    __shared__ float2 sKsb[BK];
+
+    const int tid = threadIdx.x, wave = tid >> 5, lane = tid & 31;
+    const int r = frag_row(lane);
+    const int q_block = blockIdx.x, bh = blockIdx.y;
+    const int batch = bh / H, head = bh % H;
+    const int64_t bh_base = static_cast<int64_t>(batch) * T * H * HD + static_cast<int64_t>(head) * HD;
+    const int64_t bh_s = static_cast<int64_t>(batch) * T * H + head;
+    const int64_t vT_base = static_cast<int64_t>(bh) * HD * Tp;
+    const int64_t vsc_base = static_cast<int64_t>(bh) * HD;
+    const int64_t kp_base = static_cast<int64_t>(bh) * Tp;
+    const int64_t kd_base = static_cast<int64_t>(bh) * Tp * HD;
+
+    const int q_row = q_block * BQ + wave * 16 + r;
+    const int q_clamped = imin(q_row, T - 1);
+
+    typename MmaInt8::Frag q_frag[DT];
+    {
+        const int8_t* qrow = qi + bh_base + static_cast<int64_t>(q_clamped) * H * HD;
+#pragma unroll
+        for (int dt = 0; dt < DT; ++dt) q_frag[dt] = MmaInt8::load_aligned(qrow, 0, dt * 16, 0, lane);
+    }
+    const float qsc = qs[bh_s + static_cast<int64_t>(q_clamped) * H] * scale_log2;
+
+    const size_t qb_s = static_cast<size_t>(bh) * gridDim.x + q_block;
+    const uint16_t* my_idx = blk_idx + qb_s * NTB;
+    const int n_blocks = blk_cnt[qb_s];
+
+    // resume route's state: one (o, m, l) per (b, h, query block)
+    float o_acc[NT][8];
+    {
+        const __bf16* orow = o_part + qb_s * HD;
+#pragma unroll
+        for (int nt = 0; nt < NT; ++nt) load_o_tile<__bf16>(orow, nt * 16, o_acc[nt], lane);
+    }
+    float m_r = m_part[qb_s], l_r = l_part[qb_s];
+
+    for (int kb = 0; kb < n_blocks; ++kb) {
+        const int64_t k0 = static_cast<int64_t>(my_idx[kb]) * BK;
+
+        __syncthreads();
+        for (int idx = tid; idx < BK * (HD / 8); idx += kThreads) {
+            const int p = idx / (HD / 8), c8 = (idx % (HD / 8)) * 8;
+            *reinterpret_cast<uint2*>(sK + p * kStrideK + c8) =
+                *reinterpret_cast<const uint2*>(ki + kd_base + (k0 + p) * HD + c8);
+        }
+        for (int idx = tid; idx < HD * (BK / 8); idx += kThreads) {
+            const int c = idx / (BK / 8), part = (idx % (BK / 8)) * 8;
+            *reinterpret_cast<uint2*>(sVt + c * kStrideV + part) = *reinterpret_cast<const uint2*>(
+                vT + vT_base + static_cast<int64_t>(c) * Tp + k0 + part);
+        }
+        for (int idx = tid; idx < BK; idx += kThreads) sKsb[idx] = ksb[kp_base + k0 + idx];
+        __syncthreads();
+
+        typename MmaInt8::Acc s_acc[KT];
+#pragma unroll
+        for (int kt = 0; kt < KT; ++kt) {
+            s_acc[kt] = MmaInt8::zero();
+#pragma unroll
+            for (int dt = 0; dt < DT; ++dt) {
+                s_acc[kt] = MmaInt8::mma(
+                    MmaInt8::load_aligned(sK, kt * 16 + r, dt * 16, kStrideK, lane), q_frag[dt],
+                    s_acc[kt]);
+            }
+        }
+
+        float p_val[KT][8];
+        float m_new = m_r;
+#pragma unroll
+        for (int kt = 0; kt < KT; ++kt) {
+#pragma unroll
+            for (int e = 0; e < 8; ++e) {
+                const float2 kb2 = sKsb[kt * 16 + acc_row(lane, e)];
+                // A dead key carries a zero scale and a kNeg bias, so its score is kNeg.
+                const float s = fmaf(static_cast<float>(s_acc[kt][e]), qsc * kb2.x, kb2.y);
+                p_val[kt][e] = s;
+                m_new = fmaxf(m_new, s);
+            }
+        }
+        m_new = fmaxf(m_new, swap_half_wave(m_new));
+        const float alpha = exp2f(m_r - m_new);
+        m_r = m_new;
+
+        // u8 P scale folded into the exponent (+log2 255); l carries it too
+        const float m_off = m_new - kProbU8Offset;
+        typename MmaInt8::Frag p_frag[KT];
+        uint32_t li = 0u;
+#pragma unroll
+        for (int kt = 0; kt < KT; ++kt) {
+            uint32_t packed[8];
+#pragma unroll
+            for (int e = 0; e < 8; ++e) {
+                packed[e] = prob_to_u8(exp2f(p_val[kt][e] - m_off));
+                li += packed[e];
+            }
+            p_frag[kt] = pack_prob_frag(packed, lane);
+        }
+        li += swap_half_wave_b32(li);
+        l_r = fmaf(l_r, alpha, static_cast<float>(li));
+
+#pragma unroll
+        for (int nt = 0; nt < NT; ++nt) {
+            typename MmaInt8::Acc partial = MmaInt8::zero();
+#pragma unroll
+            for (int kt = 0; kt < KT; ++kt) {
+                partial = MmaInt8::mma_ub(
+                    MmaInt8::load_aligned(sVt, nt * 16 + r, kt * 16, kStrideV, lane), p_frag[kt],
+                    partial);
+            }
+#pragma unroll
+            for (int e = 0; e < 8; ++e) {
+                o_acc[nt][e] = fmaf(o_acc[nt][e], alpha, static_cast<float>(partial[e]));
+            }
+        }
+    }
+
+    if (q_row >= T) return;
+    // l is zero only when a row got no mass from either branch; zeros are right there
+    const float inv = 1.f / fmaxf(l_r, 1e-30f);
+    __bf16* orow = out + bh_base + static_cast<int64_t>(q_row) * H * HD;
+#pragma unroll
+    for (int nt = 0; nt < NT; ++nt) {
+        float vals[8];
+#pragma unroll
+        for (int e = 0; e < 8; ++e) {
+            vals[e] = o_acc[nt][e] * inv * vsc[vsc_base + nt * 16 + acc_row(lane, e)];
+        }
+        store_o_tile<__bf16>(orow, nt * 16, vals, lane);
+    }
+}
+
+}  // namespace
+}  // namespace comfy::hip_backend::sol
+
+using namespace comfy::hip_backend::sol;
+
+void launch_sol_exact(const void* qi, const void* qs, const void* ki, const void* ksb,
+                      const void* vT, const void* vsc, const void* blk_idx, const void* blk_cnt,
+                      const void* o_part, const void* m_part, const void* l_part, void* out, int B,
+                      int T, int Tp, int H, int NQ, int NTB, float scale_log2,
+                      hipStream_t stream) {
+    dim3 grid(NQ, B * H);
+    sol_exact_kernel<<<grid, kThreads, 0, stream>>>(
+        static_cast<const int8_t*>(qi), static_cast<const float*>(qs),
+        static_cast<const int8_t*>(ki), static_cast<const float2*>(ksb),
+        static_cast<const int8_t*>(vT), static_cast<const float*>(vsc),
+        static_cast<const uint16_t*>(blk_idx), static_cast<const int32_t*>(blk_cnt),
+        static_cast<const __bf16*>(o_part), static_cast<const float*>(m_part),
+        static_cast<const float*>(l_part), static_cast<__bf16*>(out), T, Tp, H, NTB, scale_log2);
+}

--- a/comfy_kitchen/backends/hip/sage_attention/sol_attn_preprocess.hip
+++ b/comfy_kitchen/backends/hip/sage_attention/sol_attn_preprocess.hip
@@ -1,0 +1,268 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Sol-Attn preprocess: post-rope q/k/v -> the workspace carriers
+//   qi   [B,T,H,D] int8                       qs   [B,T,H] f32
+//   ki   [B*H,Tp,D] int8                      ksb  [B*H,Tp] float2 = (ks, bias)
+//   vT   [B*H,D,Tp] int8                      vsc  [B*H,D] f32  -- sol_attn_vtranspose.hip
+//   kci  [B*H,NPAD,D] int8                    kcs  [B*H,NPAD] f32
+//   vcT  [B*H,D,NPAD] bf16                    threshold [B*H,NQ] f32
+//   cen8 [B*H,NQ,D] int8                      cens [B*H,NQ] f32
+// Q-side carriers are indexed by T, K/V-side by Tp. Every carrier is in natural
+// channel and key order (see sol_common.h). Inputs are read through explicit
+// strides with a contiguous last dim. K's mean and V's scale are global
+// reductions, hence the separate passes. `launch_sol_finish` is the chunked
+// producer's second half.
+#include <hip/hip_runtime.h>
+
+#include <cstdint>
+
+#include "sol_common.h"
+
+namespace comfy::hip_backend::sol {
+namespace {
+
+constexpr int HD = kHeadDim, BLK = kBlock;
+
+// Scratch: pooled K block means (sums in the producer path), kmean, kcvar.
+struct Scratch {
+    float* kc;
+    float* kmean;
+    float* kcvar;
+};
+
+inline Scratch carve_scratch(void* scratch, int B, int H, int NPAD) {
+    Scratch s;
+    s.kc = static_cast<float*>(scratch);
+    s.kmean = s.kc + static_cast<size_t>(B) * H * NPAD * HD;
+    s.kcvar = s.kmean + static_cast<size_t>(B) * H * HD;
+    return s;
+}
+
+// routing threshold: tau sigma of the proxy row, from the centroid's proxy variance
+__forceinline__ __device__ float thr_of(float var, float tau, float log2s) {
+    return tau * sqrtf(var * log2s * log2s + 1e-6f);
+}
+
+// atomicMax over non-negative floats: the bit pattern orders the same way.
+__forceinline__ __device__ void atomic_max_pos(float* dst, float v) {
+    atomicMax(reinterpret_cast<unsigned int*>(dst), __float_as_uint(v));
+}
+
+// ---- pass 1: K/V block reductions plus V's per-channel |max| ----
+// One block per (bh, pooled block), thread == channel.
+__global__ __launch_bounds__(HD) void prep_reduce_kv(
+    const __bf16* __restrict__ k, const __bf16* __restrict__ v, float* __restrict__ kc,
+    __bf16* __restrict__ vcT, float* __restrict__ vamax, const int32_t* __restrict__ blen, int T,
+    int H, int NTB, int NPAD, int64_t sb, int64_t st, int64_t sh, int64_t vb, int64_t vt,
+    int64_t vh) {
+    const int n = blockIdx.x, bh = blockIdx.y;
+    const int batch = bh / H, head = bh % H, d = threadIdx.x;
+    const size_t o = (static_cast<size_t>(bh) * NPAD + n) * HD + d;
+    if (n >= NTB) {
+        kc[o] = 0.f;
+        vcT[(static_cast<size_t>(bh) * HD + d) * NPAD + n] = static_cast<__bf16>(0.f);
+        return;
+    }
+
+    const int t0 = n * BLK, len = block_len_of(blen, n, T);
+    float sk = 0.f, sv = 0.f, av = 0.f;
+    for (int i = 0; i < len; ++i) {
+        const int64_t koff = batch * sb + static_cast<int64_t>(t0 + i) * st + head * sh + d;
+        const int64_t voff = batch * vb + static_cast<int64_t>(t0 + i) * vt + head * vh + d;
+        const float kk = static_cast<float>(k[koff]);
+        const float vv = static_cast<float>(v[voff]);
+        sk += kk;
+        sv += vv;
+        av = fmaxf(av, fabsf(vv));
+    }
+    kc[o] = sk / static_cast<float>(len);  // block MEAN of K
+    vcT[(static_cast<size_t>(bh) * HD + d) * NPAD + n] = static_cast<__bf16>(sv);  // block SUM of V
+    atomic_max_pos(&vamax[static_cast<size_t>(bh) * HD + d], av);
+}
+
+// ---- pass 2: reductions over the pooled tensors ----
+// vamax (pass 1's |max|; null in the producer path, whose caller supplies the V
+// scale) becomes the per-channel V scale; may alias vsc.
+__global__ __launch_bounds__(HD) void prep_pooled_stats(const float* __restrict__ kc,
+                                                        float* __restrict__ kmean,
+                                                        const float* vamax, float* vsc,
+                                                        float* __restrict__ kcvar, int NTB,
+                                                        int NPAD) {
+    const int bh = blockIdx.x, d = threadIdx.x;
+    float sm = 0.f, ss = 0.f;
+    for (int n = 0; n < NTB; ++n) {
+        const float x = kc[(static_cast<size_t>(bh) * NPAD + n) * HD + d];
+        sm += x;
+        ss = fmaf(x, x, ss);
+    }
+    const float m = sm / static_cast<float>(NTB);
+    kmean[static_cast<size_t>(bh) * HD + d] = m;
+    if (vamax) {
+        vsc[static_cast<size_t>(bh) * HD + d] =
+            fmaxf(vamax[static_cast<size_t>(bh) * HD + d] / 127.0f, 1e-8f);
+    }
+    kcvar[static_cast<size_t>(bh) * HD + d] = fmaxf(ss / static_cast<float>(NTB) - m * m, 0.f);
+}
+
+// ---- pass 3: centre and quantize the pooled keys ----
+__global__ __launch_bounds__(HD) void prep_pooled_quant(const float* __restrict__ kc,
+                                                        const float* __restrict__ kmean,
+                                                        int8_t* __restrict__ kci,
+                                                        float* __restrict__ kcs, int NTB,
+                                                        int NPAD) {
+    __shared__ float sred[HD];
+    const int n = blockIdx.x, bh = blockIdx.y, d = threadIdx.x;
+    const size_t o = (static_cast<size_t>(bh) * NPAD + n) * HD + d;
+    const bool live = n < NTB;
+    const float x = live ? (kc[o] - kmean[static_cast<size_t>(bh) * HD + d]) : 0.f;
+    const float sc = fmaxf(block_max128(fabsf(x), sred) / 127.0f, 1e-12f);
+    if (d == 0) kcs[static_cast<size_t>(bh) * NPAD + n] = live ? sc : 0.f;
+    kci[(static_cast<size_t>(bh) * NPAD + n) * HD + d] = live ? q8(x, 1.f / sc)
+                                                              : static_cast<int8_t>(0);
+}
+
+// ---- pass 4: quantize Q, the centroid and the routing threshold from one tile ----
+__global__ __launch_bounds__(HD) void prep_q(const __bf16* __restrict__ q,
+                                             const float* __restrict__ kcvar,
+                                             int8_t* __restrict__ qi, float* __restrict__ qs,
+                                             float* __restrict__ thr, int8_t* __restrict__ cen8,
+                                             float* __restrict__ cens,
+                                             float* __restrict__ qmean,  // [B*H, NPAD, HD] f32
+                                             const int32_t* __restrict__ blen, int T, int H,
+                                             int NQ, int NPAD, float tau, float log2s, int64_t sb,
+                                             int64_t st, int64_t sh) {
+    __shared__ __attribute__((aligned(16))) __bf16 sQ[BLK * kLdTile];
+    __shared__ __attribute__((aligned(16))) float sred[HD];
+    const int qb = blockIdx.x, bh = blockIdx.y;
+    const int batch = bh / H, head = bh % H;
+    const int t0 = qb * BLK, len = block_len_of(blen, qb, T), nrows = imin(BLK, T - t0);
+
+    stage_tile64(sQ, q + batch * sb + static_cast<int64_t>(t0) * st + head * sh, st, len);
+    __syncthreads();
+    const size_t tok0 = static_cast<size_t>(batch) * T + t0;
+    quant_q_rows(sQ, len, nrows, qi + (tok0 * H + head) * HD, qs + tok0 * H + head, H);
+    __syncthreads();
+    const size_t qrow = static_cast<size_t>(bh) * NQ + qb;
+    const float c = centroid_quant(sQ, len, sred, cen8 + qrow * HD, cens + qrow);
+    qmean[(static_cast<size_t>(bh) * NPAD + qb) * HD + threadIdx.x] = c;
+    __syncthreads();  // sred held the centroid bytes
+    const float var = block_sum128(c * c * kcvar[static_cast<size_t>(bh) * HD + threadIdx.x], sred);
+    if (threadIdx.x == 0) thr[qrow] = thr_of(var, tau, log2s);
+}
+
+// ---- pass 5: centre and quantize K ----
+__global__ __launch_bounds__(HD) void prep_k(const __bf16* __restrict__ k,
+                                             const float* __restrict__ kmean,
+                                             int8_t* __restrict__ ki, float2* __restrict__ ksb,
+                                             const float* __restrict__ kbias,  // [B, T] log2 units
+                                             const int32_t* __restrict__ blen, int T, int Tp,
+                                             int H, int64_t sb, int64_t st, int64_t sh) {
+    __shared__ __attribute__((aligned(16))) __bf16 sK[BLK * kLdTile];
+    const int n = blockIdx.x, bh = blockIdx.y;
+    const int batch = bh / H, head = bh % H;
+    const int t0 = n * BLK, len = block_len_of(blen, n, T);
+
+    stage_tile64(sK, k + batch * sb + static_cast<int64_t>(t0) * st + head * sh, st, len);
+    __syncthreads();
+    const size_t dst0 = static_cast<size_t>(bh) * Tp + n * BLK;
+    quant_k_rows(sK, len, kmean + static_cast<size_t>(bh) * HD,
+                 kbias ? kbias + static_cast<size_t>(batch) * T + t0 : nullptr, ki + dst0 * HD,
+                 ksb + dst0);
+}
+
+// ---- producer-path finish: pooled sums -> means, next-step kmean ----
+__global__ __launch_bounds__(HD) void prep_sums_to_means(float* __restrict__ kc,
+                                                         float* __restrict__ kmean_next,
+                                                         const int32_t* __restrict__ blen, int T,
+                                                         int NTB, int NPAD) {
+    const int bh = blockIdx.x, d = threadIdx.x;
+    float total = 0.f;
+    int tokens = 0;
+    for (int n = 0; n < NTB; ++n) {
+        const size_t o = (static_cast<size_t>(bh) * NPAD + n) * HD + d;
+        const float sum = kc[o];
+        total += sum;
+        const int len = block_len_of(blen, n, T);
+        tokens += len;
+        kc[o] = sum / static_cast<float>(len);
+    }
+    kmean_next[static_cast<size_t>(bh) * HD + d] = total / static_cast<float>(tokens);
+}
+
+// ---- producer-path threshold from the quantized centroid ----
+__global__ __launch_bounds__(HD) void prep_thr_from_cen(const int8_t* __restrict__ cen8,
+                                                        const float* __restrict__ cens,
+                                                        const float* __restrict__ kcvar,
+                                                        float* __restrict__ thr, int NQ, float tau,
+                                                        float log2s) {
+    __shared__ float sred[HD];
+    const int qb = blockIdx.x, bh = blockIdx.y, d = threadIdx.x;
+    const float c = static_cast<float>(cen8[(static_cast<size_t>(bh) * NQ + qb) * HD + d]) *
+                    cens[static_cast<size_t>(bh) * NQ + qb];
+    const float var = block_sum128(c * c * kcvar[static_cast<size_t>(bh) * HD + d], sred);
+    if (d == 0) thr[static_cast<size_t>(bh) * NQ + qb] = thr_of(var, tau, log2s);
+}
+
+}  // namespace
+}  // namespace comfy::hip_backend::sol
+
+using namespace comfy::hip_backend::sol;
+
+// Producer path: block K sums left in scratch -> means, pooled quant, threshold.
+// The caller places the V scale it quantized with in the vsc slot.
+void launch_sol_finish(void* scratch, void* kci, void* kcs, void* threshold, const void* cen8,
+                       const void* cens, void* kmean_next, const void* blen, int B, int T, int H,
+                       int NTB, int NPAD, int NQ, float tau, float scale_log2,
+                       hipStream_t stream) {
+    const Scratch s = carve_scratch(scratch, B, H, NPAD);
+    prep_sums_to_means<<<B * H, HD, 0, stream>>>(s.kc, static_cast<float*>(kmean_next),
+                                                 static_cast<const int32_t*>(blen), T, NTB, NPAD);
+    prep_pooled_stats<<<B * H, HD, 0, stream>>>(s.kc, s.kmean, nullptr, nullptr, s.kcvar, NTB,
+                                                NPAD);
+    prep_pooled_quant<<<dim3(NPAD, B * H), HD, 0, stream>>>(
+        s.kc, s.kmean, static_cast<int8_t*>(kci), static_cast<float*>(kcs), NTB, NPAD);
+    prep_thr_from_cen<<<dim3(NQ, B * H), HD, 0, stream>>>(
+        static_cast<const int8_t*>(cen8), static_cast<const float*>(cens), s.kcvar,
+        static_cast<float*>(threshold), NQ, tau, scale_log2);
+}
+
+void launch_sol_preprocess(const void* q, const void* k, const void* v, void* qi, void* qs,
+                           void* ki, void* ksb, void* kci, void* kcs, void* vcT, void* threshold,
+                           void* cen8, void* cens, void* vsc, void* qmean,
+                           void* scratch,          // sol_preprocess_scratch_bytes
+                           const void* key_bias,   // [B, T] f32 in log2 units, or nullptr
+                           const void* blen,       // [NTB] int32 valid tokens per block, or nullptr
+                           int B, int T, int Tp, int H, int NTB, int NPAD, int NQ, int64_t qs_b,
+                           int64_t qs_t, int64_t qs_h, int64_t ks_b, int64_t ks_t, int64_t ks_h,
+                           int64_t vs_b, int64_t vs_t, int64_t vs_h, float tau, float scale_log2,
+                           hipStream_t stream) {
+    const Scratch s = carve_scratch(scratch, B, H, NPAD);
+
+    // pass 1 accumulates V's |max| into vsc by atomicMax
+    sol_check(hipMemsetAsync(vsc, 0, static_cast<size_t>(B) * H * HD * sizeof(float), stream),
+              "clearing the V absmax accumulator");
+    prep_reduce_kv<<<dim3(NPAD, B * H), HD, 0, stream>>>(
+        static_cast<const __bf16*>(k), static_cast<const __bf16*>(v), s.kc,
+        static_cast<__bf16*>(vcT), static_cast<float*>(vsc), static_cast<const int32_t*>(blen), T,
+        H, NTB, NPAD, ks_b, ks_t, ks_h, vs_b, vs_t, vs_h);
+    prep_pooled_stats<<<B * H, HD, 0, stream>>>(s.kc, s.kmean, static_cast<const float*>(vsc),
+                                                static_cast<float*>(vsc), s.kcvar, NTB, NPAD);
+    prep_pooled_quant<<<dim3(NPAD, B * H), HD, 0, stream>>>(
+        s.kc, s.kmean, static_cast<int8_t*>(kci), static_cast<float*>(kcs), NTB, NPAD);
+    prep_q<<<dim3(NQ, B * H), HD, 0, stream>>>(
+        static_cast<const __bf16*>(q), s.kcvar, static_cast<int8_t*>(qi), static_cast<float*>(qs),
+        static_cast<float*>(threshold), static_cast<int8_t*>(cen8), static_cast<float*>(cens),
+        static_cast<float*>(qmean), static_cast<const int32_t*>(blen), T, H, NQ, NPAD, tau,
+        scale_log2, qs_b, qs_t, qs_h);
+    prep_k<<<dim3(NTB, B * H), HD, 0, stream>>>(
+        static_cast<const __bf16*>(k), s.kmean, static_cast<int8_t*>(ki),
+        static_cast<float2*>(ksb), static_cast<const float*>(key_bias),
+        static_cast<const int32_t*>(blen), T, Tp, H, ks_b, ks_t, ks_h);
+}
+
+size_t sol_preprocess_scratch_bytes(int B, int H, int NPAD) {
+    return (static_cast<size_t>(B) * H * NPAD * kHeadDim +
+            static_cast<size_t>(2) * B * H * kHeadDim) *
+           sizeof(float);
+}

--- a/comfy_kitchen/backends/hip/sage_attention/sol_attn_producer.hip
+++ b/comfy_kitchen/backends/hip/sage_attention/sol_attn_producer.hip
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Sol-Attn chunked QKV producer: a token-major slice of the fused qkv projection
+// ([M, 3*H*HD] bf16, B=1) -> the workspace carriers for those tokens, with RMSNorm
+// and RoPE applied in-tile, so full bf16 Q/K/V never exist.
+//
+// K centering and V scaling use LAST step's kmean / V scale (range optimisations
+// only: the per-token K scale absorbs any centering vector, the V scale carries a
+// clip margin). Next-step statistics come from the pooled K sums
+// (launch_sol_finish) and the vamax atomics here.
+#include <hip/hip_runtime.h>
+
+#include <cstdint>
+
+#include "sol_common.h"
+
+namespace comfy::hip_backend::sol {
+namespace {
+
+constexpr int HD = kHeadDim, BLK = kBlock;
+
+// One workgroup per (64-token block, head); q, k, v pass through one staged tile.
+// qkv row = [q | k | v], each H*HD wide.
+__global__ __launch_bounds__(HD) void sol_producer_kernel(
+    const __bf16* __restrict__ qkv,  // [M, 3*H*HD], chunk at token t0
+    const float* __restrict__ fab,   // [T, rot, 2] packed rope coeffs
+    const __bf16* __restrict__ qw, const __bf16* __restrict__ kw,
+    const float* __restrict__ kmean,   // [H, HD] stale (may be zeros)
+    const float* __restrict__ vscale,  // [H, HD] stale V scale
+    int8_t* __restrict__ qi, float* __restrict__ qs, int8_t* __restrict__ ki,
+    float2* __restrict__ ksb, int8_t* __restrict__ vT, __bf16* __restrict__ vcT,
+    float* __restrict__ ksum,  // [H, NPAD, HD] block K sums (post-rope)
+    int8_t* __restrict__ cen8, float* __restrict__ cens,
+    float* __restrict__ qmean,       // [H, NPAD, HD] f32 block means (post-rope)
+    float* __restrict__ vamax_next,  // [H, HD] atomicMax accumulator
+    const int32_t* __restrict__ blen, float rope_eps, int rot, int t0, int M, int T, int Tp, int H,
+    int NPAD, int NQ) {
+    __shared__ __attribute__((aligned(16))) __bf16 sT[BLK * kLdTile];
+    __shared__ __attribute__((aligned(16))) float sred[HD];
+    const int blk_local = blockIdx.x, h = blockIdx.y, tid = threadIdx.x;
+    const int tb0 = t0 + blk_local * BLK;  // absolute token start
+    if (tb0 >= T) return;
+    const int nblk = tb0 / BLK;  // global 64-block index
+    const int nrows = imin(BLK, imin(M - blk_local * BLK, T - tb0));   // rows that exist
+    const int len = imin(block_len_of(blen, nblk, T), nrows);          // rows that are live
+    if (len <= 0) return;
+    const int64_t row_stride = static_cast<int64_t>(3) * H * HD;
+    const __bf16* rows = qkv + static_cast<int64_t>(blk_local * BLK) * row_stride;
+    const float* fab_t0 = fab + static_cast<int64_t>(tb0) * (rot * 2);
+
+    // ---------------- Q phase ----------------
+    stage_tile64(sT, rows + static_cast<int64_t>(h) * HD, row_stride, len);
+    __syncthreads();
+    norm_rope_rows(sT, kLdTile, len, fab_t0, qw, rope_eps, rot);
+    __syncthreads();
+    quant_q_rows(sT, len, nrows, qi + (static_cast<size_t>(tb0) * H + h) * HD,
+                 qs + static_cast<size_t>(tb0) * H + h, H);
+    __syncthreads();
+    const size_t qrow = static_cast<size_t>(h) * NQ + nblk;
+    const float c = centroid_quant(sT, len, sred, cen8 + qrow * HD, cens + qrow);
+    qmean[(static_cast<size_t>(h) * NPAD + nblk) * HD + tid] = c;
+    __syncthreads();
+
+    // ---------------- K phase ----------------
+    stage_tile64(sT, rows + static_cast<int64_t>(H + h) * HD, row_stride, len);
+    __syncthreads();
+    norm_rope_rows(sT, kLdTile, len, fab_t0, kw, rope_eps, rot);
+    __syncthreads();
+    {
+        // block K sums (post-rope, uncentered) for the pooled tensors
+        float sk = 0.f;
+        for (int t = 0; t < len; ++t) sk += static_cast<float>(sT[t * kLdTile + tid]);
+        ksum[(static_cast<size_t>(h) * NPAD + nblk) * HD + tid] = sk;
+    }
+    const size_t dst0 = static_cast<size_t>(h) * Tp + nblk * BLK;
+    quant_k_rows(sT, len, kmean + static_cast<size_t>(h) * HD, nullptr, ki + dst0 * HD,
+                 ksb + dst0);
+    __syncthreads();
+
+    // ---------------- V phase ----------------
+    stage_tile64(sT, rows + static_cast<int64_t>(2 * H + h) * HD, row_stride, len);
+    __syncthreads();
+    {
+        const int d = tid;
+        const float inv = 1.f / vscale[static_cast<size_t>(h) * HD + d];
+        float sv = 0.f, av = 0.f;
+        // vT: raw channel rows, keys in natural order
+        __attribute__((aligned(16))) int8_t col[16];
+        const size_t vbase = (static_cast<size_t>(h) * HD + d) * Tp + nblk * BLK;
+#pragma unroll
+        for (int c0 = 0; c0 < BLK; c0 += 16) {
+#pragma unroll
+            for (int j = 0; j < 16; ++j) {
+                const int t = c0 + j;
+                const float x = (t < len) ? static_cast<float>(sT[t * kLdTile + d]) : 0.f;
+                sv += x;
+                av = fmaxf(av, fabsf(x));
+                col[j] = q8(x, inv);
+            }
+            *reinterpret_cast<uint4*>(vT + vbase + c0) = *reinterpret_cast<const uint4*>(col);
+        }
+        vcT[(static_cast<size_t>(h) * HD + d) * NPAD + nblk] = static_cast<__bf16>(sv);
+        atomicMax(reinterpret_cast<unsigned int*>(&vamax_next[static_cast<size_t>(h) * HD + d]),
+                  __float_as_uint(av));
+    }
+}
+
+}  // namespace
+}  // namespace comfy::hip_backend::sol
+
+using namespace comfy::hip_backend::sol;
+
+void launch_sol_producer(const void* qkv, const void* fab, const void* qw, const void* kw,
+                         const void* kmean, const void* vscale, void* qi, void* qs, void* ki,
+                         void* ksb, void* vT, void* vcT, void* ksum, void* cen8, void* cens,
+                         void* qmean, void* vamax_next, const void* blen, float rope_eps, int rot,
+                         int t0, int M, int T, int Tp, int H, int NPAD, int NQ,
+                         hipStream_t stream) {
+    const int nblocks = (M + BLK - 1) / BLK;
+    if (nblocks <= 0) return;
+    sol_producer_kernel<<<dim3(nblocks, H), HD, 0, stream>>>(
+        static_cast<const __bf16*>(qkv), static_cast<const float*>(fab),
+        static_cast<const __bf16*>(qw), static_cast<const __bf16*>(kw),
+        static_cast<const float*>(kmean), static_cast<const float*>(vscale),
+        static_cast<int8_t*>(qi), static_cast<float*>(qs), static_cast<int8_t*>(ki),
+        static_cast<float2*>(ksb), static_cast<int8_t*>(vT), static_cast<__bf16*>(vcT),
+        static_cast<float*>(ksum), static_cast<int8_t*>(cen8), static_cast<float*>(cens),
+        static_cast<float*>(qmean), static_cast<float*>(vamax_next),
+        static_cast<const int32_t*>(blen), rope_eps, rot, t0, M, T, Tp, H, NPAD, NQ);
+}

--- a/comfy_kitchen/backends/hip/sage_attention/sol_attn_route.hip
+++ b/comfy_kitchen/backends/hip/sage_attention/sol_attn_route.hip
@@ -1,0 +1,259 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Sol-Attn routing and approximate tail. Both the routing decision and the tail
+// are centroid quantities, so this is an [N x N] problem and all rows of a query
+// block share one tail. Emits per (batch, head, query block):
+//   blk_idx / blk_cnt        the routed list the exact kernel walks
+//   o_part, m_part, l_part   one softmax state, in the exact kernel's units
+//                            (o / vsc; o and l both x255)
+//
+// Transposed like int8_attn.hip: the proxy scores come out of S^T = Kc @ Cen^T, so
+// a lane owns one query block (column lane % 16) and eight key blocks per tile
+// (rows acc_row(lane, e)). The two half-waves of a lane pair split the 64 key
+// blocks of a group, which is what the routed-list compaction below folds over.
+#include <hip/hip_runtime.h>
+
+#include <cstdint>
+
+#include "sol_common.h"
+
+namespace comfy::hip_backend::sol {
+namespace {
+
+constexpr int HD = kHeadDim;
+constexpr int BQ = 64;   // query blocks per workgroup
+constexpr int BN = 64;   // key blocks per group; also the compaction mask width
+constexpr int NWAVE = BQ / 16, kThreads = NWAVE * 32;
+constexpr int KT = BN / 16;  // proxy-score key tiles
+constexpr int DT = HD / 16;  // contraction tiles
+constexpr int NT = HD / 16;  // pooled-output tiles
+
+// Same LDS row padding as int8_attn.hip: gfx11 reads a whole 16-byte K-step per
+// lane, gfx12 eight bytes.
+#if defined(COMFY_MMA_GFX11)
+constexpr int kLdsPad = 16;
+#else
+constexpr int kLdsPad = 8;
+#endif
+constexpr int kStrideKc = HD + kLdsPad;  // bytes
+// bf16 elements, a multiple of 8 so both the staging stores and the fragment
+// reads land on 16-byte boundaries
+constexpr int kStrideVc = BN + 8;
+
+__global__ __launch_bounds__(kThreads) void sol_route_kernel(
+    const int8_t* __restrict__ cen8, const float* __restrict__ cens,
+    const int8_t* __restrict__ kci, const float* __restrict__ kcs,
+    const __bf16* __restrict__ vcT, const float* __restrict__ vsc,
+    const float* __restrict__ threshold, uint16_t* __restrict__ blk_idx,
+    int32_t* __restrict__ blk_cnt, __bf16* __restrict__ o_part, float* __restrict__ m_part,
+    float* __restrict__ l_part, const int32_t* __restrict__ blen, int tail, int T, int NTB,
+    int NPAD, int NQ, int sink_s, int sink_e, int sink_qs, int sink_qe, float scale_log2) {
+    __shared__ __attribute__((aligned(16))) int8_t sKc[BN * kStrideKc];
+    __shared__ __attribute__((aligned(16))) __bf16 sVcT[HD * kStrideVc];
+    __shared__ float sLen[BN];
+    __shared__ float sKcs[BN];
+
+    const int tid = threadIdx.x, wave = tid >> 5, lane = tid & 31;
+    const int r = frag_row(lane), half = lane >> 4;
+    const int bh = blockIdx.y;
+    const int qb = blockIdx.x * BQ + wave * 16 + r;
+    const bool live = qb < NQ;
+    const int qb_clamped = imin(qb, NQ - 1);
+
+    // Centroid fragments are loop invariant and fit: 16 VGPRs on gfx12, 32 on gfx11.
+    typename MmaInt8::Frag cen_frag[DT];
+    {
+        const int8_t* crow = cen8 + (static_cast<size_t>(bh) * NQ + qb_clamped) * HD;
+#pragma unroll
+        for (int dt = 0; dt < DT; ++dt) {
+            cen_frag[dt] = MmaInt8::load_aligned(crow, 0, dt * 16, 0, lane);
+        }
+    }
+    const float qsc = live ? cens[static_cast<size_t>(bh) * NQ + qb_clamped] * scale_log2 : 0.f;
+    const float thr = live ? threshold[static_cast<size_t>(bh) * NQ + qb_clamped] : 0.f;
+    const bool q_in_sink = live && qb >= sink_qs && qb < sink_qe;
+
+    uint16_t* my_row = blk_idx + (static_cast<size_t>(bh) * NQ + qb_clamped) * NTB;
+
+    // Sink blocks are always exact, so they head the list and the budget below
+    // counts the others only. The half-waves split the write. Clamped low as well
+    // as high: a negative start would put that many extra entries in the list, as
+    // block ids wrapped through uint16_t, and overrun the row.
+    const int sink_lo = imax(0, sink_s);
+    const int S = imax(0, imin(sink_e, NTB) - sink_lo);
+    int cnt = live ? S : 0;
+    if (live) {
+        for (int i = half; i < S; i += 2) my_row[i] = static_cast<uint16_t>(sink_lo + i);
+    }
+
+    // Accumulated in place rather than through a per-tile temporary: eight live
+    // v8f partials on top of these push gfx11 into scratch.
+    typename MmaBf16::Acc o_acc[NT];
+#pragma unroll
+    for (int nt = 0; nt < NT; ++nt) o_acc[nt] = MmaBf16::zero();
+    float m_r = kNeg, l_r = 0.f;
+
+    for (int gs = 0; gs < NTB; gs += BN) {
+        __syncthreads();
+        // 8-byte units: kStrideKc is a multiple of 8, not of 16, on gfx12.
+        for (int idx = tid; idx < BN * (HD / 8); idx += kThreads) {
+            const int p = idx / (HD / 8), c8 = (idx % (HD / 8)) * 8;
+            *reinterpret_cast<uint2*>(sKc + p * kStrideKc + c8) = *reinterpret_cast<const uint2*>(
+                kci + (static_cast<int64_t>(bh) * NPAD + gs + p) * HD + c8);
+        }
+        for (int idx = tid; idx < HD * (BN / 8); idx += kThreads) {
+            const int c = idx / (BN / 8), part = (idx % (BN / 8)) * 8;
+            *reinterpret_cast<uint4*>(sVcT + c * kStrideVc + part) = *reinterpret_cast<const uint4*>(
+                vcT + (static_cast<int64_t>(bh) * HD + c) * NPAD + gs + part);
+        }
+        if (tid < BN) {
+            const int b = gs + tid;
+            sLen[tid] = (b < NTB) ? static_cast<float>(block_len_of(blen, b, T)) : 0.f;
+            sKcs[tid] = kcs[static_cast<int64_t>(bh) * NPAD + b];
+        }
+        __syncthreads();
+
+        typename MmaInt8::Acc s_acc[KT];
+#pragma unroll
+        for (int kt = 0; kt < KT; ++kt) {
+            s_acc[kt] = MmaInt8::zero();
+#pragma unroll
+            for (int dt = 0; dt < DT; ++dt) {
+                s_acc[kt] = MmaInt8::mma(
+                    MmaInt8::load_aligned(sKc, kt * 16 + r, dt * 16, kStrideKc, lane),
+                    cen_frag[dt], s_acc[kt]);
+            }
+        }
+
+        // Routing decision, and the pooled score of every block that stays in the tail.
+        float pv[KT][8];
+        uint32_t mask_lo = 0u, mask_hi = 0u;
+#pragma unroll
+        for (int kt = 0; kt < KT; ++kt) {
+#pragma unroll
+            for (int e = 0; e < 8; ++e) {
+                const int slot = kt * 16 + acc_row(lane, e);
+                const int b = gs + slot;
+                const bool valid = live && b < NTB;
+                const bool pre = valid && b >= sink_lo && b < sink_e;
+                const float score =
+                    valid ? static_cast<float>(s_acc[kt][e]) * qsc * sKcs[slot] : kNeg;
+                const bool routed = valid && ((score >= thr) || abs(qb - b) <= 1);
+                const bool cand = !pre && (q_in_sink ? valid : routed);
+                if (cand) {
+                    if (slot < 32) {
+                        mask_lo |= 1u << slot;
+                    } else {
+                        mask_hi |= 1u << (slot - 32);
+                    }
+                }
+                // exact-routed and sink blocks leave the tail; tail == 0 hands the
+                // exact kernel an empty state (softmax over the routed blocks only)
+                pv[kt][e] = (tail && valid && !(pre || cand)) ? score : kNeg;
+            }
+        }
+
+        // The half-wave partner holds this query block's other 32 key blocks, so the
+        // pair shares one mask and then splits the writes: low half emits slots
+        // 0..31, high half emits 32..63 after them. Ascending, hence deterministic.
+        mask_lo |= swap_half_wave_b32(mask_lo);
+        mask_hi |= swap_half_wave_b32(mask_hi);
+        const int n_lo = __popc(mask_lo), n_hi = __popc(mask_hi);
+        if (live) {
+            uint32_t m = half ? mask_hi : mask_lo;
+            int at = cnt + (half ? n_lo : 0);
+            const int slot0 = gs + (half ? 32 : 0);
+            while (m) {
+                const int bit = __builtin_ctz(m);
+                m &= m - 1;
+                my_row[at++] = static_cast<uint16_t>(slot0 + bit);
+            }
+        }
+        cnt += n_lo + n_hi;
+
+        float m_new = m_r;
+#pragma unroll
+        for (int kt = 0; kt < KT; ++kt) {
+#pragma unroll
+            for (int e = 0; e < 8; ++e) m_new = fmaxf(m_new, pv[kt][e]);
+        }
+        m_new = fmaxf(m_new, swap_half_wave(m_new));
+        const float alpha = exp2f(m_r - m_new);
+        m_r = m_new;
+
+        float l_add = 0.f;
+#pragma unroll
+        for (int kt = 0; kt < KT; ++kt) {
+#pragma unroll
+            for (int e = 0; e < 8; ++e) {
+                const float p = pv[kt][e] <= kNeg ? 0.f : exp2f(pv[kt][e] - m_new);
+                pv[kt][e] = p;
+                l_add += p * sLen[kt * 16 + acc_row(lane, e)];
+            }
+        }
+        l_add += swap_half_wave(l_add);
+        l_r = l_r * alpha + l_add;
+
+        if (!tail) continue;
+        typename MmaBf16::Frag p_frag[KT];
+#pragma unroll
+        for (int kt = 0; kt < KT; ++kt) p_frag[kt] = pack_prob_frag_bf16(pv[kt], lane);
+#pragma unroll
+        for (int nt = 0; nt < NT; ++nt) {
+#pragma unroll
+            for (int e = 0; e < 8; ++e) o_acc[nt][e] *= alpha;
+#pragma unroll
+            for (int kt = 0; kt < KT; ++kt) {
+                o_acc[nt] = MmaBf16::mma(
+                    load_frag_16bit<MmaBf16>(sVcT + (nt * 16 + r) * kStrideVc + kt * 16, lane),
+                    p_frag[kt], o_acc[nt]);
+            }
+        }
+    }
+
+    if (!live) return;
+    const size_t qs = static_cast<size_t>(bh) * NQ + qb;
+    if (half == 0) {
+        blk_cnt[qs] = cnt;
+        m_part[qs] = m_r;
+        l_part[qs] = l_r * 255.0f;
+    }
+    // Handed over in the exact kernel's units: it accumulates u8 P against int8 V
+    // and multiplies by vsc in its epilogue.
+    __bf16* orow = o_part + qs * HD;
+    const float* vsrow = vsc + static_cast<size_t>(bh) * HD;
+#pragma unroll
+    for (int nt = 0; nt < NT; ++nt) {
+        float vals[8];
+#pragma unroll
+        for (int e = 0; e < 8; ++e) {
+            vals[e] = o_acc[nt][e] * (255.0f / vsrow[nt * 16 + acc_row(lane, e)]);
+        }
+        store_o_tile<__bf16>(orow, nt * 16, vals, lane);
+    }
+}
+
+}  // namespace
+}  // namespace comfy::hip_backend::sol
+
+using namespace comfy::hip_backend::sol;
+
+void launch_sol_route(const void* cen8, const void* cens, const void* kci, const void* kcs,
+                      const void* vcT, const void* vsc, const void* threshold, void* blk_idx,
+                      void* blk_cnt, void* o_part, void* m_part, void* l_part,
+                      // NQ (query blocks) and NTB (key blocks) coincide today; kept
+                      // separate so a query prefix needs no kernel change
+                      const void* blen, int tail, int B, int T, int H, int NTB, int NPAD, int NQ,
+                      int sink_s, int sink_e, int sink_qs, int sink_qe, float scale_log2,
+                      hipStream_t stream) {
+    dim3 grid((NQ + BQ - 1) / BQ, B * H);
+    sol_route_kernel<<<grid, kThreads, 0, stream>>>(
+        static_cast<const int8_t*>(cen8), static_cast<const float*>(cens),
+        static_cast<const int8_t*>(kci), static_cast<const float*>(kcs),
+        static_cast<const __bf16*>(vcT), static_cast<const float*>(vsc),
+        static_cast<const float*>(threshold), static_cast<uint16_t*>(blk_idx),
+        static_cast<int32_t*>(blk_cnt), static_cast<__bf16*>(o_part), static_cast<float*>(m_part),
+        static_cast<float*>(l_part), static_cast<const int32_t*>(blen), tail, T, NTB, NPAD, NQ,
+        sink_s, sink_e, sink_qs, sink_qe, scale_log2);
+}

--- a/comfy_kitchen/backends/hip/sage_attention/sol_attn_vtranspose.hip
+++ b/comfy_kitchen/backends/hip/sage_attention/sol_attn_vtranspose.hip
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// V quantize and transpose: the exact kernel's PV A operand needs consecutive KEYS
+// per channel, so V is stored [B*H, D, Tp] int8 through shared memory. The CUDA
+// source permutes the key axis per 64-block for its MMA layout; RDNA's WMMA reads
+// a contiguous K slice, so the key axis stays in natural order here.
+#include <hip/hip_runtime.h>
+
+#include <cstdint>
+
+#include "sol_common.h"
+
+namespace comfy::hip_backend::sol {
+namespace {
+
+constexpr int HD = kHeadDim;
+constexpr int kThreads = 256;
+constexpr int kLdsPad = HD + 16;  // must be a multiple of 16: phase 1 writes 16 bytes
+
+template <int TT>
+__global__ __launch_bounds__(kThreads) void vquant_transpose(const __bf16* __restrict__ v,
+                                                             const float* __restrict__ vsc,
+                                                             int8_t* __restrict__ vT, int T,
+                                                             int Tp, int H, int64_t sb, int64_t st,
+                                                             int64_t sh) {
+    __shared__ __attribute__((aligned(16))) int8_t sV[TT * kLdsPad];
+    const int bh = blockIdx.y, head = bh % H, batch = bh / H;
+    const int t0 = blockIdx.x * TT;
+
+    // phase 1: coalesced read (D contiguous) -> smem rows
+    for (int idx = threadIdx.x; idx < TT * (HD / 16); idx += kThreads) {
+        const int t = idx / (HD / 16), c16 = (idx % (HD / 16)) * 16;
+        __attribute__((aligned(16))) int8_t out[16];
+        if (t0 + t < T) {
+            const __bf16* src =
+                v + batch * sb + static_cast<int64_t>(t0 + t) * st + head * sh + c16;
+#pragma unroll
+            for (int j = 0; j < 16; ++j) {
+                out[j] = q8(static_cast<float>(src[j]), 1.f / vsc[bh * HD + c16 + j]);
+            }
+        } else {
+#pragma unroll
+            for (int j = 0; j < 16; ++j) out[j] = 0;
+        }
+        *reinterpret_cast<uint4*>(sV + t * kLdsPad + c16) = *reinterpret_cast<uint4*>(out);
+    }
+    __syncthreads();
+
+    // phase 2: 4x4 byte register transposes -> coalesced write (T contiguous)
+    int8_t* dst0 = vT + static_cast<int64_t>(bh) * HD * Tp + t0;
+    for (int idx = threadIdx.x; idx < (HD / 4) * (TT / 4); idx += kThreads) {
+        const int cg = idx / (TT / 4), tg = (idx % (TT / 4)) * 4;
+        if (t0 + tg >= Tp) continue;
+        uint32_t r[4];
+#pragma unroll
+        for (int j = 0; j < 4; ++j) {
+            r[j] = *reinterpret_cast<const uint32_t*>(sV + (tg + j) * kLdsPad + cg * 4);
+        }
+        // r[j] = channels 4cg..+3 of token tg+j  ->  w[i] = channel 4cg+i over tokens tg..+3
+        uint32_t w[4];
+#pragma unroll
+        for (int i = 0; i < 4; ++i) {
+            w[i] = static_cast<uint32_t>((r[0] >> (i * 8)) & 0xffu) |
+                   (static_cast<uint32_t>((r[1] >> (i * 8)) & 0xffu) << 8) |
+                   (static_cast<uint32_t>((r[2] >> (i * 8)) & 0xffu) << 16) |
+                   (static_cast<uint32_t>((r[3] >> (i * 8)) & 0xffu) << 24);
+        }
+#pragma unroll
+        for (int i = 0; i < 4; ++i) {
+            *reinterpret_cast<uint32_t*>(dst0 + static_cast<int64_t>(cg * 4 + i) * Tp + tg) = w[i];
+        }
+    }
+}
+
+}  // namespace
+}  // namespace comfy::hip_backend::sol
+
+using namespace comfy::hip_backend::sol;
+
+void launch_sol_vtranspose(const void* v, const void* vsc, void* vT, int B, int T, int Tp, int H,
+                           int64_t sb, int64_t st, int64_t sh, hipStream_t stream) {
+    dim3 grid((T + 255) / 256, B * H);
+    vquant_transpose<256><<<grid, kThreads, 0, stream>>>(
+        static_cast<const __bf16*>(v), static_cast<const float*>(vsc), static_cast<int8_t*>(vT), T,
+        Tp, H, sb, st, sh);
+}

--- a/comfy_kitchen/backends/hip/sage_attention/sol_common.h
+++ b/comfy_kitchen/backends/hip/sage_attention/sol_common.h
@@ -1,0 +1,243 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Layout contract shared by every RDNA Sol-Attn kernel: tile staging, the INT8
+// carriers, the block reductions and the fused norm+rope the chunked producer
+// applies. The CUDA backend's sage_attention/sol_layout.cuh is the reference for
+// what these compute.
+//
+// One difference runs through the whole port. The CUDA carriers are stored under
+// two permutations, sol::perm_d on the contraction axis and sol::perm_key on the
+// key axis, whose only job is to make an m16n8k32 lane's two operand words one
+// 8-byte load. RDNA's 16x16x16 WMMA hands a lane a contiguous K slice of its own
+// row, so natural order is already the fragment order and both permutations are
+// dropped: the carriers here are plain [.., D] and [.., key] arrays. Anything
+// that reads them from Python (the top-k threshold) must not un-permute.
+//
+// The scores are evaluated transposed, as in int8_attn.hip: S^T = K @ Q^T puts one
+// query on a lane and eight keys in its accumulator, so the online softmax is
+// scalar per lane and P^T is already the PV operand.
+#pragma once
+
+#include <hip/hip_runtime.h>
+
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+
+#include "../mma.h"
+#include "../rope_math.h"
+#include "sage_common.h"
+
+namespace comfy::hip_backend::sol {
+
+using namespace comfy::hip_backend::sage;
+
+constexpr int kHeadDim = 128;  // the only head_dim these kernels handle
+constexpr int kBlock = 64;     // Sol-Attn's routing granularity, in tokens
+
+// Finite, so kNeg - kNeg == 0 (unlike -inf) and every masked score survives the
+// fma and exp2 it passes through before anything tests it. Same value as the CUDA
+// sol::NEG, so both backends drop the same blocks.
+constexpr float kNeg = -3.0e38f;
+
+// bf16 row stride of a staged tile; keeps the 16-byte stores aligned.
+constexpr int kLdTile = kHeadDim + 8;
+
+// The stage launchers are host code and throw, so a failed async copy is reported
+// rather than silently leaving the workspace half-initialised.
+inline void sol_check(hipError_t err, const char* what) {
+    if (err != hipSuccess) {
+        throw std::runtime_error(std::string("sol_attn: ") + what + ": " + hipGetErrorString(err));
+    }
+}
+
+__forceinline__ __device__ int imin(int a, int b) { return a < b ? a : b; }
+__forceinline__ __device__ int imax(int a, int b) { return a > b ? a : b; }
+
+// Valid tokens at the FRONT of 64-block n: the caller's per-block table
+// (zero-padded tiles, clamped to [1, rows that exist]) or the plain ragged tail.
+// Rows past it are dead.
+__forceinline__ __device__ int block_len_of(const int32_t* blen, int n, int T) {
+    const int rem = imin(kBlock, T - n * kBlock);
+    return blen ? imin(rem, imax(1, blen[n])) : rem;
+}
+
+__forceinline__ __device__ int8_t q8(float x, float inv) {
+    const int r = static_cast<int>(rintf(x * inv));
+    return static_cast<int8_t>(imax(-127, imin(127, r)));
+}
+
+// 128-thread reductions, one thread per channel; every thread gets the result and
+// `s` is free on return.
+__forceinline__ __device__ float block_max128(float x, float* s) {
+    const int d = threadIdx.x;
+    s[d] = x;
+    __syncthreads();
+    for (int w = 64; w; w >>= 1) {
+        if (d < w) s[d] = fmaxf(s[d], s[d + w]);
+        __syncthreads();
+    }
+    const float r = s[0];
+    __syncthreads();
+    return r;
+}
+
+__forceinline__ __device__ float block_sum128(float x, float* s) {
+    const int d = threadIdx.x;
+    s[d] = x;
+    __syncthreads();
+    for (int w = 64; w; w >>= 1) {
+        if (d < w) s[d] += s[d + w];
+        __syncthreads();
+    }
+    const float r = s[0];
+    __syncthreads();
+    return r;
+}
+
+// Stage rows 0..len-1 (row t at src + t * stride, 16-byte loads) into the tile,
+// zero past len.
+__forceinline__ __device__ void stage_tile64(__bf16* tile, const __bf16* __restrict__ src,
+                                             int64_t stride, int len) {
+    for (int idx = threadIdx.x; idx < kBlock * (kHeadDim / 8); idx += kHeadDim) {
+        const int t = idx / (kHeadDim / 8), c8 = (idx % (kHeadDim / 8)) * 8;
+        uint4 val = make_uint4(0u, 0u, 0u, 0u);
+        if (t < len) {
+            val = *reinterpret_cast<const uint4*>(src + static_cast<int64_t>(t) * stride + c8);
+        }
+        *reinterpret_cast<uint4*>(tile + t * kLdTile + c8) = val;
+    }
+}
+
+// Per-token absmax scale and INT8 row, one thread per token. qi / qs point at
+// (this tile's first token, this head). Rows [len, nrows) exist in memory but are
+// dead (zero-padded tiles) and get zeros; rows past nrows do not exist.
+__forceinline__ __device__ void quant_q_rows(const __bf16* tile, int len, int nrows,
+                                             int8_t* __restrict__ qi, float* __restrict__ qs,
+                                             int H) {
+    for (int t = threadIdx.x; t < nrows; t += kHeadDim) {
+        const __bf16* row = tile + t * kLdTile;  // zero-staged past len
+        const bool live = t < len;
+        float a = 0.f;
+#pragma unroll 8
+        for (int d = 0; d < kHeadDim; ++d) a = fmaxf(a, fabsf(static_cast<float>(row[d])));
+        const float sc = live ? fmaxf(a / 127.0f, 1e-8f) : 0.f;  // dead rows: deterministic zeros
+        qs[static_cast<size_t>(t) * H] = sc;
+        const float inv = live ? 1.f / sc : 0.f;
+        int8_t* dst = qi + static_cast<size_t>(t) * H * kHeadDim;
+        // 16 bytes at a time: a whole 128-byte row in registers spills to scratch.
+#pragma unroll
+        for (int c = 0; c < kHeadDim; c += 16) {
+            __attribute__((aligned(16))) int8_t out[16];
+#pragma unroll
+            for (int j = 0; j < 16; ++j) out[j] = q8(static_cast<float>(row[c + j]), inv);
+            *reinterpret_cast<uint4*>(dst + c) = *reinterpret_cast<const uint4*>(out);
+        }
+    }
+}
+
+// Query-block centroid, quantized like a pseudo-row. One thread per channel;
+// returns this thread's channel mean. `sred` holds bytes on return -- sync before
+// reusing it.
+__forceinline__ __device__ float centroid_quant(const __bf16* tile, int len, float* sred,
+                                                int8_t* __restrict__ cen8,
+                                                float* __restrict__ cens) {
+    const int d = threadIdx.x;
+    float c = 0.f;
+    for (int t = 0; t < len; ++t) c += static_cast<float>(tile[t * kLdTile + d]);
+    c /= static_cast<float>(len);
+    const float csc = fmaxf(block_max128(fabsf(c), sred) / 127.0f, 1e-8f);
+    int8_t* s8 = reinterpret_cast<int8_t*>(sred);
+    s8[d] = q8(c, 1.f / csc);
+    __syncthreads();
+    if (d < kHeadDim / 16) {
+        reinterpret_cast<uint4*>(cen8)[d] = reinterpret_cast<const uint4*>(s8)[d];
+    }
+    if (d == 0) *cens = csc;
+    return c;
+}
+
+// Centred per-key scale and INT8 row. kbias (log2 units, or null) only the exact
+// branch reads, so biased blocks must be sink-routed. Dead rows get a zero scale,
+// a kNeg bias and zero bytes.
+__forceinline__ __device__ void quant_k_rows(const __bf16* tile, int len,
+                                             const float* __restrict__ kmean,
+                                             const float* __restrict__ kbias,
+                                             int8_t* __restrict__ ki, float2* __restrict__ ksb) {
+    for (int p = threadIdx.x; p < kBlock; p += kHeadDim) {
+        const bool live = p < len;
+        const __bf16* row = tile + p * kLdTile;
+        float a = 0.f;
+#pragma unroll 8
+        for (int d = 0; d < kHeadDim; ++d) {
+            a = fmaxf(a, fabsf(static_cast<float>(row[d]) - kmean[d]));
+        }
+        const float sc = fmaxf(a / 127.0f, 1e-8f);
+        const float bias = (kbias && live) ? kbias[p] : 0.f;
+        ksb[p] = make_float2(live ? sc : 0.f, live ? bias : kNeg);
+        const float inv = 1.f / sc;
+#pragma unroll
+        for (int c = 0; c < kHeadDim; c += 16) {
+            __attribute__((aligned(16))) int8_t out[16];
+#pragma unroll
+            for (int j = 0; j < 16; ++j) {
+                out[j] = live ? q8(static_cast<float>(row[c + j]) - kmean[c + j], inv)
+                              : static_cast<int8_t>(0);
+            }
+            *reinterpret_cast<uint4*>(ki + static_cast<size_t>(p) * kHeadDim + c) =
+                *reinterpret_cast<const uint4*>(out);
+        }
+    }
+}
+
+// Fused per-head RMSNorm + split-half RoPE in place, matching ops/rms_rope.hip
+// including its bf16 rounding between norm and rotation. One wave per token, lane
+// owns channels 4 * lane .. +3.
+__forceinline__ __device__ void norm_rope_rows(__bf16* tile, int ld, int len,
+                                               const float* __restrict__ fab_t0,
+                                               const __bf16* __restrict__ w, float eps, int rot) {
+    // fab [T, rot, 2] is per-channel: out[c] = f.x * n[c] + f.y * n[partner(c)]
+    const int lane = threadIdx.x & 31, wp = threadIdx.x >> 5;
+    const int nw = static_cast<int>(blockDim.x >> 5), c0 = lane * 4;
+    float wreg[4];
+#pragma unroll
+    for (int i = 0; i < 4; ++i) wreg[i] = static_cast<float>(w[c0 + i]);
+    for (int t = wp; t < len; t += nw) {
+        __bf16* row = tile + t * ld;
+        float x[4];
+#pragma unroll
+        for (int i = 0; i < 4; ++i) x[i] = static_cast<float>(row[c0 + i]);
+        float ss = x[0] * x[0] + x[1] * x[1] + x[2] * x[2] + x[3] * x[3];
+#pragma unroll
+        for (int off = 16; off; off >>= 1) ss += __shfl_xor(ss, off, 32);
+        const float rrms = rsqrtf(ss / static_cast<float>(kHeadDim) + eps);
+        float n[4];
+        // round_bf16, not a __bf16 round trip: -ffast-math folds the cast away.
+#pragma unroll
+        for (int i = 0; i < 4; ++i) n[i] = round_bf16(x[i] * rrms * wreg[i]);
+        // Explicit source lane: an xor shuffle is only correct for power-of-two
+        // offsets and rot/8 need not be one (H3 rot=96 -> 12).
+        const int poff = rot >> 3;
+        const int src = (c0 < (rot >> 1)) ? lane + poff : (c0 < rot ? lane - poff : lane);
+        float p[4];
+#pragma unroll
+        for (int i = 0; i < 4; ++i) p[i] = __shfl(n[i], src, 32);
+        float out[4];
+        if (c0 < rot) {
+            const float* fr = fab_t0 + static_cast<int64_t>(t) * (rot * 2) + c0 * 2;
+#pragma unroll
+            for (int i = 0; i < 4; ++i) {
+                const float2 f = *reinterpret_cast<const float2*>(fr + i * 2);
+                out[i] = f.x * n[i] + f.y * p[i];
+            }
+        } else {
+#pragma unroll
+            for (int i = 0; i < 4; ++i) out[i] = n[i];
+        }
+#pragma unroll
+        for (int i = 0; i < 4; ++i) row[c0 + i] = static_cast<__bf16>(out[i]);
+    }
+}
+
+}  // namespace comfy::hip_backend::sol

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,29 @@ def pytest_sessionfinish(session, exitstatus):
             torch.cuda.synchronize()
 
 
+@pytest.fixture(autouse=True)
+def restore_backend_selection():
+    """Put the registry's priority order and disabled set back after every test.
+
+    Both are process-global, so a test that changes one and does not restore it
+    re-routes every later test in the session. The failure is silent, and worst on
+    ROCm: the default order is ["hip", "cuda", "triton", "eager"], so a list
+    written without "hip" leaves the HIP backend registered but unreachable, and
+    later dispatch assertions get triton or eager instead of failing on the
+    backend that actually changed it.
+    """
+    from comfy_kitchen.registry import registry
+
+    priority = list(registry._priority)
+    disabled = set(registry._disabled)
+    yield
+    registry.set_priority(priority)
+    for name in set(registry._disabled) - disabled:
+        registry.enable(name)
+    for name in disabled - set(registry._disabled):
+        registry.disable(name)
+
+
 def cuda_backend_available() -> bool:
     """Whether the compiled CUDA backend is loadable.
 

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -227,7 +227,7 @@ class TestRegistryConstraintValidation:
         }
         backend = ck.registry.get_capable_backend("quantize_per_tensor_fp8", kwargs)
         assert backend is not None
-        assert backend in ["cuda", "triton", "eager"]
+        assert backend in ["hip", "cuda", "triton", "eager"]
 
     def test_get_capable_backend_no_match(self, device):
         """Test NoCapableBackendError when no backend can handle the call."""

--- a/tests/test_sol_attn.py
+++ b/tests/test_sol_attn.py
@@ -1,10 +1,14 @@
 """Sol-Attn sparse attention.
 
-The CUDA backend runs INT8 internally, so tests assert cosine similarity (not
+The fused backends run INT8 internally, so tests assert cosine similarity (not
 bitwise equality) against the full-precision eager reference, plus the
 layout and validation invariants: batch > 1, sinks, ragged tails, strided
 inputs, and the real model's constants (rot_dim, activation scales,
 inference mode).
+
+Every case runs against whichever fused backend is built here: CUDA on NVIDIA,
+HIP on ROCm. The two carry different internal layouts and the same contract, so
+the suite is the contract.
 """
 
 import math
@@ -14,10 +18,34 @@ import torch
 
 import comfy_kitchen as ck
 from comfy_kitchen.backends import cuda as cuda_backend
+from comfy_kitchen.backends import hip as hip_backend
 from comfy_kitchen.backends.eager.sol_attn import sol_attn as sol_attn_eager
 from comfy_kitchen.exceptions import NoCapableBackendError
 
-pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+
+def _fused_backend():
+    """The compiled backend that owns sol_attn here. PyTorch reports ROCm devices
+    as "cuda", so torch.cuda.is_available() does not distinguish them; ask which
+    extension actually loaded."""
+    if ck.list_backends().get("cuda", {}).get("available", False):
+        return cuda_backend
+    if hip_backend.is_available() and hip_backend.has_wmma():
+        return hip_backend
+    return None
+
+
+backend = _fused_backend()
+
+pytestmark = pytest.mark.skipif(
+    backend is None, reason="a compiled CUDA or HIP backend with sol_attn is required"
+)
+
+
+def _wrap(t):
+    """DLPack capsule in whichever spelling this backend's _C takes."""
+    fn = getattr(backend, "_wrap_for_dlpack", None) or backend._dl
+    return fn(t)
+
 
 HD = 128
 
@@ -138,7 +166,7 @@ def test_rejects_noncontiguous_last_dim():
     bad = torch.empty(1, 256, 4, HD * 2, device="cuda", dtype=torch.bfloat16)[..., ::2]
     assert bad.stride(-1) != 1
     with pytest.raises(ValueError, match="contiguous last dim"):
-        cuda_backend.sol_attn(bad, k, v, tau=1.4)
+        backend.sol_attn(bad, k, v, tau=1.4)
 
 
 def test_tau_direction():
@@ -150,14 +178,14 @@ def test_tau_direction():
 
 
 def test_output_strides_agree_across_backends():
-    """register_fake, CUDA and eager must return the same layout."""
+    """register_fake, the fused backend and eager must return the same layout."""
     from torch._subclasses.fake_tensor import FakeTensorMode
 
     qh = torch.randn(1, 4, 1024, HD, device="cuda", dtype=torch.bfloat16)
     v = qh.transpose(1, 2)
     assert not v.is_contiguous()
 
-    cuda_strides = ck.sol_attn(v, v, v, tau=1.4).stride()
+    fused_strides = ck.sol_attn(v, v, v, tau=1.4).stride()
     eager_strides = sol_attn_eager(v.float(), v.float(), v.float(), tau=1.4).stride()
     with FakeTensorMode():
         fv = torch.empty(v.shape, dtype=v.dtype, device=v.device)
@@ -165,7 +193,7 @@ def test_output_strides_agree_across_backends():
             fv, fv, fv, tau=1.4, scale=None, sink_blocks=[0, 0], sink_q=[0, 0],
             key_bias=None, topk_ratio=0.0, tail=True, block_len=None,
             coarse_gate=None).stride()
-    assert cuda_strides == eager_strides == fake_strides
+    assert fused_strides == eager_strides == fake_strides
 
 
 def test_unaligned_input_is_rejected():
@@ -175,7 +203,7 @@ def test_unaligned_input_is_rejected():
     bad = base[1:1 + n].view(1, 256, 4, HD)
     assert bad.stride(-1) == 1 and bad.data_ptr() % 16
     with pytest.raises(ValueError, match="16-byte aligned"):
-        cuda_backend.sol_attn(bad, bad, bad, tau=1.4)
+        backend.sol_attn(bad, bad, bad, tau=1.4)
 
 
 def test_misaligned_stride_is_rejected():
@@ -184,7 +212,7 @@ def test_misaligned_stride_is_rejected():
     bad = base[..., :HD]
     assert bad.stride(-1) == 1 and bad.data_ptr() % 16 == 0 and bad.stride(2) % 8
     with pytest.raises(ValueError, match="multiple of 8"):
-        cuda_backend.sol_attn(bad, bad, bad, tau=1.4)
+        backend.sol_attn(bad, bad, bad, tau=1.4)
 
 
 def test_eager_refuses_video_length_rather_than_oom():
@@ -247,7 +275,7 @@ def test_key_bias_inf_masks_out_keys():
 def test_key_bias_bad_shape_rejected():
     q, k, v = _qkv(1, 256, 4)
     with pytest.raises(ValueError, match="key_bias"):
-        cuda_backend.sol_attn(q, k, v, tau=1.4,
+        backend.sol_attn(q, k, v, tau=1.4,
                               key_bias=torch.zeros(1, 128, device="cuda"))
 
 
@@ -262,18 +290,36 @@ def test_direct_backend_validates_like_the_public_path():
     """The backend-direct entry runs the same shared rule as the registry."""
     q, k, v = _qkv(1, 512, 4)
     with pytest.raises(ValueError, match="bfloat16"):
-        cuda_backend.sol_attn(q.half(), k.half(), v.half(), tau=1.4)
+        backend.sol_attn(q.half(), k.half(), v.half(), tau=1.4)
     with pytest.raises(ValueError, match="shape"):
-        cuda_backend.sol_attn(q, k[:, :256].contiguous(), v, tau=1.4)
+        backend.sol_attn(q, k[:, :256].contiguous(), v, tau=1.4)
 
 
-def test_sub_sm80_rejected_at_the_wrapper(monkeypatch):
-    """Sub-sm_80 cubins are stubs returning uninitialised memory; the wrapper
-    must check q.device itself since the registry gate caches one device."""
+def test_incapable_device_rejected_at_the_wrapper(monkeypatch):
+    """A device below the kernels' floor returns uninitialised memory rather than
+    failing, so the wrapper must check it itself: the registry gate caches one
+    device's capability while the launch follows the tensor's."""
     q, k, v = _qkv(1, 256, 4)
-    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda *_: (7, 5))
-    with pytest.raises(RuntimeError, match="sm_80"):
-        cuda_backend.sol_attn(q, k, v, tau=1.4)
+    # The same call has to succeed first, or the raise below would prove nothing
+    # about the gate.
+    assert backend.sol_attn(q, k, v, tau=1.4).shape == q.shape
+    if backend is hip_backend:
+        # RDNA2 compiles the WMMA kernels to a trap and reports no matrix cores.
+        # The gate lives in the shared _check_sol_args, which sol_attn runs before
+        # it plans a workspace; patching the module attribute is what the call
+        # inside it resolves.
+        monkeypatch.setattr(backend, "has_wmma", lambda: False)
+        match = "WMMA"
+    else:
+        monkeypatch.setattr(torch.cuda, "get_device_capability", lambda *_: (7, 5))
+        match = "sm_80"
+    with pytest.raises(RuntimeError, match=match):
+        backend.sol_attn(q, k, v, tau=1.4)
+    # The chunked entry runs the same check, ahead of planning a workspace or
+    # taking a chunk: an ungated call would fail on the empty chunk list instead.
+    with pytest.raises(RuntimeError, match=match):
+        backend.sol_attn_chunked([], 256, 4, torch.randn(1, 256, 1, 32, 2, 2, device="cuda"),
+                                 (torch.ones(HD, device="cuda"), torch.ones(HD, device="cuda")))
 
 
 @pytest.mark.parametrize("t", [4096, 1000, 3137])
@@ -318,7 +364,7 @@ def test_topk_ratio_validation():
     """The range lives in the shared rule, so every entry rejects it."""
     q, k, v = _qkv(1, 1024, 1)
     with pytest.raises(ValueError, match="topk_ratio"):
-        cuda_backend.sol_attn(q, k, v, topk_ratio=1.5)
+        backend.sol_attn(q, k, v, topk_ratio=1.5)
     with pytest.raises(NoCapableBackendError, match="topk_ratio"):
         ck.sol_attn(q, k, v, topk_ratio=1.5)
 
@@ -328,17 +374,17 @@ def test_chunked_producer_matches_separate_rope(rot):
     """Chunked producer vs rms_rope_split_half_ + sol_attn. rot=96 is H3's real
     rot_dim (non-power-of-two lane offset); V is scaled to realistic size."""
     c = _chunked_case(seed=11, rot=rot, v_scale=0.02)
-    ref = cuda_backend.sol_attn(c["q"], c["k"], c["v"], tau=1.4, sink_blocks=[0, 2])
-    out1, km, vs = cuda_backend.sol_attn_chunked(
+    ref = backend.sol_attn(c["q"], c["k"], c["v"], tau=1.4, sink_blocks=[0, 2])
+    out1, km, vs = backend.sol_attn_chunked(
         c["chunks"], c["t"], c["h"], c["freqs"], c["norm"], tau=1.4, sink_blocks=[0, 2])
-    out2, _, _ = cuda_backend.sol_attn_chunked(
+    out2, _, _ = backend.sol_attn_chunked(
         c["chunks"], c["t"], c["h"], c["freqs"], c["norm"], kmean=km, vscale=vs,
         tau=1.4, sink_blocks=[0, 2])
     assert _cos(out1, ref) > 0.995       # bootstrap self-measures, no blind scales
     assert _cos(out2, ref) > 0.995
     # ComfyUI runs under inference_mode: no ._version access anywhere
     with torch.inference_mode():
-        out3, _, _ = cuda_backend.sol_attn_chunked(
+        out3, _, _ = backend.sol_attn_chunked(
             c["chunks"], c["t"], c["h"], c["freqs"].clone(), c["norm"], kmean=km, vscale=vs,
             tau=1.4, sink_blocks=[0, 2])
     assert _cos(out3, ref) > 0.995
@@ -347,19 +393,18 @@ def test_chunked_producer_matches_separate_rope(rot):
 def test_bindings_check_buffer_sizes():
     """The _C entries take bare pointers sized from integers; each must reject
     an undersized buffer itself, not rely on the Python wrappers."""
-    from comfy_kitchen.backends.cuda import _C
-    from comfy_kitchen.backends.cuda import _wrap_for_dlpack as w
+    ext, w = backend._C, _wrap
     t, h = 256, 2
     q, k, v = _qkv(1, t, h)
-    ws = torch.empty(_C.sol_attn_plan(1, t, h)["total"], dtype=torch.uint8, device="cuda")
+    ws = torch.empty(ext.sol_attn_plan(1, t, h)["total"], dtype=torch.uint8, device="cuda")
     stream = torch.cuda.current_stream().cuda_stream
     args = (1, t, h, HD, 1.0, HD ** -0.5, 0, 0, 0, 0, stream)
     with pytest.raises(RuntimeError, match="out"):
-        _C.sol_attn(w(q), w(k), w(v), w(q[:, :128].contiguous()), w(ws), *args)
+        ext.sol_attn(w(q), w(k), w(v), w(q[:, :128].contiguous()), w(ws), *args)
     with pytest.raises(RuntimeError, match="workspace"):
-        _C.sol_attn(w(q), w(k), w(v), w(torch.empty_like(q)), w(ws[:-1]), *args)
+        ext.sol_attn(w(q), w(k), w(v), w(torch.empty_like(q)), w(ws[:-1]), *args)
     with pytest.raises(RuntimeError, match="\\(B, T, H, D\\)"):
-        _C.sol_attn(w(q.view(t, h, HD)), w(k), w(v), w(torch.empty_like(q)), w(ws), *args)
+        ext.sol_attn(w(q.view(t, h, HD)), w(k), w(v), w(torch.empty_like(q)), w(ws), *args)
     # staging-load layout contract, checked at the binding too
     base = torch.randn(1, t, h, HD + 4, device="cuda", dtype=torch.bfloat16)   # row stride 132: not a multiple of 8
     off = torch.randn(t * h * HD + 8, device="cuda", dtype=torch.bfloat16)
@@ -367,23 +412,23 @@ def test_bindings_check_buffer_sizes():
     bad_layouts = (wide[..., ::2], off[1:1 + t * h * HD].view(1, t, h, HD), base[..., :HD])
     for bad in bad_layouts:
         with pytest.raises(RuntimeError, match="16-byte aligned base"):
-            _C.sol_attn(w(bad), w(k), w(v), w(torch.empty_like(q)), w(ws), *args)
+            ext.sol_attn(w(bad), w(k), w(v), w(torch.empty_like(q)), w(ws), *args)
     with pytest.raises(RuntimeError, match="out must be contiguous"):
-        _C.sol_attn(w(q), w(k), w(v), w(torch.empty(1, h, t, HD, device="cuda", dtype=torch.bfloat16).transpose(1, 2)),
+        ext.sol_attn(w(q), w(k), w(v), w(torch.empty(1, h, t, HD, device="cuda", dtype=torch.bfloat16).transpose(1, 2)),
                     w(ws), *args)
     stats = torch.empty(h, HD, device="cuda")
     with pytest.raises(RuntimeError, match="out"):
-        _C.sol_attn_core(w(ws), w(q[:, :128].contiguous()), w(stats), w(stats), w(stats),
+        ext.sol_attn_core(w(ws), w(q[:, :128].contiguous()), w(stats), w(stats), w(stats),
                          1, t, h, 1.0, HD ** -0.5, 0, 0, 0, 0, stream)
     with pytest.raises(RuntimeError, match="qkv"):
-        _C.sol_producer_chunk(w(ws), w(torch.empty(64, 3 * h * HD - 8, device="cuda", dtype=torch.bfloat16)),
+        ext.sol_producer_chunk(w(ws), w(torch.empty(64, 3 * h * HD - 8, device="cuda", dtype=torch.bfloat16)),
                               w(torch.empty(t, 64, 2, device="cuda")), w(stats[0]), w(stats[0]),
                               w(stats), w(stats), 1e-6, 64, 0, 64, 1, t, h, stream)
     # producer metadata: rot_dim, batch, and the chunk range are checked before launch
     chunk, fab = torch.empty(64, 3 * h * HD, device="cuda", dtype=torch.bfloat16), torch.empty(t, 64, 2, device="cuda")
 
     def produce(rot=64, t0=0, m=64, batch=1):
-        _C.sol_producer_chunk(w(ws), w(chunk), w(fab), w(stats[0]), w(stats[0]), w(stats), w(stats),
+        ext.sol_producer_chunk(w(ws), w(chunk), w(fab), w(stats[0]), w(stats[0]), w(stats), w(stats),
                               1e-6, rot, t0, m, batch, t, h, stream)
     with pytest.raises(RuntimeError, match="rot_dim"):
         produce(rot=12)
@@ -394,36 +439,128 @@ def test_bindings_check_buffer_sizes():
             produce(t0=t0, m=m)
 
 
+def test_bindings_check_dtype_and_layout():
+    """Element count alone does not bound a bare pointer: a narrower dtype is
+    shorter in bytes than the kernel reads, and a strided view of the right count
+    is read as though it were packed."""
+    ext, w = backend._C, _wrap
+    t, h = 256, 2
+    q, k, v = _qkv(1, t, h)
+    ws = torch.empty(ext.sol_attn_plan(1, t, h)["total"], dtype=torch.uint8, device="cuda")
+    stream = torch.cuda.current_stream().cuda_stream
+    args = (1, t, h, HD, 1.0, HD ** -0.5, 0, 0, 0, 0, stream)
+    out = torch.empty_like(q)
+    n_thr = (t + 63) // 64 * h
+
+    # big enough in bytes, but the plan's offsets are byte offsets
+    with pytest.raises(RuntimeError, match="workspace must be a uint8"):
+        ext.sol_attn(w(q), w(k), w(v), w(out), w(torch.zeros(ws.numel(), device="cuda")), *args)
+    with pytest.raises(RuntimeError, match="threshold"):   # right count, half the bytes
+        ext.sol_attn(w(q), w(k), w(v), w(out), w(ws), *args,
+                     threshold=w(torch.zeros(n_thr, device="cuda", dtype=torch.bfloat16)))
+    with pytest.raises(RuntimeError, match="threshold"):   # right count, strided
+        ext.sol_attn(w(q), w(k), w(v), w(out), w(ws), *args,
+                     threshold=w(torch.zeros(2 * n_thr, device="cuda")[::2]))
+    with pytest.raises(RuntimeError, match="key_bias"):
+        ext.sol_attn(w(q), w(k), w(v), w(out), w(ws), *args,
+                     key_bias=w(torch.zeros(t, device="cuda", dtype=torch.float16)))
+    stats = torch.empty(h, HD, device="cuda")
+    with pytest.raises(RuntimeError, match="out"):         # int8 out: half the bytes written
+        ext.sol_attn_core(w(ws), w(torch.zeros(1, t, h, HD, device="cuda", dtype=torch.int8)),
+                          w(stats), w(stats), w(stats), 1, t, h, 1.0, HD ** -0.5, 0, 0, 0, 0,
+                          stream)
+
+
+@pytest.mark.parametrize("bad", [(-1, 2), (0, -2), (3, 1)])
+@pytest.mark.parametrize("which", ["sink_blocks", "sink_q"])
+def test_bindings_reject_a_bad_sink_range(bad, which):
+    """A negative sink start would put that many extra entries in each routed
+    list, as block ids wrapped through uint16_t, and overrun the row."""
+    ext, w = backend._C, _wrap
+    t, h = 256, 2
+    q, k, v = _qkv(1, t, h)
+    ws = torch.empty(ext.sol_attn_plan(1, t, h)["total"], dtype=torch.uint8, device="cuda")
+    sinks = [*bad, 0, 0] if which == "sink_blocks" else [0, 0, *bad]
+    with pytest.raises(RuntimeError, match=which):
+        ext.sol_attn(w(q), w(k), w(v), w(torch.empty_like(q)), w(ws), 1, t, h, HD, 1.0,
+                     HD ** -0.5, *sinks, torch.cuda.current_stream().cuda_stream)
+
+
+@pytest.mark.parametrize("extents", [(0, 256, 2), (1, 0, 2), (1, 256, 0), (-1, 256, 2)])
+def test_bindings_reject_non_positive_extents(extents):
+    """Extents size every workspace slot and every grid; a non-positive one plans
+    a workspace nothing checks again."""
+    ext, w = backend._C, _wrap
+    q, k, v = _qkv(1, 256, 2)
+    ws = torch.empty(ext.sol_attn_plan(1, 256, 2)["total"], dtype=torch.uint8, device="cuda")
+    b, t, h = extents
+    with pytest.raises(RuntimeError, match="positive"):
+        ext.sol_attn(w(q), w(k), w(v), w(torch.empty_like(q)), w(ws), b, t, h, HD, 1.0,
+                     HD ** -0.5, 0, 0, 0, 0, torch.cuda.current_stream().cuda_stream)
+
+
+def test_zero_block_len_is_clamped_to_one_row():
+    """block_len is clamped to [1, rows in the block] by the kernels, matching the
+    eager reference, so a zero or negative entry is one live row and never a
+    zero divisor in the pooled means."""
+    t, h = 64 * 8, 2
+    q, k, v = _qkv(1, t, h, seed=31)
+    n = (t + 63) // 64
+    zeros = torch.zeros(n, dtype=torch.int32, device="cuda")
+    ones = torch.ones(n, dtype=torch.int32, device="cuda")
+    negative = torch.full((n,), -7, dtype=torch.int32, device="cuda")
+    got = ck.sol_attn(q, k, v, tau=1.4, block_len=zeros)
+    assert torch.isfinite(got.float()).all()
+    assert torch.equal(got, ck.sol_attn(q, k, v, tau=1.4, block_len=ones))
+    assert torch.equal(got, ck.sol_attn(q, k, v, tau=1.4, block_len=negative))
+    assert _cos(got[:, ::64], sol_attn_eager(q, k, v, tau=1.4, block_len=ones)[:, ::64]) > 0.998
+
+    # The producer skips a block whose length is not positive, which would leave
+    # that block's carriers at whatever the fresh workspace held, so the chunked
+    # path is pinned too.
+    c = _chunked_case(seed=11, rot=64)
+    n_c = (c["t"] + 63) // 64
+    kw = {"tau": 1.4, "kmean": torch.zeros(c["h"], HD, device="cuda"),
+          "vscale": torch.ones(c["h"], HD, device="cuda")}
+    zero_c = torch.zeros(n_c, dtype=torch.int32, device="cuda")
+    one_c = torch.ones(n_c, dtype=torch.int32, device="cuda")
+    from_zero = backend.sol_attn_chunked(c["chunks"], c["t"], c["h"], c["freqs"], c["norm"],
+                                         block_len=zero_c, **kw)[0]
+    assert torch.isfinite(from_zero.float()).all()
+    assert torch.equal(from_zero, backend.sol_attn_chunked(
+        c["chunks"], c["t"], c["h"], c["freqs"], c["norm"], block_len=one_c, **kw)[0])
+
+
 def test_chunked_producer_validates():
     """Coverage, width and device are checked before any launch."""
     c = _chunked_case(seed=11, rot=64)
     with pytest.raises(ValueError, match="chunks cover"):
-        cuda_backend.sol_attn_chunked(c["chunks"][:-1], c["t"], c["h"], c["freqs"], c["norm"])
+        backend.sol_attn_chunked(c["chunks"][:-1], c["t"], c["h"], c["freqs"], c["norm"])
     with pytest.raises(ValueError, match="chunks must be"):
-        cuda_backend.sol_attn_chunked(
+        backend.sol_attn_chunked(
             [ch[:, :-8] for ch in c["chunks"]], c["t"], c["h"], c["freqs"], c["norm"])
     with pytest.raises(ValueError, match="topk_ratio"):
-        cuda_backend.sol_attn_chunked(
+        backend.sol_attn_chunked(
             c["chunks"], c["t"], c["h"], c["freqs"], c["norm"], topk_ratio=2.0)
     with pytest.raises(ValueError, match="sink_blocks"):
-        cuda_backend.sol_attn_chunked(
+        backend.sol_attn_chunked(
             c["chunks"], c["t"], c["h"], c["freqs"], c["norm"], sink_blocks=[3, 1])
     # rot 12: a lane's four channels would straddle rot/2 and need two partner lanes
     bad_freqs = torch.randn(1, c["t"], 1, 6, 2, 2, device="cuda")
     with pytest.raises(ValueError, match="rot_dim"):
-        cuda_backend.sol_attn_chunked(c["chunks"], c["t"], c["h"], bad_freqs, c["norm"])
+        backend.sol_attn_chunked(c["chunks"], c["t"], c["h"], bad_freqs, c["norm"])
 
 
 def test_chunked_zero_vscale_is_clamped():
     """A caller-supplied all-zero V scale must not poison the run (1/0 in the
     producer, 255/0 in route); it is clamped like the internal bootstrap."""
     c = _chunked_case(seed=11, rot=64)
-    ref = cuda_backend.sol_attn(c["q"], c["k"], c["v"], tau=1.4)
+    ref = backend.sol_attn(c["q"], c["k"], c["v"], tau=1.4)
     zeros = torch.zeros(c["h"], HD, device="cuda")
-    out, km, vs = cuda_backend.sol_attn_chunked(
+    out, km, vs = backend.sol_attn_chunked(
         c["chunks"], c["t"], c["h"], c["freqs"], c["norm"], kmean=zeros, vscale=zeros, tau=1.4)
     assert torch.isfinite(out.float()).all()          # that step's V is sign-quantized: finite is the bar
-    out, _, _ = cuda_backend.sol_attn_chunked(
+    out, _, _ = backend.sol_attn_chunked(
         c["chunks"], c["t"], c["h"], c["freqs"], c["norm"], kmean=km, vscale=vs, tau=1.4)
     assert _cos(out, ref) > 0.995                      # and its statistics recover the next step
 
@@ -431,10 +568,10 @@ def test_chunked_zero_vscale_is_clamped():
 def test_chunked_producer_topk():
     """Producer-path top-k (threshold from the workspace) vs the separate-rope path."""
     c = _chunked_case(seed=13, rot=64)
-    ref = cuda_backend.sol_attn(c["q"], c["k"], c["v"], topk_ratio=0.2, sink_blocks=[0, 2])
-    _, km, vs = cuda_backend.sol_attn_chunked(
+    ref = backend.sol_attn(c["q"], c["k"], c["v"], topk_ratio=0.2, sink_blocks=[0, 2])
+    _, km, vs = backend.sol_attn_chunked(
         c["chunks"], c["t"], c["h"], c["freqs"], c["norm"], topk_ratio=0.2, sink_blocks=[0, 2])
-    out, _, _ = cuda_backend.sol_attn_chunked(
+    out, _, _ = backend.sol_attn_chunked(
         c["chunks"], c["t"], c["h"], c["freqs"], c["norm"], kmean=km, vscale=vs,
         topk_ratio=0.2, sink_blocks=[0, 2])
     assert _cos(out, ref) > 0.995
@@ -548,8 +685,9 @@ def test_coarse_gate_batch():
 def test_topk_budget_excludes_sinks():
     """Sink blocks are always exact, so the top-k budget ranks and counts only
     the other blocks; a sink range running past n counts only what exists."""
-    from comfy_kitchen.backends.cuda import _topk_from_pooled
     from comfy_kitchen.backends.eager.sol_attn import _topk_count
+
+    _topk_from_pooled = backend._topk_from_pooled
     g = torch.Generator(device="cuda").manual_seed(2)
     n, bh, d = 32, 3, HD
     c8 = torch.randint(-127, 128, (bh, n, d), device="cuda", generator=g).float()
@@ -583,7 +721,7 @@ def test_topk_zero_budget_routes_nothing():
 def test_topk_ties_over_select():
     """A tied group straddling the budget must be kept whole. Blocks 8..31 are
     identical and score highest for every query block, so with k = 8 the
-    boundary is always inside the group; CUDA must agree with eager."""
+    boundary is always inside the group; the kernel must agree with eager."""
     q, k, v = _qkv(1, 64 * 32, 2)
     u = q.mean(dim=1, keepdim=True) * 640           # scores highest for every query block
     k = k.clone()
@@ -604,9 +742,9 @@ def test_chunked_vsa_mode():
     gate = torch.randn(1, t, h, HD, device="cuda", dtype=torch.bfloat16) * 0.5
     kw = {"topk_ratio": 0.2, "tail": False, "block_len": block_len, "coarse_gate": gate,
           "sink_blocks": [0, 2]}
-    ref = cuda_backend.sol_attn(c["q"], c["k"], c["v"], **kw)
-    _, km, vs = cuda_backend.sol_attn_chunked(c["chunks"], t, h, c["freqs"], c["norm"], **kw)
-    out, _, _ = cuda_backend.sol_attn_chunked(c["chunks"], t, h, c["freqs"], c["norm"],
+    ref = backend.sol_attn(c["q"], c["k"], c["v"], **kw)
+    _, km, vs = backend.sol_attn_chunked(c["chunks"], t, h, c["freqs"], c["norm"], **kw)
+    out, _, _ = backend.sol_attn_chunked(c["chunks"], t, h, c["freqs"], c["norm"],
                                               kmean=km, vscale=vs, **kw)
     assert torch.isfinite(out.float()).all()
     assert _cos_rows(out, ref, valid) > 0.995
@@ -622,9 +760,9 @@ def test_block_len_validation():
     for bad in ({"block_len": bad_n}, {"block_len": bad_dtype}, {"coarse_gate": bad_gate}):
         name = next(iter(bad))
         with pytest.raises(ValueError, match=name):
-            cuda_backend.sol_attn(q, k, v, tau=1.4, **bad)
+            backend.sol_attn(q, k, v, tau=1.4, **bad)
         with pytest.raises(NoCapableBackendError, match=name):
             ck.sol_attn(q, k, v, tau=1.4, **bad)
     c = _chunked_case(seed=11, rot=64)
     with pytest.raises(ValueError, match="block_len"):
-        cuda_backend.sol_attn_chunked(c["chunks"], c["t"], c["h"], c["freqs"], c["norm"], block_len=bad_dtype)
+        backend.sol_attn_chunked(c["chunks"], c["t"], c["h"], c["freqs"], c["norm"], block_len=bad_dtype)

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -1394,12 +1394,20 @@ class TestINT8LinearOperations:
 
         result = torch.nn.functional.linear(x, qt_w, bias)
 
-        # Reference: same quantized math through the eager backend.
+        # Reference: the same quantized weight through the eager backend.
         with ck.registry.use_backend("eager"):
             expected = torch.nn.functional.linear(x, qt_w, bias)
 
         assert result.shape == expected.shape
-        assert torch.allclose(result, expected, rtol=1e-2, atol=1e-1)
+        # Not the same arithmetic: eager dequantizes and multiplies in floating
+        # point, a fused backend accumulates INT32 exactly and scales once. On an
+        # element where the sum nearly cancels they differ by far more than a
+        # relative tolerance allows, so both are checked against the exact product
+        # of the dequantized operands, which is what each one approximates.
+        truth = x.float() @ qt_w.dequantize().float().t() + bias.float()
+        limit = 0.05 * truth.abs().max()
+        for name, got in (("fused", result), ("eager", expected)):
+            assert (got.float() - truth).abs().max() < limit, name
 
     def test_int8_mm(self):
         import comfy_kitchen as ck
@@ -1416,4 +1424,8 @@ class TestINT8LinearOperations:
             expected = torch.mm(a, qt_b.t())
 
         assert result.shape == expected.shape
-        assert torch.allclose(result, expected, rtol=1e-2, atol=1e-1)
+        # See test_int8_linear_weight_quantized on why this is not an allclose.
+        truth = a.float() @ qt_b.dequantize().float().t()
+        limit = 0.05 * truth.abs().max()
+        for name, got in (("fused", result), ("eager", expected)):
+            assert (got.float() - truth).abs().max() < limit, name


### PR DESCRIPTION
Brings the HIP backend back to parity with #117. 

A capability port: `sol_attn` and `sol_attn_chunked` did not exist on HIP, so ROCm fell through to the O(T^2) eager reference, which refuses video length outright. Both entry points, the workspace plan, the chunked QKV producer, `key_bias`, `block_len`, `tail=False` and the VSA coarse gate are all covered, and `tests/test_sol_attn.py` now runs against whichever fused backend is built.

The kernels are a reimplementation. The CUDA carriers are stored under `sol::perm_d` and `sol::perm_key`, which exist only to turn an `m16n8k32` lane's two operand words into one 8-byte load; RDNA's `16x16x16` WMMA already hands a lane a contiguous K slice, so both permutations are dropped and the scores are evaluated transposed the way `int8_attn.hip` does, which puts one query per lane and makes `P^T` the operand of the second MMA directly. Everything goes through the existing `MmaInt8` / `MmaBf16` policies, so gfx11 and gfx12 both fall out of the port.

On a gfx1200 card, `(1, T, H, 128)` bf16 at `tau=1.4`, against bf16 SDPA with the AOTriton flash backend enabled: 11.3x at T=32768 (113.3 ms to 10.0 ms), and 2.3x to 7.1x against this backend's own fused INT8 attention. Cosine against the eager Sol-Attn reference is 0.9999. Compile-verified on all 17 targets in `architectures.json` with no scratch spill; run-verified on RDNA4 only. RDNA2 is unsupported because it has no matrix cores.

One fix rides along in its own commit because it is what hid the rest. `test_backend_priority` changes registry priority without restoring it, leaving HIP registered but unreachable and causing two INT8 tests to run against eager incorrectly. `tests/conftest.py` now restores priority and the disabled set per test. Those INT8 tests now compare against the exact dequantized product instead of eager, since the fused kernels accumulate in INT32. ROCm failures drop from 113 to 101 - the same failures already present on `main`.