### PR TITLE
Sparse attention: Add token routing for improved quality

### DIFF
--- a/comfy_kitchen/__init__.py
+++ b/comfy_kitchen/__init__.py
@@ -1,6 +1,6 @@
 import torch
 
-from .backends import cuda as _cuda_backend  # noqa: F401
+from .backends import cuda as _cuda_backend
 
 # Import backends to trigger auto-registration
 from .backends import eager as _eager_backend  # noqa: F401
@@ -66,6 +66,7 @@ __all__ = [
     "na3d",
     "sol_attn",
     "sol_attn_chunked",
+    "sol_attn_is_available",
     # Quantization / dequantization
     "quantize_per_tensor_fp8",
     "dequantize_per_tensor_fp8",
@@ -143,6 +144,7 @@ def sol_attn(
     tail: bool = True,
     block_len: torch.Tensor | None = None,
     coarse_gate: torch.Tensor | None = None,
+    token_aug: int = 0,
 ) -> torch.Tensor:
     """Sol-Attn training-free sparse attention (arXiv 2607.24027).
 
@@ -175,6 +177,10 @@ def sol_attn(
             output rows are unspecified.
         coarse_gate: ``(B, T, H, 128)`` per-token gate for VSA's coarse branch:
             ``gate * softmax(q_mean k_mean^T * scale) v_mean`` is added per block.
+        token_aug: 0, or a multiple of 64 up to 256: up to that many tokens per
+            query block are routed individually, the highest-scoring ones outside
+            the routed blocks, and attended exactly. CUDA only; other backends
+            run without it.
 
     Returns:
         ``(B, T, H, 128)`` attention output.
@@ -188,7 +194,23 @@ def sol_attn(
         bool(tail),
         block_len,
         coarse_gate,
+        int(token_aug),
     )
+
+
+def sol_attn_is_available(device: torch.device | int | None = None) -> bool:
+    """Whether the compiled Sol-Attn kernels can run on ``device``: the CUDA
+    backend on sm_80+, or the HIP backend on a GPU with matrix cores. The
+    per-call rules (bf16/fp16, head_dim 128, matching q/k/v) still apply."""
+    if not torch.cuda.is_available():
+        return False
+    if getattr(torch.version, "hip", None):
+        # torch.cuda is the ROCm API here; the HIP backend advertises sol_attn
+        # only on WMMA parts, so its registration is the answer
+        return registry.is_available("hip") and registry.get_constraints("hip", "sol_attn") is not None
+    rules = registry.get_constraints("cuda", "sol_attn")
+    return (registry.is_available("cuda") and _cuda_backend._EXT_AVAILABLE and rules is not None
+            and torch.cuda.get_device_capability(device) >= rules.min_compute_capability)
 
 
 def na3d(

--- a/comfy_kitchen/__init__.py
+++ b/comfy_kitchen/__init__.py
@@ -209,7 +209,9 @@ def sol_attn_is_available(device: torch.device | int | None = None) -> bool:
         # only on WMMA parts, so its registration is the answer
         return registry.is_available("hip") and registry.get_constraints("hip", "sol_attn") is not None
     rules = registry.get_constraints("cuda", "sol_attn")
-    return (registry.is_available("cuda") and _cuda_backend._EXT_AVAILABLE and rules is not None
+    ext = getattr(_cuda_backend, "_C", None)
+    return (registry.is_available("cuda") and _cuda_backend._EXT_AVAILABLE and hasattr(ext, "sol_attn")
+            and rules is not None
             and torch.cuda.get_device_capability(device) >= rules.min_compute_capability)
 
 

--- a/comfy_kitchen/backends/cuda/CMakeLists.txt
+++ b/comfy_kitchen/backends/cuda/CMakeLists.txt
@@ -138,6 +138,7 @@ set(CUDA_SOURCES
     sage_attention/sol_attn_vtranspose.cu
     sage_attention/sol_attn_route.cu
     sage_attention/sol_attn_exact.cu
+    sage_attention/sol_attn_token.cu
     ops/quantize_svdquant_w4a4.cu
     ops/scaled_mm_svdquant_w4a4.cu
     ops/awq_w4a16.cu

--- a/comfy_kitchen/backends/cuda/__init__.py
+++ b/comfy_kitchen/backends/cuda/__init__.py
@@ -2463,6 +2463,7 @@ def sol_attn(
     tail: bool = True,
     block_len: torch.Tensor | None = None,
     coarse_gate: torch.Tensor | None = None,
+    token_aug: int = 0,
 ) -> torch.Tensor:
     """Sol-Attn sparse attention over ``(B, T, H, 128)`` bf16 or fp16 tensors.
     See sage_attention/sol_attn.cu and the public docstring for ``tail``,
@@ -2471,6 +2472,14 @@ def sol_attn(
     ``topk_ratio`` > 0 switches selection from the tau threshold to SLA-style
     per-query-block top-k: keep that fraction of key blocks per query block
     (sinks and the diagonal still ride on top). tau is ignored then.
+
+    ``token_aug`` (0, or a multiple of 64 up to 256): on top of the routed
+    blocks, every row attends up to ``token_aug`` unrouted tokens its query
+    block's centroid scores highest (whole histogram bins only, so the set
+    never depends on scheduling; a flat score profile may admit none), and the
+    remaining tail is exact for the centroid instead of pooled per block.
+    CUDA only: the HIP backend runs without it (one warning), the eager
+    reference ignores it.
     """
     batch, t, h, d = q.shape
     if q.dtype not in (torch.bfloat16, torch.float16):
@@ -2510,7 +2519,7 @@ def sol_attn(
         kb = _normalize_key_bias(key_bias, batch, t, q.device)
         kb = (kb * _LOG2E).expand(batch, t).contiguous()
     out = torch.empty(q.shape, dtype=q.dtype, device=q.device)
-    p = _C.sol_attn_plan(batch, t, h)
+    p = _C.sol_attn_plan(batch, t, h, token_aug=int(token_aug))
     workspace = torch.empty(p["total"], dtype=torch.uint8, device=q.device)
     _C.sol_attn(
         _wrap_for_dlpack(q),
@@ -2525,7 +2534,7 @@ def sol_attn(
         key_bias=None if kb is None else _wrap_for_dlpack(kb),
         threshold=None if thr is None else _wrap_for_dlpack(thr),
         block_len=None if block_len is None else _wrap_for_dlpack(block_len),
-        tail=bool(tail),
+        tail=bool(tail), token_aug=int(token_aug),
     )
     if coarse_gate is not None:
         add_coarse_(out, coarse_output(*_ws_block_means(workspace, p, batch * h, lengths), scale),
@@ -2550,10 +2559,11 @@ def sol_attn_chunked(
     tail: bool = True,
     block_len: torch.Tensor | None = None,
     coarse_gate: torch.Tensor | None = None,
+    token_aug: int = 0,
 ):
     """Chunked-producer Sol-Attn over fused qkv projection chunks ([M, 3*H*128]
     bf16, 64-aligned starts, B=1); full Q/K/V are never materialised.
-    ``tail`` / ``block_len`` / ``coarse_gate`` as in ``sol_attn``.
+    ``tail`` / ``block_len`` / ``coarse_gate`` / ``token_aug`` as in ``sol_attn``.
 
     ``qkv_chunks``: an iterable of chunks or a zero-arg callable returning one.
     ``kmean``/``vscale`` are LAST step's statistics ([H,128] f32); when None the
@@ -2579,13 +2589,13 @@ def sol_attn_chunked(
     if factory is None and (kmean is None or vscale is None):
         qkv_chunks = list(qkv_chunks)          # need two passes over it
         factory = lambda: iter(qkv_chunks)     # noqa: E731
-    p = _C.sol_attn_plan(1, t, h)
+    p = _C.sol_attn_plan(1, t, h, token_aug=int(token_aug))
     ws = torch.empty(p["total"], dtype=torch.uint8, device=dev)
     stream = torch.cuda.current_stream(dev).cuda_stream
     width = 3 * h * d
 
     def produce(km, vsc):
-        _C.sol_producer_begin(_wrap_for_dlpack(ws), 1, t, h, stream)
+        _C.sol_producer_begin(_wrap_for_dlpack(ws), 1, t, h, stream, token_aug=int(token_aug))
         t0 = 0
         for chunk in (factory() if factory is not None else qkv_chunks):
             m = chunk.shape[-2]
@@ -2601,7 +2611,8 @@ def sol_attn_chunked(
                 _wrap_for_dlpack(fab), _wrap_for_dlpack(qw), _wrap_for_dlpack(kw),
                 _wrap_for_dlpack(km), _wrap_for_dlpack(vsc),
                 float(rope_eps), rot, t0, m, 1, t, h, stream,
-                block_len=None if block_len is None else _wrap_for_dlpack(block_len))
+                block_len=None if block_len is None else _wrap_for_dlpack(block_len),
+                token_aug=int(token_aug))
             t0 += m
         if t0 != t:
             raise ValueError(f"sol_attn_chunked: chunks cover {t0} tokens, T={t}")
@@ -2630,7 +2641,7 @@ def sol_attn_chunked(
         _wrap_for_dlpack(kmean_next), _wrap_for_dlpack(vamax),
         1, t, h, float(tau), float(scale), sb[0], sb[1], sq[0], sq[1], stream,
         threshold=None if threshold is None else _wrap_for_dlpack(threshold),
-        block_len=None if block_len is None else _wrap_for_dlpack(block_len), tail=bool(tail))
+        block_len=None if block_len is None else _wrap_for_dlpack(block_len), tail=bool(tail), token_aug=int(token_aug))
     if coarse_gate is not None:
         add_coarse_(out, coarse_output(*_ws_block_means(ws, p, h, lengths), scale), coarse_gate)
     return out, kmean_next, vscale_of(vamax)

--- a/comfy_kitchen/backends/cuda/dlpack_bindings.cpp
+++ b/comfy_kitchen/backends/cuda/dlpack_bindings.cpp
@@ -262,21 +262,21 @@ extern "C" {
 
     // Sol-Attn sparse attention — see sage_attention/sol_attn.cu.
     extern const char* const sol_attn_plan_names[];   // null-terminated
-    int sol_attn_plan(int batch, int seq_len, int num_heads, int64_t* out, int cap);
+    int sol_attn_plan(int batch, int seq_len, int num_heads, int n_tok, int64_t* out, int cap);
     void sol_producer_begin(void* workspace, int batch, int seq_len,
-                            int num_heads, cudaStream_t stream);
+                            int num_heads, int n_tok, cudaStream_t stream);
     void sol_producer_chunk(
         void* workspace, const void* qkv, const void* fab,
         const void* qw, const void* kw, const void* kmean, const void* vscale,
         const void* blen, float rope_eps, int rot_dim, int t0, int M,
-        int batch, int seq_len, int num_heads, cudaStream_t stream);
+        int batch, int seq_len, int num_heads, int n_tok, cudaStream_t stream);
     void launch_sol_attn_core(
         void* workspace, void* out, const void* vscale, void* kmean_next, void* vamax_out,
         const void* blen, int tail,
         int batch, int seq_len, int num_heads,
         float tau, float scale, const void* ext_threshold,
         int sink_start, int sink_end, int sink_q_start, int sink_q_end,
-        cudaStream_t stream);
+        int n_tok, cudaStream_t stream);
     void launch_sol_attn(
         const void* q, const void* k, const void* v, void* out, void* workspace,
         int batch, int seq_len, int num_heads, int head_dim, int elem,
@@ -286,7 +286,7 @@ extern "C" {
         int64_t qs_b, int64_t qs_t, int64_t qs_h,
         int64_t ks_b, int64_t ks_t, int64_t ks_h,
         int64_t vs_b, int64_t vs_t, int64_t vs_h,
-        cudaStream_t stream);
+        int n_tok, cudaStream_t stream);
 
     // Fused AdaLN — see ops/adaln.cu. subtract_mean selects LayerNorm (true)
     // or RMSNorm (false) statistics.
@@ -1497,10 +1497,10 @@ static void need_elems(const nb::ndarray<nb::device::cuda>& a, int64_t n, const 
                                  + " elements, got " + std::to_string(a.size()));
 }
 static void need_workspace(const nb::ndarray<nb::device::cuda>& ws, int64_t batch, int64_t seq_len,
-                           int64_t num_heads, const char* who) {
-    int64_t v[32];
-    const int n = sol_attn_plan((int)batch, (int)seq_len, (int)num_heads, v, 32);
-    if (n > 32 || (int64_t)ws.size() < v[n - 1])   // last slot is "total"
+                           int64_t num_heads, int64_t token_aug, const char* who) {
+    int64_t v[48];
+    const int n = sol_attn_plan((int)batch, (int)seq_len, (int)num_heads, (int)token_aug, v, 48);
+    if (n > 48 || (int64_t)ws.size() < v[n - 1])   // last slot is "total"
         throw std::runtime_error(std::string(who) + ": workspace too small for this shape");
 }
 // q/k/v/out element code for launch_sol_attn: 0 = bfloat16, 1 = float16, -1 = neither
@@ -1536,10 +1536,10 @@ static void need_contiguous(const nb::ndarray<nb::device::cuda>& a, const char* 
 }
 
 // Workspace dims and slot byte offsets, from the C++ Plan (the one definition).
-nb::dict sol_attn_plan_py(int64_t batch, int64_t seq_len, int64_t num_heads) {
-    int64_t v[32];
-    const int n = sol_attn_plan((int)batch, (int)seq_len, (int)num_heads, v, 32);
-    if (n > 32)
+nb::dict sol_attn_plan_py(int64_t batch, int64_t seq_len, int64_t num_heads, int64_t token_aug = 0) {
+    int64_t v[48];
+    const int n = sol_attn_plan((int)batch, (int)seq_len, (int)num_heads, (int)token_aug, v, 48);
+    if (n > 48)
         throw std::runtime_error("sol_attn_plan: Plan grew past the binding's buffer");
     nb::dict d;
     for (int i = 0; i < n && sol_attn_plan_names[i]; ++i) d[sol_attn_plan_names[i]] = v[i];
@@ -1559,7 +1559,7 @@ void sol_attn(
     std::optional<nb::ndarray<nb::device::cuda>> key_bias = std::nullopt,
     std::optional<nb::ndarray<nb::device::cuda>> threshold = std::nullopt,
     std::optional<nb::ndarray<nb::device::cuda>> block_len = std::nullopt,
-    bool tail = true)
+    bool tail = true, int64_t token_aug = 0)
 {
     cudaStream_t stream = reinterpret_cast<cudaStream_t>(stream_ptr);
     if (threshold && (int64_t)threshold->size() != batch * num_heads * ((seq_len + 63) / 64))
@@ -1575,7 +1575,7 @@ void sol_attn(
     need_staging_layout(k, "sol_attn", "k");
     need_staging_layout(v, "sol_attn", "v");
     need_contiguous(out, "sol_attn", "out");
-    need_workspace(workspace, batch, seq_len, num_heads, "sol_attn");
+    need_workspace(workspace, batch, seq_len, num_heads, token_aug, "sol_attn");
     if (key_bias) need_elems(*key_bias, batch * seq_len, "sol_attn", "key_bias");
     // Explicit strides: only the last dim must be contiguous (BHND views go in as-is).
     launch_sol_attn(
@@ -1588,14 +1588,14 @@ void sol_attn(
         (int)sink_start, (int)sink_end, (int)sink_q_start, (int)sink_q_end,
         q.stride(0), q.stride(1), q.stride(2),
         k.stride(0), k.stride(1), k.stride(2),
-        v.stride(0), v.stride(1), v.stride(2), stream);
+        v.stride(0), v.stride(1), v.stride(2), (int)token_aug, stream);
 }
 
 void sol_producer_begin_py(nb::ndarray<nb::device::cuda> workspace,
                            int64_t batch, int64_t seq_len, int64_t num_heads,
-                           uintptr_t stream_ptr) {
+                           uintptr_t stream_ptr, int64_t token_aug = 0) {
     sol_producer_begin(workspace.data(), (int)batch, (int)seq_len,
-                       (int)num_heads, reinterpret_cast<cudaStream_t>(stream_ptr));
+                       (int)num_heads, (int)token_aug, reinterpret_cast<cudaStream_t>(stream_ptr));
 }
 
 void sol_producer_chunk_py(
@@ -1606,7 +1606,7 @@ void sol_producer_chunk_py(
     float rope_eps, int64_t rot_dim, int64_t t0, int64_t m,
     int64_t batch, int64_t seq_len, int64_t num_heads,
     uintptr_t stream_ptr,
-    std::optional<nb::ndarray<nb::device::cuda>> block_len = std::nullopt) {
+    std::optional<nb::ndarray<nb::device::cuda>> block_len = std::nullopt, int64_t token_aug = 0) {
     if (batch != 1)
         throw std::runtime_error("sol_producer_chunk: the producer path is B=1 only");
     if (rot_dim <= 0 || rot_dim > 128 || rot_dim % 8)
@@ -1614,7 +1614,7 @@ void sol_producer_chunk_py(
     if (t0 < 0 || m < 0 || t0 + m > seq_len || (m && t0 % 64))
         throw std::runtime_error("sol_producer_chunk: chunk [t0, t0 + m) must lie in [0, seq_len] with a 64-aligned start");
     if (block_len) check_block_len(*block_len, seq_len, "sol_producer_chunk");
-    need_workspace(workspace, batch, seq_len, num_heads, "sol_producer_chunk");
+    need_workspace(workspace, batch, seq_len, num_heads, token_aug, "sol_producer_chunk");
     need_elems(qkv, m * 3 * num_heads * 128, "sol_producer_chunk", "qkv");
     need_elems(fab, seq_len * rot_dim * 2, "sol_producer_chunk", "fab");
     need_elems(qw, 128, "sol_producer_chunk", "qw");
@@ -1625,7 +1625,7 @@ void sol_producer_chunk_py(
                        kw.data(), kmean.data(), vscale.data(),
                        block_len ? block_len->data() : nullptr,
                        rope_eps, (int)rot_dim, (int)t0, (int)m,
-                       (int)batch, (int)seq_len, (int)num_heads,
+                       (int)batch, (int)seq_len, (int)num_heads, (int)token_aug,
                        reinterpret_cast<cudaStream_t>(stream_ptr));
 }
 
@@ -1639,7 +1639,7 @@ void sol_attn_core_py(
     uintptr_t stream_ptr,
     std::optional<nb::ndarray<nb::device::cuda>> threshold = std::nullopt,
     std::optional<nb::ndarray<nb::device::cuda>> block_len = std::nullopt,
-    bool tail = true) {
+    bool tail = true, int64_t token_aug = 0) {
     const int64_t stats = batch * num_heads * 128;
     if ((int64_t)vscale.size() != stats || (int64_t)kmean_next.size() != stats ||
         (int64_t)vamax_out.size() != stats)
@@ -1647,7 +1647,7 @@ void sol_attn_core_py(
     if (threshold && (int64_t)threshold->size() != batch * num_heads * ((seq_len + 63) / 64))
         throw std::runtime_error("sol_attn_core: threshold must have B*H*ceil(T/64) elements");
     if (block_len) check_block_len(*block_len, seq_len, "sol_attn_core");
-    need_workspace(workspace, batch, seq_len, num_heads, "sol_attn_core");
+    need_workspace(workspace, batch, seq_len, num_heads, token_aug, "sol_attn_core");
     need_elems(out, batch * seq_len * num_heads * 128, "sol_attn_core", "out");
     launch_sol_attn_core(
         workspace.data(), out.data(), vscale.data(), kmean_next.data(), vamax_out.data(),
@@ -1655,7 +1655,7 @@ void sol_attn_core_py(
         (int)batch, (int)seq_len, (int)num_heads,
         tau, scale, threshold ? threshold->data() : nullptr,
         (int)sink_start, (int)sink_end, (int)sink_q_start, (int)sink_q_end,
-        reinterpret_cast<cudaStream_t>(stream_ptr));
+        (int)token_aug, reinterpret_cast<cudaStream_t>(stream_ptr));
 }
 
 // Nanobind wrapper for fused AdaLN (LayerNorm statistics)
@@ -3903,8 +3903,8 @@ NB_MODULE(_C, m) {
           nb::arg("scale"), nb::arg("dtype_code"), nb::arg("stream_ptr"));
 
     m.def("sol_attn_plan", &sol_attn_plan_py,
-          "Workspace dims, slot byte offsets and total bytes for this shape",
-          nb::arg("batch"), nb::arg("seq_len"), nb::arg("num_heads"));
+          "Workspace dims, slot byte offsets and total bytes for this shape and token budget",
+          nb::arg("batch"), nb::arg("seq_len"), nb::arg("num_heads"), nb::arg("token_aug") = 0);
 
     m.def("sol_attn", &sol_attn,
           "Sol-Attn training-free sparse attention (BF16 or FP16 in/out, head_dim 128)",
@@ -3919,17 +3919,17 @@ NB_MODULE(_C, m) {
           nb::arg("key_bias") = nb::none(),
           nb::arg("threshold") = nb::none(),
           nb::arg("block_len") = nb::none(),
-          nb::arg("tail") = true);
+          nb::arg("tail") = true, nb::arg("token_aug") = 0);
 
     m.def("sol_producer_begin", &sol_producer_begin_py,
           nb::arg("workspace"), nb::arg("batch"), nb::arg("seq_len"),
-          nb::arg("num_heads"), nb::arg("stream_ptr"));
+          nb::arg("num_heads"), nb::arg("stream_ptr"), nb::arg("token_aug") = 0);
     m.def("sol_producer_chunk", &sol_producer_chunk_py,
           nb::arg("workspace"), nb::arg("qkv"), nb::arg("fab"), nb::arg("qw"),
           nb::arg("kw"), nb::arg("kmean"), nb::arg("vscale"),
           nb::arg("rope_eps"), nb::arg("rot_dim"), nb::arg("t0"), nb::arg("m"),
           nb::arg("batch"), nb::arg("seq_len"), nb::arg("num_heads"),
-          nb::arg("stream_ptr"), nb::arg("block_len") = nb::none());
+          nb::arg("stream_ptr"), nb::arg("block_len") = nb::none(), nb::arg("token_aug") = 0);
     m.def("sol_attn_core", &sol_attn_core_py,
           nb::arg("workspace"), nb::arg("out"), nb::arg("vscale"),
           nb::arg("kmean_next"), nb::arg("vamax_out"),
@@ -3939,7 +3939,7 @@ NB_MODULE(_C, m) {
           nb::arg("sink_q_start"), nb::arg("sink_q_end"), nb::arg("stream_ptr"),
           nb::arg("threshold") = nb::none(),
           nb::arg("block_len") = nb::none(),
-          nb::arg("tail") = true);
+          nb::arg("tail") = true, nb::arg("token_aug") = 0);
 
     m.def("flash_attention_decode", &flash_attention_decode,
           "Flash Attention decode over a fixed-capacity variable-length KV cache",

--- a/comfy_kitchen/backends/cuda/sage_attention/sol_attn.cu
+++ b/comfy_kitchen/backends/cuda/sage_attention/sol_attn.cu
@@ -43,23 +43,28 @@ void launch_sol_preprocess(const void*, const void*, const void*, void*, void*, 
 size_t sol_preprocess_scratch_bytes(int, int, int);
 void launch_sol_producer(const void*, const void*, const void*, const void*,
                          const void*, const void*, void*, void*, void*, void*,
-                         void*, void*, void*, void*, void*, void*, void*,
+                         void*, void*, void*, void*, void*, void*, void*, void*,
                          const void*, float, int, int, int, int, int, int, int, int,
                          cudaStream_t);
 void launch_sol_finish(void*, void*, void*, void*, const void*, const void*, void*,
                        const void*, int, int, int, int, int, int, float, float,
                        cudaStream_t);
-void launch_sol_vtranspose(const void*, const void*, void*, int, int, int, int,
+void launch_sol_vtranspose(const void*, const void*, void*, void*, int, int, int, int,
                            int64_t, int64_t, int64_t, int, cudaStream_t);
 void launch_sol_route(const void*, const void*, const void*, const void*, const void*,
-                      const void*, const void*, void*, void*, void*, void*, void*,
-                      const void*, int,
+                      const void*, const void*, void*, void*, void*, void*, void*, void*,
+                      void*, const void*, int,
                       int, int, int, int, int, int, int, int, int, int,
                       float, cudaStream_t);
 void launch_sol_exact(const void*, const void*, const void*, const void*, const void*,
                       const void*, const void*, const void*, const void*, const void*,
-                      const void*, void*, int, int, int, int, int, int, float, int,
-                      cudaStream_t);
+                      const void*, const void*, const void*, const void*, int, void*,
+                      int, int, int, int, int, int, float, int, cudaStream_t);
+void launch_sol_token(const void*, const void*, const void*, void*, void*, void*, void*,
+                      const void*, const void*, const void*, void*, void*,
+                      void*, void*, void*, void*, void*, void*, void*, void*, void*,
+                      int, int, int, int, int, int, int, int, int, int, float, cudaStream_t);
+int sol_token_splits(int, int, int);
 
 namespace {
 
@@ -68,13 +73,15 @@ constexpr int BLK = sol::BLOCK;
 
 inline size_t align16(size_t n) { return (n + 15u) & ~(size_t)15u; }
 
-// Workspace carve-up, a pure function of the shape; exported by sol_attn_plan.
+// Workspace carve-up, a function of the shape and the token budget; exported by sol_attn_plan.
 struct Plan {
     int Tp, NTB, NPAD, NQ;
     size_t qiP, qs, kiP, ksb, vTi, vsc, kciP, kcs, vcT, thr, cen8, cens;
-    size_t idx, cnt, oPart, mPart, lPart, statsV, qmean, scratch, total;
+    size_t idx, cnt, oPart, mPart, lPart, statsV, qmean, vRow, tokIdx, tokCnt, tokRef, tokHist, tokBits;
+    size_t tokTiles, tokTileCnt, gCen8, gCens, gRef, gBits;
+    size_t tokPartO, tokPartM, tokPartL, scratch, total;
 
-    Plan(int B, int T, int H) {
+    Plan(int B, int T, int H, int n_tok) {
         NTB = (T + BLK - 1) / BLK;
         Tp = NTB * BLK;
         NPAD = ((NTB + 63) / 64) * 64;      // route reads pooled keys in 64-block groups
@@ -102,10 +109,36 @@ struct Plan {
         lPart   = take(bh * NQ * sizeof(float));
         statsV  = take(bh * HD * sizeof(float));   // producer vamax accumulator
         qmean   = take(bh * NPAD * HD * sizeof(float));   // f32 query-block means (coarse branch)
+        // token routing (empty at n_tok 0)
+        const size_t on = n_tok > 0 ? 1 : 0;
+        const size_t NG = (NQ + sol::TOK_GROUP - 1) / sol::TOK_GROUP, W = (NTB + 31) / 32;
+        vRow    = take(on * bh * Tp * HD);
+        tokRef  = take(on * bh * NQ * sizeof(float));             // per query block (route)
+        tokBits = take(on * bh * NQ * W * sizeof(uint32_t));
+        gCen8   = take(on * bh * NG * HD);                         // per group
+        gCens   = take(on * bh * NG * sizeof(float));
+        gRef    = take(on * bh * NG * sizeof(float));
+        gBits   = take(on * bh * NG * W * sizeof(uint32_t));
+        tokIdx  = take(on * bh * NG * n_tok * sizeof(uint32_t));
+        tokCnt  = take(on * bh * NG * sizeof(int32_t));
+        tokHist = take(on * bh * NG * sol::TOK_HIST_BINS * sizeof(uint32_t));
+        const size_t groups = (size_t)((NG + BLK - 1) / BLK) * bh;   // CTAs of 64 rows
+        tokTiles = take(on * groups * NTB * sizeof(uint16_t));
+        tokTileCnt = take(on * groups * sizeof(int32_t));
+        const size_t parts = (size_t)sol_token_splits(B, H, (int)NG) * bh * NG;
+        tokPartO = take(on * parts * HD * sizeof(uint16_t));   // bf16 partial o
+        tokPartM = take(on * parts * sizeof(float));
+        tokPartL = take(on * parts * sizeof(float));
         scratch = take(sol_preprocess_scratch_bytes(B, H, NPAD));
         total = o;
     }
 };
+
+void validate_token_aug(int n_tok) {
+    if (n_tok < 0 || n_tok > sol::NTOK_MAX || n_tok % BLK)
+        throw std::runtime_error("sol_attn: token_aug must be a multiple of 64 up to "
+                                 + std::to_string(sol::NTOK_MAX) + ", got " + std::to_string(n_tok));
+}
 
 void validate_shape(int batch, int seq_len, int num_heads) {
     if ((seq_len + BLK - 1) / BLK > 65535)
@@ -122,16 +155,28 @@ void run_route_exact(const Plan& p, char* w, const void* ext_threshold, void* ou
                      const void* blen, int tail,
                      int batch, int seq_len, int num_heads,
                      int sink_start, int sink_end, int sink_q_start, int sink_q_end,
-                     float scale_log2, int elem, cudaStream_t stream)
+                     float scale_log2, int elem, int n_tok, cudaStream_t stream)
 {
     // top-k mode: the caller supplies the per-query-block threshold
     const void* thr = ext_threshold ? ext_threshold : (const void*)(w + p.thr);
+    // with token routing route also flags the unrouted blocks and leaves their tail to the token stage
     launch_sol_route(w + p.cen8, w + p.cens, w + p.kciP, w + p.kcs, w + p.vcT, w + p.vsc,
                      thr, w + p.idx, w + p.cnt, w + p.oPart, w + p.mPart, w + p.lPart,
+                     n_tok ? w + p.tokRef : nullptr, n_tok ? w + p.tokBits : nullptr,
                      blen, tail, batch, seq_len, num_heads, p.NTB, p.NPAD, p.NQ,
                      sink_start, sink_end, sink_q_start, sink_q_end, scale_log2, stream);
+    if (n_tok)
+        launch_sol_token(w + p.qmean, w + p.tokRef, w + p.tokBits,
+                         w + p.gCen8, w + p.gCens, w + p.gRef, w + p.gBits,
+                         w + p.kiP, w + p.ksb, w + p.vTi, w + p.tokTiles, w + p.tokTileCnt,
+                         w + p.tokHist, w + p.tokIdx, w + p.tokCnt,
+                         w + p.tokPartO, w + p.tokPartM, w + p.tokPartL,
+                         w + p.oPart, w + p.mPart, w + p.lPart,
+                         batch, p.Tp, num_heads, p.NQ, p.NPAD, p.NTB, n_tok, tail,
+                         sink_q_start, sink_q_end, scale_log2, stream);
     launch_sol_exact(w + p.qiP, w + p.qs, w + p.kiP, w + p.ksb, w + p.vTi, w + p.vsc,
-                     w + p.idx, w + p.cnt, w + p.oPart, w + p.mPart, w + p.lPart, out,
+                     w + p.idx, w + p.cnt, w + p.oPart, w + p.mPart, w + p.lPart,
+                     w + p.vRow, w + p.tokIdx, w + p.tokCnt, n_tok, out,
                      batch, seq_len, p.Tp, num_heads, p.NQ, p.NTB,
                      scale_log2, elem, stream);
     const cudaError_t err = cudaGetLastError();
@@ -146,18 +191,26 @@ void run_route_exact(const Plan& p, char* w, const void* ext_threshold, void* ou
 extern "C" const char* const sol_attn_plan_names[] = {
     "Tp", "NTB", "NPAD", "NQ",
     "qiP", "qs", "kiP", "ksb", "vTi", "vsc", "kciP", "kcs", "vcT", "thr", "cen8", "cens",
-    "idx", "cnt", "oPart", "mPart", "lPart", "statsV", "qmean", "scratch", "total", nullptr,
+    "idx", "cnt", "oPart", "mPart", "lPart", "statsV", "qmean",
+    "vRow", "tokIdx", "tokCnt", "tokRef", "tokHist", "tokBits", "tokTiles", "tokTileCnt",
+    "gCen8", "gCens", "gRef", "gBits", "tokPartO", "tokPartM", "tokPartL",
+    "scratch", "total", nullptr,
 };
 // Writes the values into out[0..count) and returns count; writes nothing if
 // cap < count, so a caller with a fixed buffer can detect a grown Plan.
-extern "C" int sol_attn_plan(int batch, int seq_len, int num_heads, int64_t* out, int cap) {
-    const Plan p(batch, seq_len, num_heads);
+extern "C" int sol_attn_plan(int batch, int seq_len, int num_heads, int n_tok, int64_t* out, int cap) {
+    validate_token_aug(n_tok);
+    const Plan p(batch, seq_len, num_heads, n_tok);
     const int64_t v[] = {
         p.Tp, p.NTB, p.NPAD, p.NQ,
         (int64_t)p.qiP, (int64_t)p.qs, (int64_t)p.kiP, (int64_t)p.ksb, (int64_t)p.vTi,
         (int64_t)p.vsc, (int64_t)p.kciP, (int64_t)p.kcs, (int64_t)p.vcT, (int64_t)p.thr,
         (int64_t)p.cen8, (int64_t)p.cens, (int64_t)p.idx, (int64_t)p.cnt, (int64_t)p.oPart,
         (int64_t)p.mPart, (int64_t)p.lPart, (int64_t)p.statsV, (int64_t)p.qmean,
+        (int64_t)p.vRow, (int64_t)p.tokIdx, (int64_t)p.tokCnt, (int64_t)p.tokRef, (int64_t)p.tokHist,
+        (int64_t)p.tokBits, (int64_t)p.tokTiles, (int64_t)p.tokTileCnt,
+        (int64_t)p.gCen8, (int64_t)p.gCens, (int64_t)p.gRef, (int64_t)p.gBits,
+        (int64_t)p.tokPartO, (int64_t)p.tokPartM, (int64_t)p.tokPartL,
         (int64_t)p.scratch, (int64_t)p.total,
     };
     const int count = (int)(sizeof(v) / sizeof(v[0]));
@@ -168,9 +221,10 @@ extern "C" int sol_attn_plan(int batch, int seq_len, int num_heads, int64_t* out
 
 // ---- chunked producer path ----
 extern "C" void sol_producer_begin(void* workspace, int batch, int seq_len,
-                                   int num_heads, cudaStream_t stream) {
+                                   int num_heads, int n_tok, cudaStream_t stream) {
     validate_shape(batch, seq_len, num_heads);
-    const Plan p(batch, seq_len, num_heads);
+    validate_token_aug(n_tok);
+    const Plan p(batch, seq_len, num_heads, n_tok);
     char* w = reinterpret_cast<char*>(workspace);
     const size_t bh = (size_t)batch * num_heads;
     // route reads vcT's pad columns; statsV is an atomicMax accumulator
@@ -182,13 +236,14 @@ extern "C" void sol_producer_chunk(
     void* workspace, const void* qkv, const void* fab,
     const void* qw, const void* kw, const void* kmean, const void* vscale,
     const void* blen, float rope_eps, int rot_dim, int t0, int M,
-    int batch, int seq_len, int num_heads, cudaStream_t stream)
+    int batch, int seq_len, int num_heads, int n_tok, cudaStream_t stream)
 {
-    const Plan p(batch, seq_len, num_heads);
+    validate_token_aug(n_tok);
+    const Plan p(batch, seq_len, num_heads, n_tok);
     char* w = reinterpret_cast<char*>(workspace);
     launch_sol_producer(qkv, fab, qw, kw, kmean, vscale,
                         w + p.qiP, w + p.qs, w + p.kiP, w + p.ksb,
-                        w + p.vTi, w + p.vcT, w + p.scratch,
+                        w + p.vTi, n_tok ? w + p.vRow : nullptr, w + p.vcT, w + p.scratch,
                         w + p.cen8, w + p.cens, w + p.qmean, w + p.statsV,
                         blen, rope_eps, rot_dim, t0, M, seq_len, p.Tp, num_heads,
                         p.NPAD, p.NQ, stream);
@@ -202,10 +257,11 @@ extern "C" void launch_sol_attn_core(
     int batch, int seq_len, int num_heads,
     float tau, float scale, const void* ext_threshold,
     int sink_start, int sink_end, int sink_q_start, int sink_q_end,
-    cudaStream_t stream)
+    int n_tok, cudaStream_t stream)
 {
     validate_shape(batch, seq_len, num_heads);
-    const Plan p(batch, seq_len, num_heads);
+    validate_token_aug(n_tok);
+    const Plan p(batch, seq_len, num_heads, n_tok);
     char* w = reinterpret_cast<char*>(workspace);
     const float scale_log2 = scale * 1.4426950408889634f;
     const size_t stats_bytes = (size_t)batch * num_heads * HD * sizeof(float);
@@ -216,7 +272,7 @@ extern "C" void launch_sol_attn_core(
                       tau, scale_log2, stream);
     run_route_exact(p, w, ext_threshold, out, blen, tail, batch, seq_len, num_heads,
                     sink_start, sink_end, sink_q_start, sink_q_end, scale_log2,
-                    sol::SOL_BF16, stream);
+                    sol::SOL_BF16, n_tok, stream);
     cudaMemcpyAsync(vamax_out, w + p.statsV, stats_bytes, cudaMemcpyDeviceToDevice, stream);
 }
 
@@ -229,13 +285,14 @@ extern "C" void launch_sol_attn(
     int64_t qs_b, int64_t qs_t, int64_t qs_h,
     int64_t ks_b, int64_t ks_t, int64_t ks_h,
     int64_t vs_b, int64_t vs_t, int64_t vs_h,
-    cudaStream_t stream)
+    int n_tok, cudaStream_t stream)
 {
     if (head_dim != HD)
         throw std::runtime_error("sol_attn supports head_dim 128, got " + std::to_string(head_dim));
     validate_shape(batch, seq_len, num_heads);
+    validate_token_aug(n_tok);
 
-    const Plan p(batch, seq_len, num_heads);
+    const Plan p(batch, seq_len, num_heads, n_tok);
     char* w = reinterpret_cast<char*>(workspace);
     const float scale_log2 = scale * 1.4426950408889634f;
     launch_sol_preprocess(q, k, v, w + p.qiP, w + p.qs, w + p.kiP, w + p.ksb,
@@ -245,8 +302,8 @@ extern "C" void launch_sol_attn(
                           batch, seq_len, p.Tp, num_heads, p.NTB, p.NPAD, p.NQ,
                           qs_b, qs_t, qs_h, ks_b, ks_t, ks_h, vs_b, vs_t, vs_h,
                           tau, scale_log2, elem, stream);
-    launch_sol_vtranspose(v, w + p.vsc, w + p.vTi, batch, seq_len, p.Tp, num_heads,
+    launch_sol_vtranspose(v, w + p.vsc, w + p.vTi, n_tok ? w + p.vRow : nullptr, batch, seq_len, p.Tp, num_heads,
                           vs_b, vs_t, vs_h, elem, stream);
     run_route_exact(p, w, ext_threshold, out, blen, tail, batch, seq_len, num_heads,
-                    sink_start, sink_end, sink_q_start, sink_q_end, scale_log2, elem, stream);
+                    sink_start, sink_end, sink_q_start, sink_q_end, scale_log2, elem, n_tok, stream);
 }

--- a/comfy_kitchen/backends/cuda/sage_attention/sol_attn_exact.cu
+++ b/comfy_kitchen/backends/cuda/sage_attention/sol_attn_exact.cu
@@ -38,12 +38,8 @@ using namespace sol;
 
 constexpr int HD = HEAD_DIM, BQ = BLOCK, BK = BLOCK;
 constexpr int NWARP = BQ / 16, NTHREADS = NWARP * 32;
-constexpr int KC  = HD / 32;   // int8 k-chunks for S = Q.K^T
-constexpr int NKT = BK / 8;    // score n8 tiles
-constexpr int NT  = HD / 8;    // output n8 tiles
-constexpr int PKC = BK / 32;   // int8 k-chunks for O += P.V
-constexpr int LDK = HD;        // 128 B, XOR-swizzled
-constexpr int LDV = BK;        // 64 B, XOR-swizzled
+constexpr int KC = TILE_KC, NKT = TILE_NKT, NT = TILE_NT;   // tile shapes: sol_layout.cuh
+constexpr int LDK = TILE_LDK, LDV = TILE_LDV;               // 128 B / 64 B rows, XOR-swizzled
 constexpr int NSTAGE = 2;      // pipeline depth; occupancy beats depth here
 
 // qi:  [B,T,H,D] int8
@@ -65,6 +61,8 @@ __global__ void SOL_EXACT_BOUNDS sol_exact_kernel(
     const uint16_t* __restrict__ blk_idx, const int32_t* __restrict__ blk_cnt,
     const __nv_bfloat16* __restrict__ o_part, const float* __restrict__ m_part,
     const float* __restrict__ l_part,
+    const int8_t* __restrict__ vRow,          // [B*H,Tp,D] int8, row-major (token tiles)
+    const uint32_t* __restrict__ tok_idx, const int32_t* __restrict__ tok_cnt, int n_tok,
     TOut* __restrict__ out,
     int T, int Tp, int H, int NTB, float scale_log2)
 {
@@ -151,6 +149,16 @@ __global__ void SOL_EXACT_BOUNDS sol_exact_kernel(
         cp_commit();
     }
 
+    auto compute_tile = [&](int cur, const float2* kb_src) {
+        int32_t s_acc[NKT][4];
+        tile_qk(SK(cur), qa, g, qd, s_acc);
+        float p_val[NKT][4];
+        float bmax[2] = {m_r[0] - 20.f, m_r[1] - 20.f};   // floor: 2^-20 under the running max
+        bool has[2] = {true, true};                         // routed blocks always hold live keys
+        tile_scores<true>(s_acc, kb_src, qsc, qd, p_val, bmax);
+        tile_softmax_pv<false>(p_val, bmax, has, SVT(cur), g, qd, m_r, l_r, c_r, o_acc);
+    };
+
     for (int kb = 0; kb < n_blocks; ++kb) {
         const int cur = kb % NSTAGE;
         const int64_t cur_k0 = (int64_t)my_idx[kb] * BK;
@@ -162,114 +170,63 @@ __global__ void SOL_EXACT_BOUNDS sol_exact_kernel(
         cp_wait<NSTAGE - 1>();
         __syncthreads();
 
-        int32_t s_acc[NKT][4];
-        #pragma unroll
-        for (int nt = 0; nt < NKT; ++nt) {
-            s_acc[nt][0] = 0; s_acc[nt][1] = 0; s_acc[nt][2] = 0; s_acc[nt][3] = 0;
-            const int R = nt * 8 + g;
-            const int8_t* krow = SK(cur) + R * LDK + ((qd & 1) << 3);
-            const int swk = swz_k(R), qhi = qd >> 1;
-            #pragma unroll
-            for (int kc = 0; kc < KC; ++kc) {
-                const uint2 kb = *reinterpret_cast<const uint2*>(
-                    krow + (((kc * 2 + qhi) ^ swk) << 4));
-                uint32_t kbf[2] = {kb.x, kb.y};
-                mma_s8(s_acc[nt], qa[kc], kbf);
-            }
-        }
-
-        float p_val[NKT][4];
-        // P is quantized against the block max (floored 2^-20 under the running
-        // max) so every block gets the full u8 range
-        float bmax[2] = {m_r[0] - 20.f, m_r[1] - 20.f};
-        #pragma unroll
-        for (int nt = 0; nt < NKT; ++nt) {
-            const int c0 = nt * 8 + qd * 2;
-            // (ks, bias) x 2 columns = one aligned float4 (c0 is even)
-            const float4 kb4 = *reinterpret_cast<const float4*>(ksb + kp_base + cur_k0 + c0);
-            const float k0s = kb4.x, m0 = kb4.y, k1s = kb4.z, m1 = kb4.w;
-            #pragma unroll
-            for (int e = 0; e < 4; ++e) {
-                const int row = e >> 1;
-                const float s = (e & 1) ? fmaf((float)s_acc[nt][e], qsc[row] * k1s, m1)
-                                        : fmaf((float)s_acc[nt][e], qsc[row] * k0s, m0);
-                p_val[nt][e] = s;
-                bmax[row] = fmaxf(bmax[row], s);
-            }
-        }
-        #pragma unroll
-        for (int off = 1; off <= 2; off <<= 1) {
-            bmax[0] = fmaxf(bmax[0], __shfl_xor_sync(0xffffffffu, bmax[0], off));
-            bmax[1] = fmaxf(bmax[1], __shfl_xor_sync(0xffffffffu, bmax[1], off));
-        }
-        const float alpha0 = exp2f(c_r[0] - bmax[0]);
-        const float alpha1 = exp2f(c_r[1] - bmax[1]);
-        c_r[0] = bmax[0]; c_r[1] = bmax[1];
-        m_r[0] = fmaxf(m_r[0], bmax[0]);
-        m_r[1] = fmaxf(m_r[1], bmax[1]);
-
-        // u8 P scale folded into the exponent (+log2 255); l carries it too
-        const float m_off[2] = {bmax[0] - 7.99435344f, bmax[1] - 7.99435344f};
-        #pragma unroll
-        for (int nt = 0; nt < NKT; ++nt) {
-            #pragma unroll
-            for (int e = 0; e < 4; ++e)
-                p_val[nt][e] = exp2f(p_val[nt][e] - m_off[e >> 1]);
-        }
-
-        // free repack (see header): n-tiles (4kk, 4kk+1) -> keys 32kk+4q..+3
-        uint32_t pa[PKC][4];
-        #pragma unroll
-        for (int kk = 0; kk < PKC; ++kk) {
-            const int b0 = 4 * kk, b1 = b0 + 1, b2 = b0 + 2, b3 = b0 + 3;
-            pa[kk][0] = mma::pack_u8x4(
-                p_val[b0][0], p_val[b0][1], p_val[b1][0], p_val[b1][1]);
-            pa[kk][1] = mma::pack_u8x4(
-                p_val[b0][2], p_val[b0][3], p_val[b1][2], p_val[b1][3]);
-            pa[kk][2] = mma::pack_u8x4(
-                p_val[b2][0], p_val[b2][1], p_val[b3][0], p_val[b3][1]);
-            pa[kk][3] = mma::pack_u8x4(
-                p_val[b2][2], p_val[b2][3], p_val[b3][2], p_val[b3][3]);
-        }
-
-        // l sums the PACKED bytes so num and den quantize identically
-        uint32_t li[2] = {0, 0};
-        #pragma unroll
-        for (int kk = 0; kk < PKC; ++kk) {
-            li[0] = __dp4a(pa[kk][0], 0x01010101u, li[0]);
-            li[0] = __dp4a(pa[kk][2], 0x01010101u, li[0]);
-            li[1] = __dp4a(pa[kk][1], 0x01010101u, li[1]);
-            li[1] = __dp4a(pa[kk][3], 0x01010101u, li[1]);
-        }
-        #pragma unroll
-        for (int off = 1; off <= 2; off <<= 1) {
-            li[0] += __shfl_xor_sync(0xffffffffu, li[0], off);
-            li[1] += __shfl_xor_sync(0xffffffffu, li[1], off);
-        }
-        l_r[0] = l_r[0] * alpha0 + (float)li[0];
-        l_r[1] = l_r[1] * alpha1 + (float)li[1];
-
-        #pragma unroll
-        for (int nt = 0; nt < NT; ++nt) {
-            int32_t d[4] = {0, 0, 0, 0};
-            const int C = nt * 8 + g;
-            const int8_t* vcol = SVT(cur) + C * LDV + ((qd & 1) << 3);
-            const int swv = swz_v(C), qhi2 = qd >> 1;
-            #pragma unroll
-            for (int kk = 0; kk < PKC; ++kk) {
-                const uint2 vb = *reinterpret_cast<const uint2*>(
-                    vcol + (((kk * 2 + qhi2) ^ swv) << 4));
-                uint32_t vbf[2] = {vb.x, vb.y};
-                mma_u8s8(d, pa[kk], vbf);
-            }
-            o_acc[nt][0] = fmaf(o_acc[nt][0], alpha0, (float)d[0]);
-            o_acc[nt][1] = fmaf(o_acc[nt][1], alpha0, (float)d[1]);
-            o_acc[nt][2] = fmaf(o_acc[nt][2], alpha1, (float)d[2]);
-            o_acc[nt][3] = fmaf(o_acc[nt][3], alpha1, (float)d[3]);
-        }
+        compute_tile(cur, ksb + kp_base + cur_k0);
         __syncthreads();   // next iteration refills `cur`
     }
 #undef SOLX_STAGE
+
+    // token tiles: the listed tokens gathered into the block layout
+    if (n_tok > 0) {
+        cp_wait<0>();
+        __syncthreads();
+        // (scale, bias) go in the idle stage-1 V buffer: more static smem would cost a CTA/SM
+        float2* sKsb = reinterpret_cast<float2*>(SVT(1));
+        const int NG = (gridDim.x + TOK_GROUP - 1) / TOK_GROUP;   // one list per group
+        const int64_t qs_tok = (int64_t)bh * NG + q_block / TOK_GROUP;
+        const int n_sel = min(tok_cnt[qs_tok], n_tok);
+        const uint32_t* my_tok = tok_idx + qs_tok * n_tok;
+        constexpr int VEC = HD / 16;
+        for (int ti = 0; ti < (n_sel + BK - 1) / BK; ++ti) {
+            const int nvalid = min(BK, n_sel - ti * BK);
+            for (int idx = tid; idx < BK * VEC; idx += NTHREADS) {
+                const int p = idx / VEC, c16 = idx % VEC, jj = perm_key(p);
+                int8_t* dst = SK(0) + p * LDK + ((c16 ^ swz_k(p)) << 4);
+                if (jj < nvalid) {
+                    const uint32_t t = my_tok[ti * BK + jj];
+                    cp_async16(dst, kiP + kd_base + ((int64_t)(t >> 6) * BK + perm_key_inv(t & 63)) * HD + c16 * 16);
+                } else {
+                    *reinterpret_cast<uint4*>(dst) = make_uint4(0u, 0u, 0u, 0u);
+                }
+            }
+            if (tid < BK) {
+                const int jj = perm_key(tid);
+                float2 kb = make_float2(0.f, NEG);
+                if (jj < nvalid) {
+                    const uint32_t t = my_tok[ti * BK + jj];
+                    kb = ksb[kp_base + (int64_t)(t >> 6) * BK + perm_key_inv(t & 63)];
+                }
+                sKsb[tid] = kb;
+            }
+            for (int idx = tid; idx < BK * VEC; idx += NTHREADS) {
+                const int j = idx / VEC, c16 = idx % VEC, kp = perm_d(j);
+                uint4 raw = make_uint4(0u, 0u, 0u, 0u);
+                if (j < nvalid)
+                    raw = *reinterpret_cast<const uint4*>(
+                        vRow + ((int64_t)bh * Tp + my_tok[ti * BK + j]) * HD + c16 * 16);
+                const uint8_t* b = reinterpret_cast<const uint8_t*>(&raw);
+                #pragma unroll
+                for (int i = 0; i < 16; ++i) {
+                    const int c = c16 * 16 + i;
+                    SVT(0)[c * LDV + (((kp >> 4) ^ swz_v(c)) << 4) + (kp & 15)] = (int8_t)b[i];
+                }
+            }
+            cp_commit();
+            cp_wait<0>();
+            __syncthreads();
+            compute_tile(0, sKsb);
+            __syncthreads();
+        }
+    }
 
     // l is zero only when a row got no mass from either branch; zeros are right there
     const float inv0 = 1.f / fmaxf(l_r[0], 1e-30f);
@@ -296,7 +253,8 @@ void launch_sol_exact(
     const void* qi, const void* qs, const void* kiP, const void* ksb,
     const void* vTi, const void* vsc,
     const void* blk_idx, const void* blk_cnt,
-    const void* o_part, const void* m_part, const void* l_part, void* out,
+    const void* o_part, const void* m_part, const void* l_part,
+    const void* vRow, const void* tok_idx, const void* tok_cnt, int n_tok, void* out,
     int B, int T, int Tp, int H, int NQ, int NTB,
     float scale_log2, int elem, cudaStream_t stream)
 {
@@ -307,6 +265,7 @@ void launch_sol_exact(
         (const int8_t*)vTi, (const float*)vsc,                                         \
         (const uint16_t*)blk_idx, (const int32_t*)blk_cnt,                             \
         (const __nv_bfloat16*)o_part, (const float*)m_part, (const float*)l_part,     \
+        (const int8_t*)vRow, (const uint32_t*)tok_idx, (const int32_t*)tok_cnt, n_tok, \
         (TOut*)out, T, Tp, H, NTB, scale_log2)
     if (elem == sol::SOL_FP16) SOLX_LAUNCH(__half);
     else SOLX_LAUNCH(__nv_bfloat16);

--- a/comfy_kitchen/backends/cuda/sage_attention/sol_attn_producer.cu
+++ b/comfy_kitchen/backends/cuda/sage_attention/sol_attn_producer.cu
@@ -45,7 +45,7 @@ __global__ void sol_producer_kernel(
     const float* __restrict__ vscale,        // [H, HD] stale V scale (may be ~0 -> margin)
     int8_t* __restrict__ qiP, float* __restrict__ qs,
     int8_t* __restrict__ kiP, float2* __restrict__ ksb,
-    int8_t* __restrict__ vTi, __nv_bfloat16* __restrict__ vcT,
+    int8_t* __restrict__ vTi, int8_t* __restrict__ vRow, __nv_bfloat16* __restrict__ vcT,
     float* __restrict__ ksumP,               // [H, NPAD, HD] block K sums (post-rope)
     int8_t* __restrict__ cen8, float* __restrict__ cens,
     float* __restrict__ qmean,               // [H, NPAD, HD] f32 block means (post-rope)
@@ -107,6 +107,7 @@ __global__ void sol_producer_kernel(
             const float x = (t < len) ? __bfloat162float(sT[t * LD_TILE + d]) : 0.f;
             sv += x; av = fmaxf(av, fabsf(x));
             col[perm_d(t)] = q8(x, inv);
+            if (vRow) vRow[((size_t)h * Tp + nblk * BLK + t) * HD + d] = col[perm_d(t)];   // row-major copy (token routing)
         }
         const size_t vbase = ((size_t)h * HD + d) * Tp + nblk * BLK;
         #pragma unroll
@@ -123,7 +124,7 @@ __global__ void sol_producer_kernel(
 void launch_sol_producer(
     const void* qkv, const void* fab, const void* qw, const void* kw,
     const void* kmean, const void* vscale,
-    void* qiP, void* qs, void* kiP, void* ksb, void* vTi, void* vcT,
+    void* qiP, void* qs, void* kiP, void* ksb, void* vTi, void* vRow, void* vcT,
     void* ksumP, void* cen8, void* cens, void* qmean, void* vamax_next,
     const void* blen, float rope_eps, int rot,
     int t0, int M, int T, int Tp, int H, int NPAD, int NQ,
@@ -135,7 +136,7 @@ void launch_sol_producer(
         (const __nv_bfloat16*)qw, (const __nv_bfloat16*)kw,
         (const float*)kmean, (const float*)vscale,
         (int8_t*)qiP, (float*)qs, (int8_t*)kiP, (float2*)ksb,
-        (int8_t*)vTi, (__nv_bfloat16*)vcT, (float*)ksumP,
+        (int8_t*)vTi, (int8_t*)vRow, (__nv_bfloat16*)vcT, (float*)ksumP,
         (int8_t*)cen8, (float*)cens, (float*)qmean, (float*)vamax_next,
         (const int32_t*)blen, rope_eps, rot, t0, M, T, Tp, H, NPAD, NQ);
 }

--- a/comfy_kitchen/backends/cuda/sage_attention/sol_attn_route.cu
+++ b/comfy_kitchen/backends/cuda/sage_attention/sol_attn_route.cu
@@ -45,6 +45,8 @@ __global__ void __launch_bounds__(NTHREADS) sol_route_kernel(
     uint16_t* __restrict__ blk_idx, int32_t* __restrict__ blk_cnt,
     __nv_bfloat16* __restrict__ o_part, float* __restrict__ m_part,
     float* __restrict__ l_part,
+    float* __restrict__ tok_ref,       // token routing: best unrouted pooled score per query block, or null
+    uint32_t* __restrict__ cand_bits,  // token routing: [B*H, NQ, ceil(NTB/32)] unrouted-block bitmap, or null
     const int32_t* __restrict__ blen, int tail,
     int T, int NTB, int NPAD, int NQ,
     int sink_s, int sink_e, int sink_qs, int sink_qe, float scale_log2) {
@@ -100,8 +102,11 @@ __global__ void __launch_bounds__(NTHREADS) sol_route_kernel(
         o_acc[nt][2] = 0.f; o_acc[nt][3] = 0.f;
     }
     float m_r[2] = {NEG, NEG}, l_r[2] = {0.f, 0.f};
+    float refm[2] = {NEG, NEG};
+    const int W = (NTB + 31) >> 5;
 
     for (int gs = 0; gs < NTB; gs += BN) {
+        uint32_t cbits[2][2] = {{0u, 0u}, {0u, 0u}};   // this thread's candidate flags in the 64-block group
         __syncthreads();
         for (int idx = tid; idx < BN * (HD / 16); idx += NTHREADS) {
             const int p = idx / (HD / 16), c16 = idx % (HD / 16);
@@ -173,13 +178,40 @@ __global__ void __launch_bounds__(NTHREADS) sol_route_kernel(
                     if (cand[1]) row[slot1] = (uint16_t)(gs + c0 + 1);
                 }
                 cnt[rr] += total;
+                if (valid[0] && !pre[0] && !cand[0]) refm[rr] = fmaxf(refm[rr], score[0]);
+                if (valid[1] && !pre[1] && !cand[1]) refm[rr] = fmaxf(refm[rr], score[1]);
+                // token routing: unrouted blocks go to the token passes instead of the pooled tail
+                bool ctok[2] = {false, false};
+                if (cand_bits) {
+                    #pragma unroll
+                    for (int cc = 0; cc < 2; ++cc) {
+                        ctok[cc] = valid[cc] && !pre[cc] && !cand[cc];
+                        const int bit = c0 + cc;   // 0..63 within the group
+                        if (ctok[cc]) cbits[rr][bit >> 5] |= 1u << (bit & 31);
+                    }
+                }
                 // exact-routed and sink blocks leave the tail (this form costs 3 fewer regs);
                 // tail == 0 hands the exact kernel an empty state (softmax over routed only)
-                pv[nt][rr * 2] = tail && valid[0] && !(pre[0] || cand[0]) ? score[0] : NEG;
-                pv[nt][rr * 2 + 1] = tail && valid[1] && !(pre[1] || cand[1]) ? score[1] : NEG;
+                pv[nt][rr * 2] = tail && valid[0] && !(pre[0] || cand[0] || ctok[0]) ? score[0] : NEG;
+                pv[nt][rr * 2 + 1] = tail && valid[1] && !(pre[1] || cand[1] || ctok[1]) ? score[1] : NEG;
             }
         }
 
+        if (cand_bits) {
+            // the four lanes of a row hold disjoint bits: OR them and let one lane store
+            #pragma unroll
+            for (int rr = 0; rr < 2; ++rr) {
+                #pragma unroll
+                for (int wd = 0; wd < 2; ++wd) {
+                    uint32_t b = cbits[rr][wd];
+                    b |= __shfl_xor_sync(0xffffffffu, b, 1);
+                    b |= __shfl_xor_sync(0xffffffffu, b, 2);
+                    const int word = (gs >> 5) + wd;
+                    if (qd == 0 && live[rr] && word < W)
+                        cand_bits[((size_t)bh * NQ + qr[rr]) * W + word] = b;
+                }
+            }
+        }
         float m_new[2] = {m_r[0], m_r[1]};
         #pragma unroll
         for (int nt = 0; nt < NKT; ++nt) {
@@ -241,11 +273,17 @@ __global__ void __launch_bounds__(NTHREADS) sol_route_kernel(
     }
 
     #pragma unroll
+    for (int off = 1; off <= 2; off <<= 1) {
+        refm[0] = fmaxf(refm[0], __shfl_xor_sync(0xffffffffu, refm[0], off));
+        refm[1] = fmaxf(refm[1], __shfl_xor_sync(0xffffffffu, refm[1], off));
+    }
+    #pragma unroll
     for (int rr = 0; rr < 2; ++rr) {
         if (!live[rr]) continue;
         const size_t qs = (size_t)bh * NQ + qr[rr];
         if (qd == 0) {
             blk_cnt[qs] = cnt[rr];
+            if (tok_ref) tok_ref[qs] = refm[rr];
             m_part[qs] = m_r[rr];
             l_part[qs] = l_r[rr] * 255.0f;
         }
@@ -266,7 +304,7 @@ __global__ void __launch_bounds__(NTHREADS) sol_route_kernel(
 void launch_sol_route(
     const void* cen8, const void* cens, const void* kciP, const void* kcs,
     const void* vcT, const void* vsc, const void* threshold,
-    void* blk_idx, void* blk_cnt, void* o_part, void* m_part, void* l_part,
+    void* blk_idx, void* blk_cnt, void* o_part, void* m_part, void* l_part, void* tok_ref, void* cand_bits,
     // NQ (query blocks) and NTB (key blocks) coincide today; kept separate so
     // a query prefix (LTX-2 guide attention) needs no kernel change
     const void* blen, int tail,
@@ -280,7 +318,7 @@ void launch_sol_route(
         (const float*)kcs, (const __nv_bfloat16*)vcT, (const float*)vsc,
         (const float*)threshold,
         (uint16_t*)blk_idx, (int32_t*)blk_cnt, (__nv_bfloat16*)o_part,
-        (float*)m_part, (float*)l_part, (const int32_t*)blen, tail,
+        (float*)m_part, (float*)l_part, (float*)tok_ref, (uint32_t*)cand_bits, (const int32_t*)blen, tail,
         T, NTB, NPAD, NQ, sink_s, sink_e, sink_qs, sink_qe,
         scale_log2);
 }

--- a/comfy_kitchen/backends/cuda/sage_attention/sol_attn_route.cu
+++ b/comfy_kitchen/backends/cuda/sage_attention/sol_attn_route.cu
@@ -178,16 +178,20 @@ __global__ void __launch_bounds__(NTHREADS) sol_route_kernel(
                     if (cand[1]) row[slot1] = (uint16_t)(gs + c0 + 1);
                 }
                 cnt[rr] += total;
-                if (valid[0] && !pre[0] && !cand[0]) refm[rr] = fmaxf(refm[rr], score[0]);
-                if (valid[1] && !pre[1] && !cand[1]) refm[rr] = fmaxf(refm[rr], score[1]);
-                // token routing: unrouted blocks go to the token passes instead of the pooled tail
+                // token routing: a block unrouted by this row AND by its TOK_GROUP partner
+                // (row q ^ 1, four lanes over) goes to the token passes instead of the
+                // pooled tail; a block the partner routed stays pooled here
                 bool ctok[2] = {false, false};
                 if (cand_bits) {
+                    const uint32_t unr = (valid[0] && !pre[0] && !cand[0] ? 1u : 0u)
+                                       | (valid[1] && !pre[1] && !cand[1] ? 2u : 0u);
+                    const uint32_t peer = __shfl_xor_sync(0xffffffffu, unr | (live[rr] ? 4u : 0u), 4);
+                    const uint32_t both = unr & ((peer & 4u) ? peer : 3u);   // no live partner: own bits
                     #pragma unroll
                     for (int cc = 0; cc < 2; ++cc) {
-                        ctok[cc] = valid[cc] && !pre[cc] && !cand[cc];
+                        ctok[cc] = (both >> cc) & 1u;
                         const int bit = c0 + cc;   // 0..63 within the group
-                        if (ctok[cc]) cbits[rr][bit >> 5] |= 1u << (bit & 31);
+                        if (ctok[cc]) { cbits[rr][bit >> 5] |= 1u << (bit & 31); refm[rr] = fmaxf(refm[rr], score[cc]); }
                     }
                 }
                 // exact-routed and sink blocks leave the tail (this form costs 3 fewer regs);

--- a/comfy_kitchen/backends/cuda/sage_attention/sol_attn_token.cu
+++ b/comfy_kitchen/backends/cuda/sage_attention/sol_attn_token.cu
@@ -54,7 +54,7 @@ __device__ __forceinline__ int hist_bin(float rel) {
 __device__ __forceinline__ float hist_edge(int b) {
     return b <= NB_FINE ? (float)b * HW : (float)NB_FINE * HW + (float)(b - NB_FINE) * HW_COARSE;
 }
-constexpr int P1_MAX_TILES = 1024;            // per pass-1 split, so a 16-bit bin cannot overflow
+constexpr int P1_MAX_TILES = 1023;            // per pass-1 split: 1023 x 64 counts stay below a 16-bit bin
 constexpr float MASKED = TILE_MASKED;         // scores at or below this are masked
 constexpr int HIST_STRIDE = 1;                // pass 1 walks every tile; exact counts keep the cap from binding
 
@@ -377,24 +377,23 @@ __global__ void SOL_TOKEN_BOUNDS sol_token_kernel(
 #endif  // SOL_SM80
 }
 
-// sort each list (n_tok is a power of two <= 256) so the exact kernel's order is deterministic
+// sort each list so the exact kernel's order is deterministic: a 256-lane bitonic
+// network padded with a max sentinel (n_tok need not be a power of two)
 __global__ void sol_token_sort_kernel(uint32_t* __restrict__ tok_idx, const int32_t* __restrict__ tok_cnt,
                                       int NQ, int n_tok) {
-    __shared__ uint32_t s[256];
+    __shared__ uint32_t s[NTOK_MAX];
     const size_t qs = (size_t)blockIdx.y * NQ + blockIdx.x;
     const int n = min(tok_cnt[qs], n_tok), t = threadIdx.x;
     uint32_t* row = tok_idx + qs * n_tok;
-    if (t < n_tok) s[t] = t < n ? row[t] : 0xffffffffu;
+    s[t] = t < n ? row[t] : 0xffffffffu;
     __syncthreads();
-    for (int k = 2; k <= n_tok; k <<= 1) {
+    for (int k = 2; k <= NTOK_MAX; k <<= 1) {
         for (int j = k >> 1; j > 0; j >>= 1) {
-            if (t < n_tok) {
-                const int p = t ^ j;
-                if (p > t) {
-                    const bool up = (t & k) == 0;
-                    const uint32_t a = s[t], b = s[p];
-                    if ((a > b) == up) { s[t] = b; s[p] = a; }
-                }
+            const int p = t ^ j;
+            if (p > t) {
+                const bool up = (t & k) == 0;
+                const uint32_t a = s[t], b = s[p];
+                if ((a > b) == up) { s[t] = b; s[p] = a; }
             }
             __syncthreads();
         }
@@ -476,7 +475,7 @@ void launch_sol_token(
     sol_token_kernel<1><<<grid1, NTHREADS, s1, stream>>>(SOLT_ARGS);
     sol_token_kernel<2><<<grid, NTHREADS, s2, stream>>>(SOLT_ARGS);
 #undef SOLT_ARGS
-    sol_token_sort_kernel<<<dim3(NG, B * H), 256, 0, stream>>>((uint32_t*)tok_idx, (const int32_t*)tok_cnt, NG, n_tok);
+    sol_token_sort_kernel<<<dim3(NG, B * H), NTOK_MAX, 0, stream>>>((uint32_t*)tok_idx, (const int32_t*)tok_cnt, NG, n_tok);
     sol_token_merge_kernel<<<dim3(NQ, B * H), HD, 0, stream>>>(
         (const __nv_bfloat16*)part_o, (const float*)part_m, (const float*)part_l,
         (__nv_bfloat16*)o_part, (float*)m_part, (float*)l_part, NQ, NG, nsplit);

--- a/comfy_kitchen/backends/cuda/sage_attention/sol_attn_token.cu
+++ b/comfy_kitchen/backends/cuda/sage_attention/sol_attn_token.cu
@@ -1,0 +1,483 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Sol-Attn token routing: a centroid shared by TOK_GROUP neighbouring
+// query blocks scores every token in the blocks none of them routed, using the
+// exact kernel's tile body. 64 centroids per CTA, the tile list split over
+// gridDim.y:
+//   pass 1  per-centroid score histogram (0.25 log2 bins on [ref - 8, ref + 16),
+//           2.0 bins up to ref + 80; ref = route's best unrouted pooled score)
+//   pass 2  the threshold admits whole bins until n_tok would overflow, so the
+//           selected set does not depend on scheduling; tokens above it are
+//           listed for the exact kernel, the rest become a softmax state that
+//           replaces route's pooled tail
+// A sort makes each list's order deterministic and a merge folds the splits'
+// states into the exact kernel's handover buffers. Shared memory stays under
+// 33 KB so three CTAs fit per SM.
+
+#include <cuda_runtime.h>
+#include <cuda_bf16.h>
+#include <cstdint>
+
+#include "sol_layout.cuh"
+
+namespace {
+using namespace sol;
+
+constexpr int HD = HEAD_DIM, BQ = BLOCK, BK = BLOCK;
+constexpr int NWARP = BQ / 16, NTHREADS = NWARP * 32;
+constexpr int KC = TILE_KC, NKT = TILE_NKT, NT = TILE_NT;   // tile shapes: sol_layout.cuh
+constexpr int LDK = TILE_LDK, LDV = TILE_LDV;
+constexpr int NSTAGE = 2;
+constexpr int NB = TOK_HIST_BINS;             // histogram bins, 16-bit counts packed in pairs
+constexpr float HLO = 8.f, HW = 0.25f;        // window below ref / fine bin width, log2 units
+constexpr int NB_FINE = 96;                   // fine bins cover [ref - 8, ref + 16); coarse ones above
+constexpr float HW_COARSE = 2.f;              // coarse bin width: 32 bins up to ref + 80
+// bin index for a score `rel` log2 units above (ref - HLO), and the lower edge of a bin
+__device__ __forceinline__ int hist_bin(float rel) {
+    const float fine = (float)NB_FINE * HW;
+    return rel < fine ? (int)(rel / HW) : min(NB - 1, NB_FINE + (int)((rel - fine) / HW_COARSE));
+}
+__device__ __forceinline__ float hist_edge(int b) {
+    return b <= NB_FINE ? (float)b * HW : (float)NB_FINE * HW + (float)(b - NB_FINE) * HW_COARSE;
+}
+constexpr int P1_MAX_TILES = 1024;            // per pass-1 split, so a 16-bit bin cannot overflow
+constexpr float MASKED = TILE_MASKED;         // scores at or below this are masked
+constexpr int HIST_STRIDE = 1;                // pass 1 walks every tile; exact counts keep the cap from binding
+
+__host__ size_t token_smem_bytes(int pass) {
+    size_t n = (size_t)NSTAGE * BK * LDK;
+    n += pass == 1 ? (size_t)BQ * NB * sizeof(uint16_t)
+                   : (size_t)NSTAGE * HD * LDV + (size_t)BQ * sizeof(float);
+    return n;
+}
+
+// per group of TOK_GROUP query blocks: centroid (quantized like prep_q's), best
+// unrouted pooled score, and the blocks unrouted by every member
+__global__ void sol_token_group_kernel(const float* __restrict__ qmean,        // [B*H, NPAD, HD]
+                                       const float* __restrict__ tok_ref,      // [B*H, NQ]
+                                       const uint32_t* __restrict__ bits,      // [B*H, NQ, W] unrouted
+                                       int8_t* __restrict__ gcen8, float* __restrict__ gcens,
+                                       float* __restrict__ gref, uint32_t* __restrict__ gbits,
+                                       int NQ, int NPAD, int NG, int W) {
+    __shared__ __align__(16) float sred[HD];
+    const int grp = blockIdx.x, bh = blockIdx.y, d = threadIdx.x;
+    const int qb0 = grp * TOK_GROUP, qb1 = min(NQ, qb0 + TOK_GROUP);
+    float c = 0.f;
+    for (int qb = qb0; qb < qb1; ++qb) c += qmean[((size_t)bh * NPAD + qb) * HD + d];
+    c /= (float)(qb1 - qb0);
+    const float csc = fmaxf(block_max128(fabsf(c), sred) / 127.0f, 1e-8f);
+    const size_t gs = (size_t)bh * NG + grp;
+    gcen8[gs * HD + perm_d(d)] = q8(c, 1.f / csc);
+    if (d == 0) {
+        gcens[gs] = csc;
+        float r = NEG;
+        for (int qb = qb0; qb < qb1; ++qb) r = fmaxf(r, tok_ref[(size_t)bh * NQ + qb]);
+        gref[gs] = r;
+    }
+    for (int w = d; w < W; w += HD) {
+        uint32_t u = 0xffffffffu;
+        for (int qb = qb0; qb < qb1; ++qb) u &= bits[((size_t)bh * NQ + qb) * W + w];
+        gbits[gs * W + w] = u;
+    }
+}
+
+// per CTA of 64 groups: the union of the rows' unrouted blocks as a tile list
+__global__ void sol_token_tiles_kernel(const uint32_t* __restrict__ bits, uint16_t* __restrict__ tiles,
+                                       int32_t* __restrict__ tile_cnt, int NQ, int NTB, int W) {
+    __shared__ uint32_t su[2048];   // NTB <= 65536 blocks
+    __shared__ int scount;
+    const int grp = blockIdx.x, bh = blockIdx.y, qb0 = grp * BQ;
+    for (int w = threadIdx.x; w < W; w += blockDim.x) {
+        uint32_t u = 0u;
+        for (int r = 0; r < BQ && qb0 + r < NQ; ++r) u |= bits[((size_t)bh * NQ + qb0 + r) * W + w];
+        su[w] = u;
+    }
+    if (threadIdx.x == 0) scount = 0;
+    __syncthreads();
+    uint16_t* out = tiles + ((size_t)bh * gridDim.x + grp) * NTB;
+    if (threadIdx.x == 0) {   // in order, so the walk streams K/V sequentially
+        int n = 0;
+        for (int w = 0; w < W; ++w) {
+            uint32_t u = su[w];
+            while (u) {
+                const int b = __ffs(u) - 1;
+                out[n++] = (uint16_t)(w * 32 + b);
+                u &= u - 1;
+            }
+        }
+        tile_cnt[(size_t)bh * gridDim.x + grp] = n;
+    }
+}
+
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 1200
+#define SOL_TOKEN_BOUNDS __launch_bounds__(NTHREADS, 3)   // pass 2 sits at the exact kernel's 168 regs
+#else
+#define SOL_TOKEN_BOUNDS __launch_bounds__(NTHREADS)
+#endif
+
+template <int PASS>
+__global__ void SOL_TOKEN_BOUNDS sol_token_kernel(
+    const int8_t* __restrict__ cen8, const float* __restrict__ cens,
+    const int8_t* __restrict__ kiP, const float2* __restrict__ ksb,
+    const int8_t* __restrict__ vTi,
+    const uint32_t* __restrict__ bits,                                    // [B*H,NQ,W] candidate bitmap
+    const uint16_t* __restrict__ tiles, const int32_t* __restrict__ tile_cnt,   // per CTA candidate tile list
+    const float* __restrict__ tok_ref, uint32_t* __restrict__ tok_hist,   // [B*H,NQ,NB]
+    uint32_t* __restrict__ tok_idx, int32_t* __restrict__ tok_cnt,
+    __nv_bfloat16* __restrict__ part_o, float* __restrict__ part_m,     // [NSPLIT,B*H,NQ,(HD)]; o in bf16 like the route handover
+    float* __restrict__ part_l,
+    int Tp, int NQ, int NTB, int n_tok, int tail,       // NQ: rows = groups of TOK_GROUP query blocks
+    int NQB, int sink_q_start, int sink_q_end, float scale_log2)   // NQB: query blocks
+{
+#if SOL_SM80
+    extern __shared__ __align__(16) int8_t smem[];
+    const int W = (NTB + 31) >> 5;
+    int8_t* sK = smem;
+    int8_t* sVt = sK + NSTAGE * BK * LDK;
+    uint32_t* hist = reinterpret_cast<uint32_t*>(PASS == 2 ? sVt + NSTAGE * HD * LDV : sVt);   // PASS 1: BQ x NB/2 words (two 16-bit counts); PASS 2: BQ thresholds
+    float* sthr = reinterpret_cast<float*>(hist);
+    // grid (groups, splits, B*H): one head's CTAs are consecutive so its K/V stays in L2
+    const int bh = blockIdx.z;
+    const int split = blockIdx.y, nsplit = gridDim.y;
+    const uint16_t* my_tiles = tiles + ((size_t)bh * gridDim.x + blockIdx.x) * NTB;
+    const int n_tiles = tile_cnt[(size_t)bh * gridDim.x + blockIdx.x];
+    const int chunk = (n_tiles + nsplit - 1) / nsplit;
+    const int kb_begin = split * chunk, kb_end = min(n_tiles, kb_begin + chunk);
+    constexpr int STEP = PASS == 1 ? HIST_STRIDE : 1;
+#define SK(b)   (sK   + (size_t)(b) * BK * LDK)
+#define SVT(b)  (sVt  + (size_t)(b) * HD * LDV)
+
+    const int tid = threadIdx.x, warp = tid >> 5, lane = tid & 31;
+    const int g = lane >> 2, qd = lane & 3;
+    const int qb0 = blockIdx.x * BQ;
+    const int64_t vT_base = (int64_t)bh * HD * Tp;
+    const int64_t kp_base = (int64_t)bh * Tp;
+    const int64_t kd_base = (int64_t)bh * Tp * HD;
+
+    const int row0 = warp * 16 + g;
+    const int rows[2] = {row0, row0 + 8};
+    const int qbr[2] = {qb0 + row0, qb0 + row0 + 8};
+    bool active[2];   // a group is dense only when every member block is a sink_q row
+    #pragma unroll
+    for (int rr = 0; rr < 2; ++rr) {
+        const int m0 = qbr[rr] * TOK_GROUP, m1 = min(NQB, m0 + TOK_GROUP) - 1;
+        active[rr] = qbr[rr] < NQ && !(m0 >= sink_q_start && m1 < sink_q_end);
+    }
+
+    // centroid fragments (cen8 is perm_d'd like the q rows)
+    uint32_t qa[KC][4];
+    float qsc[2];
+    {
+        const int r0 = min(qbr[0], NQ - 1), r1 = min(qbr[1], NQ - 1);
+        const int8_t* p0 = cen8 + ((size_t)bh * NQ + r0) * HD;
+        const int8_t* p1 = cen8 + ((size_t)bh * NQ + r1) * HD;
+        #pragma unroll
+        for (int kc = 0; kc < KC; ++kc) {
+            const int c0 = kc * 32 + qd * 8;
+            const uint2 a0 = *reinterpret_cast<const uint2*>(p0 + c0);
+            const uint2 a1 = *reinterpret_cast<const uint2*>(p1 + c0);
+            qa[kc][0] = a0.x; qa[kc][2] = a0.y;
+            qa[kc][1] = a1.x; qa[kc][3] = a1.y;
+        }
+        qsc[0] = cens[(size_t)bh * NQ + r0] * scale_log2;
+        qsc[1] = cens[(size_t)bh * NQ + r1] * scale_log2;
+    }
+    float ref[2], thr[2] = {3.0e38f, 3.0e38f};
+    #pragma unroll
+    for (int rr = 0; rr < 2; ++rr) {
+        const size_t qs = (size_t)bh * NQ + min(qbr[rr], NQ - 1);
+        ref[rr] = active[rr] ? tok_ref[qs] : NEG;
+    }
+
+    if (PASS == 1) for (int i = tid; i < BQ * NB / 2; i += NTHREADS) hist[i] = 0u;
+    if (PASS == 2 && tid < BQ) {
+        // threshold: admit whole bins from the top until the next would overflow n_tok
+        const int qb = qb0 + tid;
+        float t = 3.0e38f;
+        const int m0 = qb * TOK_GROUP, m1 = min(NQB, m0 + TOK_GROUP) - 1;
+        if (qb < NQ && !(m0 >= sink_q_start && m1 < sink_q_end)) {
+            const uint32_t* h = tok_hist + ((size_t)bh * NQ + qb) * NB;
+            uint32_t acc = 0;
+            int b = NB - 1;
+            for (; b >= 0; --b) {
+                acc += h[b] * HIST_STRIDE;
+                if (acc > (uint32_t)n_tok) break;
+            }
+            // if every bin fits, nothing below the window is admitted: it was never counted
+            t = tok_ref[(size_t)bh * NQ + qb] - HLO + hist_edge(b + 1);
+        }
+        sthr[tid] = t;
+    }
+    __syncthreads();
+    if (PASS == 2) { thr[0] = sthr[rows[0]]; thr[1] = sthr[rows[1]]; }
+    // candidate bitmap rows (dense rows have no candidates, so they mask out)
+    const uint32_t* bmrow[2] = {bits + ((size_t)bh * NQ + min(qbr[0], NQ - 1)) * W,
+                                bits + ((size_t)bh * NQ + min(qbr[1], NQ - 1)) * W};
+
+    float o_acc[NT][4];
+    #pragma unroll
+    for (int nt = 0; nt < NT; ++nt) {
+        o_acc[nt][0] = 0.f; o_acc[nt][1] = 0.f; o_acc[nt][2] = 0.f; o_acc[nt][3] = 0.f;
+    }
+    float m_r[2] = {NEG, NEG}, l_r[2] = {0.f, 0.f}, c_r[2] = {NEG, NEG};
+
+#define SOLT_STAGE(kbi, buf)                                                   \
+    {                                                                          \
+        const int64_t k0_ = (int64_t)(kbi) * BK;                               \
+        constexpr int VEC = HD / 16;                                           \
+        for (int idx = tid; idx < BK * VEC; idx += NTHREADS) {                 \
+            const int p = idx / VEC, c16 = idx % VEC;                          \
+            cp_async16(SK(buf) + p * LDK + ((c16 ^ swz_k(p)) << 4),            \
+                       kiP + kd_base + (k0_ + p) * HD + c16 * 16);             \
+        }                                                                      \
+        if (PASS == 2) {                                                       \
+            for (int idx = tid; idx < HD * 4; idx += NTHREADS) {               \
+                const int c = idx >> 2, part = idx & 3;                        \
+                cp_async16(SVT(buf) + c * LDV + ((part ^ swz_v(c)) << 4),      \
+                           vTi + vT_base + (int64_t)c * Tp + k0_ + part * 16); \
+            }                                                                  \
+        }                                                                      \
+    }
+
+    #pragma unroll
+    for (int st = 0; st < NSTAGE - 1; ++st) {
+        if (kb_begin + st * STEP < kb_end) SOLT_STAGE(my_tiles[kb_begin + st * STEP], st);
+        cp_commit();
+    }
+
+    for (int kb = kb_begin, it = 0; kb < kb_end; kb += STEP, ++it) {
+        const int j = my_tiles[kb];
+        const int cur = it % NSTAGE;
+        const int ahead = kb + STEP * (NSTAGE - 1);
+        if (ahead < kb_end) SOLT_STAGE(my_tiles[ahead], (it + NSTAGE - 1) % NSTAGE);
+        cp_commit();
+        cp_wait<NSTAGE - 1>();
+        __syncthreads();
+
+        const bool masked[2] = {
+            !active[0] || !((__ldg(bmrow[0] + (j >> 5)) >> (j & 31)) & 1u),
+            !active[1] || !((__ldg(bmrow[1] + (j >> 5)) >> (j & 31)) & 1u)};
+        // skip only when the whole warp's rows are routed here: the shuffles need every lane
+        if (__all_sync(0xffffffffu, masked[0] && masked[1])) {
+            __syncthreads();
+            continue;
+        }
+
+        int32_t s_acc[NKT][4];
+        tile_qk(SK(cur), qa, g, qd, s_acc);
+        float p_val[NKT][4];
+        float bmax[2] = {m_r[0] - 20.f, m_r[1] - 20.f};
+        bool has[2] = {false, false};
+        tile_scores<false>(s_acc, ksb + kp_base + (int64_t)j * BK, qsc, qd, p_val, bmax);
+        uint32_t sel[2] = {0u, 0u};   // PASS 2: this lane's selected columns, bit nt*2 + (e&1)
+        #pragma unroll
+        for (int nt = 0; nt < NKT; ++nt) {
+            #pragma unroll
+            for (int e = 0; e < 4; ++e) {
+                const int row = e >> 1;
+                float s = p_val[nt][e];
+                if (masked[row]) s = NEG;
+                if (s > MASKED) {
+                    if (PASS == 1) {
+                        const float rel = s - ref[row] + HLO;   // below the window: not counted, not admitted
+                        if (rel >= 0.f) {
+                            const int bin = hist_bin(rel);
+                            atomicAdd(&hist[(rows[row] * NB + bin) >> 1], (bin & 1) ? 0x10000u : 1u);
+                        }
+                    } else if (s >= thr[row]) {
+                        sel[row] |= 1u << (nt * 2 + (e & 1));
+                    }
+                }
+                p_val[nt][e] = s;
+            }
+        }
+        if (PASS == 2) {
+            // one slot reservation per row per tile: quad prefix, lane 0 takes the range
+            #pragma unroll
+            for (int row = 0; row < 2; ++row) {
+                const int mine = __popc(sel[row]);
+                int prefix = mine;
+                int x = __shfl_up_sync(0xffffffffu, prefix, 1, 4);
+                if (qd >= 1) prefix += x;
+                x = __shfl_up_sync(0xffffffffu, prefix, 2, 4);
+                if (qd >= 2) prefix += x;
+                const int total = __shfl_sync(0xffffffffu, prefix, 3, 4);
+                uint32_t base = 0u;
+                if (qd == 0 && total) base = (uint32_t)atomicAdd(&tok_cnt[(size_t)bh * NQ + qbr[row]], total);
+                base = __shfl_sync(0xffffffffu, base, lane & ~3);
+                const uint32_t first = base + (uint32_t)(prefix - mine);
+                #pragma unroll
+                for (int b = 0; b < 2 * NKT; ++b) {   // static indexing keeps p_val in registers
+                    if (sel[row] & (1u << b)) {
+                        const uint32_t slot = first + (uint32_t)__popc(sel[row] & ((1u << b) - 1u));
+                        if (slot < (uint32_t)n_tok) {
+                            const int nt = b >> 1;
+                            tok_idx[((size_t)bh * NQ + qbr[row]) * n_tok + slot] =
+                                (uint32_t)(j * BK + perm_key(nt * 8 + qd * 2 + (b & 1)));
+                            p_val[nt][row * 2 + (b & 1)] = NEG;   // exact for every row now; leaves the tail
+                        }
+                    }
+                }
+            }
+        }
+        if (PASS == 1 || !tail) {
+            __syncthreads();
+            continue;
+        }
+        tile_rowmax(p_val, bmax, has);   // after the masks and the listed tokens left the tail
+        tile_softmax_pv<true>(p_val, bmax, has, SVT(cur), g, qd, m_r, l_r, c_r, o_acc);   // shared with the exact kernel
+        __syncthreads();
+    }
+#undef SOLT_STAGE
+
+    if (PASS == 1) {
+        // this split's counts join the global histogram
+        for (int i = tid; i < BQ * NB; i += NTHREADS) {
+            const int r = i / NB, qb = qb0 + r;
+            const uint32_t cnt = (hist[i >> 1] >> ((i & 1) ? 16 : 0)) & 0xffffu;
+            if (qb < NQ && cnt) atomicAdd(&tok_hist[((size_t)bh * NQ + qb) * NB + (i % NB)], cnt);
+        }
+        return;
+    }
+
+    // this split's softmax state, in the exact kernel's units (o and l x255 / vsc)
+    #pragma unroll
+    for (int rr = 0; rr < 2; ++rr) {
+        if (qbr[rr] >= NQ) continue;
+        const size_t qs = ((size_t)split * gridDim.z + bh) * NQ + qbr[rr];
+        const float f = m_r[rr] > MASKED ? exp2f(c_r[rr] - m_r[rr]) : 1.f;
+        if (qd == 0) {
+            part_m[qs] = m_r[rr];
+            part_l[qs] = l_r[rr] * f;
+        }
+        __nv_bfloat16* orow = part_o + qs * HD;
+        #pragma unroll
+        for (int nt = 0; nt < NT; ++nt) {
+            const int c = nt * 8 + qd * 2;
+            *reinterpret_cast<__nv_bfloat162*>(orow + c) =
+                __floats2bfloat162_rn(o_acc[nt][rr * 2] * f, o_acc[nt][rr * 2 + 1] * f);
+        }
+    }
+#undef SK
+#undef SVT
+#endif  // SOL_SM80
+}
+
+// sort each list (n_tok is a power of two <= 256) so the exact kernel's order is deterministic
+__global__ void sol_token_sort_kernel(uint32_t* __restrict__ tok_idx, const int32_t* __restrict__ tok_cnt,
+                                      int NQ, int n_tok) {
+    __shared__ uint32_t s[256];
+    const size_t qs = (size_t)blockIdx.y * NQ + blockIdx.x;
+    const int n = min(tok_cnt[qs], n_tok), t = threadIdx.x;
+    uint32_t* row = tok_idx + qs * n_tok;
+    if (t < n_tok) s[t] = t < n ? row[t] : 0xffffffffu;
+    __syncthreads();
+    for (int k = 2; k <= n_tok; k <<= 1) {
+        for (int j = k >> 1; j > 0; j >>= 1) {
+            if (t < n_tok) {
+                const int p = t ^ j;
+                if (p > t) {
+                    const bool up = (t & k) == 0;
+                    const uint32_t a = s[t], b = s[p];
+                    if ((a > b) == up) { s[t] = b; s[p] = a; }
+                }
+            }
+            __syncthreads();
+        }
+    }
+    if (t < n) row[t] = s[t];
+}
+
+// merge the split states into the exact kernel's handover buffers
+__global__ void sol_token_merge_kernel(
+    const __nv_bfloat16* __restrict__ part_o, const float* __restrict__ part_m,
+    const float* __restrict__ part_l,
+    __nv_bfloat16* __restrict__ o_part, float* __restrict__ m_part, float* __restrict__ l_part,
+    int NQ, int NG, int nsplit)
+{
+    const int qb = blockIdx.x, bh = blockIdx.y, c = threadIdx.x;
+    const size_t qs = (size_t)bh * NQ + qb;
+    const size_t qg = (size_t)bh * NG + qb / TOK_GROUP, stride = (size_t)gridDim.y * NG;
+    // route's pooled tail joins as one more split
+    const float rm = m_part[qs], rl = l_part[qs], ro = __bfloat162float(o_part[qs * HD + c]);
+    float m = rm;
+    for (int s = 0; s < nsplit; ++s) m = fmaxf(m, part_m[qg + s * stride]);
+    float l = 0.f, o = 0.f;
+    if (m > MASKED) {
+        if (rm > MASKED) { const float w = exp2f(rm - m); l += rl * w; o += ro * w; }
+        for (int s = 0; s < nsplit; ++s) {
+            const size_t p = qg + s * stride;
+            const float w = part_m[p] > MASKED ? exp2f(part_m[p] - m) : 0.f;
+            l += part_l[p] * w;
+            o += __bfloat162float(part_o[p * HD + c]) * w;
+        }
+    }
+    __syncthreads();   // every thread has read route's m/l before thread 0 overwrites them
+    o_part[qs * HD + c] = __float2bfloat16(o);
+    if (c == 0) { m_part[qs] = m; l_part[qs] = l; }
+}
+
+}  // namespace
+
+// splits of the tile list: enough CTAs that short sequences fill the GPU and a
+// head's K/V stays in L2. A function of the shape only, so the plan can size the slots.
+int sol_token_splits(int B, int H, int NG) {
+    (void)B; (void)H;
+    const int groups = (NG + BQ - 1) / BQ;   // CTAs of 64 rows over the NG centroid rows
+    return max(1, min(8, (512 + groups - 1) / groups));
+}
+
+void launch_sol_token(
+    const void* qmean, const void* tok_ref, const void* cand_bits,          // per query block (route / preprocess)
+    void* gcen8, void* gcens, void* gref, void* gbits,                        // per group
+    const void* kiP, const void* ksb, const void* vTi,
+    void* tok_tiles, void* tok_tilecnt,
+    void* tok_hist, void* tok_idx, void* tok_cnt, void* part_o, void* part_m, void* part_l,
+    void* o_part, void* m_part, void* l_part,
+    int B, int Tp, int H, int NQ, int NPAD, int NTB, int n_tok, int tail,
+    int sink_q_start, int sink_q_end, float scale_log2, cudaStream_t stream)
+{
+    const size_t s1 = token_smem_bytes(1), s2 = token_smem_bytes(2);
+    const int W = (NTB + 31) / 32;
+    const int NG = (NQ + TOK_GROUP - 1) / TOK_GROUP;
+    const int nsplit = sol_token_splits(B, H, NG);
+    dim3 grid((NG + BQ - 1) / BQ, nsplit, B * H);
+    sol_token_group_kernel<<<dim3(NG, B * H), HD, 0, stream>>>(
+        (const float*)qmean, (const float*)tok_ref, (const uint32_t*)cand_bits,
+        (int8_t*)gcen8, (float*)gcens, (float*)gref, (uint32_t*)gbits, NQ, NPAD, NG, W);
+    // pass 1 has no partial state, so it may split further to keep the 16-bit bins from overflowing
+    const int nsplit1 = max(nsplit, (NTB + P1_MAX_TILES * HIST_STRIDE - 1) / (P1_MAX_TILES * HIST_STRIDE));
+    dim3 grid1(grid.x, nsplit1, B * H);
+    sol_token_tiles_kernel<<<dim3(grid.x, B * H), 128, 0, stream>>>(   // (CTAs of 64 groups, B*H)
+        (const uint32_t*)gbits, (uint16_t*)tok_tiles, (int32_t*)tok_tilecnt, NG, NTB, W);
+    cudaMemsetAsync(tok_hist, 0, (size_t)B * H * NG * NB * sizeof(uint32_t), stream);
+    cudaMemsetAsync(tok_cnt, 0, (size_t)B * H * NG * sizeof(int32_t), stream);
+#define SOLT_ARGS                                                                          \
+    (const int8_t*)gcen8, (const float*)gcens, (const int8_t*)kiP, (const float2*)ksb,     \
+    (const int8_t*)vTi, (const uint32_t*)gbits, (const uint16_t*)tok_tiles,               \
+    (const int32_t*)tok_tilecnt,                                                           \
+    (const float*)gref, (uint32_t*)tok_hist, (uint32_t*)tok_idx, (int32_t*)tok_cnt,        \
+    (__nv_bfloat16*)part_o, (float*)part_m, (float*)part_l,                                \
+    Tp, NG, NTB, n_tok, tail, NQ, sink_q_start, sink_q_end, scale_log2
+    sol_token_kernel<1><<<grid1, NTHREADS, s1, stream>>>(SOLT_ARGS);
+    sol_token_kernel<2><<<grid, NTHREADS, s2, stream>>>(SOLT_ARGS);
+#undef SOLT_ARGS
+    sol_token_sort_kernel<<<dim3(NG, B * H), 256, 0, stream>>>((uint32_t*)tok_idx, (const int32_t*)tok_cnt, NG, n_tok);
+    sol_token_merge_kernel<<<dim3(NQ, B * H), HD, 0, stream>>>(
+        (const __nv_bfloat16*)part_o, (const float*)part_m, (const float*)part_l,
+        (__nv_bfloat16*)o_part, (float*)m_part, (float*)l_part, NQ, NG, nsplit);
+}

--- a/comfy_kitchen/backends/cuda/sage_attention/sol_attn_vtranspose.cu
+++ b/comfy_kitchen/backends/cuda/sage_attention/sol_attn_vtranspose.cu
@@ -35,7 +35,7 @@ constexpr int LDS_PAD = HD + 16;   // must be a multiple of 16: phase 1 writes u
 template <int TT, typename E>
 __global__ void vquant_transpose(const E* __restrict__ v,
                                  const float* __restrict__ vsc,
-                                 int8_t* __restrict__ vT,
+                                 int8_t* __restrict__ vT, int8_t* __restrict__ vRow,
                                  int T, int Tp, int H,
                                  int64_t sb, int64_t st, int64_t sh) {
     __shared__ __align__(16) int8_t sV[TT * LDS_PAD];
@@ -56,6 +56,8 @@ __global__ void vquant_transpose(const E* __restrict__ v,
             #pragma unroll
             for (int j = 0; j < 16; ++j) out[j] = 0;
         }
+        if (vRow && t0 + t < Tp)   // row-major copy for the gathered token tiles (token routing)
+            *reinterpret_cast<uint4*>(vRow + ((int64_t)bh * Tp + t0 + t) * HD + c16) = *reinterpret_cast<uint4*>(out);
         // perm_d on the key axis, per 64-block
         const int tp = (t / 64) * 64 + perm_d(t % 64);
         *reinterpret_cast<uint4*>(sV + tp * LDS_PAD + c16) = *reinterpret_cast<uint4*>(out);
@@ -88,16 +90,16 @@ __global__ void vquant_transpose(const E* __restrict__ v,
 
 }  // namespace
 
-void launch_sol_vtranspose(const void* v, const void* vsc, void* vT,
+void launch_sol_vtranspose(const void* v, const void* vsc, void* vT, void* vRow,
                            int B, int T, int Tp, int H,
                            int64_t sb, int64_t st, int64_t sh,
                            int elem, cudaStream_t stream) {
     dim3 grid((T + 255) / 256, B * H);
     if (elem == sol::SOL_FP16)
         vquant_transpose<256, __half><<<grid, NTHREADS, 0, stream>>>(
-            (const __half*)v, (const float*)vsc, (int8_t*)vT, T, Tp, H, sb, st, sh);
+            (const __half*)v, (const float*)vsc, (int8_t*)vT, (int8_t*)vRow, T, Tp, H, sb, st, sh);
     else
         vquant_transpose<256, __nv_bfloat16><<<grid, NTHREADS, 0, stream>>>(
-            (const __nv_bfloat16*)v, (const float*)vsc, (int8_t*)vT, T, Tp, H, sb, st, sh);
+            (const __nv_bfloat16*)v, (const float*)vsc, (int8_t*)vT, (int8_t*)vRow, T, Tp, H, sb, st, sh);
 }
 

--- a/comfy_kitchen/backends/cuda/sage_attention/sol_layout.cuh
+++ b/comfy_kitchen/backends/cuda/sage_attention/sol_layout.cuh
@@ -40,6 +40,9 @@ namespace sol {
 constexpr int HEAD_DIM = 128;   // the only head_dim these kernels handle
 constexpr int BLOCK    = 64;    // Sol-Attn's routing granularity, in tokens
 constexpr float NEG    = -3.0e38f;   // finite, so NEG - NEG == 0 (unlike -inf)
+constexpr int NTOK_MAX = 256;        // token routing: largest token budget
+constexpr int TOK_HIST_BINS = 128;   // token routing: histogram bins per centroid
+constexpr int TOK_GROUP = 2;         // token routing: query blocks per centroid
 
 // Contraction-axis permutation: each lane's two MMA operand words become one
 // 8-byte load. Applied to Q/K/pooled-K d axes and V^T's key axis.
@@ -52,6 +55,10 @@ __host__ __device__ __forceinline__ int perm_d(int d) {
 // Applied to K rows + scales; NOT to V^T.
 __host__ __device__ __forceinline__ int perm_key(int p) {
     return 16 * (p >> 4) + 4 * ((p & 7) >> 1) + 2 * ((p >> 3) & 1) + (p & 1);
+}
+// Which stored row holds source token s of its block (perm_key's inverse).
+__host__ __device__ __forceinline__ int perm_key_inv(int s) {
+    return 16 * (s >> 4) + 8 * ((s >> 1) & 1) + 4 * ((s >> 3) & 1) + 2 * ((s >> 2) & 1) + (s & 1);
 }
 
 // Smem XOR swizzles (K tile 64 x 128 B, V^T tile 128 x 64 B). Verify any
@@ -288,6 +295,156 @@ __device__ __forceinline__ void mma_bf16(float* d, const uint32_t* a, const uint
                  : "+f"(d[0]), "+f"(d[1]), "+f"(d[2]), "+f"(d[3])
                  : "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]), "r"(b[0]), "r"(b[1]));
 #endif
+}
+
+// ---- Shared 64-key tile body (exact kernel and token passes) ----
+// Staged K tile (64 x 128 int8) and V^T tile (128 x 64 int8), XOR-swizzled 16-byte
+// chunks. One warp owns 16 rows: g = lane >> 2 picks rows g and g + 8, qd = lane & 3
+// the column pair, so every per-row array below is [2].
+
+constexpr int TILE_KC  = HEAD_DIM / 32;   // int8 k-chunks of S = Q.K^T
+constexpr int TILE_NKT = BLOCK / 8;       // score n8 tiles
+constexpr int TILE_NT  = HEAD_DIM / 8;    // output n8 tiles
+constexpr int TILE_PKC = BLOCK / 32;      // int8 k-chunks of O += P.V
+constexpr int TILE_LDK = HEAD_DIM;        // K tile row stride, bytes
+constexpr int TILE_LDV = BLOCK;           // V^T tile row stride, bytes
+constexpr float TILE_MASKED = -1.0e37f;   // scores at or below this are masked (NEG lands here)
+
+// S = Q.K^T: the warp's 16 rows against the tile's 64 keys, int32 accumulators.
+__device__ __forceinline__ void tile_qk(const int8_t* sK_tile, const uint32_t (&qa)[TILE_KC][4],
+                                        int g, int qd, int32_t (&s_acc)[TILE_NKT][4]) {
+    #pragma unroll
+    for (int nt = 0; nt < TILE_NKT; ++nt) {
+        s_acc[nt][0] = 0; s_acc[nt][1] = 0; s_acc[nt][2] = 0; s_acc[nt][3] = 0;
+        const int R = nt * 8 + g;
+        const int8_t* krow = sK_tile + R * TILE_LDK + ((qd & 1) << 3);
+        const int swk = swz_k(R), qhi = qd >> 1;
+        #pragma unroll
+        for (int kc = 0; kc < TILE_KC; ++kc) {
+            const uint2 kb = *reinterpret_cast<const uint2*>(krow + (((kc * 2 + qhi) ^ swk) << 4));
+            uint32_t kbf[2] = {kb.x, kb.y};
+            mma_s8(s_acc[nt], qa[kc], kbf);
+        }
+    }
+}
+
+// Scores in log2 units: (int dot) * qsc[row] * ks + bias, with the tile's 64
+// (ks, bias) pairs at kb_src. FOLD_MAX takes the row max in the same loop (the
+// exact kernel's shape; splitting it costs registers); otherwise call tile_rowmax.
+template <bool FOLD_MAX>
+__device__ __forceinline__ void tile_scores(const int32_t (&s_acc)[TILE_NKT][4], const float2* kb_src,
+                                            const float (&qsc)[2], int qd, float (&p_val)[TILE_NKT][4],
+                                            float (&bmax)[2]) {
+    #pragma unroll
+    for (int nt = 0; nt < TILE_NKT; ++nt) {
+        const int c0 = nt * 8 + qd * 2;
+        const float4 kb4 = *reinterpret_cast<const float4*>(kb_src + c0);
+        const float k0s = kb4.x, m0 = kb4.y, k1s = kb4.z, m1 = kb4.w;
+        #pragma unroll
+        for (int e = 0; e < 4; ++e) {
+            const int row = e >> 1;
+            const float s = (e & 1) ? fmaf((float)s_acc[nt][e], qsc[row] * k1s, m1)
+                                    : fmaf((float)s_acc[nt][e], qsc[row] * k0s, m0);
+            p_val[nt][e] = s;
+            if (FOLD_MAX) bmax[row] = fmaxf(bmax[row], s);
+        }
+    }
+}
+
+// Row max over the tile's scores (<= TILE_MASKED masked), and whether any is live.
+__device__ __forceinline__ void tile_rowmax(const float (&p_val)[TILE_NKT][4], float (&bmax)[2], bool (&has)[2]) {
+    #pragma unroll
+    for (int nt = 0; nt < TILE_NKT; ++nt) {
+        #pragma unroll
+        for (int e = 0; e < 4; ++e) {
+            const int row = e >> 1;
+            if (p_val[nt][e] > TILE_MASKED) { has[row] = true; bmax[row] = fmaxf(bmax[row], p_val[nt][e]); }
+        }
+    }
+}
+
+// Online softmax over the tile's scores (<= TILE_MASKED masked) and O += P.V.
+// P is u8 against the block max bmax; l sums the packed bytes so numerator and
+// denominator quantize identically. (m_r, l_r, c_r) is the row state, c_r the
+// scale of o_acc and l_r. GUARD: a row with no live score keeps its state
+// (alpha 1, P 0); the exact kernel only sees live tiles and skips it.
+template <bool GUARD>
+__device__ __forceinline__ void tile_softmax_pv(float (&p_val)[TILE_NKT][4], float (&bmax)[2], bool (&has)[2],
+                                                const int8_t* sVt_tile, int g, int qd,
+                                                float (&m_r)[2], float (&l_r)[2], float (&c_r)[2],
+                                                float (&o_acc)[TILE_NT][4]) {
+    #pragma unroll
+    for (int off = 1; off <= 2; off <<= 1) {
+        bmax[0] = fmaxf(bmax[0], __shfl_xor_sync(0xffffffffu, bmax[0], off));
+        bmax[1] = fmaxf(bmax[1], __shfl_xor_sync(0xffffffffu, bmax[1], off));
+        if (GUARD) {
+            has[0] |= __shfl_xor_sync(0xffffffffu, (int)has[0], off);
+            has[1] |= __shfl_xor_sync(0xffffffffu, (int)has[1], off);
+        }
+    }
+    if (GUARD) {
+        if (!has[0]) bmax[0] = c_r[0];
+        if (!has[1]) bmax[1] = c_r[1];
+    }
+    const float alpha0 = exp2f(c_r[0] - bmax[0]);
+    const float alpha1 = exp2f(c_r[1] - bmax[1]);
+    c_r[0] = bmax[0]; c_r[1] = bmax[1];
+    m_r[0] = fmaxf(m_r[0], bmax[0]);
+    m_r[1] = fmaxf(m_r[1], bmax[1]);
+
+    // u8 P scale folded into the exponent (+log2 255); l carries it too
+    const float m_off[2] = {GUARD && !has[0] ? 3.0e38f : bmax[0] - 7.99435344f,
+                            GUARD && !has[1] ? 3.0e38f : bmax[1] - 7.99435344f};
+    #pragma unroll
+    for (int nt = 0; nt < TILE_NKT; ++nt) {
+        #pragma unroll
+        for (int e = 0; e < 4; ++e)
+            p_val[nt][e] = exp2f(p_val[nt][e] - m_off[e >> 1]);
+    }
+
+    // free repack (see the header comment): n-tiles (4kk, 4kk+1) -> keys 32kk+4q..+3
+    uint32_t pa[TILE_PKC][4];
+    #pragma unroll
+    for (int kk = 0; kk < TILE_PKC; ++kk) {
+        const int b0 = 4 * kk, b1 = b0 + 1, b2 = b0 + 2, b3 = b0 + 3;
+        pa[kk][0] = mma::pack_u8x4(p_val[b0][0], p_val[b0][1], p_val[b1][0], p_val[b1][1]);
+        pa[kk][1] = mma::pack_u8x4(p_val[b0][2], p_val[b0][3], p_val[b1][2], p_val[b1][3]);
+        pa[kk][2] = mma::pack_u8x4(p_val[b2][0], p_val[b2][1], p_val[b3][0], p_val[b3][1]);
+        pa[kk][3] = mma::pack_u8x4(p_val[b2][2], p_val[b2][3], p_val[b3][2], p_val[b3][3]);
+    }
+    uint32_t li[2] = {0, 0};
+    #pragma unroll
+    for (int kk = 0; kk < TILE_PKC; ++kk) {
+        li[0] = __dp4a(pa[kk][0], 0x01010101u, li[0]);
+        li[0] = __dp4a(pa[kk][2], 0x01010101u, li[0]);
+        li[1] = __dp4a(pa[kk][1], 0x01010101u, li[1]);
+        li[1] = __dp4a(pa[kk][3], 0x01010101u, li[1]);
+    }
+    #pragma unroll
+    for (int off = 1; off <= 2; off <<= 1) {
+        li[0] += __shfl_xor_sync(0xffffffffu, li[0], off);
+        li[1] += __shfl_xor_sync(0xffffffffu, li[1], off);
+    }
+    l_r[0] = l_r[0] * alpha0 + (float)li[0];
+    l_r[1] = l_r[1] * alpha1 + (float)li[1];
+
+    #pragma unroll
+    for (int nt = 0; nt < TILE_NT; ++nt) {
+        int32_t d[4] = {0, 0, 0, 0};
+        const int C = nt * 8 + g;
+        const int8_t* vcol = sVt_tile + C * TILE_LDV + ((qd & 1) << 3);
+        const int swv = swz_v(C), qhi2 = qd >> 1;
+        #pragma unroll
+        for (int kk = 0; kk < TILE_PKC; ++kk) {
+            const uint2 vb = *reinterpret_cast<const uint2*>(vcol + (((kk * 2 + qhi2) ^ swv) << 4));
+            uint32_t vbf[2] = {vb.x, vb.y};
+            mma_u8s8(d, pa[kk], vbf);
+        }
+        o_acc[nt][0] = fmaf(o_acc[nt][0], alpha0, (float)d[0]);
+        o_acc[nt][1] = fmaf(o_acc[nt][1], alpha0, (float)d[1]);
+        o_acc[nt][2] = fmaf(o_acc[nt][2], alpha1, (float)d[2]);
+        o_acc[nt][3] = fmaf(o_acc[nt][3], alpha1, (float)d[3]);
+    }
 }
 
 __device__ __forceinline__ uint32_t pack_bf2(float lo, float hi) {

--- a/comfy_kitchen/backends/eager/sol_attn.py
+++ b/comfy_kitchen/backends/eager/sol_attn.py
@@ -130,6 +130,8 @@ def sol_attn(
     tail: bool = True,
     block_len: torch.Tensor | None = None,
     coarse_gate: torch.Tensor | None = None,
+    token_aug: int = 0,   # ignored: the reference is exact arithmetic over the same
+                          # block selection, so there is no token routing stage to model
 ) -> torch.Tensor:
     """Sol-Attn over ``(B, T, H, D)`` tensors. See the module docstring.
 
@@ -257,12 +259,14 @@ def _op_sol_attn(
     tail: bool,
     block_len: torch.Tensor | None,
     coarse_gate: torch.Tensor | None,
+    token_aug: int = 0,
 ) -> torch.Tensor:
     kwargs = {
         "q": q, "k": k, "v": v, "tau": tau, "scale": scale,
         "sink_blocks": sink_blocks, "sink_q": sink_q,
         "key_bias": key_bias, "topk_ratio": topk_ratio,
         "tail": tail, "block_len": block_len, "coarse_gate": coarse_gate,
+        "token_aug": token_aug,
     }
     impl = registry.get_implementation("sol_attn", kwargs=kwargs)
     return impl(**kwargs)
@@ -270,6 +274,6 @@ def _op_sol_attn(
 
 @_op_sol_attn.register_fake
 def _op_sol_attn_fake(q, k, v, tau, scale, sink_blocks, sink_q,
-                      key_bias, topk_ratio, tail, block_len, coarse_gate):
+                      key_bias, topk_ratio, tail, block_len, coarse_gate, token_aug=0):
     # contiguous, NOT empty_like(v): both real implementations return contiguous
     return torch.empty(v.shape, dtype=v.dtype, device=v.device)

--- a/comfy_kitchen/backends/hip/__init__.py
+++ b/comfy_kitchen/backends/hip/__init__.py
@@ -218,6 +218,16 @@ def is_available() -> bool:
     return _EXT_AVAILABLE and _unsupported_arch_reason(_visible_gfx_arches()) is None
 
 
+_token_aug_warned = False
+
+
+def _warn_token_aug_once() -> None:
+    global _token_aug_warned
+    if not _token_aug_warned:
+        _token_aug_warned = True
+        logger.warning("sol_attn: token_aug is not implemented on the HIP backend; running without it")
+
+
 def has_wmma() -> bool:
     """Whether the GEMM kernels can run: every visible device has matrix cores.
 
@@ -1867,6 +1877,7 @@ def sol_attn(
     tail: bool = True,
     block_len: torch.Tensor | None = None,
     coarse_gate: torch.Tensor | None = None,
+    token_aug: int = 0,
 ) -> torch.Tensor:
     """Sol-Attn sparse attention over ``(B, T, H, 128)`` bf16 or fp16 tensors.
     See sage_attention/sol_attn.hip and the public docstring for ``tail``,
@@ -1876,6 +1887,8 @@ def sol_attn(
     per-query-block top-k: keep that fraction of key blocks per query block (sinks
     and the diagonal still ride on top). tau is ignored then.
     """
+    if token_aug:
+        _warn_token_aug_once()
     batch, t, h, d = q.shape
     if q.dtype not in (torch.bfloat16, torch.float16):
         raise ValueError(f"sol_attn: q/k/v must be bfloat16 or float16, got {q.dtype}")
@@ -1950,6 +1963,7 @@ def sol_attn_chunked(
     tail: bool = True,
     block_len: torch.Tensor | None = None,
     coarse_gate: torch.Tensor | None = None,
+    token_aug: int = 0,
 ):
     """Chunked-producer Sol-Attn over fused qkv projection chunks ([M, 3*H*128]
     bf16, 64-aligned starts, B=1); full Q/K/V are never materialised.
@@ -1959,6 +1973,8 @@ def sol_attn_chunked(
     ``kmean``/``vscale`` are LAST step's statistics ([H,128] f32); when None the
     producer runs twice (measure, then quantize), so pass a callable to stream on
     the first call. Returns ``(out[1,T,H,128] bf16, kmean_next, vscale_next)``."""
+    if token_aug:
+        _warn_token_aug_once()
     d = _SOL_HD
     rot = rope_freqs.shape[-3] * 2
     # the fused rope pairs channels across lanes of 4: rot/2 must be lane-aligned

--- a/comfy_kitchen/constraints.py
+++ b/comfy_kitchen/constraints.py
@@ -309,6 +309,10 @@ def sol_attn_common_call_rule(kwargs):
     topk_ratio = kwargs.get("topk_ratio")
     if topk_ratio and not 0.0 < topk_ratio < 1.0:
         return ValidationResult.fail("topk_ratio", f"must be 0 or in (0, 1), got {topk_ratio}")
+    # token routing budget: 64-token tiles, at most the kernels' list capacity
+    token_aug = kwargs.get("token_aug") or 0
+    if token_aug < 0 or token_aug > 256 or token_aug % 64:
+        return ValidationResult.fail("token_aug", f"must be 0 or a multiple of 64 up to 256, got {token_aug}")
     return ValidationResult.ok()
 
 

--- a/tests/test_sol_attn.py
+++ b/tests/test_sol_attn.py
@@ -402,10 +402,9 @@ def test_exact_branch_quantization_error():
 
 @pytest.mark.parametrize("t", [1024, 3137])
 def test_fp16_inputs_match_bf16(t):
-    """fp16 q/k/v go straight into the same int8 pipeline (only the loads and the
-    output store convert), so the two dtypes agree to output rounding."""
+    """fp16 and bf16 inputs run the same int8 pipeline; only the loads and stores differ."""
     q, k, v = _qkv(1, t, 4)
-    q16, k16, v16 = (x.half() for x in (q, k, v))   # bf16 values are exact in fp16
+    q16, k16, v16 = (x.half() for x in (q, k, v))
     ref = ck.sol_attn(q, k, v, tau=1.0)
     got = ck.sol_attn(q16, k16, v16, tau=1.0)
     assert got.dtype == torch.float16
@@ -415,7 +414,7 @@ def test_fp16_inputs_match_bf16(t):
 
 
 def test_fp16_strided_inputs_and_mixed_dtype():
-    """BHND fp16 views go in as-is; the binding rejects out/k/v that differ from q."""
+    """Strided fp16 views are accepted; mixed dtypes are rejected."""
     b, t, h = 2, 1000, 3
     q, k, v = _qkv(b, t, h, seed=5)
     q16, k16, v16 = (x.half().permute(0, 2, 1, 3).contiguous().permute(0, 2, 1, 3)
@@ -435,6 +434,102 @@ def test_fp16_strided_inputs_and_mixed_dtype():
     with pytest.raises(RuntimeError, match="k must be"):
         ext.sol_attn(w(q1.half()), w(k1), w(v1.half()), w(torch.empty_like(q1, dtype=torch.float16)),
                      w(ws), *args)
+
+
+def test_is_available_tracks_the_device(monkeypatch):
+    """True where a fused backend is built, false below the CUDA compute-capability floor."""
+    assert ck.sol_attn_is_available()
+    if backend is not cuda_backend:
+        pytest.skip("the compute-capability floor belongs to the CUDA backend")
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda device=None: (7, 5))
+    assert not ck.sol_attn_is_available()
+
+
+def _rel(a, b):
+    return ((a.float() - b.float()).norm() / b.float().norm()).item()
+
+
+def _token_routing_case(t=4096 + 5, h=8, seed=7):
+    """Queries share a direction per run of 4 blocks; a few keys aligned with it are
+    scattered over every block. Block routing misses them, token routing finds them."""
+    g = torch.Generator(device="cuda").manual_seed(seed)
+    d, nb = HD, (t + 63) // 64
+    bases = torch.randn(8, h, d, device="cuda", generator=g)
+    bases = 4.0 * bases / bases.norm(dim=-1, keepdim=True)
+    base_of_block = (torch.arange(nb, device="cuda") // 4) % 8
+    q = bases[base_of_block].repeat_interleave(64, dim=0)[:t] + 0.5 * torch.randn(t, h, d, device="cuda", generator=g)
+    k = 0.5 * torch.randn(t, h, d, device="cuda", generator=g)
+    v = torch.randn(t, h, d, device="cuda", generator=g)
+    per_base = t // 32
+    idx = torch.randperm(t, generator=g, device="cuda")[:8 * per_base]
+    gain = torch.empty(8 * per_base, device="cuda").uniform_(1.0, 3.0, generator=g)
+    k[idx] = bases[torch.arange(8 * per_base, device="cuda") % 8] * gain[:, None, None] + 0.5 * k[idx]
+    return tuple(x[None].to(torch.bfloat16) for x in (q, k, v))
+
+
+cuda_only = pytest.mark.skipif(backend is not cuda_backend, reason="token routing is a CUDA-backend stage")
+
+
+@cuda_only
+@pytest.mark.parametrize("mode", [{"tau": 1.4}, {"topk_ratio": 0.1}])
+def test_token_aug_improves_exactness(mode):
+    """A larger token budget brings the output closer to dense and shrinks the DC bias."""
+    q, k, v = _token_routing_case()
+    ref = _dense(q, k, v)
+    errs, bias = {}, {}
+    for n in (0, 64, 256):
+        out = ck.sol_attn(q, k, v, sink_blocks=[0, 2], token_aug=n, **mode)
+        assert torch.isfinite(out.float()).all()
+        errs[n] = _rel(out, ref)
+        bias[n] = (out.float() - ref).mean(dim=1).norm().item()
+    assert errs[256] < errs[64] < 0.5 * errs[0], errs
+    assert bias[256] < bias[0], bias
+
+
+@cuda_only
+def test_token_aug_is_deterministic():
+    """Reruns and strided views are bit-identical."""
+    q, k, v = _token_routing_case(seed=3)
+    a = ck.sol_attn(q, k, v, topk_ratio=0.1, token_aug=256)
+    for _ in range(3):
+        assert torch.equal(a, ck.sol_attn(q, k, v, topk_ratio=0.1, token_aug=256))
+    qb, kb, vb = (x.permute(0, 2, 1, 3).contiguous().permute(0, 2, 1, 3) for x in (q, k, v))
+    assert torch.equal(a, ck.sol_attn(qb, kb, vb, topk_ratio=0.1, token_aug=256))
+
+
+@cuda_only
+def test_token_aug_chunked_matches_direct():
+    """The chunked path runs the same token stage."""
+    c = _chunked_case(seed=13, rot=96, v_scale=0.02)
+    ref = backend.sol_attn(c["q"], c["k"], c["v"], tau=1.4, sink_blocks=[0, 2], token_aug=256)
+    out, km, vs = backend.sol_attn_chunked(
+        c["chunks"], c["t"], c["h"], c["freqs"], c["norm"], tau=1.4, sink_blocks=[0, 2], token_aug=256)
+    # the two paths quantize K differently, so the token picks differ at the margin
+    assert _cos(out, ref) > 0.95
+    plain = backend.sol_attn_chunked(
+        c["chunks"], c["t"], c["h"], c["freqs"], c["norm"], kmean=km, vscale=vs, tau=1.4, sink_blocks=[0, 2])[0]
+    assert _rel(out, _dense(c["q"], c["k"], c["v"])) < _rel(plain, _dense(c["q"], c["k"], c["v"]))
+
+
+@cuda_only
+def test_token_aug_validation_and_no_tail():
+    """Bad budgets are rejected; flat scores admit nothing; dense rows are untouched;
+    the stage works without the tail."""
+    q, k, v = _qkv(1, 2048, 4)
+    for bad in (100, 512, -64):
+        with pytest.raises(NoCapableBackendError, match="token_aug"):
+            ck.sol_attn(q, k, v, topk_ratio=0.2, token_aug=bad)
+        with pytest.raises(RuntimeError, match="token_aug"):
+            backend._C.sol_attn_plan(1, 2048, 4, token_aug=bad)
+    flat = ck.sol_attn(q, k, v, topk_ratio=0.2, tail=False, token_aug=256)
+    assert torch.equal(flat, ck.sol_attn(q, k, v, topk_ratio=0.2, tail=False))
+    full = ck.sol_attn(q, k, v, tau=1.4, sink_q=[0, 32], token_aug=256)
+    assert torch.equal(full, ck.sol_attn(q, k, v, tau=1.4, sink_q=[0, 32]))
+    q, k, v = _token_routing_case(t=2048, h=4)
+    no_tail = ck.sol_attn(q, k, v, topk_ratio=0.2, tail=False)
+    aug = ck.sol_attn(q, k, v, topk_ratio=0.2, tail=False, token_aug=256)
+    assert torch.isfinite(aug.float()).all()
+    assert _rel(aug, _dense(q, k, v)) < _rel(no_tail, _dense(q, k, v))
 
 
 def test_chunked_producer_public_entry():

--- a/tests/test_sol_attn.py
+++ b/tests/test_sol_attn.py
@@ -513,16 +513,18 @@ def test_token_aug_chunked_matches_direct():
 
 @cuda_only
 def test_token_aug_validation_and_no_tail():
-    """Bad budgets are rejected; flat scores admit nothing; dense rows are untouched;
-    the stage works without the tail."""
+    """Bad budgets are rejected; identical keys admit nothing (one score bin, over budget);
+    dense rows are untouched; the stage works without the tail and with a budget that is
+    not a power of two."""
     q, k, v = _qkv(1, 2048, 4)
     for bad in (100, 512, -64):
         with pytest.raises(NoCapableBackendError, match="token_aug"):
             ck.sol_attn(q, k, v, topk_ratio=0.2, token_aug=bad)
         with pytest.raises(RuntimeError, match="token_aug"):
             backend._C.sol_attn_plan(1, 2048, 4, token_aug=bad)
-    flat = ck.sol_attn(q, k, v, topk_ratio=0.2, tail=False, token_aug=256)
-    assert torch.equal(flat, ck.sol_attn(q, k, v, topk_ratio=0.2, tail=False))
+    kf = k[:, :1].expand_as(k).contiguous()
+    flat = ck.sol_attn(q, kf, v, topk_ratio=0.2, tail=False, token_aug=256)
+    assert torch.equal(flat, ck.sol_attn(q, kf, v, topk_ratio=0.2, tail=False))
     full = ck.sol_attn(q, k, v, tau=1.4, sink_q=[0, 32], token_aug=256)
     assert torch.equal(full, ck.sol_attn(q, k, v, tau=1.4, sink_q=[0, 32]))
     q, k, v = _token_routing_case(t=2048, h=4)
@@ -530,6 +532,10 @@ def test_token_aug_validation_and_no_tail():
     aug = ck.sol_attn(q, k, v, topk_ratio=0.2, tail=False, token_aug=256)
     assert torch.isfinite(aug.float()).all()
     assert _rel(aug, _dense(q, k, v)) < _rel(no_tail, _dense(q, k, v))
+    aug192 = ck.sol_attn(q, k, v, topk_ratio=0.2, tail=False, token_aug=192)
+    assert torch.isfinite(aug192.float()).all()
+    assert _rel(aug192, _dense(q, k, v)) < _rel(no_tail, _dense(q, k, v))
+    assert torch.equal(aug192, ck.sol_attn(q, k, v, topk_ratio=0.2, tail=False, token_aug=192))
 
 
 def test_chunked_producer_public_entry():


### PR DESCRIPTION
Adds token_aug (0, or a multiple of 64 up to 256): each query block additionally attends up to that many top-scoring tokens outside its routed blocks, with the remaining tail made exact for the block centroid. 

For now CUDA only (HIP warns and runs without it), needs someone with AMD to support and test. 

On MiniMax-H3 captures it roughly halves the sparse-pass error and DC bias for about a third more attention time.

The DC error manifests as brightness/detail "pulsing" every 5 latent frames (around 0.7s)

sol-attn test, before:

https://github.com/user-attachments/assets/d461b1e5-310e-45fc-858f-8d1459bd323c

after:

https://github.com/user-attachments/assets/852e08e4-e299-4f09-9246-2b74f00b5f9a


