### PR TITLE
sol-attn: Full-range P quantization in the exact branch and public `sol_attn_chunked`

### DIFF
--- a/comfy_kitchen/__init__.py
+++ b/comfy_kitchen/__init__.py
@@ -152,8 +152,8 @@ def sol_attn(
     below roughly 12k tokens dense or a fused attention is usually faster.
 
     Args:
-        q, k, v: ``(B, T, H, 128)`` tensors, same shape and dtype. The CUDA
-            backend requires bfloat16; head_dim is fixed at 128.
+        q, k, v: ``(B, T, H, 128)`` tensors, same shape and dtype. The fused
+            backends take bfloat16 or float16; head_dim is fixed at 128.
         tau: Routing threshold in sigmas of the proxy row. Higher routes fewer
             blocks exactly: cheaper and less accurate.
         scale: Score scale; None means ``head_dim ** -0.5``.

--- a/comfy_kitchen/__init__.py
+++ b/comfy_kitchen/__init__.py
@@ -5,6 +5,7 @@ from .backends import cuda as _cuda_backend  # noqa: F401
 # Import backends to trigger auto-registration
 from .backends import eager as _eager_backend  # noqa: F401
 from .backends import triton as _triton_backend  # noqa: F401
+from .backends.cuda import sol_attn_chunked  # chunked-producer form of sol_attn (HIP's below)
 from .backends.eager.quantization import DTYPE_TO_CODE
 from .backends.eager.quantization import mm_int8 as _mm_int8
 from .exceptions import (
@@ -39,12 +40,13 @@ from .tensor.w4a8_int8 import (
 # ROCm PyTorch build so CUDA/CPU processes do not pay the import cost or acquire
 # an unrelated GPU runtime merely because a combined wheel contains the module.
 if getattr(torch.version, "hip", None):
-    from .backends import hip as _hip_backend  # noqa: F401
+    from .backends import hip as _hip_backend
 
     # The HIP backend registers only on a supported AMD device (RDNA2/3/3.5/4),
     # and advertises only the ops that device can run; prefer it where it registers.
     if registry.is_available("hip"):
         registry.set_priority(["hip", "cuda", "triton", "eager"])
+        sol_attn_chunked = _hip_backend.sol_attn_chunked
 else:
     registry.mark_unavailable("hip", "PyTorch ROCm/HIP runtime not available")
 
@@ -63,6 +65,7 @@ __all__ = [
     "na2d",
     "na3d",
     "sol_attn",
+    "sol_attn_chunked",
     # Quantization / dequantization
     "quantize_per_tensor_fp8",
     "dequantize_per_tensor_fp8",

--- a/comfy_kitchen/backends/cuda/__init__.py
+++ b/comfy_kitchen/backends/cuda/__init__.py
@@ -2464,7 +2464,7 @@ def sol_attn(
     block_len: torch.Tensor | None = None,
     coarse_gate: torch.Tensor | None = None,
 ) -> torch.Tensor:
-    """Sol-Attn sparse attention over ``(B, T, H, 128)`` bf16 tensors.
+    """Sol-Attn sparse attention over ``(B, T, H, 128)`` bf16 or fp16 tensors.
     See sage_attention/sol_attn.cu and the public docstring for ``tail``,
     ``block_len`` and ``coarse_gate``.
 
@@ -2473,8 +2473,8 @@ def sol_attn(
     (sinks and the diagonal still ride on top). tau is ignored then.
     """
     batch, t, h, d = q.shape
-    if q.dtype != torch.bfloat16:
-        raise ValueError(f"sol_attn: q/k/v must be bfloat16, got {q.dtype}")
+    if q.dtype not in (torch.bfloat16, torch.float16):
+        raise ValueError(f"sol_attn: q/k/v must be bfloat16 or float16, got {q.dtype}")
     _check_sol_args(q.device, sink_blocks, sink_q, topk_ratio, q=q, k=k, v=v,
                     block_len=block_len, coarse_gate=coarse_gate)
     if scale is None:
@@ -3376,15 +3376,15 @@ def _build_constraints() -> dict:
         "sol_attn": FunctionConstraints(
             params={
                 "q": ParamConstraint(
-                    dtypes=frozenset({torch.bfloat16}),
+                    dtypes=frozenset({torch.bfloat16, torch.float16}),
                     shape_rules=(ExactDims(4),),
                 ),
                 "k": ParamConstraint(
-                    dtypes=frozenset({torch.bfloat16}),
+                    dtypes=frozenset({torch.bfloat16, torch.float16}),
                     shape_rules=(ExactDims(4),),
                 ),
                 "v": ParamConstraint(
-                    dtypes=frozenset({torch.bfloat16}),
+                    dtypes=frozenset({torch.bfloat16, torch.float16}),
                     shape_rules=(ExactDims(4),),
                 ),
             },

--- a/comfy_kitchen/backends/cuda/dlpack_bindings.cpp
+++ b/comfy_kitchen/backends/cuda/dlpack_bindings.cpp
@@ -279,7 +279,7 @@ extern "C" {
         cudaStream_t stream);
     void launch_sol_attn(
         const void* q, const void* k, const void* v, void* out, void* workspace,
-        int batch, int seq_len, int num_heads, int head_dim,
+        int batch, int seq_len, int num_heads, int head_dim, int elem,
         float tau, float scale, const void* key_bias,
         const void* ext_threshold, const void* blen, int tail,
         int sink_start, int sink_end, int sink_q_start, int sink_q_end,
@@ -1503,12 +1503,19 @@ static void need_workspace(const nb::ndarray<nb::device::cuda>& ws, int64_t batc
     if (n > 32 || (int64_t)ws.size() < v[n - 1])   // last slot is "total"
         throw std::runtime_error(std::string(who) + ": workspace too small for this shape");
 }
+// q/k/v/out element code for launch_sol_attn: 0 = bfloat16, 1 = float16, -1 = neither
+static int sol_elem_code(const nb::ndarray<nb::device::cuda>& a) {
+    if (a.dtype().bits != 16) return -1;
+    if (a.dtype().code == (uint8_t)nb::dlpack::dtype_code::Bfloat) return 0;
+    if (a.dtype().code == (uint8_t)nb::dlpack::dtype_code::Float) return 1;
+    return -1;
+}
 static void need_bthd(const nb::ndarray<nb::device::cuda>& a, int64_t b, int64_t t, int64_t h, int64_t d,
-                      const char* who, const char* what) {
-    const bool bf16 = a.dtype().code == (uint8_t)nb::dlpack::dtype_code::Bfloat && a.dtype().bits == 16;
-    if (a.ndim() != 4 || !bf16 ||
+                      int elem, const char* who, const char* what) {
+    if (a.ndim() != 4 || sol_elem_code(a) != elem ||
         a.shape(0) != (size_t)b || a.shape(1) != (size_t)t || a.shape(2) != (size_t)h || a.shape(3) != (size_t)d)
-        throw std::runtime_error(std::string(who) + ": " + what + " must be a (B, T, H, D) bfloat16 array");
+        throw std::runtime_error(std::string(who) + ": " + what
+                                 + " must be a (B, T, H, D) array of q's dtype (bfloat16 or float16)");
 }
 // The kernels stage rows with 16-byte loads: unit last stride, 16 B base, and
 // leading strides (of non-singleton dims) that keep every row 16 B aligned.
@@ -1558,10 +1565,12 @@ void sol_attn(
     if (threshold && (int64_t)threshold->size() != batch * num_heads * ((seq_len + 63) / 64))
         throw std::runtime_error("sol_attn: threshold must have B*H*ceil(T/64) elements");
     if (block_len) check_block_len(*block_len, seq_len, "sol_attn");
-    need_bthd(q, batch, seq_len, num_heads, head_dim, "sol_attn", "q");
-    need_bthd(k, batch, seq_len, num_heads, head_dim, "sol_attn", "k");
-    need_bthd(v, batch, seq_len, num_heads, head_dim, "sol_attn", "v");
-    need_bthd(out, batch, seq_len, num_heads, head_dim, "sol_attn", "out");
+    const int elem = sol_elem_code(q);
+    if (elem < 0) throw std::runtime_error("sol_attn: q must be bfloat16 or float16");
+    need_bthd(q, batch, seq_len, num_heads, head_dim, elem, "sol_attn", "q");
+    need_bthd(k, batch, seq_len, num_heads, head_dim, elem, "sol_attn", "k");
+    need_bthd(v, batch, seq_len, num_heads, head_dim, elem, "sol_attn", "v");
+    need_bthd(out, batch, seq_len, num_heads, head_dim, elem, "sol_attn", "out");
     need_staging_layout(q, "sol_attn", "q");
     need_staging_layout(k, "sol_attn", "k");
     need_staging_layout(v, "sol_attn", "v");
@@ -1571,7 +1580,7 @@ void sol_attn(
     // Explicit strides: only the last dim must be contiguous (BHND views go in as-is).
     launch_sol_attn(
         q.data(), k.data(), v.data(), out.data(), workspace.data(),
-        (int)batch, (int)seq_len, (int)num_heads, (int)head_dim,
+        (int)batch, (int)seq_len, (int)num_heads, (int)head_dim, elem,
         tau, scale,
         key_bias ? key_bias->data() : nullptr,
         threshold ? threshold->data() : nullptr,
@@ -3898,7 +3907,7 @@ NB_MODULE(_C, m) {
           nb::arg("batch"), nb::arg("seq_len"), nb::arg("num_heads"));
 
     m.def("sol_attn", &sol_attn,
-          "Sol-Attn training-free sparse attention (BF16 in/out, head_dim 128)",
+          "Sol-Attn training-free sparse attention (BF16 or FP16 in/out, head_dim 128)",
           nb::arg("q"), nb::arg("k"), nb::arg("v"), nb::arg("out"),
           nb::arg("workspace"),
           nb::arg("batch"), nb::arg("seq_len"), nb::arg("num_heads"),

--- a/comfy_kitchen/backends/cuda/sage_attention/sol_attn.cu
+++ b/comfy_kitchen/backends/cuda/sage_attention/sol_attn.cu
@@ -22,7 +22,8 @@
 //   exact       walk each routed list, resuming route's online softmax
 // Entry paths: `launch_sol_attn` (post-rope q/k/v) or the chunked producer
 // (`sol_producer_begin/chunk`, then `launch_sol_attn_core`). sm_80+, tuned
-// for sm_120; tensors are (B, T, H, 128) bf16.
+// for sm_120; tensors are (B, T, H, 128) bf16 or fp16 (the chunked producer
+// takes bf16 only).
 
 #include <cuda_runtime.h>
 #include <cstdint>
@@ -38,7 +39,7 @@ void launch_sol_preprocess(const void*, const void*, const void*, void*, void*, 
                            void*, const void*, const void*,
                            int, int, int, int, int, int, int,
                            int64_t, int64_t, int64_t, int64_t, int64_t, int64_t,
-                           int64_t, int64_t, int64_t, float, float, cudaStream_t);
+                           int64_t, int64_t, int64_t, float, float, int, cudaStream_t);
 size_t sol_preprocess_scratch_bytes(int, int, int);
 void launch_sol_producer(const void*, const void*, const void*, const void*,
                          const void*, const void*, void*, void*, void*, void*,
@@ -49,7 +50,7 @@ void launch_sol_finish(void*, void*, void*, void*, const void*, const void*, voi
                        const void*, int, int, int, int, int, int, float, float,
                        cudaStream_t);
 void launch_sol_vtranspose(const void*, const void*, void*, int, int, int, int,
-                           int64_t, int64_t, int64_t, cudaStream_t);
+                           int64_t, int64_t, int64_t, int, cudaStream_t);
 void launch_sol_route(const void*, const void*, const void*, const void*, const void*,
                       const void*, const void*, void*, void*, void*, void*, void*,
                       const void*, int,
@@ -57,7 +58,7 @@ void launch_sol_route(const void*, const void*, const void*, const void*, const 
                       float, cudaStream_t);
 void launch_sol_exact(const void*, const void*, const void*, const void*, const void*,
                       const void*, const void*, const void*, const void*, const void*,
-                      const void*, void*, int, int, int, int, int, int, float,
+                      const void*, void*, int, int, int, int, int, int, float, int,
                       cudaStream_t);
 
 namespace {
@@ -121,7 +122,7 @@ void run_route_exact(const Plan& p, char* w, const void* ext_threshold, void* ou
                      const void* blen, int tail,
                      int batch, int seq_len, int num_heads,
                      int sink_start, int sink_end, int sink_q_start, int sink_q_end,
-                     float scale_log2, cudaStream_t stream)
+                     float scale_log2, int elem, cudaStream_t stream)
 {
     // top-k mode: the caller supplies the per-query-block threshold
     const void* thr = ext_threshold ? ext_threshold : (const void*)(w + p.thr);
@@ -132,7 +133,7 @@ void run_route_exact(const Plan& p, char* w, const void* ext_threshold, void* ou
     launch_sol_exact(w + p.qiP, w + p.qs, w + p.kiP, w + p.ksb, w + p.vTi, w + p.vsc,
                      w + p.idx, w + p.cnt, w + p.oPart, w + p.mPart, w + p.lPart, out,
                      batch, seq_len, p.Tp, num_heads, p.NQ, p.NTB,
-                     scale_log2, stream);
+                     scale_log2, elem, stream);
     const cudaError_t err = cudaGetLastError();
     if (err != cudaSuccess)
         throw std::runtime_error(std::string("sol_attn: kernel launch failed: ")
@@ -214,13 +215,14 @@ extern "C" void launch_sol_attn_core(
                       batch, seq_len, num_heads, p.NTB, p.NPAD, p.NQ,
                       tau, scale_log2, stream);
     run_route_exact(p, w, ext_threshold, out, blen, tail, batch, seq_len, num_heads,
-                    sink_start, sink_end, sink_q_start, sink_q_end, scale_log2, stream);
+                    sink_start, sink_end, sink_q_start, sink_q_end, scale_log2,
+                    sol::SOL_BF16, stream);
     cudaMemcpyAsync(vamax_out, w + p.statsV, stats_bytes, cudaMemcpyDeviceToDevice, stream);
 }
 
 extern "C" void launch_sol_attn(
     const void* q, const void* k, const void* v, void* out, void* workspace,
-    int batch, int seq_len, int num_heads, int head_dim,
+    int batch, int seq_len, int num_heads, int head_dim, int elem,
     float tau, float scale, const void* key_bias,
     const void* ext_threshold, const void* blen, int tail,
     int sink_start, int sink_end, int sink_q_start, int sink_q_end,
@@ -242,9 +244,9 @@ extern "C" void launch_sol_attn(
                           key_bias, blen,
                           batch, seq_len, p.Tp, num_heads, p.NTB, p.NPAD, p.NQ,
                           qs_b, qs_t, qs_h, ks_b, ks_t, ks_h, vs_b, vs_t, vs_h,
-                          tau, scale_log2, stream);
+                          tau, scale_log2, elem, stream);
     launch_sol_vtranspose(v, w + p.vsc, w + p.vTi, batch, seq_len, p.Tp, num_heads,
-                          vs_b, vs_t, vs_h, stream);
+                          vs_b, vs_t, vs_h, elem, stream);
     run_route_exact(p, w, ext_threshold, out, blen, tail, batch, seq_len, num_heads,
-                    sink_start, sink_end, sink_q_start, sink_q_end, scale_log2, stream);
+                    sink_start, sink_end, sink_q_start, sink_q_end, scale_log2, elem, stream);
 }

--- a/comfy_kitchen/backends/cuda/sage_attention/sol_attn_exact.cu
+++ b/comfy_kitchen/backends/cuda/sage_attention/sol_attn_exact.cu
@@ -109,7 +109,7 @@ __global__ void SOL_EXACT_BOUNDS sol_exact_kernel(
 
     // resume route's state: one (o, m, l) per (b, h, query block)
     float o_acc[NT][4];
-    float m_r[2], l_r[2];
+    float m_r[2], l_r[2], c_r[2];   // c_r: scale o_acc / l_r are carried in
     {
         const int64_t qb_s = (int64_t)bh * gridDim.x + q_block;
         const __nv_bfloat16* orow = o_part + qb_s * HD;
@@ -122,6 +122,7 @@ __global__ void SOL_EXACT_BOUNDS sol_exact_kernel(
             o_acc[nt][1] = v1; o_acc[nt][3] = v1;
         }
         m_r[0] = m_r[1] = m_part[qb_s];
+        c_r[0] = c_r[1] = m_part[qb_s];
         l_r[0] = l_r[1] = l_part[qb_s];
     }
 
@@ -177,7 +178,9 @@ __global__ void SOL_EXACT_BOUNDS sol_exact_kernel(
         }
 
         float p_val[NKT][4];
-        float m_new[2] = {m_r[0], m_r[1]};
+        // P is quantized against the block max (floored 2^-20 under the running
+        // max) so every block gets the full u8 range
+        float bmax[2] = {m_r[0] - 20.f, m_r[1] - 20.f};
         #pragma unroll
         for (int nt = 0; nt < NKT; ++nt) {
             const int c0 = nt * 8 + qd * 2;
@@ -190,20 +193,22 @@ __global__ void SOL_EXACT_BOUNDS sol_exact_kernel(
                 const float s = (e & 1) ? fmaf((float)s_acc[nt][e], qsc[row] * k1s, m1)
                                         : fmaf((float)s_acc[nt][e], qsc[row] * k0s, m0);
                 p_val[nt][e] = s;
-                m_new[row] = fmaxf(m_new[row], s);
+                bmax[row] = fmaxf(bmax[row], s);
             }
         }
         #pragma unroll
         for (int off = 1; off <= 2; off <<= 1) {
-            m_new[0] = fmaxf(m_new[0], __shfl_xor_sync(0xffffffffu, m_new[0], off));
-            m_new[1] = fmaxf(m_new[1], __shfl_xor_sync(0xffffffffu, m_new[1], off));
+            bmax[0] = fmaxf(bmax[0], __shfl_xor_sync(0xffffffffu, bmax[0], off));
+            bmax[1] = fmaxf(bmax[1], __shfl_xor_sync(0xffffffffu, bmax[1], off));
         }
-        const float alpha0 = exp2f(m_r[0] - m_new[0]);
-        const float alpha1 = exp2f(m_r[1] - m_new[1]);
-        m_r[0] = m_new[0]; m_r[1] = m_new[1];
+        const float alpha0 = exp2f(c_r[0] - bmax[0]);
+        const float alpha1 = exp2f(c_r[1] - bmax[1]);
+        c_r[0] = bmax[0]; c_r[1] = bmax[1];
+        m_r[0] = fmaxf(m_r[0], bmax[0]);
+        m_r[1] = fmaxf(m_r[1], bmax[1]);
 
         // u8 P scale folded into the exponent (+log2 255); l carries it too
-        const float m_off[2] = {m_new[0] - 7.99435344f, m_new[1] - 7.99435344f};
+        const float m_off[2] = {bmax[0] - 7.99435344f, bmax[1] - 7.99435344f};
         #pragma unroll
         for (int nt = 0; nt < NKT; ++nt) {
             #pragma unroll

--- a/comfy_kitchen/backends/cuda/sage_attention/sol_attn_exact.cu
+++ b/comfy_kitchen/backends/cuda/sage_attention/sol_attn_exact.cu
@@ -57,6 +57,7 @@ constexpr int NSTAGE = 2;      // pipeline depth; occupancy beats depth here
 #define SOL_EXACT_BOUNDS __launch_bounds__(NTHREADS)
 #endif
 
+template <typename TOut>
 __global__ void SOL_EXACT_BOUNDS sol_exact_kernel(
     const int8_t* __restrict__ qi, const float* __restrict__ qs,
     const int8_t* __restrict__ kiP, const float2* __restrict__ ksb,
@@ -64,7 +65,7 @@ __global__ void SOL_EXACT_BOUNDS sol_exact_kernel(
     const uint16_t* __restrict__ blk_idx, const int32_t* __restrict__ blk_cnt,
     const __nv_bfloat16* __restrict__ o_part, const float* __restrict__ m_part,
     const float* __restrict__ l_part,
-    __nv_bfloat16* __restrict__ out,
+    TOut* __restrict__ out,
     int T, int Tp, int H, int NTB, float scale_log2)
 {
 #if SOL_SM80
@@ -278,12 +279,12 @@ __global__ void SOL_EXACT_BOUNDS sol_exact_kernel(
         const int r = q_row0 + rr * 8;
         if (r >= T) continue;
         const float inv = rr ? inv1 : inv0;
-        __nv_bfloat16* orow = out + bh_base + (int64_t)r * H * HD;
+        TOut* orow = out + bh_base + (int64_t)r * H * HD;
         #pragma unroll
         for (int nt = 0; nt < NT; ++nt) {
             const int c = nt * 8 + qd * 2;
-            orow[c]     = __float2bfloat16(o_acc[nt][rr * 2]     * inv * vsc[vsc_base + c]);
-            orow[c + 1] = __float2bfloat16(o_acc[nt][rr * 2 + 1] * inv * vsc[vsc_base + c + 1]);
+            orow[c]     = from_f32<TOut>(o_acc[nt][rr * 2]     * inv * vsc[vsc_base + c]);
+            orow[c + 1] = from_f32<TOut>(o_acc[nt][rr * 2 + 1] * inv * vsc[vsc_base + c + 1]);
         }
     }
 #endif  // SOL_SM80
@@ -297,14 +298,18 @@ void launch_sol_exact(
     const void* blk_idx, const void* blk_cnt,
     const void* o_part, const void* m_part, const void* l_part, void* out,
     int B, int T, int Tp, int H, int NQ, int NTB,
-    float scale_log2, cudaStream_t stream)
+    float scale_log2, int elem, cudaStream_t stream)
 {
     dim3 grid(NQ, B * H);
-    sol_exact_kernel<<<grid, NTHREADS, 0, stream>>>(
-        (const int8_t*)qi, (const float*)qs, (const int8_t*)kiP, (const float2*)ksb,
-        (const int8_t*)vTi, (const float*)vsc,
-        (const uint16_t*)blk_idx, (const int32_t*)blk_cnt,
-        (const __nv_bfloat16*)o_part, (const float*)m_part, (const float*)l_part,
-        (__nv_bfloat16*)out, T, Tp, H, NTB, scale_log2);
+#define SOLX_LAUNCH(TOut)                                                              \
+    sol_exact_kernel<TOut><<<grid, NTHREADS, 0, stream>>>(                             \
+        (const int8_t*)qi, (const float*)qs, (const int8_t*)kiP, (const float2*)ksb,   \
+        (const int8_t*)vTi, (const float*)vsc,                                         \
+        (const uint16_t*)blk_idx, (const int32_t*)blk_cnt,                             \
+        (const __nv_bfloat16*)o_part, (const float*)m_part, (const float*)l_part,     \
+        (TOut*)out, T, Tp, H, NTB, scale_log2)
+    if (elem == sol::SOL_FP16) SOLX_LAUNCH(__half);
+    else SOLX_LAUNCH(__nv_bfloat16);
+#undef SOLX_LAUNCH
 }
 

--- a/comfy_kitchen/backends/cuda/sage_attention/sol_attn_preprocess.cu
+++ b/comfy_kitchen/backends/cuda/sage_attention/sol_attn_preprocess.cu
@@ -56,8 +56,9 @@ __device__ __forceinline__ float thr_of(float var, float tau, float log2s) {
 
 // ---- pass 1: K/V block reductions + V's per-channel |max| ----
 // One block per (bh, pooled block), thread == channel.
-__global__ void prep_reduce_kv(const __nv_bfloat16* __restrict__ k,
-                               const __nv_bfloat16* __restrict__ v,
+template <typename E>
+__global__ void prep_reduce_kv(const E* __restrict__ k,
+                               const E* __restrict__ v,
                                float* __restrict__ kc, __nv_bfloat16* __restrict__ vcT,
                                float* __restrict__ vamax, const int32_t* __restrict__ blen,
                                int T, int H, int NTB, int NPAD,
@@ -76,8 +77,8 @@ __global__ void prep_reduce_kv(const __nv_bfloat16* __restrict__ k,
     float sk = 0.f, sv = 0.f, av = 0.f;
     for (int i = 0; i < len; ++i) {
         const int64_t voff = batch * vb + (int64_t)(t0 + i) * vt + head * vh + d;
-        const float kk = __bfloat162float(k[batch * sb + (int64_t)(t0 + i) * st + head * sh + d]);
-        const float vv = __bfloat162float(v[voff]);
+        const float kk = to_f32(k[batch * sb + (int64_t)(t0 + i) * st + head * sh + d]);
+        const float vv = to_f32(v[voff]);
         sk += kk; sv += vv; av = fmaxf(av, fabsf(vv));
     }
     kc[o] = sk / (float)len;    // block MEAN of K
@@ -122,7 +123,8 @@ __global__ void prep_pooled_quant(const float* __restrict__ kc,
 }
 
 // ---- pass 4: quantize Q, centroid, routing threshold from one staged tile ----
-__global__ void prep_q(const __nv_bfloat16* __restrict__ q, const float* __restrict__ kcvar,
+template <typename E>
+__global__ void prep_q(const E* __restrict__ q, const float* __restrict__ kcvar,
                        int8_t* __restrict__ qiP, float* __restrict__ qs,
                        float* __restrict__ thr,
                        int8_t* __restrict__ cen8, float* __restrict__ cens,
@@ -130,7 +132,7 @@ __global__ void prep_q(const __nv_bfloat16* __restrict__ q, const float* __restr
                        const int32_t* __restrict__ blen,
                        int T, int H, int NQ, int NPAD, float tau, float log2s,
                        int64_t sb, int64_t st, int64_t sh) {
-    __shared__ __align__(16) __nv_bfloat16 sQ[BLK * LD_TILE];
+    __shared__ __align__(16) E sQ[BLK * LD_TILE];
     __shared__ __align__(16) float sred[HD];
     const int qb = blockIdx.x, bh = blockIdx.y;
     const int batch = bh / H, head = bh % H;
@@ -150,13 +152,14 @@ __global__ void prep_q(const __nv_bfloat16* __restrict__ q, const float* __restr
 }
 
 // ---- pass 5: centre + quantize K into the permuted layout ----
-__global__ void prep_k(const __nv_bfloat16* __restrict__ k, const float* __restrict__ kmean,
+template <typename E>
+__global__ void prep_k(const E* __restrict__ k, const float* __restrict__ kmean,
                        int8_t* __restrict__ kiP, float2* __restrict__ ksb,
                        const float* __restrict__ kbias,   // [B, T] log2 units, or null
                        const int32_t* __restrict__ blen,
                        int T, int Tp, int H,
                        int64_t sb, int64_t st, int64_t sh) {
-    __shared__ __align__(16) __nv_bfloat16 sK[BLK * LD_TILE];
+    __shared__ __align__(16) E sK[BLK * LD_TILE];
     const int n = blockIdx.x, bh = blockIdx.y;
     const int batch = bh / H, head = bh % H;
     const int t0 = n * BLK, len = block_len_of(blen, n, T);
@@ -224,7 +227,8 @@ void launch_sol_finish(
         NQ, tau, scale_log2);
 }
 
-void launch_sol_preprocess(
+template <typename E>
+static void preprocess_launch(
     const void* q, const void* k, const void* v,
     void* qiP, void* qs, void* kiP, void* ksb, void* kciP, void* kcs,
     void* vcT, void* threshold, void* cen8, void* cens, void* vsc, void* qmean,
@@ -241,20 +245,37 @@ void launch_sol_preprocess(
 
     // pass 1 accumulates V's |max| into vsc by atomicMax
     cudaMemsetAsync(vsc, 0, (size_t)B * H * HD * sizeof(float), stream);
-    prep_reduce_kv<<<dim3(NPAD, B * H), HD, 0, stream>>>(
-        (const __nv_bfloat16*)k, (const __nv_bfloat16*)v, s.kc, (__nv_bfloat16*)vcT,
+    prep_reduce_kv<E><<<dim3(NPAD, B * H), HD, 0, stream>>>(
+        (const E*)k, (const E*)v, s.kc, (__nv_bfloat16*)vcT,
         (float*)vsc, (const int32_t*)blen, T, H, NTB, NPAD, ks_b, ks_t, ks_h, vs_b, vs_t, vs_h);
     prep_pooled_stats<<<B * H, HD, 0, stream>>>(
         s.kc, s.kmean, (const float*)vsc, (float*)vsc, s.kcvar, NTB, NPAD);
     prep_pooled_quant<<<dim3(NPAD, B * H), HD, 0, stream>>>(
         s.kc, s.kmean, (int8_t*)kciP, (float*)kcs, NTB, NPAD);
-    prep_q<<<dim3(NQ, B * H), HD, 0, stream>>>(
-        (const __nv_bfloat16*)q, s.kcvar, (int8_t*)qiP, (float*)qs, (float*)threshold,
+    prep_q<E><<<dim3(NQ, B * H), HD, 0, stream>>>(
+        (const E*)q, s.kcvar, (int8_t*)qiP, (float*)qs, (float*)threshold,
         (int8_t*)cen8, (float*)cens, (float*)qmean, (const int32_t*)blen,
         T, H, NQ, NPAD, tau, scale_log2, qs_b, qs_t, qs_h);
-    prep_k<<<dim3(NTB, B * H), HD, 0, stream>>>(
-        (const __nv_bfloat16*)k, s.kmean, (int8_t*)kiP, (float2*)ksb,
+    prep_k<E><<<dim3(NTB, B * H), HD, 0, stream>>>(
+        (const E*)k, s.kmean, (int8_t*)kiP, (float2*)ksb,
         (const float*)key_bias, (const int32_t*)blen, T, Tp, H, ks_b, ks_t, ks_h);
+}
+
+void launch_sol_preprocess(
+    const void* q, const void* k, const void* v,
+    void* qiP, void* qs, void* kiP, void* ksb, void* kciP, void* kcs,
+    void* vcT, void* threshold, void* cen8, void* cens, void* vsc, void* qmean,
+    void* scratch, const void* key_bias, const void* blen,
+    int B, int T, int Tp, int H, int NTB, int NPAD, int NQ,
+    int64_t qs_b, int64_t qs_t, int64_t qs_h,
+    int64_t ks_b, int64_t ks_t, int64_t ks_h,
+    int64_t vs_b, int64_t vs_t, int64_t vs_h,
+    float tau, float scale_log2, int elem, cudaStream_t stream)
+{
+    auto fn = elem == sol::SOL_FP16 ? preprocess_launch<__half> : preprocess_launch<__nv_bfloat16>;
+    fn(q, k, v, qiP, qs, kiP, ksb, kciP, kcs, vcT, threshold, cen8, cens, vsc, qmean,
+       scratch, key_bias, blen, B, T, Tp, H, NTB, NPAD, NQ,
+       qs_b, qs_t, qs_h, ks_b, ks_t, ks_h, vs_b, vs_t, vs_h, tau, scale_log2, stream);
 }
 
 size_t sol_preprocess_scratch_bytes(int B, int H, int NPAD) {

--- a/comfy_kitchen/backends/cuda/sage_attention/sol_attn_vtranspose.cu
+++ b/comfy_kitchen/backends/cuda/sage_attention/sol_attn_vtranspose.cu
@@ -32,8 +32,8 @@ constexpr int HD = HEAD_DIM;
 constexpr int NTHREADS = 256;
 constexpr int LDS_PAD = HD + 16;   // must be a multiple of 16: phase 1 writes uint4
 
-template <int TT>
-__global__ void vquant_transpose(const __nv_bfloat16* __restrict__ v,
+template <int TT, typename E>
+__global__ void vquant_transpose(const E* __restrict__ v,
                                  const float* __restrict__ vsc,
                                  int8_t* __restrict__ vT,
                                  int T, int Tp, int H,
@@ -47,11 +47,11 @@ __global__ void vquant_transpose(const __nv_bfloat16* __restrict__ v,
         const int t = idx / (HD / 16), c16 = (idx % (HD / 16)) * 16;
         __align__(16) int8_t out[16];
         if (t0 + t < T) {
-            const __nv_bfloat16* src =
+            const E* src =
                 v + batch * sb + (int64_t)(t0 + t) * st + head * sh + c16;
             #pragma unroll
             for (int j = 0; j < 16; ++j)
-                out[j] = q8(__bfloat162float(src[j]), 1.f / vsc[bh * HD + c16 + j]);
+                out[j] = q8(to_f32(src[j]), 1.f / vsc[bh * HD + c16 + j]);
         } else {
             #pragma unroll
             for (int j = 0; j < 16; ++j) out[j] = 0;
@@ -91,9 +91,13 @@ __global__ void vquant_transpose(const __nv_bfloat16* __restrict__ v,
 void launch_sol_vtranspose(const void* v, const void* vsc, void* vT,
                            int B, int T, int Tp, int H,
                            int64_t sb, int64_t st, int64_t sh,
-                           cudaStream_t stream) {
+                           int elem, cudaStream_t stream) {
     dim3 grid((T + 255) / 256, B * H);
-    vquant_transpose<256><<<grid, NTHREADS, 0, stream>>>(
-        (const __nv_bfloat16*)v, (const float*)vsc, (int8_t*)vT, T, Tp, H, sb, st, sh);
+    if (elem == sol::SOL_FP16)
+        vquant_transpose<256, __half><<<grid, NTHREADS, 0, stream>>>(
+            (const __half*)v, (const float*)vsc, (int8_t*)vT, T, Tp, H, sb, st, sh);
+    else
+        vquant_transpose<256, __nv_bfloat16><<<grid, NTHREADS, 0, stream>>>(
+            (const __nv_bfloat16*)v, (const float*)vsc, (int8_t*)vT, T, Tp, H, sb, st, sh);
 }
 

--- a/comfy_kitchen/backends/cuda/sage_attention/sol_layout.cuh
+++ b/comfy_kitchen/backends/cuda/sage_attention/sol_layout.cuh
@@ -23,6 +23,7 @@
 
 #include <cuda_runtime.h>
 #include <cuda_bf16.h>
+#include <cuda_fp16.h>
 #include <cstdint>
 
 #include "mma.cuh"
@@ -66,9 +67,9 @@ __device__ __forceinline__ int block_len_of(const int32_t* blen, int n, int T) {
     return blen ? min(rem, max(1, blen[n])) : rem;
 }
 
-// ---- Tile quantization: one 128-thread CTA per staged 64 x 128 bf16 tile ----
+// ---- Tile quantization: one 128-thread CTA per staged 64 x 128 16-bit tile ----
 
-constexpr int LD_TILE = HEAD_DIM + 8;   // bf16 row stride; keeps uint4 stores aligned
+constexpr int LD_TILE = HEAD_DIM + 8;   // 16-bit row stride; keeps uint4 stores aligned
 
 __device__ __forceinline__ int8_t q8(float x, float inv) {
     return (int8_t)max(-127, min(127, __float2int_rn(x * inv)));
@@ -101,10 +102,21 @@ __device__ __forceinline__ float block_sum128(float x, float* s) {
     return r;
 }
 
+// q/k/v/out element type: bf16 or fp16. Everything after the load (tiles,
+// scales, int8 carriers) is the same; only the loads and the final store
+// convert.
+enum SolElem : int { SOL_BF16 = 0, SOL_FP16 = 1 };
+__device__ __forceinline__ float to_f32(__nv_bfloat16 x) { return __bfloat162float(x); }
+__device__ __forceinline__ float to_f32(__half x) { return __half2float(x); }
+template <typename T> __device__ __forceinline__ T from_f32(float x);
+template <> __device__ __forceinline__ __nv_bfloat16 from_f32<__nv_bfloat16>(float x) { return __float2bfloat16(x); }
+template <> __device__ __forceinline__ __half from_f32<__half>(float x) { return __float2half(x); }
+
 // Stage rows 0..len-1 (row t at src + t*stride, 16 B loads) into the tile,
 // zero past len.
+template <typename T>
 __device__ __forceinline__ void stage_tile64(
-    __nv_bfloat16* tile, const __nv_bfloat16* __restrict__ src, int64_t stride, int len)
+    T* tile, const T* __restrict__ src, int64_t stride, int len)
 {
     for (int idx = threadIdx.x; idx < BLOCK * (HEAD_DIM / 8); idx += HEAD_DIM) {
         const int t = idx / (HEAD_DIM / 8), c8 = (idx % (HEAD_DIM / 8)) * 8;
@@ -120,22 +132,23 @@ __device__ __forceinline__ void stage_tile64(
 // memory but are dead (zero-padded tiles) and get zeros; rows past nrows do
 // not exist. The permuted row is built in registers: scattered byte stores
 // cost 128 per token.
+template <typename T>
 __device__ __forceinline__ void quant_q_rows(
-    const __nv_bfloat16* tile, int len, int nrows,
+    const T* tile, int len, int nrows,
     int8_t* __restrict__ qiP, float* __restrict__ qs, int H)
 {
     for (int t = threadIdx.x; t < nrows; t += HEAD_DIM) {
-        const __nv_bfloat16* row = tile + t * LD_TILE;   // zero-staged past len
+        const T* row = tile + t * LD_TILE;   // zero-staged past len
         const bool live = t < len;
         float a = 0.f;
         #pragma unroll 8   // unbounded, nvcc hoists all 128 loads: 168 regs in the producer
-        for (int d = 0; d < HEAD_DIM; ++d) a = fmaxf(a, fabsf(__bfloat162float(row[d])));
+        for (int d = 0; d < HEAD_DIM; ++d) a = fmaxf(a, fabsf(to_f32(row[d])));
         const float sc = live ? fmaxf(a / 127.0f, 1e-8f) : 0.f;   // dead rows: deterministic zeros
         qs[(size_t)t * H] = sc;
         const float inv = live ? 1.f / sc : 0.f;
         __align__(16) int8_t out[HEAD_DIM];
         #pragma unroll
-        for (int d = 0; d < HEAD_DIM; ++d) out[perm_d(d)] = q8(__bfloat162float(row[d]), inv);
+        for (int d = 0; d < HEAD_DIM; ++d) out[perm_d(d)] = q8(to_f32(row[d]), inv);
         int8_t* dst = qiP + (size_t)t * H * HEAD_DIM;
         #pragma unroll
         for (int c = 0; c < HEAD_DIM; c += 16)
@@ -146,13 +159,14 @@ __device__ __forceinline__ void quant_q_rows(
 // Query-block centroid, quantized like a pseudo-row with the pooled keys'
 // perm_d. One thread per channel; returns this thread's channel mean. `sred`
 // holds bytes on return -- sync before reusing it.
+template <typename T>
 __device__ __forceinline__ float centroid_quant(
-    const __nv_bfloat16* tile, int len, float* sred,
+    const T* tile, int len, float* sred,
     int8_t* __restrict__ cen8, float* __restrict__ cens)
 {
     const int d = threadIdx.x;
     float c = 0.f;
-    for (int t = 0; t < len; ++t) c += __bfloat162float(tile[t * LD_TILE + d]);
+    for (int t = 0; t < len; ++t) c += to_f32(tile[t * LD_TILE + d]);
     c /= (float)len;
     const float csc = fmaxf(block_max128(fabsf(c), sred) / 127.0f, 1e-8f);
     char* s8 = reinterpret_cast<char*>(sred);
@@ -168,17 +182,18 @@ __device__ __forceinline__ float centroid_quant(
 // row perm_key(p). kbias (log2 units, or null) is indexed by source row and
 // only the exact branch reads it, so biased blocks must be sink-routed. Dead
 // rows get a zero scale, NEG bias and zero bytes.
+template <typename T>
 __device__ __forceinline__ void quant_k_rows(
-    const __nv_bfloat16* tile, int len, const float* __restrict__ kmean,
+    const T* tile, int len, const float* __restrict__ kmean,
     const float* __restrict__ kbias, int8_t* __restrict__ kiP, float2* __restrict__ ksb)
 {
     for (int p = threadIdx.x; p < BLOCK; p += HEAD_DIM) {
         const int s = perm_key(p);
         const bool live = s < len;
-        const __nv_bfloat16* row = tile + s * LD_TILE;
+        const T* row = tile + s * LD_TILE;
         float a = 0.f;
         for (int d = 0; d < HEAD_DIM; ++d)
-            a = fmaxf(a, fabsf(__bfloat162float(row[d]) - kmean[d]));
+            a = fmaxf(a, fabsf(to_f32(row[d]) - kmean[d]));
         const float sc = fmaxf(a / 127.0f, 1e-8f);
         const float bias = (kbias && live) ? kbias[s] : 0.f;
         ksb[p] = make_float2(live ? sc : 0.f, live ? bias : NEG);
@@ -186,7 +201,7 @@ __device__ __forceinline__ void quant_k_rows(
         __align__(16) int8_t out[HEAD_DIM];
         #pragma unroll
         for (int d = 0; d < HEAD_DIM; ++d)
-            out[perm_d(d)] = live ? q8(__bfloat162float(row[d]) - kmean[d], inv) : (int8_t)0;
+            out[perm_d(d)] = live ? q8(to_f32(row[d]) - kmean[d], inv) : (int8_t)0;
         #pragma unroll
         for (int c = 0; c < HEAD_DIM; c += 16)
             *reinterpret_cast<uint4*>(kiP + (size_t)p * HEAD_DIM + c) =

--- a/comfy_kitchen/backends/eager/sol_attn.py
+++ b/comfy_kitchen/backends/eager/sol_attn.py
@@ -155,7 +155,7 @@ def sol_attn(
             f"sol_attn: the eager reference is O(T^2) and would need "
             f"{score_bytes / 2**30:.1f} GiB for the score tensor at "
             f"(B={b}, H={h}, T={t}). It was selected because no fused backend "
-            f"accepted these inputs -- the CUDA backend requires bfloat16 on CUDA "
+            f"accepted these inputs -- the fused backends take bfloat16 or float16 "
             f"with head_dim 128, and got {q.dtype} on {q.device.type}."
         )
 

--- a/comfy_kitchen/backends/hip/__init__.py
+++ b/comfy_kitchen/backends/hip/__init__.py
@@ -1868,7 +1868,7 @@ def sol_attn(
     block_len: torch.Tensor | None = None,
     coarse_gate: torch.Tensor | None = None,
 ) -> torch.Tensor:
-    """Sol-Attn sparse attention over ``(B, T, H, 128)`` bf16 tensors.
+    """Sol-Attn sparse attention over ``(B, T, H, 128)`` bf16 or fp16 tensors.
     See sage_attention/sol_attn.hip and the public docstring for ``tail``,
     ``block_len`` and ``coarse_gate``.
 
@@ -1877,8 +1877,8 @@ def sol_attn(
     and the diagonal still ride on top). tau is ignored then.
     """
     batch, t, h, d = q.shape
-    if q.dtype != torch.bfloat16:
-        raise ValueError(f"sol_attn: q/k/v must be bfloat16, got {q.dtype}")
+    if q.dtype not in (torch.bfloat16, torch.float16):
+        raise ValueError(f"sol_attn: q/k/v must be bfloat16 or float16, got {q.dtype}")
     _check_sol_args(sink_blocks, sink_q, topk_ratio, q=q, k=k, v=v,
                     block_len=block_len, coarse_gate=coarse_gate)
     if scale is None:
@@ -2104,15 +2104,15 @@ def _build_constraints(has_wmma: bool = True) -> dict:
         "sol_attn": FunctionConstraints(
             params={
                 "q": ParamConstraint(
-                    dtypes=frozenset({torch.bfloat16}),
+                    dtypes=frozenset({torch.bfloat16, torch.float16}),
                     shape_rules=(ExactDims(4),),
                 ),
                 "k": ParamConstraint(
-                    dtypes=frozenset({torch.bfloat16}),
+                    dtypes=frozenset({torch.bfloat16, torch.float16}),
                     shape_rules=(ExactDims(4),),
                 ),
                 "v": ParamConstraint(
-                    dtypes=frozenset({torch.bfloat16}),
+                    dtypes=frozenset({torch.bfloat16, torch.float16}),
                     shape_rules=(ExactDims(4),),
                 ),
             },

--- a/comfy_kitchen/backends/hip/dlpack_bindings.cpp
+++ b/comfy_kitchen/backends/hip/dlpack_bindings.cpp
@@ -1573,13 +1573,18 @@ static void sol_need_workspace(const nb::ndarray<>& ws, int64_t batch, int64_t s
     }
 }
 
+// q/k/v/out element code for launch_sol_attn: 0 = bfloat16, 1 = float16, -1 = neither
+static int sol_elem_code(const nb::ndarray<>& a) {
+    const int code = map_dtype_to_code(a.dtype());
+    return code == 2 ? 0 : code == 1 ? 1 : -1;
+}
 static void sol_need_bthd(const nb::ndarray<>& a, int64_t b, int64_t t, int64_t h, int64_t d,
-                          const char* fn, const char* what) {
-    if (a.ndim() != 4 || map_dtype_to_code(a.dtype()) != 2 ||
+                          int elem, const char* fn, const char* what) {
+    if (a.ndim() != 4 || sol_elem_code(a) != elem ||
         a.shape(0) != static_cast<size_t>(b) || a.shape(1) != static_cast<size_t>(t) ||
         a.shape(2) != static_cast<size_t>(h) || a.shape(3) != static_cast<size_t>(d)) {
         throw std::runtime_error(std::string(fn) + ": " + what +
-                                 " must be a (B, T, H, D) bfloat16 array");
+                                 " must be a (B, T, H, D) array of q's dtype (bfloat16 or float16)");
     }
 }
 
@@ -1632,10 +1637,12 @@ void sol_attn(nb::ndarray<> q, nb::ndarray<> k, nb::ndarray<> v, nb::ndarray<> o
         sol_need_elems(*threshold, batch * num_heads * ((seq_len + 63) / 64), 0, kFn, "threshold");
     }
     if (block_len) sol_check_block_len(*block_len, seq_len, kFn);
-    sol_need_bthd(q, batch, seq_len, num_heads, head_dim, kFn, "q");
-    sol_need_bthd(k, batch, seq_len, num_heads, head_dim, kFn, "k");
-    sol_need_bthd(v, batch, seq_len, num_heads, head_dim, kFn, "v");
-    sol_need_bthd(out, batch, seq_len, num_heads, head_dim, kFn, "out");
+    const int elem = sol_elem_code(q);
+    if (elem < 0) throw std::runtime_error(std::string(kFn) + ": q must be bfloat16 or float16");
+    sol_need_bthd(q, batch, seq_len, num_heads, head_dim, elem, kFn, "q");
+    sol_need_bthd(k, batch, seq_len, num_heads, head_dim, elem, kFn, "k");
+    sol_need_bthd(v, batch, seq_len, num_heads, head_dim, elem, kFn, "v");
+    sol_need_bthd(out, batch, seq_len, num_heads, head_dim, elem, kFn, "out");
     sol_need_staging_layout(q, kFn, "q");
     sol_need_staging_layout(k, kFn, "k");
     sol_need_staging_layout(v, kFn, "v");
@@ -1645,7 +1652,7 @@ void sol_attn(nb::ndarray<> q, nb::ndarray<> k, nb::ndarray<> v, nb::ndarray<> o
     // Explicit strides: only the last dim must be contiguous (BHND views go in as-is).
     launch_sol_attn(q.data(), k.data(), v.data(), out.data(), workspace.data(),
                     static_cast<int>(batch), static_cast<int>(seq_len),
-                    static_cast<int>(num_heads), static_cast<int>(head_dim), tau, scale,
+                    static_cast<int>(num_heads), static_cast<int>(head_dim), elem, tau, scale,
                     opt_data(key_bias), opt_data(threshold), opt_data(block_len), tail ? 1 : 0,
                     static_cast<int>(sink_start), static_cast<int>(sink_end),
                     static_cast<int>(sink_q_start), static_cast<int>(sink_q_end), q.stride(0),
@@ -1732,7 +1739,7 @@ NB_MODULE(_C, m) {
           "Workspace dims, slot byte offsets and total bytes for this shape",
           nb::arg("batch"), nb::arg("seq_len"), nb::arg("num_heads"));
     m.def("sol_attn", &sol_attn,
-          "Sol-Attn training-free sparse attention (BF16 in/out, head_dim 128)",
+          "Sol-Attn training-free sparse attention (BF16 or FP16 in/out, head_dim 128)",
           nb::arg("q"), nb::arg("k"), nb::arg("v"), nb::arg("out"), nb::arg("workspace"),
           nb::arg("batch"), nb::arg("seq_len"), nb::arg("num_heads"), nb::arg("head_dim"),
           nb::arg("tau"), nb::arg("scale"), nb::arg("sink_start"), nb::arg("sink_end"),

--- a/comfy_kitchen/backends/hip/launchers.h
+++ b/comfy_kitchen/backends/hip/launchers.h
@@ -77,7 +77,7 @@ void launch_sol_attn_core(void* workspace, void* out, const void* vscale, void* 
                           int sink_start, int sink_end, int sink_q_start, int sink_q_end,
                           hipStream_t stream);
 void launch_sol_attn(const void* q, const void* k, const void* v, void* out, void* workspace,
-                     int batch, int seq_len, int num_heads, int head_dim, float tau, float scale,
+                     int batch, int seq_len, int num_heads, int head_dim, int elem, float tau, float scale,
                      const void* key_bias, const void* ext_threshold, const void* blen, int tail,
                      int sink_start, int sink_end, int sink_q_start, int sink_q_end, int64_t qs_b,
                      int64_t qs_t, int64_t qs_h, int64_t ks_b, int64_t ks_t, int64_t ks_h,

--- a/comfy_kitchen/backends/hip/sage_attention/sol_attn.hip
+++ b/comfy_kitchen/backends/hip/sage_attention/sol_attn.hip
@@ -8,7 +8,8 @@
 //   exact       walk each routed list, resuming route's online softmax
 // Entry paths: `launch_sol_attn` (post-rope q/k/v) or the chunked producer
 // (`sol_producer_begin/chunk`, then `launch_sol_attn_core`). Tensors are
-// (B, T, H, 128) bf16 and the kernels need WMMA, so gfx11 and gfx12 only.
+// (B, T, H, 128) bf16 or fp16 (the chunked producer takes bf16 only) and the
+// kernels need WMMA, so gfx11 and gfx12 only.
 //
 // The workspace carve-up matches the CUDA backend's sol_attn.cu slot for slot, so
 // the Python layer reads the same plan. What the slots CONTAIN differs by the two
@@ -28,7 +29,7 @@ void launch_sol_preprocess(const void*, const void*, const void*, void*, void*, 
                            void*, void*, void*, void*, void*, void*, void*, void*, void*,
                            const void*, const void*, int, int, int, int, int, int, int, int64_t,
                            int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t,
-                           float, float, hipStream_t);
+                           float, float, int, hipStream_t);
 size_t sol_preprocess_scratch_bytes(int, int, int);
 void launch_sol_producer(const void*, const void*, const void*, const void*, const void*,
                          const void*, void*, void*, void*, void*, void*, void*, void*, void*,
@@ -37,13 +38,13 @@ void launch_sol_producer(const void*, const void*, const void*, const void*, con
 void launch_sol_finish(void*, void*, void*, void*, const void*, const void*, void*, const void*,
                        int, int, int, int, int, int, float, float, hipStream_t);
 void launch_sol_vtranspose(const void*, const void*, void*, int, int, int, int, int64_t, int64_t,
-                           int64_t, hipStream_t);
+                           int64_t, int, hipStream_t);
 void launch_sol_route(const void*, const void*, const void*, const void*, const void*, const void*,
                       const void*, void*, void*, void*, void*, void*, const void*, int, int, int,
                       int, int, int, int, int, int, int, int, float, hipStream_t);
 void launch_sol_exact(const void*, const void*, const void*, const void*, const void*,
                       const void*, const void*, const void*, const void*, const void*,
-                      const void*, void*, int, int, int, int, int, int, float, hipStream_t);
+                      const void*, void*, int, int, int, int, int, int, float, int, hipStream_t);
 
 namespace {
 
@@ -109,7 +110,7 @@ void validate_shape(int batch, int seq_len, int num_heads) {
 void run_route_exact(const Plan& p, char* w, const void* ext_threshold, void* out,
                      const void* blen, int tail, int batch, int seq_len, int num_heads,
                      int sink_start, int sink_end, int sink_q_start, int sink_q_end,
-                     float scale_log2, hipStream_t stream) {
+                     float scale_log2, int elem, hipStream_t stream) {
     // top-k mode: the caller supplies the per-query-block threshold
     const void* thr = ext_threshold ? ext_threshold : static_cast<const void*>(w + p.thr);
     launch_sol_route(w + p.cen8, w + p.cens, w + p.kciP, w + p.kcs, w + p.vcT, w + p.vsc, thr,
@@ -118,7 +119,7 @@ void run_route_exact(const Plan& p, char* w, const void* ext_threshold, void* ou
                      sink_q_start, sink_q_end, scale_log2, stream);
     launch_sol_exact(w + p.qiP, w + p.qs, w + p.kiP, w + p.ksb, w + p.vTi, w + p.vsc, w + p.idx,
                      w + p.cnt, w + p.oPart, w + p.mPart, w + p.lPart, out, batch, seq_len, p.Tp,
-                     num_heads, p.NQ, p.NTB, scale_log2, stream);
+                     num_heads, p.NQ, p.NTB, scale_log2, elem, stream);
     const hipError_t err = hipGetLastError();
     if (err != hipSuccess)
         throw std::runtime_error(std::string("sol_attn: kernel launch failed: ") +
@@ -202,14 +203,16 @@ extern "C" void launch_sol_attn_core(void* workspace, void* out, const void* vsc
                       kmean_next, blen, batch, seq_len, num_heads, p.NTB, p.NPAD, p.NQ, tau,
                       scale_log2, stream);
     run_route_exact(p, w, ext_threshold, out, blen, tail, batch, seq_len, num_heads, sink_start,
-                    sink_end, sink_q_start, sink_q_end, scale_log2, stream);
+                    sink_end, sink_q_start, sink_q_end, scale_log2,
+                    comfy::hip_backend::sol::kSolBf16, stream);
     sol_check(hipMemcpyAsync(vamax_out, w + p.statsV, stats_bytes, hipMemcpyDeviceToDevice, stream),
               "reading back the V absmax");
 }
 
 extern "C" void launch_sol_attn(const void* q, const void* k, const void* v, void* out,
                                 void* workspace, int batch, int seq_len, int num_heads,
-                                int head_dim, float tau, float scale, const void* key_bias,
+                                int head_dim, int elem, float tau, float scale,
+                                const void* key_bias,
                                 const void* ext_threshold, const void* blen, int tail,
                                 int sink_start, int sink_end, int sink_q_start, int sink_q_end,
                                 int64_t qs_b, int64_t qs_t, int64_t qs_h, int64_t ks_b,
@@ -226,9 +229,9 @@ extern "C" void launch_sol_attn(const void* q, const void* k, const void* v, voi
                           w + p.kcs, w + p.vcT, w + p.thr, w + p.cen8, w + p.cens, w + p.vsc,
                           w + p.qmean, w + p.scratch, key_bias, blen, batch, seq_len, p.Tp,
                           num_heads, p.NTB, p.NPAD, p.NQ, qs_b, qs_t, qs_h, ks_b, ks_t, ks_h,
-                          vs_b, vs_t, vs_h, tau, scale_log2, stream);
+                          vs_b, vs_t, vs_h, tau, scale_log2, elem, stream);
     launch_sol_vtranspose(v, w + p.vsc, w + p.vTi, batch, seq_len, p.Tp, num_heads, vs_b, vs_t,
-                          vs_h, stream);
+                          vs_h, elem, stream);
     run_route_exact(p, w, ext_threshold, out, blen, tail, batch, seq_len, num_heads, sink_start,
-                    sink_end, sink_q_start, sink_q_end, scale_log2, stream);
+                    sink_end, sink_q_start, sink_q_end, scale_log2, elem, stream);
 }

--- a/comfy_kitchen/backends/hip/sage_attention/sol_attn_exact.hip
+++ b/comfy_kitchen/backends/hip/sage_attention/sol_attn_exact.hip
@@ -42,12 +42,13 @@ constexpr int kStrideV = BK + kLdsPad;
 // qi:  [B,T,H,D] int8                  qs:  [B,T,H] f32
 // ki:  [B*H,Tp,D] int8                 ksb: [B*H,Tp] float2 = (ks, bias)
 // vT:  [B*H,D,Tp] int8 (transposed)    vsc: [B*H,D] f32
+template <typename TOut>
 __global__ __launch_bounds__(kThreads) void sol_exact_kernel(
     const int8_t* __restrict__ qi, const float* __restrict__ qs, const int8_t* __restrict__ ki,
     const float2* __restrict__ ksb, const int8_t* __restrict__ vT, const float* __restrict__ vsc,
     const uint16_t* __restrict__ blk_idx, const int32_t* __restrict__ blk_cnt,
     const __bf16* __restrict__ o_part, const float* __restrict__ m_part,
-    const float* __restrict__ l_part, __bf16* __restrict__ out, int T, int Tp, int H, int NTB,
+    const float* __restrict__ l_part, TOut* __restrict__ out, int T, int Tp, int H, int NTB,
     float scale_log2) {
     __shared__ __attribute__((aligned(16))) int8_t sK[BK * kStrideK];
     __shared__ __attribute__((aligned(16))) int8_t sVt[HD * kStrideV];
@@ -173,7 +174,7 @@ __global__ __launch_bounds__(kThreads) void sol_exact_kernel(
     if (q_row >= T) return;
     // l is zero only when a row got no mass from either branch; zeros are right there
     const float inv = 1.f / fmaxf(l_r, 1e-30f);
-    __bf16* orow = out + bh_base + static_cast<int64_t>(q_row) * H * HD;
+    TOut* orow = out + bh_base + static_cast<int64_t>(q_row) * H * HD;
 #pragma unroll
     for (int nt = 0; nt < NT; ++nt) {
         float vals[8];
@@ -181,7 +182,7 @@ __global__ __launch_bounds__(kThreads) void sol_exact_kernel(
         for (int e = 0; e < 8; ++e) {
             vals[e] = o_acc[nt][e] * inv * vsc[vsc_base + nt * 16 + acc_row(lane, e)];
         }
-        store_o_tile<__bf16>(orow, nt * 16, vals, lane);
+        store_o_tile<TOut>(orow, nt * 16, vals, lane);
     }
 }
 
@@ -193,14 +194,21 @@ using namespace comfy::hip_backend::sol;
 void launch_sol_exact(const void* qi, const void* qs, const void* ki, const void* ksb,
                       const void* vT, const void* vsc, const void* blk_idx, const void* blk_cnt,
                       const void* o_part, const void* m_part, const void* l_part, void* out, int B,
-                      int T, int Tp, int H, int NQ, int NTB, float scale_log2,
+                      int T, int Tp, int H, int NQ, int NTB, float scale_log2, int elem,
                       hipStream_t stream) {
     dim3 grid(NQ, B * H);
-    sol_exact_kernel<<<grid, kThreads, 0, stream>>>(
-        static_cast<const int8_t*>(qi), static_cast<const float*>(qs),
-        static_cast<const int8_t*>(ki), static_cast<const float2*>(ksb),
-        static_cast<const int8_t*>(vT), static_cast<const float*>(vsc),
-        static_cast<const uint16_t*>(blk_idx), static_cast<const int32_t*>(blk_cnt),
-        static_cast<const __bf16*>(o_part), static_cast<const float*>(m_part),
-        static_cast<const float*>(l_part), static_cast<__bf16*>(out), T, Tp, H, NTB, scale_log2);
+#define SOLX_LAUNCH(TOut)                                                                    \
+    sol_exact_kernel<TOut><<<grid, kThreads, 0, stream>>>(                                   \
+        static_cast<const int8_t*>(qi), static_cast<const float*>(qs),                       \
+        static_cast<const int8_t*>(ki), static_cast<const float2*>(ksb),                     \
+        static_cast<const int8_t*>(vT), static_cast<const float*>(vsc),                      \
+        static_cast<const uint16_t*>(blk_idx), static_cast<const int32_t*>(blk_cnt),         \
+        static_cast<const __bf16*>(o_part), static_cast<const float*>(m_part),               \
+        static_cast<const float*>(l_part), static_cast<TOut*>(out), T, Tp, H, NTB, scale_log2)
+    if (elem == kSolFp16) {
+        SOLX_LAUNCH(_Float16);
+    } else {
+        SOLX_LAUNCH(__bf16);
+    }
+#undef SOLX_LAUNCH
 }

--- a/comfy_kitchen/backends/hip/sage_attention/sol_attn_exact.hip
+++ b/comfy_kitchen/backends/hip/sage_attention/sol_attn_exact.hip
@@ -86,7 +86,7 @@ __global__ __launch_bounds__(kThreads) void sol_exact_kernel(
 #pragma unroll
         for (int nt = 0; nt < NT; ++nt) load_o_tile<__bf16>(orow, nt * 16, o_acc[nt], lane);
     }
-    float m_r = m_part[qb_s], l_r = l_part[qb_s];
+    float m_r = m_part[qb_s], l_r = l_part[qb_s], c_r = m_r;   // c_r: scale o_acc / l_r are carried in
 
     for (int kb = 0; kb < n_blocks; ++kb) {
         const int64_t k0 = static_cast<int64_t>(my_idx[kb]) * BK;
@@ -118,7 +118,9 @@ __global__ __launch_bounds__(kThreads) void sol_exact_kernel(
         }
 
         float p_val[KT][8];
-        float m_new = m_r;
+        // P is quantized against the block max (floored 2^-20 under the running
+        // max) so every block gets the full u8 range
+        float bmax = m_r - 20.f;
 #pragma unroll
         for (int kt = 0; kt < KT; ++kt) {
 #pragma unroll
@@ -127,15 +129,16 @@ __global__ __launch_bounds__(kThreads) void sol_exact_kernel(
                 // A dead key carries a zero scale and a kNeg bias, so its score is kNeg.
                 const float s = fmaf(static_cast<float>(s_acc[kt][e]), qsc * kb2.x, kb2.y);
                 p_val[kt][e] = s;
-                m_new = fmaxf(m_new, s);
+                bmax = fmaxf(bmax, s);
             }
         }
-        m_new = fmaxf(m_new, swap_half_wave(m_new));
-        const float alpha = exp2f(m_r - m_new);
-        m_r = m_new;
+        bmax = fmaxf(bmax, swap_half_wave(bmax));
+        const float alpha = exp2f(c_r - bmax);
+        c_r = bmax;
+        m_r = fmaxf(m_r, bmax);
 
         // u8 P scale folded into the exponent (+log2 255); l carries it too
-        const float m_off = m_new - kProbU8Offset;
+        const float m_off = bmax - kProbU8Offset;
         typename MmaInt8::Frag p_frag[KT];
         uint32_t li = 0u;
 #pragma unroll

--- a/comfy_kitchen/backends/hip/sage_attention/sol_attn_preprocess.hip
+++ b/comfy_kitchen/backends/hip/sage_attention/sol_attn_preprocess.hip
@@ -51,8 +51,9 @@ __forceinline__ __device__ void atomic_max_pos(float* dst, float v) {
 
 // ---- pass 1: K/V block reductions plus V's per-channel |max| ----
 // One block per (bh, pooled block), thread == channel.
+template <typename E>
 __global__ __launch_bounds__(HD) void prep_reduce_kv(
-    const __bf16* __restrict__ k, const __bf16* __restrict__ v, float* __restrict__ kc,
+    const E* __restrict__ k, const E* __restrict__ v, float* __restrict__ kc,
     __bf16* __restrict__ vcT, float* __restrict__ vamax, const int32_t* __restrict__ blen, int T,
     int H, int NTB, int NPAD, int64_t sb, int64_t st, int64_t sh, int64_t vb, int64_t vt,
     int64_t vh) {
@@ -123,7 +124,8 @@ __global__ __launch_bounds__(HD) void prep_pooled_quant(const float* __restrict_
 }
 
 // ---- pass 4: quantize Q, the centroid and the routing threshold from one tile ----
-__global__ __launch_bounds__(HD) void prep_q(const __bf16* __restrict__ q,
+template <typename E>
+__global__ __launch_bounds__(HD) void prep_q(const E* __restrict__ q,
                                              const float* __restrict__ kcvar,
                                              int8_t* __restrict__ qi, float* __restrict__ qs,
                                              float* __restrict__ thr, int8_t* __restrict__ cen8,
@@ -132,7 +134,7 @@ __global__ __launch_bounds__(HD) void prep_q(const __bf16* __restrict__ q,
                                              const int32_t* __restrict__ blen, int T, int H,
                                              int NQ, int NPAD, float tau, float log2s, int64_t sb,
                                              int64_t st, int64_t sh) {
-    __shared__ __attribute__((aligned(16))) __bf16 sQ[BLK * kLdTile];
+    __shared__ __attribute__((aligned(16))) E sQ[BLK * kLdTile];
     __shared__ __attribute__((aligned(16))) float sred[HD];
     const int qb = blockIdx.x, bh = blockIdx.y;
     const int batch = bh / H, head = bh % H;
@@ -152,13 +154,14 @@ __global__ __launch_bounds__(HD) void prep_q(const __bf16* __restrict__ q,
 }
 
 // ---- pass 5: centre and quantize K ----
-__global__ __launch_bounds__(HD) void prep_k(const __bf16* __restrict__ k,
+template <typename E>
+__global__ __launch_bounds__(HD) void prep_k(const E* __restrict__ k,
                                              const float* __restrict__ kmean,
                                              int8_t* __restrict__ ki, float2* __restrict__ ksb,
                                              const float* __restrict__ kbias,  // [B, T] log2 units
                                              const int32_t* __restrict__ blen, int T, int Tp,
                                              int H, int64_t sb, int64_t st, int64_t sh) {
-    __shared__ __attribute__((aligned(16))) __bf16 sK[BLK * kLdTile];
+    __shared__ __attribute__((aligned(16))) E sK[BLK * kLdTile];
     const int n = blockIdx.x, bh = blockIdx.y;
     const int batch = bh / H, head = bh % H;
     const int t0 = n * BLK, len = block_len_of(blen, n, T);
@@ -227,7 +230,8 @@ void launch_sol_finish(void* scratch, void* kci, void* kcs, void* threshold, con
         static_cast<float*>(threshold), NQ, tau, scale_log2);
 }
 
-void launch_sol_preprocess(const void* q, const void* k, const void* v, void* qi, void* qs,
+template <typename E>
+static void preprocess_launch(const void* q, const void* k, const void* v, void* qi, void* qs,
                            void* ki, void* ksb, void* kci, void* kcs, void* vcT, void* threshold,
                            void* cen8, void* cens, void* vsc, void* qmean,
                            void* scratch,          // sol_preprocess_scratch_bytes
@@ -242,23 +246,37 @@ void launch_sol_preprocess(const void* q, const void* k, const void* v, void* qi
     // pass 1 accumulates V's |max| into vsc by atomicMax
     sol_check(hipMemsetAsync(vsc, 0, static_cast<size_t>(B) * H * HD * sizeof(float), stream),
               "clearing the V absmax accumulator");
-    prep_reduce_kv<<<dim3(NPAD, B * H), HD, 0, stream>>>(
-        static_cast<const __bf16*>(k), static_cast<const __bf16*>(v), s.kc,
+    prep_reduce_kv<E><<<dim3(NPAD, B * H), HD, 0, stream>>>(
+        static_cast<const E*>(k), static_cast<const E*>(v), s.kc,
         static_cast<__bf16*>(vcT), static_cast<float*>(vsc), static_cast<const int32_t*>(blen), T,
         H, NTB, NPAD, ks_b, ks_t, ks_h, vs_b, vs_t, vs_h);
     prep_pooled_stats<<<B * H, HD, 0, stream>>>(s.kc, s.kmean, static_cast<const float*>(vsc),
                                                 static_cast<float*>(vsc), s.kcvar, NTB, NPAD);
     prep_pooled_quant<<<dim3(NPAD, B * H), HD, 0, stream>>>(
         s.kc, s.kmean, static_cast<int8_t*>(kci), static_cast<float*>(kcs), NTB, NPAD);
-    prep_q<<<dim3(NQ, B * H), HD, 0, stream>>>(
-        static_cast<const __bf16*>(q), s.kcvar, static_cast<int8_t*>(qi), static_cast<float*>(qs),
+    prep_q<E><<<dim3(NQ, B * H), HD, 0, stream>>>(
+        static_cast<const E*>(q), s.kcvar, static_cast<int8_t*>(qi), static_cast<float*>(qs),
         static_cast<float*>(threshold), static_cast<int8_t*>(cen8), static_cast<float*>(cens),
         static_cast<float*>(qmean), static_cast<const int32_t*>(blen), T, H, NQ, NPAD, tau,
         scale_log2, qs_b, qs_t, qs_h);
-    prep_k<<<dim3(NTB, B * H), HD, 0, stream>>>(
-        static_cast<const __bf16*>(k), s.kmean, static_cast<int8_t*>(ki),
+    prep_k<E><<<dim3(NTB, B * H), HD, 0, stream>>>(
+        static_cast<const E*>(k), s.kmean, static_cast<int8_t*>(ki),
         static_cast<float2*>(ksb), static_cast<const float*>(key_bias),
         static_cast<const int32_t*>(blen), T, Tp, H, ks_b, ks_t, ks_h);
+}
+
+void launch_sol_preprocess(const void* q, const void* k, const void* v, void* qi, void* qs,
+                           void* ki, void* ksb, void* kci, void* kcs, void* vcT, void* threshold,
+                           void* cen8, void* cens, void* vsc, void* qmean, void* scratch,
+                           const void* key_bias, const void* blen, int B, int T, int Tp, int H,
+                           int NTB, int NPAD, int NQ, int64_t qs_b, int64_t qs_t, int64_t qs_h,
+                           int64_t ks_b, int64_t ks_t, int64_t ks_h, int64_t vs_b, int64_t vs_t,
+                           int64_t vs_h, float tau, float scale_log2, int elem,
+                           hipStream_t stream) {
+    auto fn = elem == kSolFp16 ? preprocess_launch<_Float16> : preprocess_launch<__bf16>;
+    fn(q, k, v, qi, qs, ki, ksb, kci, kcs, vcT, threshold, cen8, cens, vsc, qmean, scratch,
+       key_bias, blen, B, T, Tp, H, NTB, NPAD, NQ, qs_b, qs_t, qs_h, ks_b, ks_t, ks_h, vs_b,
+       vs_t, vs_h, tau, scale_log2, stream);
 }
 
 size_t sol_preprocess_scratch_bytes(int B, int H, int NPAD) {

--- a/comfy_kitchen/backends/hip/sage_attention/sol_attn_vtranspose.hip
+++ b/comfy_kitchen/backends/hip/sage_attention/sol_attn_vtranspose.hip
@@ -18,8 +18,8 @@ constexpr int HD = kHeadDim;
 constexpr int kThreads = 256;
 constexpr int kLdsPad = HD + 16;  // must be a multiple of 16: phase 1 writes 16 bytes
 
-template <int TT>
-__global__ __launch_bounds__(kThreads) void vquant_transpose(const __bf16* __restrict__ v,
+template <int TT, typename E>
+__global__ __launch_bounds__(kThreads) void vquant_transpose(const E* __restrict__ v,
                                                              const float* __restrict__ vsc,
                                                              int8_t* __restrict__ vT, int T,
                                                              int Tp, int H, int64_t sb, int64_t st,
@@ -33,7 +33,7 @@ __global__ __launch_bounds__(kThreads) void vquant_transpose(const __bf16* __res
         const int t = idx / (HD / 16), c16 = (idx % (HD / 16)) * 16;
         __attribute__((aligned(16))) int8_t out[16];
         if (t0 + t < T) {
-            const __bf16* src =
+            const E* src =
                 v + batch * sb + static_cast<int64_t>(t0 + t) * st + head * sh + c16;
 #pragma unroll
             for (int j = 0; j < 16; ++j) {
@@ -79,9 +79,15 @@ __global__ __launch_bounds__(kThreads) void vquant_transpose(const __bf16* __res
 using namespace comfy::hip_backend::sol;
 
 void launch_sol_vtranspose(const void* v, const void* vsc, void* vT, int B, int T, int Tp, int H,
-                           int64_t sb, int64_t st, int64_t sh, hipStream_t stream) {
+                           int64_t sb, int64_t st, int64_t sh, int elem, hipStream_t stream) {
     dim3 grid((T + 255) / 256, B * H);
-    vquant_transpose<256><<<grid, kThreads, 0, stream>>>(
-        static_cast<const __bf16*>(v), static_cast<const float*>(vsc), static_cast<int8_t*>(vT), T,
-        Tp, H, sb, st, sh);
+    if (elem == kSolFp16) {
+        vquant_transpose<256, _Float16><<<grid, kThreads, 0, stream>>>(
+            static_cast<const _Float16*>(v), static_cast<const float*>(vsc),
+            static_cast<int8_t*>(vT), T, Tp, H, sb, st, sh);
+    } else {
+        vquant_transpose<256, __bf16><<<grid, kThreads, 0, stream>>>(
+            static_cast<const __bf16*>(v), static_cast<const float*>(vsc),
+            static_cast<int8_t*>(vT), T, Tp, H, sb, st, sh);
+    }
 }

--- a/comfy_kitchen/backends/hip/sage_attention/sol_common.h
+++ b/comfy_kitchen/backends/hip/sage_attention/sol_common.h
@@ -41,7 +41,7 @@ constexpr int kBlock = 64;     // Sol-Attn's routing granularity, in tokens
 // sol::NEG, so both backends drop the same blocks.
 constexpr float kNeg = -3.0e38f;
 
-// bf16 row stride of a staged tile; keeps the 16-byte stores aligned.
+// 16-bit row stride of a staged tile; keeps the 16-byte stores aligned.
 constexpr int kLdTile = kHeadDim + 8;
 
 // The stage launchers are host code and throw, so a failed async copy is reported
@@ -96,9 +96,15 @@ __forceinline__ __device__ float block_sum128(float x, float* s) {
     return r;
 }
 
+// q/k/v/out element type: bf16 or fp16 (_Float16). Everything after the load
+// (tiles, scales, int8 carriers) is the same; only the loads and the final store
+// convert.
+enum SolElem : int { kSolBf16 = 0, kSolFp16 = 1 };
+
 // Stage rows 0..len-1 (row t at src + t * stride, 16-byte loads) into the tile,
 // zero past len.
-__forceinline__ __device__ void stage_tile64(__bf16* tile, const __bf16* __restrict__ src,
+template <typename T>
+__forceinline__ __device__ void stage_tile64(T* tile, const T* __restrict__ src,
                                              int64_t stride, int len) {
     for (int idx = threadIdx.x; idx < kBlock * (kHeadDim / 8); idx += kHeadDim) {
         const int t = idx / (kHeadDim / 8), c8 = (idx % (kHeadDim / 8)) * 8;
@@ -113,11 +119,12 @@ __forceinline__ __device__ void stage_tile64(__bf16* tile, const __bf16* __restr
 // Per-token absmax scale and INT8 row, one thread per token. qi / qs point at
 // (this tile's first token, this head). Rows [len, nrows) exist in memory but are
 // dead (zero-padded tiles) and get zeros; rows past nrows do not exist.
-__forceinline__ __device__ void quant_q_rows(const __bf16* tile, int len, int nrows,
+template <typename T>
+__forceinline__ __device__ void quant_q_rows(const T* tile, int len, int nrows,
                                              int8_t* __restrict__ qi, float* __restrict__ qs,
                                              int H) {
     for (int t = threadIdx.x; t < nrows; t += kHeadDim) {
-        const __bf16* row = tile + t * kLdTile;  // zero-staged past len
+        const T* row = tile + t * kLdTile;  // zero-staged past len
         const bool live = t < len;
         float a = 0.f;
 #pragma unroll 8
@@ -140,7 +147,8 @@ __forceinline__ __device__ void quant_q_rows(const __bf16* tile, int len, int nr
 // Query-block centroid, quantized like a pseudo-row. One thread per channel;
 // returns this thread's channel mean. `sred` holds bytes on return -- sync before
 // reusing it.
-__forceinline__ __device__ float centroid_quant(const __bf16* tile, int len, float* sred,
+template <typename T>
+__forceinline__ __device__ float centroid_quant(const T* tile, int len, float* sred,
                                                 int8_t* __restrict__ cen8,
                                                 float* __restrict__ cens) {
     const int d = threadIdx.x;
@@ -161,13 +169,14 @@ __forceinline__ __device__ float centroid_quant(const __bf16* tile, int len, flo
 // Centred per-key scale and INT8 row. kbias (log2 units, or null) only the exact
 // branch reads, so biased blocks must be sink-routed. Dead rows get a zero scale,
 // a kNeg bias and zero bytes.
-__forceinline__ __device__ void quant_k_rows(const __bf16* tile, int len,
+template <typename T>
+__forceinline__ __device__ void quant_k_rows(const T* tile, int len,
                                              const float* __restrict__ kmean,
                                              const float* __restrict__ kbias,
                                              int8_t* __restrict__ ki, float2* __restrict__ ksb) {
     for (int p = threadIdx.x; p < kBlock; p += kHeadDim) {
         const bool live = p < len;
-        const __bf16* row = tile + p * kLdTile;
+        const T* row = tile + p * kLdTile;
         float a = 0.f;
 #pragma unroll 8
         for (int d = 0; d < kHeadDim; ++d) {

--- a/tests/test_sol_attn.py
+++ b/tests/test_sol_attn.py
@@ -401,9 +401,10 @@ def test_exact_branch_quantization_error():
 
 
 def test_chunked_producer_public_entry():
-    """comfy_kitchen.sol_attn_chunked is the CUDA backend's function."""
+    """comfy_kitchen.sol_attn_chunked is the registered backend's function."""
+    expected = hip_backend if ck.registry.is_available("hip") else cuda_backend
     assert "sol_attn_chunked" in ck.__all__
-    assert ck.sol_attn_chunked is cuda_backend.sol_attn_chunked
+    assert ck.sol_attn_chunked is expected.sol_attn_chunked
 
 
 def test_bindings_check_buffer_sizes():

--- a/tests/test_sol_attn.py
+++ b/tests/test_sol_attn.py
@@ -390,6 +390,22 @@ def test_chunked_producer_matches_separate_rope(rot):
     assert _cos(out3, ref) > 0.995
 
 
+def test_exact_branch_quantization_error():
+    """Full-range per-block P quantization: with every block routed the exact
+    branch must sit well under the ~2%% relL2 of the running-max scheme."""
+    q, k, v = _qkv(1, 4096, 8)
+    out = ck.sol_attn(q, k, v, tau=-1e9)
+    ref = _dense(q, k, v)
+    rel = ((out.float() - ref.float()).norm() / ref.float().norm()).item()
+    assert rel < 0.016, rel
+
+
+def test_chunked_producer_public_entry():
+    """comfy_kitchen.sol_attn_chunked is the CUDA backend's function."""
+    assert "sol_attn_chunked" in ck.__all__
+    assert ck.sol_attn_chunked is cuda_backend.sol_attn_chunked
+
+
 def test_bindings_check_buffer_sizes():
     """The _C entries take bare pointers sized from integers; each must reject
     an undersized buffer itself, not rely on the Python wrappers."""

--- a/tests/test_sol_attn.py
+++ b/tests/test_sol_attn.py
@@ -290,7 +290,7 @@ def test_direct_backend_validates_like_the_public_path():
     """The backend-direct entry runs the same shared rule as the registry."""
     q, k, v = _qkv(1, 512, 4)
     with pytest.raises(ValueError, match="bfloat16"):
-        backend.sol_attn(q.half(), k.half(), v.half(), tau=1.4)
+        backend.sol_attn(q.float(), k.float(), v.float(), tau=1.4)
     with pytest.raises(ValueError, match="shape"):
         backend.sol_attn(q, k[:, :256].contiguous(), v, tau=1.4)
 
@@ -398,6 +398,43 @@ def test_exact_branch_quantization_error():
     ref = _dense(q, k, v)
     rel = ((out.float() - ref.float()).norm() / ref.float().norm()).item()
     assert rel < 0.016, rel
+
+
+@pytest.mark.parametrize("t", [1024, 3137])
+def test_fp16_inputs_match_bf16(t):
+    """fp16 q/k/v go straight into the same int8 pipeline (only the loads and the
+    output store convert), so the two dtypes agree to output rounding."""
+    q, k, v = _qkv(1, t, 4)
+    q16, k16, v16 = (x.half() for x in (q, k, v))   # bf16 values are exact in fp16
+    ref = ck.sol_attn(q, k, v, tau=1.0)
+    got = ck.sol_attn(q16, k16, v16, tau=1.0)
+    assert got.dtype == torch.float16
+    rel = ((got.float() - ref.float()).norm() / ref.float().norm()).item()
+    assert rel < 4e-3, rel
+    assert _cos(got, sol_attn_eager(q16, k16, v16, tau=1.0)) > 0.998
+
+
+def test_fp16_strided_inputs_and_mixed_dtype():
+    """BHND fp16 views go in as-is; the binding rejects out/k/v that differ from q."""
+    b, t, h = 2, 1000, 3
+    q, k, v = _qkv(b, t, h, seed=5)
+    q16, k16, v16 = (x.half().permute(0, 2, 1, 3).contiguous().permute(0, 2, 1, 3)
+                     for x in (q, k, v))
+    got = ck.sol_attn(q16, k16, v16, tau=1.0)
+    ref = ck.sol_attn(q, k, v, tau=1.0)
+    rel = ((got.float() - ref.float()).norm() / ref.float().norm()).item()
+    assert rel < 4e-3, rel
+
+    ext, w = backend._C, _wrap
+    ws = torch.empty(ext.sol_attn_plan(1, 256, 1)["total"], dtype=torch.uint8, device="cuda")
+    q1, k1, v1 = _qkv(1, 256, 1)
+    stream = torch.cuda.current_stream().cuda_stream
+    args = (1, 256, 1, HD, 1.0, HD ** -0.5, 0, 0, 0, 0, stream)
+    with pytest.raises(RuntimeError, match="out"):
+        ext.sol_attn(w(q1), w(k1), w(v1), w(torch.empty_like(q1, dtype=torch.float16)), w(ws), *args)
+    with pytest.raises(RuntimeError, match="k must be"):
+        ext.sol_attn(w(q1.half()), w(k1), w(v1.half()), w(torch.empty_like(q1, dtype=torch.float16)),
+                     w(ws), *args)
 
 
 def test_chunked_producer_public_entry():


### PR DESCRIPTION
Small follow-up PR to the sparse attention kernels

Quantize P against the block max instead of the running max in the Sol exact branch, so that every routed block uses the full u8 range 

Also exports`sol_attn_chunked` at top level, and adds support for fp16 attention (previously only bf16).

H3 capture, 10% keep: per-head cos 0.9830/0.9447 → 0.9853/0.9521 (mean/worst)

all-blocks relL2 vs fp32 1.96% → 1.40%. Registers unchanged, ≤3% per-call cost.
