### PR TITLE
Build managed SageAttention wheels for CUDA 13

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+sageattention/packaging.patch text eol=lf

--- a/.github/workflows/build-sageattention-wheels.yml
+++ b/.github/workflows/build-sageattention-wheels.yml
@@ -56,6 +56,7 @@ jobs:
             dnf install -y \
               cuda-nvcc-13-0 cuda-cuobjdump-13-0 \
               cuda-cudart-devel-13-0 cuda-driver-devel-13-0 \
+              libcublas-devel-13-0 libcusolver-devel-13-0 \
               libcusparse-devel-13-0
             /usr/local/cuda-13.0/bin/nvcc --version
           CIBW_ENVIRONMENT_LINUX: >-

--- a/.github/workflows/build-sageattention-wheels.yml
+++ b/.github/workflows/build-sageattention-wheels.yml
@@ -32,10 +32,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
@@ -43,11 +43,11 @@ jobs:
         run: python sageattention/prepare_source.py sageattention/build/source
 
       - name: Build and test wheel
-        uses: pypa/cibuildwheel@v2.22.0
+        uses: pypa/cibuildwheel@ee63bf16da6cddfb925f542f2c7b59ad50e93969 # v2.22.0
         env:
           CIBW_BUILD: "cp312-manylinux_x86_64"
           CIBW_SKIP: "*-musllinux_*"
-          CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux_2_28_x86_64
+          CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux_2_28_x86_64@sha256:94c816d38ad56d2dc1df2f28007d18d306b0f5d05096c6f6b9141345df504d3e
           CIBW_BUILD_FRONTEND: "pip; args: --no-build-isolation"
           CIBW_BEFORE_ALL_LINUX: |
             dnf install -y dnf-plugins-core
@@ -101,7 +101,7 @@ jobs:
           auditwheel show wheelhouse/comfy_kitchen_sageattention-*.whl
 
       - name: Upload Linux wheel
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: sageattention-manylinux-x86_64
           path: wheelhouse/*.whl
@@ -113,10 +113,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Install CUDA Toolkit 13.0.2
-        uses: Jimver/cuda-toolkit@v0.2.29
+        uses: Jimver/cuda-toolkit@6008063726ffe3309d1b22e413d9e88fed91a2f2 # v0.2.29
         with:
           cuda: "13.0.2"
           method: network
@@ -124,10 +124,10 @@ jobs:
           log-file-suffix: sageattention-windows-2022.txt
 
       - name: Setup MSVC
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
@@ -148,6 +148,7 @@ jobs:
         env:
           EXT_PARALLEL: "1"
           MAX_JOBS: "4"
+          DISTUTILS_USE_SDK: "1"
         run: |
           python setup.py bdist_wheel
 
@@ -161,7 +162,7 @@ jobs:
           python sageattention/verify_architectures.py "$env:CUDA_PATH\bin\cuobjdump.exe"
 
       - name: Upload Windows wheel
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: sageattention-windows-x86_64
           path: sageattention/build/source/dist/*.whl
@@ -176,19 +177,19 @@ jobs:
 
     steps:
       - name: Download Linux wheel
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: sageattention-manylinux-x86_64
           path: dist
 
       - name: Download Windows wheel
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: sageattention-windows-x86_64
           path: dist
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
         with:
           password: ${{ secrets.PYPI_TOKEN }}
           packages-dir: dist

--- a/.github/workflows/build-sageattention-wheels.yml
+++ b/.github/workflows/build-sageattention-wheels.yml
@@ -69,8 +69,8 @@ jobs:
             PIP_EXTRA_INDEX_URL=https://pypi.org/simple
             SOURCE_DATE_EPOCH=1761613216
           CIBW_BEFORE_BUILD: >-
-            pip install "setuptools>=62,<75" "wheel>=0.38,<0.44" "packaging>=21,<24"
-            ninja "torch==2.13.0"
+            pip install "setuptools==78.1.0" "wheel==0.45.1" "packaging==25.0"
+            "ninja==1.13.2" "torch==2.13.0"
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: >-
             auditwheel repair -w {dest_dir} {wheel}
             --exclude libcuda.so.1
@@ -135,7 +135,7 @@ jobs:
         shell: pwsh
         run: |
           python -m pip install --upgrade pip
-          python -m pip install "setuptools>=62,<75" "wheel>=0.38,<0.44" "packaging>=21,<24" ninja
+          python -m pip install "setuptools==78.1.0" "wheel==0.45.1" "packaging==25.0" "ninja==1.13.2"
           python -m pip install "torch==$env:TORCH_VERSION" --index-url $env:TORCH_INDEX
           python -m pip install "triton-windows==3.7.1.post27"
 

--- a/.github/workflows/build-sageattention-wheels.yml
+++ b/.github/workflows/build-sageattention-wheels.yml
@@ -64,7 +64,7 @@ jobs:
             LIBRARY_PATH=/usr/local/cuda-13.0/lib64/stubs:$LIBRARY_PATH
             TORCH_CUDA_ARCH_LIST="8.0;8.6;8.9;9.0;12.0"
             EXT_PARALLEL=1
-            MAX_JOBS=8
+            MAX_JOBS=2
             PIP_INDEX_URL=https://download.pytorch.org/whl/cu130
             PIP_EXTRA_INDEX_URL=https://pypi.org/simple
             SOURCE_DATE_EPOCH=1761613216

--- a/.github/workflows/build-sageattention-wheels.yml
+++ b/.github/workflows/build-sageattention-wheels.yml
@@ -1,0 +1,195 @@
+name: Build managed SageAttention wheels
+
+on:
+  push:
+    branches:
+      - main
+      - "dev/**"
+    tags:
+      - "sageattention-v*"
+    paths:
+      - ".github/workflows/build-sageattention-wheels.yml"
+      - "sageattention/**"
+  pull_request:
+    paths:
+      - ".github/workflows/build-sageattention-wheels.yml"
+      - "sageattention/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  TORCH_VERSION: "2.13.0"
+  TORCH_INDEX: "https://download.pytorch.org/whl/cu130"
+  TORCH_CUDA_ARCH_LIST: "8.0;8.6;8.9;9.0;12.0"
+  SOURCE_DATE_EPOCH: "1761613216"
+
+jobs:
+  build_linux:
+    name: Build manylinux x86_64 wheel
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Prepare pinned source
+        run: python sageattention/prepare_source.py sageattention/build/source
+
+      - name: Build and test wheel
+        uses: pypa/cibuildwheel@v2.22.0
+        env:
+          CIBW_BUILD: "cp312-manylinux_x86_64"
+          CIBW_SKIP: "*-musllinux_*"
+          CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux_2_28_x86_64
+          CIBW_BUILD_FRONTEND: "pip; args: --no-build-isolation"
+          CIBW_BEFORE_ALL_LINUX: |
+            dnf install -y dnf-plugins-core
+            dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo
+            dnf clean all
+            dnf install -y \
+              cuda-nvcc-13-0 cuda-cuobjdump-13-0 \
+              cuda-cudart-devel-13-0 cuda-driver-devel-13-0
+            /usr/local/cuda-13.0/bin/nvcc --version
+          CIBW_ENVIRONMENT_LINUX: >-
+            CUDA_HOME=/usr/local/cuda-13.0
+            PATH=/usr/local/cuda-13.0/bin:$PATH
+            LD_LIBRARY_PATH=/usr/local/cuda-13.0/lib64:$LD_LIBRARY_PATH
+            LIBRARY_PATH=/usr/local/cuda-13.0/lib64/stubs:$LIBRARY_PATH
+            TORCH_CUDA_ARCH_LIST="8.0;8.6;8.9;9.0;12.0"
+            EXT_PARALLEL=1
+            MAX_JOBS=8
+            PIP_INDEX_URL=https://download.pytorch.org/whl/cu130
+            PIP_EXTRA_INDEX_URL=https://pypi.org/simple
+            SOURCE_DATE_EPOCH=1761613216
+          CIBW_BEFORE_BUILD: >-
+            pip install "setuptools>=62,<75" "wheel>=0.38,<0.44" "packaging>=21,<24"
+            ninja "torch==2.13.0"
+          CIBW_REPAIR_WHEEL_COMMAND_LINUX: >-
+            auditwheel repair -w {dest_dir} {wheel}
+            --exclude libcuda.so.1
+            --exclude libcudart.so.13
+            --exclude libc10.so
+            --exclude libc10_cuda.so
+            --exclude libtorch.so
+            --exclude libtorch_cpu.so
+            --exclude libtorch_cuda.so
+            --exclude libtorch_python.so
+          CIBW_TEST_COMMAND: >-
+            python -c "import importlib.metadata as m;
+            import sageattention;
+            assert m.version('comfy-kitchen-sageattention') == '2.2.0.post1';
+            assert sageattention.__version__ == '2.2.0';
+            assert sageattention.__source_commit__ == 'eb615cf6cf4d221338033340ee2de1c37fbdba4a'" &&
+            python {project}/sageattention/verify_architectures.py /usr/local/cuda-13.0/bin/cuobjdump
+        with:
+          package-dir: ./sageattention/build/source
+          output-dir: wheelhouse
+
+      - name: Verify wheel contents and metadata
+        run: |
+          python -m pip install packaging auditwheel
+          python sageattention/verify_wheel.py \
+            wheelhouse/comfy_kitchen_sageattention-*.whl \
+            --platform manylinux_x86_64
+          auditwheel show wheelhouse/comfy_kitchen_sageattention-*.whl
+
+      - name: Upload Linux wheel
+        uses: actions/upload-artifact@v4
+        with:
+          name: sageattention-manylinux-x86_64
+          path: wheelhouse/*.whl
+          if-no-files-found: error
+
+  build_windows:
+    name: Build Windows x86_64 wheel
+    runs-on: windows-2022
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install CUDA Toolkit 13.0.2
+        uses: Jimver/cuda-toolkit@v0.2.29
+        with:
+          cuda: "13.0.2"
+          method: network
+          use-github-cache: "true"
+          log-file-suffix: sageattention-windows-2022.txt
+
+      - name: Setup MSVC
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build and runtime dependencies
+        shell: pwsh
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "setuptools>=62,<75" "wheel>=0.38,<0.44" "packaging>=21,<24" ninja
+          python -m pip install "torch==$env:TORCH_VERSION" --index-url $env:TORCH_INDEX
+          python -m pip install "triton-windows==3.7.1.post27"
+
+      - name: Prepare pinned source
+        run: python sageattention/prepare_source.py sageattention/build/source
+
+      - name: Build Windows wheel
+        working-directory: sageattention/build/source
+        shell: pwsh
+        env:
+          EXT_PARALLEL: "1"
+          MAX_JOBS: "4"
+        run: |
+          python setup.py bdist_wheel
+
+      - name: Verify wheel contents and metadata
+        shell: pwsh
+        run: |
+          $wheel = Get-ChildItem sageattention/build/source/dist/comfy_kitchen_sageattention-*.whl | Select-Object -ExpandProperty FullName
+          python sageattention/verify_wheel.py $wheel --platform win_amd64
+          python -m pip install --no-deps $wheel
+          python -c "import importlib.metadata as m; import sageattention; assert m.version('comfy-kitchen-sageattention') == '2.2.0.post1'; assert sageattention.__version__ == '2.2.0'; assert sageattention.__source_commit__ == 'eb615cf6cf4d221338033340ee2de1c37fbdba4a'"
+          python sageattention/verify_architectures.py "$env:CUDA_PATH\bin\cuobjdump.exe"
+
+      - name: Upload Windows wheel
+        uses: actions/upload-artifact@v4
+        with:
+          name: sageattention-windows-x86_64
+          path: sageattention/build/source/dist/*.whl
+          if-no-files-found: error
+
+  publish:
+    name: Publish managed SageAttention wheels
+    needs: [build_linux, build_windows]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/tags/sageattention-v2.2.0.post1'
+    environment: pypi
+
+    steps:
+      - name: Download Linux wheel
+        uses: actions/download-artifact@v4
+        with:
+          name: sageattention-manylinux-x86_64
+          path: dist
+
+      - name: Download Windows wheel
+        uses: actions/download-artifact@v4
+        with:
+          name: sageattention-windows-x86_64
+          path: dist
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_TOKEN }}
+          packages-dir: dist
+          verbose: true

--- a/.github/workflows/build-sageattention-wheels.yml
+++ b/.github/workflows/build-sageattention-wheels.yml
@@ -55,7 +55,8 @@ jobs:
             dnf clean all
             dnf install -y \
               cuda-nvcc-13-0 cuda-cuobjdump-13-0 \
-              cuda-cudart-devel-13-0 cuda-driver-devel-13-0
+              cuda-cudart-devel-13-0 cuda-driver-devel-13-0 \
+              libcusparse-devel-13-0
             /usr/local/cuda-13.0/bin/nvcc --version
           CIBW_ENVIRONMENT_LINUX: >-
             CUDA_HOME=/usr/local/cuda-13.0

--- a/sageattention/README.md
+++ b/sageattention/README.md
@@ -12,6 +12,12 @@ the upstream Apache-2.0 license, attribution, and machine-readable provenance.
 The build uses the pinned source archive timestamp for deterministic wheel
 timestamps. The pinned upstream source has no NOTICE file.
 
+The managed patch includes upstream commit
+`e5bf6ee147e00107cb65042787d3a34b2e014c8c`, which restores direct native
+extension calls and removes the compile wrappers associated with incorrect
+SM90 output reports. The Linux build also omits upstream debug and OpenMP
+flags because the extension sources do not use OpenMP.
+
 The first binary line supports Python 3.12, Torch 2.13.0, CUDA 13.0, Linux
 x86_64, and Windows x86_64. Its compiled arms cover the upstream 2.2.0 dispatch
 set: SM80, SM86, SM89, SM90, and SM120. Triton 3.7.1 is installed as a runtime

--- a/sageattention/README.md
+++ b/sageattention/README.md
@@ -1,0 +1,29 @@
+# Managed SageAttention wheels
+
+This directory builds a companion `comfy-kitchen-sageattention` distribution
+from the pinned official SageAttention source. The companion owns the
+`sageattention` import namespace while keeping its Torch ABI-sensitive native
+extensions out of the stable-ABI `comfy-kitchen` wheel.
+
+The source archive, upstream commit, license, Torch/CUDA line, and packaging
+revision are pinned in `source.json`. `prepare_source.py` verifies the archive
+before extracting it and applies `packaging.patch`. Published wheels include
+the upstream Apache-2.0 license, attribution, and machine-readable provenance.
+The build uses the pinned source archive timestamp for deterministic wheel
+timestamps. The pinned upstream source has no NOTICE file.
+
+The first binary line supports Python 3.12, Torch 2.13.0, CUDA 13.0, Linux
+x86_64, and Windows x86_64. Its compiled arms cover the upstream 2.2.0 dispatch
+set: SM80, SM86, SM89, SM90, and SM120. Triton 3.7.1 is installed as a runtime
+dependency; Windows uses `triton-windows==3.7.1.post27`.
+
+Prepare the source without changing the checkout:
+
+```bash
+python sageattention/prepare_source.py sageattention/build/source
+```
+
+Use `--archive` for an already-downloaded source archive. The GitHub Actions
+workflow builds and verifies manylinux x86_64 and win_amd64 wheels, including
+the cubin coverage of each native extension. A dedicated
+`sageattention-v2.2.0.post1` tag publishes only after both platform jobs pass.

--- a/sageattention/packaging.patch
+++ b/sageattention/packaging.patch
@@ -1,14 +1,17 @@
 diff --git a/NOTICE b/NOTICE
 new file mode 100644
-index 0000000..863a99a
+index 0000000..8649f2d
 --- /dev/null
 +++ b/NOTICE
-@@ -0,0 +1,10 @@
+@@ -0,0 +1,13 @@
 +Comfy Kitchen SageAttention binary distribution
 +
 +This distribution packages SageAttention 2.2.0 from
 +https://github.com/thu-ml/SageAttention at commit
 +eb615cf6cf4d221338033340ee2de1c37fbdba4a.
++
++It incorporates the upstream direct-call correction from commit
++e5bf6ee147e00107cb65042787d3a34b2e014c8c.
 +
 +Copyright (c) 2024 SageAttention team.
 +Licensed under the Apache License, Version 2.0. See LICENSE.
@@ -25,10 +28,10 @@ index 73b0256..96d34a5 100644
 +from ._version import __distribution__, __distribution_version__, __source_commit__, __version__
 diff --git a/sageattention/_comfy_kitchen_provenance.json b/sageattention/_comfy_kitchen_provenance.json
 new file mode 100644
-index 0000000..1903ec5
+index 0000000..61fab9b
 --- /dev/null
 +++ b/sageattention/_comfy_kitchen_provenance.json
-@@ -0,0 +1,18 @@
+@@ -0,0 +1,19 @@
 +{
 +  "distribution": "comfy-kitchen-sageattention",
 +  "distribution_version": "2.2.0.post1",
@@ -36,6 +39,7 @@ index 0000000..1903ec5
 +  "upstream_source_sha256": "2c8232be47d35d20f095b1e38a052c6aa7b79dfd8ae4ab733d4df99c301ca7d0",
 +  "upstream_tag": "v2.2.0",
 +  "upstream_version": "2.2.0",
++  "backport_commit": "e5bf6ee147e00107cb65042787d3a34b2e014c8c",
 +  "python": "3.12",
 +  "torch": "2.13.0",
 +  "cuda": "13.0",
@@ -57,6 +61,59 @@ index 0000000..376f309
 +__source_commit__ = "eb615cf6cf4d221338033340ee2de1c37fbdba4a"
 +__distribution__ = "comfy-kitchen-sageattention"
 +__distribution_version__ = "2.2.0.post1"
+diff --git a/sageattention/core.py b/sageattention/core.py
+index 9f15284..e2c2c5b 100644
+--- a/sageattention/core.py
++++ b/sageattention/core.py
+@@ -30 +30 @@ try:
+-    from . import sm80_compile
++    from . import _qattn_sm80
+@@ -36 +36 @@ except:
+-    from . import sm89_compile
++    from . import _qattn_sm89
+@@ -42 +42 @@ except:
+-    from . import sm90_compile
++    from . import _qattn_sm90
+@@ -157,0 +158 @@ def sageattn(
++@torch.compiler.disable
+@@ -331,0 +333 @@ def sageattn_qk_int8_pv_fp16_triton(
++@torch.compiler.disable
+@@ -448,0 +451 @@ def sageattn_varlen(
++@torch.compiler.disable
+@@ -612 +615 @@ def sageattn_qk_int8_pv_fp16_cuda(
+-        lse = sm80_compile.qk_int8_sv_f16_accum_f32_attn(q_int8, k_int8, v, o, q_scale, k_scale, _tensor_layout, _is_caual, _qk_quant_gran, sm_scale, _return_lse)
++        lse = _qattn_sm80.qk_int8_sv_f16_accum_f32_attn(q_int8, k_int8, v, o, q_scale, k_scale, _tensor_layout, _is_caual, _qk_quant_gran, sm_scale, _return_lse)
+@@ -616 +619 @@ def sageattn_qk_int8_pv_fp16_cuda(
+-            lse = sm80_compile.qk_int8_sv_f16_accum_f16_fuse_v_mean_attn(q_int8, k_int8, smoothed_v, o, q_scale, k_scale, vm, _tensor_layout, _is_caual, _qk_quant_gran, sm_scale, _return_lse)
++            lse = _qattn_sm80.qk_int8_sv_f16_accum_f16_fuse_v_mean_attn(q_int8, k_int8, smoothed_v, o, q_scale, k_scale, vm, _tensor_layout, _is_caual, _qk_quant_gran, sm_scale, _return_lse)
+@@ -619 +622 @@ def sageattn_qk_int8_pv_fp16_cuda(
+-            lse = sm80_compile.qk_int8_sv_f16_accum_f16_attn(q_int8, k_int8, v, o, q_scale, k_scale, _tensor_layout, _is_caual, _qk_quant_gran, sm_scale, _return_lse)
++            lse = _qattn_sm80.qk_int8_sv_f16_accum_f16_attn(q_int8, k_int8, v, o, q_scale, k_scale, _tensor_layout, _is_caual, _qk_quant_gran, sm_scale, _return_lse)
+@@ -622 +625 @@ def sageattn_qk_int8_pv_fp16_cuda(
+-        lse = sm80_compile.qk_int8_sv_f16_accum_f16_attn_inst_buf(q_int8, k_int8, v, o, q_scale, k_scale, _tensor_layout, _is_caual, _qk_quant_gran, sm_scale, _return_lse)
++        lse = _qattn_sm80.qk_int8_sv_f16_accum_f16_attn_inst_buf(q_int8, k_int8, v, o, q_scale, k_scale, _tensor_layout, _is_caual, _qk_quant_gran, sm_scale, _return_lse)
+@@ -633,0 +637 @@ def sageattn_qk_int8_pv_fp16_cuda(
++@torch.compiler.disable
+@@ -811 +815 @@ def sageattn_qk_int8_pv_fp8_cuda(
+-            lse = sm89_compile.qk_int8_sv_f8_accum_f32_fuse_v_scale_fuse_v_mean_attn(q_int8, k_int8, v_fp8, o, q_scale, k_scale, v_scale, vm, _tensor_layout, _is_caual, _qk_quant_gran, sm_scale, _return_lse)
++            lse = _qattn_sm89.qk_int8_sv_f8_accum_f32_fuse_v_scale_fuse_v_mean_attn(q_int8, k_int8, v_fp8, o, q_scale, k_scale, v_scale, vm, _tensor_layout, _is_caual, _qk_quant_gran, sm_scale, _return_lse)
+@@ -813 +817 @@ def sageattn_qk_int8_pv_fp8_cuda(
+-            lse = sm89_compile.qk_int8_sv_f8_accum_f32_fuse_v_scale_attn(q_int8, k_int8, v_fp8, o, q_scale, k_scale, v_scale, _tensor_layout, _is_caual, _qk_quant_gran, sm_scale, _return_lse)
++            lse = _qattn_sm89.qk_int8_sv_f8_accum_f32_fuse_v_scale_attn(q_int8, k_int8, v_fp8, o, q_scale, k_scale, v_scale, _tensor_layout, _is_caual, _qk_quant_gran, sm_scale, _return_lse)
+@@ -815 +819 @@ def sageattn_qk_int8_pv_fp8_cuda(
+-        lse = sm89_compile.qk_int8_sv_f8_accum_f32_fuse_v_scale_attn_inst_buf(q_int8, k_int8, v_fp8, o, q_scale, k_scale, v_scale, _tensor_layout, _is_caual, _qk_quant_gran, sm_scale, _return_lse)
++        lse = _qattn_sm89.qk_int8_sv_f8_accum_f32_fuse_v_scale_attn_inst_buf(q_int8, k_int8, v_fp8, o, q_scale, k_scale, v_scale, _tensor_layout, _is_caual, _qk_quant_gran, sm_scale, _return_lse)
+@@ -817 +821 @@ def sageattn_qk_int8_pv_fp8_cuda(
+-        lse = sm89_compile.qk_int8_sv_f8_accum_f16_fuse_v_scale_attn_inst_buf(q_int8, k_int8, v_fp8, o, q_scale, k_scale, v_scale, _tensor_layout, _is_caual, _qk_quant_gran, sm_scale, _return_lse)
++        lse = _qattn_sm89.qk_int8_sv_f8_accum_f16_fuse_v_scale_attn_inst_buf(q_int8, k_int8, v_fp8, o, q_scale, k_scale, v_scale, _tensor_layout, _is_caual, _qk_quant_gran, sm_scale, _return_lse)
+@@ -826,0 +831 @@ def sageattn_qk_int8_pv_fp8_cuda(
++@torch.compiler.disable
+@@ -985 +990 @@ def sageattn_qk_int8_pv_fp8_cuda_sm90(
+-        lse = sm90_compile.qk_int8_sv_f8_accum_f32_fuse_v_scale_attn(q_int8, k_int8, v_fp8, o, q_scale, k_scale, v_scale, _tensor_layout, _is_caual, _qk_quant_gran, sm_scale, _return_lse)
++        lse = _qattn_sm90.qk_int8_sv_f8_accum_f32_fuse_v_scale_attn(q_int8, k_int8, v_fp8, o, q_scale, k_scale, v_scale, _tensor_layout, _is_caual, _qk_quant_gran, sm_scale, _return_lse)
+@@ -987 +992 @@ def sageattn_qk_int8_pv_fp8_cuda_sm90(
+-        lse = sm90_compile.qk_int8_sv_f8_accum_f32_fuse_v_scale_attn_inst_buf(q_int8, k_int8, v_fp8, o, q_scale, k_scale, v_scale, _tensor_layout, _is_caual, _qk_quant_gran, sm_scale, _return_lse)
++        lse = _qattn_sm90.qk_int8_sv_f8_accum_f32_fuse_v_scale_attn_inst_buf(q_int8, k_int8, v_fp8, o, q_scale, k_scale, v_scale, _tensor_layout, _is_caual, _qk_quant_gran, sm_scale, _return_lse)
 diff --git a/setup.py b/setup.py
 index ab569e9..3060f2f 100644
 --- a/setup.py
@@ -111,9 +168,12 @@ index ab569e9..3060f2f 100644
 +                    "cxx": CXX_FLAGS,
 +                    "nvcc": nvcc_flags("80", "86", "89", "90a", "120"),
 +                },
+@@ -178 +198 @@ if not SKIP_CUDA_BUILD:
+-    if HAS_SM89 or HAS_SM90 or HAS_SM120:
++    if HAS_SM89 or HAS_SM120:
 @@ -192 +212 @@ if not SKIP_CUDA_BUILD:
 -                extra_compile_args={"cxx": CXX_FLAGS, "nvcc": NVCC_FLAGS},
-+                extra_compile_args={"cxx": CXX_FLAGS, "nvcc": nvcc_flags("89", "90a", "120")},
++                extra_compile_args={"cxx": CXX_FLAGS, "nvcc": nvcc_flags("89", "120")},
 @@ -204,2 +224,2 @@ if not SKIP_CUDA_BUILD:
 -                extra_compile_args={"cxx": CXX_FLAGS, "nvcc": NVCC_FLAGS},
 -                extra_link_args=['-lcuda'],

--- a/sageattention/packaging.patch
+++ b/sageattention/packaging.patch
@@ -1,0 +1,136 @@
+diff --git a/NOTICE b/NOTICE
+new file mode 100644
+index 0000000..863a99a
+--- /dev/null
++++ b/NOTICE
+@@ -0,0 +1,10 @@
++Comfy Kitchen SageAttention binary distribution
++
++This distribution packages SageAttention 2.2.0 from
++https://github.com/thu-ml/SageAttention at commit
++eb615cf6cf4d221338033340ee2de1c37fbdba4a.
++
++Copyright (c) 2024 SageAttention team.
++Licensed under the Apache License, Version 2.0. See LICENSE.
++
++The pinned upstream source does not contain a NOTICE file.
+diff --git a/sageattention/__init__.py b/sageattention/__init__.py
+index 73b0256..96d34a5 100644
+--- a/sageattention/__init__.py
++++ b/sageattention/__init__.py
+@@ -5 +5,2 @@ from .core import sageattn_qk_int8_pv_fp8_cuda
+-from .core import sageattn_qk_int8_pv_fp8_cuda_sm90
+\ No newline at end of file
++from .core import sageattn_qk_int8_pv_fp8_cuda_sm90
++from ._version import __distribution__, __distribution_version__, __source_commit__, __version__
+diff --git a/sageattention/_comfy_kitchen_provenance.json b/sageattention/_comfy_kitchen_provenance.json
+new file mode 100644
+index 0000000..2f6ad96
+--- /dev/null
++++ b/sageattention/_comfy_kitchen_provenance.json
+@@ -0,0 +1,12 @@
++{
++  "distribution": "comfy-kitchen-sageattention",
++  "distribution_version": "2.2.0.post1",
++  "upstream_commit": "eb615cf6cf4d221338033340ee2de1c37fbdba4a",
++  "upstream_source_sha256": "2c8232be47d35d20f095b1e38a052c6aa7b79dfd8ae4ab733d4df99c301ca7d0",
++  "upstream_tag": "v2.2.0",
++  "upstream_version": "2.2.0",
++  "python": "3.12",
++  "torch": "2.13.0",
++  "cuda": "13.0",
++  "source_date_epoch": 1761613216
++}
+diff --git a/sageattention/_version.py b/sageattention/_version.py
+new file mode 100644
+index 0000000..376f309
+--- /dev/null
++++ b/sageattention/_version.py
+@@ -0,0 +1,4 @@
++__version__ = "2.2.0"
++__source_commit__ = "eb615cf6cf4d221338033340ee2de1c37fbdba4a"
++__distribution__ = "comfy-kitchen-sageattention"
++__distribution_version__ = "2.2.0.post1"
+diff --git a/setup.py b/setup.py
+index ab569e9..3060f2f 100644
+--- a/setup.py
++++ b/setup.py
+@@ -18 +17,0 @@ import os
+-import sys
+@@ -19,0 +19 @@ import subprocess
++import sys
+@@ -21,0 +22 @@ import warnings
++from pathlib import Path
+@@ -49 +50,5 @@ if not SKIP_CUDA_BUILD:
+-    CXX_FLAGS = ["-g", "-O3", "-fopenmp", "-lgomp", "-std=c++17", "-DENABLE_BF16"]
++    CXX_FLAGS = (
++        ["/O2", "/std:c++17", "/DENABLE_BF16"]
++        if sys.platform == "win32"
++        else ["-O3", "-std=c++17", "-DENABLE_BF16"]
++    )
+@@ -69,3 +74,4 @@ if not SKIP_CUDA_BUILD:
+-    ABI = 1 if torch._C._GLIBCXX_USE_CXX11_ABI else 0
+-    CXX_FLAGS += [f"-D_GLIBCXX_USE_CXX11_ABI={ABI}"]
+-    NVCC_FLAGS += [f"-D_GLIBCXX_USE_CXX11_ABI={ABI}"]
++    if sys.platform != "win32":
++        ABI = 1 if torch._C._GLIBCXX_USE_CXX11_ABI else 0
++        CXX_FLAGS += [f"-D_GLIBCXX_USE_CXX11_ABI={ABI}"]
++        NVCC_FLAGS += [f"-D_GLIBCXX_USE_CXX11_ABI={ABI}"]
+@@ -82 +88,2 @@ if not SKIP_CUDA_BUILD:
+-        nvcc_output = subprocess.check_output([cuda_dir + "/bin/nvcc", "-V"],
++        nvcc = Path(cuda_dir) / "bin" / ("nvcc.exe" if sys.platform == "win32" else "nvcc")
++        nvcc_output = subprocess.check_output([str(nvcc), "-V"],
+@@ -140 +147,3 @@ if not SKIP_CUDA_BUILD:
+-    # Add target compute capabilities to NVCC flags.
++    # Keep architecture flags per extension. The Hopper source uses WGMMA
++    # instructions that ptxas cannot compile for the other target families.
++    ARCH_FLAGS = {}
+@@ -159 +168 @@ if not SKIP_CUDA_BUILD:
+-        NVCC_FLAGS += ["-gencode", f"arch=compute_{num},code=sm_{num}"]
++        flags = ["-gencode", f"arch=compute_{num},code=sm_{num}"]
+@@ -161 +170,9 @@ if not SKIP_CUDA_BUILD:
+-            NVCC_FLAGS += ["-gencode", f"arch=compute_{num},code=compute_{num}"]
++            flags += ["-gencode", f"arch=compute_{num},code=compute_{num}"]
++        ARCH_FLAGS[num] = flags
++
++    def nvcc_flags(*architectures: str) -> list[str]:
++        return NVCC_FLAGS + [
++            flag
++            for architecture in architectures
++            for flag in ARCH_FLAGS.get(architecture, ())
++        ]
+@@ -174 +191,4 @@ if not SKIP_CUDA_BUILD:
+-                extra_compile_args={"cxx": CXX_FLAGS, "nvcc": NVCC_FLAGS},
++                extra_compile_args={
++                    "cxx": CXX_FLAGS,
++                    "nvcc": nvcc_flags("80", "86", "89", "90a", "120"),
++                },
+@@ -192 +212 @@ if not SKIP_CUDA_BUILD:
+-                extra_compile_args={"cxx": CXX_FLAGS, "nvcc": NVCC_FLAGS},
++                extra_compile_args={"cxx": CXX_FLAGS, "nvcc": nvcc_flags("89", "90a", "120")},
+@@ -204,2 +224,2 @@ if not SKIP_CUDA_BUILD:
+-                extra_compile_args={"cxx": CXX_FLAGS, "nvcc": NVCC_FLAGS},
+-                extra_link_args=['-lcuda'],
++                extra_compile_args={"cxx": CXX_FLAGS, "nvcc": nvcc_flags("90a")},
++                extra_link_args=["cuda.lib" if sys.platform == "win32" else "-lcuda"],
+@@ -213 +233,4 @@ if not SKIP_CUDA_BUILD:
+-            extra_compile_args={"cxx": CXX_FLAGS, "nvcc": NVCC_FLAGS},
++            extra_compile_args={
++                "cxx": CXX_FLAGS,
++                "nvcc": nvcc_flags("80", "86", "89", "90a", "120"),
++            },
+@@ -265,2 +288,2 @@ setup(
+-    name='sageattention',
+-    version='2.2.0',
++    name='comfy-kitchen-sageattention',
++    version='2.2.0.post1',
+@@ -274 +297,8 @@ setup(
+-    python_requires='>=3.9',
++    package_data={"sageattention": ["_comfy_kitchen_provenance.json"]},
++    python_requires='>=3.12,<3.13',
++    install_requires=[
++        "torch==2.13.0",
++        "triton==3.7.1; sys_platform != 'win32'",
++        "triton-windows==3.7.1.post27; sys_platform == 'win32'",
++    ],
++    license_files=["LICENSE", "NOTICE"],

--- a/sageattention/packaging.patch
+++ b/sageattention/packaging.patch
@@ -127,10 +127,13 @@ index ab569e9..3060f2f 100644
 @@ -49 +50,5 @@ if not SKIP_CUDA_BUILD:
 -    CXX_FLAGS = ["-g", "-O3", "-fopenmp", "-lgomp", "-std=c++17", "-DENABLE_BF16"]
 +    CXX_FLAGS = (
-+        ["/O2", "/std:c++17", "/DENABLE_BF16"]
++        ["/O2", "/std:c++20", "/DENABLE_BF16"]
 +        if sys.platform == "win32"
-+        else ["-O3", "-std=c++17", "-DENABLE_BF16"]
++        else ["-O3", "-std=c++20", "-DENABLE_BF16"]
 +    )
+@@ -52 +57 @@ if not SKIP_CUDA_BUILD:
+-        "-std=c++17",
++        "-std=c++20",
 @@ -69,3 +74,4 @@ if not SKIP_CUDA_BUILD:
 -    ABI = 1 if torch._C._GLIBCXX_USE_CXX11_ABI else 0
 -    CXX_FLAGS += [f"-D_GLIBCXX_USE_CXX11_ABI={ABI}"]

--- a/sageattention/packaging.patch
+++ b/sageattention/packaging.patch
@@ -25,10 +25,10 @@ index 73b0256..96d34a5 100644
 +from ._version import __distribution__, __distribution_version__, __source_commit__, __version__
 diff --git a/sageattention/_comfy_kitchen_provenance.json b/sageattention/_comfy_kitchen_provenance.json
 new file mode 100644
-index 0000000..2f6ad96
+index 0000000..1903ec5
 --- /dev/null
 +++ b/sageattention/_comfy_kitchen_provenance.json
-@@ -0,0 +1,12 @@
+@@ -0,0 +1,18 @@
 +{
 +  "distribution": "comfy-kitchen-sageattention",
 +  "distribution_version": "2.2.0.post1",
@@ -39,6 +39,12 @@ index 0000000..2f6ad96
 +  "python": "3.12",
 +  "torch": "2.13.0",
 +  "cuda": "13.0",
++  "build_tools": {
++    "setuptools": "78.1.0",
++    "wheel": "0.45.1",
++    "packaging": "25.0",
++    "ninja": "1.13.2"
++  },
 +  "source_date_epoch": 1761613216
 +}
 diff --git a/sageattention/_version.py b/sageattention/_version.py

--- a/sageattention/prepare_source.py
+++ b/sageattention/prepare_source.py
@@ -94,6 +94,11 @@ def prepare_source(destination: Path, archive: Path | None = None) -> None:
 
         source = extracted / expected_root
         subprocess.run(["git", "apply", "--unidiff-zero", str(PATCH)], cwd=source, check=True)
+        for relative_path in manifest["backport"]["removed_files"]:
+            backported_removal = source / relative_path
+            if not backported_removal.is_file():
+                raise FileNotFoundError(f"backport removal is missing: {relative_path}")
+            backported_removal.unlink()
         destination.parent.mkdir(parents=True, exist_ok=True)
         shutil.move(source, destination)
 

--- a/sageattention/prepare_source.py
+++ b/sageattention/prepare_source.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import tarfile
+import tempfile
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parent
+MANIFEST = ROOT / "source.json"
+PATCH = ROOT / "packaging.patch"
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _download(url: str, destination: Path) -> None:
+    request = urllib.request.Request(url, headers={"User-Agent": "comfy-kitchen-build"})
+    with (
+        urllib.request.urlopen(request, timeout=120) as response,
+        destination.open("wb") as output,
+    ):
+        shutil.copyfileobj(response, output)
+
+
+def _load_manifest() -> dict[str, Any]:
+    data: object = json.loads(MANIFEST.read_text())
+    if not isinstance(data, dict):
+        raise ValueError("source.json must contain an object")
+    return data
+
+
+def prepare_source(destination: Path, archive: Path | None = None) -> None:
+    if destination.exists():
+        raise FileExistsError(f"destination already exists: {destination}")
+
+    manifest = _load_manifest()
+    upstream = manifest["upstream"]
+    commit = upstream["commit"]
+    expected_root = f"SageAttention-{commit}"
+    source_date_epoch = manifest["build"]["source_date_epoch"]
+    environment_epoch = os.environ.get("SOURCE_DATE_EPOCH")
+    if environment_epoch is not None and int(environment_epoch) != source_date_epoch:
+        raise ValueError(f"SOURCE_DATE_EPOCH is {environment_epoch}, expected {source_date_epoch}")
+
+    with tempfile.TemporaryDirectory(prefix="comfy-kitchen-sageattention-") as temporary:
+        temporary_path = Path(temporary)
+        source_archive = archive if archive is not None else temporary_path / "source.tar.gz"
+        if archive is None:
+            _download(upstream["archive_url"], source_archive)
+
+        actual_size = source_archive.stat().st_size
+        if actual_size != upstream["archive_size"]:
+            raise ValueError(
+                f"source archive size is {actual_size}, expected {upstream['archive_size']}"
+            )
+        actual_digest = _sha256(source_archive)
+        if actual_digest != upstream["archive_sha256"]:
+            raise ValueError(
+                f"source archive sha256 is {actual_digest}, expected {upstream['archive_sha256']}"
+            )
+
+        extracted = temporary_path / "extracted"
+        extracted.mkdir()
+        with tarfile.open(source_archive, "r:gz") as bundle:
+            members = bundle.getmembers()
+            roots = {Path(member.name).parts[0] for member in members if member.name}
+            if roots != {expected_root}:
+                raise ValueError(
+                    f"source archive root is {sorted(roots)}, expected {expected_root}"
+                )
+            root_members = [
+                member
+                for member in members
+                if Path(member.name).parts == (expected_root,) and member.isdir()
+            ]
+            if len(root_members) != 1 or root_members[0].mtime != source_date_epoch:
+                actual_mtimes = [member.mtime for member in root_members]
+                raise ValueError(
+                    f"source archive root mtime is {actual_mtimes}, expected {source_date_epoch}"
+                )
+            bundle.extractall(extracted, filter="data")
+
+        source = extracted / expected_root
+        subprocess.run(["git", "apply", "--unidiff-zero", str(PATCH)], cwd=source, check=True)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(source, destination)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Verify, extract, and patch the pinned SageAttention source"
+    )
+    parser.add_argument("destination", type=Path)
+    parser.add_argument("--archive", type=Path)
+    args = parser.parse_args()
+    prepare_source(args.destination.resolve(), args.archive.resolve() if args.archive else None)
+
+
+if __name__ == "__main__":
+    main()

--- a/sageattention/source.json
+++ b/sageattention/source.json
@@ -1,0 +1,32 @@
+{
+  "distribution": {
+    "name": "comfy-kitchen-sageattention",
+    "version": "2.2.0.post1"
+  },
+  "upstream": {
+    "repository": "https://github.com/thu-ml/SageAttention",
+    "tag": "v2.2.0",
+    "commit": "eb615cf6cf4d221338033340ee2de1c37fbdba4a",
+    "archive_url": "https://codeload.github.com/thu-ml/SageAttention/tar.gz/eb615cf6cf4d221338033340ee2de1c37fbdba4a",
+    "archive_size": 43420690,
+    "archive_sha256": "2c8232be47d35d20f095b1e38a052c6aa7b79dfd8ae4ab733d4df99c301ca7d0",
+    "version": "2.2.0",
+    "license": "Apache-2.0",
+    "notice_file": false
+  },
+  "build": {
+    "python": "3.12",
+    "torch": "2.13.0",
+    "cuda": "13.0",
+    "source_date_epoch": 1761613216,
+    "triton_linux": "3.7.1",
+    "triton_windows": "3.7.1.post27",
+    "cuda_arch_list": "8.0;8.6;8.9;9.0;12.0",
+    "extension_architectures": {
+      "_fused": [80, 86, 89, 90, 120],
+      "_qattn_sm80": [80, 86, 89, 90, 120],
+      "_qattn_sm89": [89, 90, 120],
+      "_qattn_sm90": [90]
+    }
+  }
+}

--- a/sageattention/source.json
+++ b/sageattention/source.json
@@ -14,6 +14,15 @@
     "license": "Apache-2.0",
     "notice_file": false
   },
+  "backport": {
+    "commit": "e5bf6ee147e00107cb65042787d3a34b2e014c8c",
+    "description": "Restore direct native extension calls after incorrect SM90 output reports",
+    "removed_files": [
+      "sageattention/sm80_compile.py",
+      "sageattention/sm89_compile.py",
+      "sageattention/sm90_compile.py"
+    ]
+  },
   "build": {
     "python": "3.12",
     "torch": "2.13.0",
@@ -31,7 +40,7 @@
     "extension_architectures": {
       "_fused": [80, 86, 89, 90, 120],
       "_qattn_sm80": [80, 86, 89, 90, 120],
-      "_qattn_sm89": [89, 90, 120],
+      "_qattn_sm89": [89, 120],
       "_qattn_sm90": [90]
     }
   }

--- a/sageattention/source.json
+++ b/sageattention/source.json
@@ -21,6 +21,12 @@
     "source_date_epoch": 1761613216,
     "triton_linux": "3.7.1",
     "triton_windows": "3.7.1.post27",
+    "build_tools": {
+      "setuptools": "78.1.0",
+      "wheel": "0.45.1",
+      "packaging": "25.0",
+      "ninja": "1.13.2"
+    },
     "cuda_arch_list": "8.0;8.6;8.9;9.0;12.0",
     "extension_architectures": {
       "_fused": [80, 86, 89, 90, 120],

--- a/sageattention/verify_architectures.py
+++ b/sageattention/verify_architectures.py
@@ -39,7 +39,7 @@ def verify_architectures(cuobjdump: Path) -> None:
             capture_output=True,
             text=True,
         )
-        actual = {int(value) for value in re.findall(r"\.sm_(\d+)\.cubin", result.stdout)}
+        actual = {int(value) for value in re.findall(r"\.sm_(\d+)(?:a)?\.cubin", result.stdout)}
         if actual != expected:
             raise RuntimeError(
                 f"{stem} has architectures {sorted(actual)}, expected {sorted(expected)}"

--- a/sageattention/verify_architectures.py
+++ b/sageattention/verify_architectures.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import re
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+MANIFEST = json.loads((ROOT / "source.json").read_text())
+EXPECTED_ARCHITECTURES = {
+    stem: set(architectures)
+    for stem, architectures in MANIFEST["build"]["extension_architectures"].items()
+}
+
+
+def _package_directory() -> Path:
+    spec = importlib.util.find_spec("sageattention")
+    if spec is None or spec.submodule_search_locations is None:
+        raise RuntimeError("installed sageattention package was not found")
+    locations = list(spec.submodule_search_locations)
+    if len(locations) != 1:
+        raise RuntimeError(f"expected one sageattention package directory, found {locations}")
+    return Path(locations[0])
+
+
+def verify_architectures(cuobjdump: Path) -> None:
+    package = _package_directory()
+    for stem, expected in EXPECTED_ARCHITECTURES.items():
+        extensions = [
+            path for path in package.glob(f"{stem}.*") if path.suffix.lower() in {".pyd", ".so"}
+        ]
+        if len(extensions) != 1:
+            raise RuntimeError(f"expected one {stem} native extension, found {extensions}")
+        result = subprocess.run(
+            [str(cuobjdump), "--list-elf", str(extensions[0])],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        actual = {int(value) for value in re.findall(r"\.sm_(\d+)\.cubin", result.stdout)}
+        if actual != expected:
+            raise RuntimeError(
+                f"{stem} has architectures {sorted(actual)}, expected {sorted(expected)}"
+            )
+        print(f"verified {stem}: {', '.join(f'SM{value}' for value in sorted(actual))}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Verify installed SageAttention cubin coverage")
+    parser.add_argument("cuobjdump", type=Path)
+    args = parser.parse_args()
+    verify_architectures(args.cuobjdump.resolve())
+
+
+if __name__ == "__main__":
+    main()

--- a/sageattention/verify_wheel.py
+++ b/sageattention/verify_wheel.py
@@ -27,6 +27,7 @@ def _single(names: list[str], suffix: str) -> str:
 def verify_wheel(path: Path, platform: str) -> None:
     distribution = MANIFEST["distribution"]
     upstream = MANIFEST["upstream"]
+    backport = MANIFEST["backport"]
     build = MANIFEST["build"]
     normalized = distribution["name"].replace("-", "_")
     dist_info = f"{normalized}-{distribution['version']}.dist-info/"
@@ -90,6 +91,7 @@ def verify_wheel(path: Path, platform: str) -> None:
             "upstream_source_sha256": upstream["archive_sha256"],
             "upstream_tag": upstream["tag"],
             "upstream_version": upstream["version"],
+            "backport_commit": backport["commit"],
             "python": build["python"],
             "torch": build["torch"],
             "cuda": build["cuda"],
@@ -98,6 +100,11 @@ def verify_wheel(path: Path, platform: str) -> None:
         }
         if provenance != expected_provenance:
             raise ValueError(f"wheel provenance does not match source.json: {provenance}")
+
+        removed_modules = set(backport["removed_files"])
+        unexpected_modules = [name for name in names if name in removed_modules]
+        if unexpected_modules:
+            raise ValueError(f"wheel contains removed compile wrappers: {unexpected_modules}")
 
         license_names = [name for name in names if name.startswith(dist_info)]
         if not any(name.endswith("/LICENSE") for name in license_names):

--- a/sageattention/verify_wheel.py
+++ b/sageattention/verify_wheel.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import argparse
+import email.parser
+import json
+import zipfile
+from pathlib import Path
+
+from packaging.requirements import Requirement
+
+ROOT = Path(__file__).resolve().parent
+MANIFEST = json.loads((ROOT / "source.json").read_text())
+PLATFORM_TAGS = {
+    "linux_x86_64": "cp312-cp312-linux_x86_64",
+    "manylinux_x86_64": "cp312-cp312-manylinux_2_28_x86_64",
+    "win_amd64": "cp312-cp312-win_amd64",
+}
+
+
+def _single(names: list[str], suffix: str) -> str:
+    matches = [name for name in names if name.endswith(suffix)]
+    if len(matches) != 1:
+        raise ValueError(f"expected one *{suffix} member, found {matches}")
+    return matches[0]
+
+
+def verify_wheel(path: Path, platform: str) -> None:
+    distribution = MANIFEST["distribution"]
+    upstream = MANIFEST["upstream"]
+    build = MANIFEST["build"]
+    normalized = distribution["name"].replace("-", "_")
+    dist_info = f"{normalized}-{distribution['version']}.dist-info/"
+
+    with zipfile.ZipFile(path) as wheel:
+        names = wheel.namelist()
+        metadata_name = _single(names, ".dist-info/METADATA")
+        wheel_name = _single(names, ".dist-info/WHEEL")
+        if not metadata_name.startswith(dist_info) or not wheel_name.startswith(dist_info):
+            raise ValueError("wheel dist-info directory does not match the managed distribution")
+
+        metadata = email.parser.BytesParser().parsebytes(wheel.read(metadata_name))
+        if metadata["Name"] != distribution["name"]:
+            raise ValueError(f"unexpected distribution name: {metadata['Name']}")
+        if metadata["Version"] != distribution["version"]:
+            raise ValueError(f"unexpected distribution version: {metadata['Version']}")
+        if metadata["Requires-Python"] != ">=3.12,<3.13":
+            raise ValueError(f"unexpected Python requirement: {metadata['Requires-Python']}")
+
+        parsed_requirements = [Requirement(raw) for raw in metadata.get_all("Requires-Dist", [])]
+        requirements = {requirement.name: requirement for requirement in parsed_requirements}
+        if set(requirements) != {"torch", "triton", "triton-windows"}:
+            raise ValueError(f"unexpected runtime requirements: {requirements}")
+        expected_versions = {
+            "torch": build["torch"],
+            "triton": build["triton_linux"],
+            "triton-windows": build["triton_windows"],
+        }
+        for name, version in expected_versions.items():
+            if str(requirements[name].specifier) != f"=={version}":
+                raise ValueError(f"unexpected {name} requirement: {requirements[name]}")
+        expected_markers = {
+            "torch": None,
+            "triton": 'sys_platform != "win32"',
+            "triton-windows": 'sys_platform == "win32"',
+        }
+        for name, marker in expected_markers.items():
+            actual = str(requirements[name].marker) if requirements[name].marker else None
+            if actual != marker:
+                raise ValueError(f"unexpected {name} environment marker: {actual}")
+
+        wheel_metadata = wheel.read(wheel_name).decode()
+        expected_tag = f"Tag: {PLATFORM_TAGS[platform]}"
+        if expected_tag not in wheel_metadata:
+            raise ValueError(f"wheel is missing {expected_tag!r}:\n{wheel_metadata}")
+
+        extension_suffix = ".pyd" if platform == "win_amd64" else ".so"
+        for stem in ("_fused", "_qattn_sm80", "_qattn_sm89", "_qattn_sm90"):
+            if not any(
+                name.startswith(f"sageattention/{stem}.") and name.endswith(extension_suffix)
+                for name in names
+            ):
+                raise ValueError(f"wheel is missing the {stem} native extension")
+
+        provenance_name = "sageattention/_comfy_kitchen_provenance.json"
+        provenance = json.loads(wheel.read(provenance_name))
+        expected_provenance = {
+            "distribution": distribution["name"],
+            "distribution_version": distribution["version"],
+            "upstream_commit": upstream["commit"],
+            "upstream_source_sha256": upstream["archive_sha256"],
+            "upstream_tag": upstream["tag"],
+            "upstream_version": upstream["version"],
+            "python": build["python"],
+            "torch": build["torch"],
+            "cuda": build["cuda"],
+            "source_date_epoch": build["source_date_epoch"],
+        }
+        if provenance != expected_provenance:
+            raise ValueError(f"wheel provenance does not match source.json: {provenance}")
+
+        license_names = [name for name in names if name.startswith(dist_info)]
+        if not any(name.endswith("/LICENSE") for name in license_names):
+            raise ValueError("wheel is missing the upstream LICENSE")
+        if not any(name.endswith("/NOTICE") for name in license_names):
+            raise ValueError("wheel is missing the managed distribution NOTICE")
+
+        forbidden_suffixes = (".cu", ".cuh", ".cpp", ".hpp")
+        forbidden = [name for name in names if name.endswith(forbidden_suffixes)]
+        if forbidden:
+            raise ValueError(f"binary wheel contains build sources: {forbidden}")
+
+    print(f"verified {path.name}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Verify a managed SageAttention wheel")
+    parser.add_argument("wheel", type=Path)
+    parser.add_argument("--platform", choices=tuple(PLATFORM_TAGS), required=True)
+    args = parser.parse_args()
+    verify_wheel(args.wheel, args.platform)
+
+
+if __name__ == "__main__":
+    main()

--- a/sageattention/verify_wheel.py
+++ b/sageattention/verify_wheel.py
@@ -93,6 +93,7 @@ def verify_wheel(path: Path, platform: str) -> None:
             "python": build["python"],
             "torch": build["torch"],
             "cuda": build["cuda"],
+            "build_tools": build["build_tools"],
             "source_date_epoch": build["source_date_epoch"],
         }
         if provenance != expected_provenance:


### PR DESCRIPTION
## Summary

- pin SageAttention 2.2.0 source, archive digest, license, and reproducible build inputs
- build Python 3.12 / Torch 2.13 / CUDA 13 wheels for manylinux x86_64 and Windows x86_64
- package the upstream `sageattention` namespace as `comfy-kitchen-sageattention`
- verify metadata, provenance, licenses, native files, imports, and per-extension SM80/86/89/90/120 cubin coverage
- gate PyPI publication on the exact `sageattention-v2.2.0.post1` tag after both platform builds pass

## Validation

- `ruff check .`
- `ruff format --check sageattention`
- `CUDA_VISIBLE_DEVICES='' python -m pytest -q`: 521 passed, 1361 skipped
- pinned source preparation and packaging patch verification
- local CUDA 13 wheel build: 38,397,300 bytes
- per-extension `cuobjdump --list-elf` inventory passed
- wheel metadata, provenance, license, and import checks passed
- locked RTX PRO 6000 Blackwell SM120 smoke passed for causal and non-causal attention

Refs #147
