### PR TITLE
Reuse Sage INT8 kernel for Sol exact attention

### DIFF
--- a/comfy_kitchen/backends/cuda/CMakeLists.txt
+++ b/comfy_kitchen/backends/cuda/CMakeLists.txt
@@ -147,6 +147,7 @@ set(CUDA_SOURCES
     sage_attention/quant_v_int8.cu
     sage_attention/quant_qk_int8.cu
     sage_attention/sage_attn_launcher.cu
+    sage_attention/sage_attn_sparse_launcher.cu
 )
 
 set(CPP_SOURCES

--- a/comfy_kitchen/backends/cuda/sage_attention/qk_int_sv_i8_cuda.cuh
+++ b/comfy_kitchen/backends/cuda/sage_attention/qk_int_sv_i8_cuda.cuh
@@ -56,7 +56,7 @@ template <uint32_t CTA_Q, uint32_t CTA_K, uint32_t WARP_Q, uint32_t WARP_K,
           MaskMode mask_mode = MaskMode::kNone, bool return_lse = false,
           bool fuse_v_scale = false, bool fuse_v_mean = false,
           bool use_pv_fp16_accu = false,
-          bool fuse_fp32_probabilities = true>
+          bool fuse_fp32_probabilities = true, bool use_sparse_kv = false>
 __global__ void qk_int_sv_i8_attn_kernel(
     int8_t *__restrict__ Q, int8_t *__restrict__ K, int8_t *__restrict__ V,
     DTypeOut *__restrict__ O, float *__restrict__ Lse,
@@ -71,7 +71,10 @@ __global__ void qk_int_sv_i8_attn_kernel(
     const uint32_t stride_seq_k, const uint32_t stride_h_k,
     const uint32_t stride_bz_v, const uint32_t stride_h_v,
     const uint32_t stride_d_v, const uint32_t stride_bz_o,
-    const uint32_t stride_seq_o, const uint32_t stride_h_o, float sm_scale) {
+    const uint32_t stride_seq_o, const uint32_t stride_h_o, float sm_scale,
+    const uint32_t stride_bz_q_scale, const uint32_t stride_h_q_scale,
+    const uint16_t *__restrict__ BlockLut,
+    const int32_t *__restrict__ ValidBlockNum, const uint32_t lut_stride) {
   // compile time check
   static_assert(DTypeQK == DataType::kInt8 || DTypeQK == DataType::kInt4,
                 "DTypeQK must be int8 or int4");
@@ -93,6 +96,14 @@ __global__ void qk_int_sv_i8_attn_kernel(
                 "DTypeOut must be half or nv_bfloat16");
   static_assert(CTA_K % 64 == 0);
   static_assert(CTA_Q / CTA_K <= 2); // for efficient causal implementation
+  static_assert(!use_sparse_kv || mask_mode == MaskMode::kNone,
+                "the sparse traversal takes no attention mask");
+  static_assert(!use_sparse_kv ||
+                    (CTA_Q == 64 && CTA_K == 64 && WARP_Q == 16 &&
+                     WARP_K == 64 && head_dim == 128 &&
+                     Q_GRAN == QuantGranularity::kPerThread &&
+                     K_GRAN == QuantGranularity::kPerThread),
+                "the sparse traversal is fixed to Sol's 64Q x 64KV geometry");
 
   constexpr uint32_t num_warps_q = CTA_Q / WARP_Q;
   constexpr uint32_t num_warps_k = CTA_K / WARP_K;
@@ -158,11 +169,17 @@ __global__ void qk_int_sv_i8_attn_kernel(
   } else if constexpr (Q_GRAN == QuantGranularity::kPerThread) {
     if constexpr (head_dim == 128 && WARP_Q == 16) {
       constexpr uint32_t quant_warps_q = CTA_Q / 32;
-      const uint32_t num_warp_block_q = gridDim.x * quant_warps_q;
-      q_scale_idx =
-          batch_id * num_qo_heads * (num_warp_block_q * 8) +
-          head_id * (num_warp_block_q * 8) + bx * (quant_warps_q * 8) +
-          (get_warp_idx_q<num_warps_q, num_warps_k>() / 2) * 8 + lane_id / 4;
+      if constexpr (use_sparse_kv) {
+        q_scale_idx = batch_id * stride_bz_q_scale +
+            head_id * stride_h_q_scale + bx * (quant_warps_q * 8) +
+            (get_warp_idx_q<num_warps_q, num_warps_k>() / 2) * 8 + lane_id / 4;
+      } else {
+        const uint32_t num_warp_block_q = gridDim.x * quant_warps_q;
+        q_scale_idx =
+            batch_id * num_qo_heads * (num_warp_block_q * 8) +
+            head_id * (num_warp_block_q * 8) + bx * (quant_warps_q * 8) +
+            (get_warp_idx_q<num_warps_q, num_warps_k>() / 2) * 8 + lane_id / 4;
+      }
     } else {
       const uint32_t num_warp_block_q = gridDim.x * num_warps_q;
       q_scale_idx =
@@ -323,9 +340,36 @@ __global__ void qk_int_sv_i8_attn_kernel(
   uint32_t K_load_idx_lane_base =
       CTA_K / num_warps * warp_id + lane_id / global_to_shared_line_lanes_QK;
 
-  const uint32_t num_iterations = div_ceil(
-      mask_mode == MaskMode::kCausal ? min(kv_len, (bx + 1) * CTA_Q) : kv_len,
-      CTA_K);
+  const uint32_t route_idx =
+      (batch_id * num_qo_heads + head_id) * gridDim.x + bx;
+  const uint16_t *__restrict__ lut_row =
+      use_sparse_kv ? BlockLut + static_cast<int64_t>(route_idx) * lut_stride
+                    : nullptr;
+  uint32_t num_iterations;
+  uint32_t load_block = 0;
+  if constexpr (use_sparse_kv) {
+    // Sol always forces the diagonal neighbourhood, so every route is non-empty.
+    num_iterations = static_cast<uint32_t>(ValidBlockNum[route_idx]);
+    load_block = static_cast<uint32_t>(lut_row[0]);
+  } else {
+    num_iterations = div_ceil(
+        mask_mode == MaskMode::kCausal ? min(kv_len, (bx + 1) * CTA_Q) : kv_len,
+        CTA_K);
+  }
+
+  int8_t *const K_lane_origin = K_lane_base_ptr;
+  int8_t *const V_lane_origin = V_lane_base_ptr;
+  const uint32_t K_load_idx_origin = K_load_idx_lane_base;
+  const uint32_t K_idx_origin = K_idx_lane_base;
+  auto seek_kv_block = [&](uint32_t block) {
+    K_lane_base_ptr =
+        K_lane_origin + static_cast<int64_t>(block) * CTA_K * stride_seq_k;
+    V_lane_base_ptr = V_lane_origin + static_cast<int64_t>(block) * CTA_K;
+    K_load_idx_lane_base = K_load_idx_origin + block * CTA_K;
+  };
+
+  if constexpr (use_sparse_kv)
+    seek_kv_block(load_block);
 
   // load Q with predicate
   load_global_to_share<global_to_shared_line_lanes_QK,
@@ -361,7 +405,7 @@ __global__ void qk_int_sv_i8_attn_kernel(
 
   float original_sm_scale = sm_scale;
   float dequant_scale =
-      q_scale * K_scale[k_scale_idx + 0 * k_scale_advance_offset];
+      q_scale * K_scale[k_scale_idx + load_block * k_scale_advance_offset];
 
   sm_scale = original_sm_scale * dequant_scale;
 
@@ -374,7 +418,8 @@ __global__ void qk_int_sv_i8_attn_kernel(
       &V_lane_base_ptr, V_smem_offset_load, stride_d_v, smem_V);
   cp_async::commit_group();
 
-  K_load_idx_lane_base += CTA_K;
+  if constexpr (!use_sparse_kv)
+    K_load_idx_lane_base += CTA_K;
 
 #pragma unroll
   for (uint32_t iter = 1; iter < num_iterations - 1; iter++) {
@@ -442,20 +487,32 @@ __global__ void qk_int_sv_i8_attn_kernel(
           RS[fq][0][k] = __float_as_int(pv_scale[fq][k]);
       }
     }
-    K_idx_lane_base += CTA_K;
+    if constexpr (!use_sparse_kv)
+      K_idx_lane_base += CTA_K;
 
     __syncthreads();
 
-    // load K without predicate
-    load_global_to_share<global_to_shared_line_lanes_QK,
-                         global_to_shared_copy_lines_per_warp_QK,
-                         QK_smem_iters_row, K_smem_iters_col, swizzle_mode_QK,
-                         QK_SMEM_STRIDE / PACK_SIZE_QK, CTA_K>(
-        &K_lane_base_ptr, K_smem_offset_load, stride_seq_k, smem_K);
+    if constexpr (use_sparse_kv) {
+      load_block = static_cast<uint32_t>(lut_row[iter]);
+      seek_kv_block(load_block);
+      load_global_to_share<global_to_shared_line_lanes_QK,
+                           global_to_shared_copy_lines_per_warp_QK,
+                           QK_smem_iters_row, K_smem_iters_col, swizzle_mode_QK,
+                           QK_SMEM_STRIDE / PACK_SIZE_QK, CTA_K>(
+          &K_lane_base_ptr, K_smem_offset_load, stride_seq_k, smem_K,
+          K_load_idx_lane_base, kv_len);
+    } else {
+      load_global_to_share<global_to_shared_line_lanes_QK,
+                           global_to_shared_copy_lines_per_warp_QK,
+                           QK_smem_iters_row, K_smem_iters_col, swizzle_mode_QK,
+                           QK_SMEM_STRIDE / PACK_SIZE_QK, CTA_K>(
+          &K_lane_base_ptr, K_smem_offset_load, stride_seq_k, smem_K);
+    }
     cp_async::commit_group();
 
-    dequant_scale =
-        q_scale * K_scale[k_scale_idx + iter * k_scale_advance_offset];
+    const uint32_t scale_block = use_sparse_kv ? load_block : iter;
+    dequant_scale = q_scale *
+        K_scale[k_scale_idx + scale_block * k_scale_advance_offset];
     sm_scale = original_sm_scale * dequant_scale;
 
     // ensure V is ready
@@ -474,7 +531,8 @@ __global__ void qk_int_sv_i8_attn_kernel(
         &V_lane_base_ptr, V_smem_offset_load, stride_d_v, smem_V);
     cp_async::commit_group();
 
-    K_load_idx_lane_base += CTA_K;
+    if constexpr (!use_sparse_kv)
+      K_load_idx_lane_base += CTA_K;
   }
 
   // second last iter, apply causal mask
@@ -548,10 +606,15 @@ __global__ void qk_int_sv_i8_attn_kernel(
           RS[fq][0][k] = __float_as_int(pv_scale[fq][k]);
       }
     }
-    K_idx_lane_base += CTA_K;
+    if constexpr (!use_sparse_kv)
+      K_idx_lane_base += CTA_K;
 
     __syncthreads();
 
+    if constexpr (use_sparse_kv) {
+      load_block = static_cast<uint32_t>(lut_row[num_iterations - 1]);
+      seek_kv_block(load_block);
+    }
     // load K with predicate
     load_global_to_share<global_to_shared_line_lanes_QK,
                          global_to_shared_copy_lines_per_warp_QK,
@@ -561,9 +624,10 @@ __global__ void qk_int_sv_i8_attn_kernel(
         K_load_idx_lane_base, kv_len);
     cp_async::commit_group();
 
-    dequant_scale =
-        q_scale *
-        K_scale[k_scale_idx + (num_iterations - 1) * k_scale_advance_offset];
+    const uint32_t scale_block =
+        use_sparse_kv ? load_block : num_iterations - 1;
+    dequant_scale = q_scale *
+        K_scale[k_scale_idx + scale_block * k_scale_advance_offset];
     sm_scale = original_sm_scale * dequant_scale;
 
     // ensure V is ready
@@ -582,7 +646,8 @@ __global__ void qk_int_sv_i8_attn_kernel(
         V_SMEM_STRIDE / PACK_SIZE_V, CTA_K>(
         &V_lane_base_ptr, V_smem_offset_load, stride_d_v, smem_V);
     cp_async::commit_group();
-    K_load_idx_lane_base += CTA_K;
+    if constexpr (!use_sparse_kv)
+      K_load_idx_lane_base += CTA_K;
   }
 
   // last iter, apply causal mask and out of bound mask
@@ -634,6 +699,8 @@ __global__ void qk_int_sv_i8_attn_kernel(
           mask_stride_h, mask_stride_k, batch_id, head_id, kv_len,
           mask_dtype_code, 1.0f);
     }
+    if constexpr (use_sparse_kv)
+      K_idx_lane_base = K_idx_origin + load_block * CTA_K;
     apply_out_of_bound_mask<num_tiles_q, num_tiles_k>(
         K_idx_lane_base, RS_soft, kv_len,
         pre_scale_scores ? -50000.0f : -1.0e30f);
@@ -654,7 +721,8 @@ __global__ void qk_int_sv_i8_attn_kernel(
       for (uint32_t k = 0; k < 2; k++)
         RS[fq][0][k] = __float_as_int(pv_scale[fq][k]);
     }
-    K_idx_lane_base += CTA_K;
+    if constexpr (!use_sparse_kv)
+      K_idx_lane_base += CTA_K;
 
     // ensure V is ready
     cp_async::wait_group<0>();

--- a/comfy_kitchen/backends/cuda/sage_attention/sage_attn_launcher.cu
+++ b/comfy_kitchen/backends/cuda/sage_attention/sage_attn_launcher.cu
@@ -64,7 +64,7 @@ void launch_impl(int8_t *q, int8_t *k, int8_t *v, DTypeOut *o, float *q_scale,
       mask_dtype_code, qo_len, kv_len, num_kv_groups, stride_bz_q,
       stride_seq_q, stride_h_q, stride_bz_k, stride_seq_k, stride_h_k,
       stride_bz_v, stride_h_v, stride_d_v, stride_bz_o, stride_seq_o,
-      stride_h_o, sm_scale);
+      stride_h_o, sm_scale, 0, 0, nullptr, nullptr, 0);
 
   error = cudaGetLastError();
   if (error != cudaSuccess) {

--- a/comfy_kitchen/backends/cuda/sage_attention/sage_attn_sparse_launcher.cu
+++ b/comfy_kitchen/backends/cuda/sage_attention/sage_attn_sparse_launcher.cu
@@ -1,0 +1,97 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// The exact 64Q x 64KV branch used by Sol when no approximate tail needs to be
+// resumed. Q/K/V use Kitchen's existing pure-INT8 Sage carrier; the route is
+// Sol's absolute uint16 block list plus one int32 count per query block.
+
+#include "qk_int_sv_i8_cuda.cuh"
+
+#include <algorithm>
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+constexpr int CTA_Q = 64;
+constexpr int CTA_K = 64;
+constexpr int WARP_Q = 16;
+constexpr int WARP_K = 64;
+constexpr int HEAD_DIM = 128;
+
+template <typename DTypeOut>
+void launch_impl(
+    int8_t* q, int8_t* k, int8_t* v, DTypeOut* out,
+    float* q_scale, float* k_scale, float* v_scale,
+    const uint16_t* block_lut, const int32_t* valid_block_num,
+    int batch, int sequence, int heads, int padded_sequence,
+    int q_scale_stride_b, int q_scale_stride_h, float scale,
+    cudaStream_t stream)
+{
+    const size_t smem = std::max(
+        static_cast<size_t>((CTA_Q + CTA_K + CTA_K) * HEAD_DIM * sizeof(int8_t)),
+        static_cast<size_t>(CTA_Q * HEAD_DIM * sizeof(half)));
+
+    auto kernel = qk_int_sv_i8_attn_kernel<
+        CTA_Q, CTA_K, WARP_Q, WARP_K, HEAD_DIM,
+        DataType::kInt8, QuantGranularity::kPerThread,
+        QuantGranularity::kPerThread, float, false, DTypeOut,
+        ComputeUnit::kCudaCore, MaskMode::kNone, false, true, false, false, true, true>;
+
+    cudaError_t error = cudaFuncSetAttribute(
+        kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, static_cast<int>(smem));
+    if (error != cudaSuccess) {
+        throw std::runtime_error(
+            "sol_attn failed to request " + std::to_string(smem) +
+            " bytes for the Sage exact branch: " + cudaGetErrorString(error));
+    }
+
+    const int q_tiles = (sequence + CTA_Q - 1) / CTA_Q;
+    dim3 grid(q_tiles, heads, batch);
+    dim3 block(32, CTA_Q / WARP_Q);
+    kernel<<<grid, block, smem, stream>>>(
+        q, k, v, out, nullptr, q_scale, k_scale, v_scale, nullptr, nullptr,
+        0, 0, 0, 0, 0, sequence, sequence, 1,
+        heads * sequence * HEAD_DIM, HEAD_DIM, sequence * HEAD_DIM,
+        heads * sequence * HEAD_DIM, HEAD_DIM, sequence * HEAD_DIM,
+        heads * HEAD_DIM * padded_sequence, HEAD_DIM * padded_sequence,
+        padded_sequence,
+        sequence * heads * HEAD_DIM, heads * HEAD_DIM, HEAD_DIM, scale,
+        q_scale_stride_b, q_scale_stride_h,
+        block_lut, valid_block_num, q_tiles);
+
+    error = cudaGetLastError();
+    if (error != cudaSuccess) {
+        throw std::runtime_error(
+            std::string("Sol Sage exact kernel launch failed: ") +
+            cudaGetErrorString(error));
+    }
+}
+
+}  // namespace
+
+void launch_sage_attn_sparse64_kernel(
+    const void* q, const void* k, const void* v, void* out,
+    const void* q_scale, const void* k_scale, const void* v_scale,
+    const void* block_lut, const void* valid_block_num,
+    int batch, int sequence, int heads, int padded_sequence,
+    int q_scale_stride_b, int q_scale_stride_h, float scale,
+    cudaStream_t stream)
+{
+    auto q_ptr = const_cast<int8_t*>(static_cast<const int8_t*>(q));
+    auto k_ptr = const_cast<int8_t*>(static_cast<const int8_t*>(k));
+    auto v_ptr = const_cast<int8_t*>(static_cast<const int8_t*>(v));
+    auto qs_ptr = const_cast<float*>(static_cast<const float*>(q_scale));
+    auto ks_ptr = const_cast<float*>(static_cast<const float*>(k_scale));
+    auto vs_ptr = const_cast<float*>(static_cast<const float*>(v_scale));
+
+    launch_impl(
+        q_ptr, k_ptr, v_ptr, static_cast<nv_bfloat16*>(out),
+        qs_ptr, ks_ptr, vs_ptr,
+        static_cast<const uint16_t*>(block_lut),
+        static_cast<const int32_t*>(valid_block_num),
+        batch, sequence, heads, padded_sequence,
+        q_scale_stride_b, q_scale_stride_h, scale, stream);
+}

--- a/comfy_kitchen/backends/cuda/sage_attention/sol_attn.cu
+++ b/comfy_kitchen/backends/cuda/sage_attention/sol_attn.cu
@@ -16,8 +16,8 @@
  */
 
 // Sol-Attn (arXiv 2607.24027) orchestration over one caller-allocated workspace:
-//   preprocess  quantize Q/K/V, pool K/V per block, routing threshold
-//   vtranspose  INT8 V^T for the exact stage's PV operand
+//   preprocess  pool K/V per block, routing threshold, Sol Q/K carriers as needed
+//   carriers    Sol V transpose, or the existing Sage INT8 Q/K/V quantizers
 //   route       choose the routed blocks; approximate tail from the centroids
 //   exact       walk each routed list, resuming route's online softmax
 // Entry paths: `launch_sol_attn` (post-rope q/k/v) or the chunked producer
@@ -36,7 +36,7 @@
 void launch_sol_preprocess(const void*, const void*, const void*, void*, void*, void*,
                            void*, void*, void*, void*, void*, void*, void*, void*, void*,
                            void*, const void*, const void*,
-                           int, int, int, int, int, int, int,
+                           int, int, int, int, int, int, int, int,
                            int64_t, int64_t, int64_t, int64_t, int64_t, int64_t,
                            int64_t, int64_t, int64_t, float, float, cudaStream_t);
 size_t sol_preprocess_scratch_bytes(int, int, int);
@@ -59,11 +59,24 @@ void launch_sol_exact(const void*, const void*, const void*, const void*, const 
                       const void*, const void*, const void*, const void*, const void*,
                       const void*, void*, int, int, int, int, int, int, float,
                       cudaStream_t);
+extern "C" void launch_quant_qk_per_thread_int8(
+    const void*, void*, void*, const void*, void*, void*,
+    int, int, int, int, int, int, int, int, int, int,
+    int64_t, int64_t, int64_t, int64_t, int64_t, int64_t,
+    int, void*, cudaStream_t);
+extern "C" void launch_quant_v_int8_kernel(
+    const void*, void*, void*, int, int, int, int, int,
+    int64_t, int64_t, int64_t, int, cudaStream_t);
+void launch_sage_attn_sparse64_kernel(
+    const void*, const void*, const void*, void*, const void*, const void*,
+    const void*, const void*, const void*, int, int, int, int, int, int,
+    float, cudaStream_t);
 
 namespace {
 
 constexpr int HD = sol::HEAD_DIM;
 constexpr int BLK = sol::BLOCK;
+constexpr int SAGE_EXACT_MIN_SEQUENCE = 4096;
 
 inline size_t align16(size_t n) { return (n + 15u) & ~(size_t)15u; }
 
@@ -118,10 +131,10 @@ void validate_shape(int batch, int seq_len, int num_heads) {
 // stage launched before it; without it a rejected launch leaves route's
 // handover values in `out`.
 void run_route_exact(const Plan& p, char* w, const void* ext_threshold, void* out,
-                     const void* blen, int tail,
+                     const void* blen, int tail, bool sage_exact,
                      int batch, int seq_len, int num_heads,
                      int sink_start, int sink_end, int sink_q_start, int sink_q_end,
-                     float scale_log2, cudaStream_t stream)
+                     float scale, float scale_log2, cudaStream_t stream)
 {
     // top-k mode: the caller supplies the per-query-block threshold
     const void* thr = ext_threshold ? ext_threshold : (const void*)(w + p.thr);
@@ -129,10 +142,19 @@ void run_route_exact(const Plan& p, char* w, const void* ext_threshold, void* ou
                      thr, w + p.idx, w + p.cnt, w + p.oPart, w + p.mPart, w + p.lPart,
                      blen, tail, batch, seq_len, num_heads, p.NTB, p.NPAD, p.NQ,
                      sink_start, sink_end, sink_q_start, sink_q_end, scale_log2, stream);
-    launch_sol_exact(w + p.qiP, w + p.qs, w + p.kiP, w + p.ksb, w + p.vTi, w + p.vsc,
-                     w + p.idx, w + p.cnt, w + p.oPart, w + p.mPart, w + p.lPart, out,
-                     batch, seq_len, p.Tp, num_heads, p.NQ, p.NTB,
-                     scale_log2, stream);
+    if (sage_exact) {
+        const int q_scale_stride_h = ((seq_len + 127) / 128) * 32;
+        launch_sage_attn_sparse64_kernel(
+            w + p.qiP, w + p.kiP, w + p.vTi, out,
+            w + p.qs, w + p.ksb, w + p.vsc, w + p.idx, w + p.cnt,
+            batch, seq_len, num_heads, p.Tp,
+            num_heads * q_scale_stride_h, q_scale_stride_h, scale, stream);
+    } else {
+        launch_sol_exact(w + p.qiP, w + p.qs, w + p.kiP, w + p.ksb, w + p.vTi, w + p.vsc,
+                         w + p.idx, w + p.cnt, w + p.oPart, w + p.mPart, w + p.lPart, out,
+                         batch, seq_len, p.Tp, num_heads, p.NQ, p.NTB,
+                         scale_log2, stream);
+    }
     const cudaError_t err = cudaGetLastError();
     if (err != cudaSuccess)
         throw std::runtime_error(std::string("sol_attn: kernel launch failed: ")
@@ -213,8 +235,9 @@ extern "C" void launch_sol_attn_core(
                       w + p.cen8, w + p.cens, kmean_next, blen,
                       batch, seq_len, num_heads, p.NTB, p.NPAD, p.NQ,
                       tau, scale_log2, stream);
-    run_route_exact(p, w, ext_threshold, out, blen, tail, batch, seq_len, num_heads,
-                    sink_start, sink_end, sink_q_start, sink_q_end, scale_log2, stream);
+    run_route_exact(p, w, ext_threshold, out, blen, tail, false,
+                    batch, seq_len, num_heads, sink_start, sink_end,
+                    sink_q_start, sink_q_end, scale, scale_log2, stream);
     cudaMemcpyAsync(vamax_out, w + p.statsV, stats_bytes, cudaMemcpyDeviceToDevice, stream);
 }
 
@@ -236,15 +259,33 @@ extern "C" void launch_sol_attn(
     const Plan p(batch, seq_len, num_heads);
     char* w = reinterpret_cast<char*>(workspace);
     const float scale_log2 = scale * 1.4426950408889634f;
+    // The alternate carrier setup only amortizes at video lengths. A zero-based
+    // sink prefix also keeps the route sorted, so a ragged KV tail remains last.
+    const bool sage_exact = seq_len >= SAGE_EXACT_MIN_SEQUENCE && !tail &&
+                            key_bias == nullptr && blen == nullptr && sink_start == 0;
     launch_sol_preprocess(q, k, v, w + p.qiP, w + p.qs, w + p.kiP, w + p.ksb,
                           w + p.kciP, w + p.kcs, w + p.vcT, w + p.thr,
                           w + p.cen8, w + p.cens, w + p.vsc, w + p.qmean, w + p.scratch,
                           key_bias, blen,
                           batch, seq_len, p.Tp, num_heads, p.NTB, p.NPAD, p.NQ,
+                          sage_exact ? 0 : 1,
                           qs_b, qs_t, qs_h, ks_b, ks_t, ks_h, vs_b, vs_t, vs_h,
                           tau, scale_log2, stream);
-    launch_sol_vtranspose(v, w + p.vsc, w + p.vTi, batch, seq_len, p.Tp, num_heads,
-                          vs_b, vs_t, vs_h, stream);
-    run_route_exact(p, w, ext_threshold, out, blen, tail, batch, seq_len, num_heads,
-                    sink_start, sink_end, sink_q_start, sink_q_end, scale_log2, stream);
+    if (sage_exact) {
+        launch_quant_qk_per_thread_int8(
+            q, w + p.qiP, w + p.qs, k, w + p.kiP, w + p.ksb,
+            batch, num_heads, seq_len, num_heads, seq_len, HD,
+            128, 32, 64, 64,
+            qs_b, qs_h, qs_t, ks_b, ks_h, ks_t,
+            2, w + p.statsV, stream);
+        launch_quant_v_int8_kernel(
+            v, w + p.vTi, w + p.vsc, batch, num_heads, seq_len, HD, p.Tp,
+            vs_b, vs_h, vs_t, 2, stream);
+    } else {
+        launch_sol_vtranspose(v, w + p.vsc, w + p.vTi, batch, seq_len, p.Tp, num_heads,
+                              vs_b, vs_t, vs_h, stream);
+    }
+    run_route_exact(p, w, ext_threshold, out, blen, tail, sage_exact,
+                    batch, seq_len, num_heads, sink_start, sink_end,
+                    sink_q_start, sink_q_end, scale, scale_log2, stream);
 }

--- a/comfy_kitchen/backends/cuda/sage_attention/sol_attn_preprocess.cu
+++ b/comfy_kitchen/backends/cuda/sage_attention/sol_attn_preprocess.cu
@@ -128,7 +128,8 @@ __global__ void prep_q(const __nv_bfloat16* __restrict__ q, const float* __restr
                        int8_t* __restrict__ cen8, float* __restrict__ cens,
                        float* __restrict__ qmean,   // [B*H, NPAD, HD] f32 block means
                        const int32_t* __restrict__ blen,
-                       int T, int H, int NQ, int NPAD, float tau, float log2s,
+                       int T, int H, int NQ, int NPAD, int emit_sol_carriers,
+                       float tau, float log2s,
                        int64_t sb, int64_t st, int64_t sh) {
     __shared__ __align__(16) __nv_bfloat16 sQ[BLK * LD_TILE];
     __shared__ __align__(16) float sred[HD];
@@ -139,7 +140,9 @@ __global__ void prep_q(const __nv_bfloat16* __restrict__ q, const float* __restr
     stage_tile64(sQ, q + batch * sb + (int64_t)t0 * st + head * sh, st, len);
     __syncthreads();
     const size_t tok0 = (size_t)batch * T + t0;
-    quant_q_rows(sQ, len, nrows, qiP + (tok0 * H + head) * HD, qs + tok0 * H + head, H);
+    if (emit_sol_carriers)
+        quant_q_rows(sQ, len, nrows, qiP + (tok0 * H + head) * HD,
+                     qs + tok0 * H + head, H);
     __syncthreads();
     const size_t qrow = (size_t)bh * NQ + qb;
     const float c = centroid_quant(sQ, len, sred, cen8 + qrow * HD, cens + qrow);
@@ -232,6 +235,7 @@ void launch_sol_preprocess(
     const void* key_bias,    // [B, T] f32 in log2 units, or nullptr
     const void* blen,        // [NTB] int32 valid tokens per block, or nullptr
     int B, int T, int Tp, int H, int NTB, int NPAD, int NQ,
+    int emit_sol_carriers,
     int64_t qs_b, int64_t qs_t, int64_t qs_h,
     int64_t ks_b, int64_t ks_t, int64_t ks_h,
     int64_t vs_b, int64_t vs_t, int64_t vs_h,
@@ -251,10 +255,12 @@ void launch_sol_preprocess(
     prep_q<<<dim3(NQ, B * H), HD, 0, stream>>>(
         (const __nv_bfloat16*)q, s.kcvar, (int8_t*)qiP, (float*)qs, (float*)threshold,
         (int8_t*)cen8, (float*)cens, (float*)qmean, (const int32_t*)blen,
-        T, H, NQ, NPAD, tau, scale_log2, qs_b, qs_t, qs_h);
-    prep_k<<<dim3(NTB, B * H), HD, 0, stream>>>(
-        (const __nv_bfloat16*)k, s.kmean, (int8_t*)kiP, (float2*)ksb,
-        (const float*)key_bias, (const int32_t*)blen, T, Tp, H, ks_b, ks_t, ks_h);
+        T, H, NQ, NPAD, emit_sol_carriers, tau, scale_log2, qs_b, qs_t, qs_h);
+    if (emit_sol_carriers)
+        prep_k<<<dim3(NTB, B * H), HD, 0, stream>>>(
+            (const __nv_bfloat16*)k, s.kmean, (int8_t*)kiP, (float2*)ksb,
+            (const float*)key_bias, (const int32_t*)blen, T, Tp, H,
+            ks_b, ks_t, ks_h);
 }
 
 size_t sol_preprocess_scratch_bytes(int B, int H, int NPAD) {

--- a/tests/test_sol_attn.py
+++ b/tests/test_sol_attn.py
@@ -500,6 +500,17 @@ def test_no_tail_matches_eager():
     assert _cos_rows(dense, _masked_dense(q, k, v, valid), valid) > 0.9999
 
 
+def test_no_tail_sage_exact_ragged_and_strided():
+    """The long-sequence exact branch must preserve arbitrary BTHD strides and
+    mask the final partial KV tile after following its sparse route."""
+    q, k, v = _bhnd_views(1, 4096 + 31, 2, seed=19)
+    kw = {"topk_ratio": 0.2, "tail": False}
+    got = ck.sol_attn(q, k, v, **kw)
+    contiguous = ck.sol_attn(q.contiguous(), k.contiguous(), v.contiguous(), **kw)
+    assert torch.equal(got, contiguous)
+    assert _cos(got, sol_attn_eager(q, k, v, **kw)) > 0.99
+
+
 def _coarse_reference(q, k, v, valid, block_len, gate, scale=HD ** -0.5):
     """Independent per-block loop: masked dense attention plus gate * coarse term."""
     from comfy_kitchen.backends.eager.sol_attn import _block_lengths


### PR DESCRIPTION
## Summary

- reuse Kitchen's pure-INT8 Sage consumer for compatible long-sequence Sol `tail=False` calls
- reuse the existing Q/K/V quantizers and skip Sol's duplicate exact carriers on that path
- preserve the current Sol exact fallback for tail approximation, short sequences, key bias, block lengths, nonzero sink starts, and chunked producer calls

## Results

RTX 4070 (SM89), BF16 `[1, 79567, 56, 128]`, public `sol_attn`:

| Mode | `main` | This PR | Change |
| --- | ---: | ---: | ---: |
| Top-K 15%, no tail | 396.83 ms | 364.83 ms | -8.1% |
| All blocks, no tail | 2254.17 ms | 2038.60 ms | -9.6% |

At `[1, 4096, 4, 128]` with every block routed, relative L2 error versus FP32 dense attention improves from 1.975% to 1.545% (21.8% lower). Incremental Torch peak allocation was byte-identical in each paired benchmark.

## Tests

- CUDA build for SM89 and SM120
- `pytest tests/test_sol_attn.py tests/test_int8_attention.py -q`: 146 passed, 2 skipped
- CPU-only full suite: 520 passed, 1349 skipped; its one fused-QKV exact-equality failure reproduces unchanged on parent `dae00a1`

## Sidenote

Kitchen's pure-INT8 Sage consumer could also be extended to replace the remaining Sol exact path, including resuming from the approximate-tail softmax state. I deliberately left that out of this PR for two reasons:

1. It would make an already fairly involved kernel change significantly larger.
2. In our compute-equivalence experiments, spending the same additional attention compute on higher exact density consistently retained more attention mass and produced lower L2 error than spending it on the Sol tail approximation.

For that reason, I don't think adding tail support belongs in this optimization PR, even though the underlying online-softmax representation makes it technically feasible.
