### PR TITLE
Add stochastic FP8 rounding to Triton backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Fast kernel library for Diffusion inference with multiple compute backends.
 |-----------------------------|-------|------|--------|-----|
 | `quantize_per_tensor_fp8`   | ✓     | ✓    | ✓      | ✓   |
 | `dequantize_per_tensor_fp8` | ✓     | ✓    | ✓      | ✓   |
-| `stochastic_rounding_fp8`   | ✓     | ✓    |        | ✓   |
+| `stochastic_rounding_fp8`   | ✓     | ✓    | ✓      | ✓   |
 | `quantize_nvfp4`            | ✓     | ✓    | ✓      |     |
 | `dequantize_nvfp4`          | ✓     | ✓    | ✓      |     |
 | `scaled_mm_nvfp4`           | ✓     | ✓    |        |     |

--- a/comfy_kitchen/backends/triton/__init__.py
+++ b/comfy_kitchen/backends/triton/__init__.py
@@ -23,6 +23,7 @@ __all__ = [
     "quantize_mxfp8",
     "quantize_nvfp4",
     "quantize_per_tensor_fp8",
+    "stochastic_rounding_fp8",
     "int8_linear",
     "quantize_int8_rowwise",
     "quantize_and_rotate_rowwise",
@@ -62,6 +63,7 @@ try:
         quantize_mxfp8,
         quantize_nvfp4,
         quantize_per_tensor_fp8,
+        stochastic_rounding_fp8,
     )
     from .quantization import (
         triton_quantize_and_rotate_rowwise as _triton_quantize_and_rotate_rowwise,
@@ -167,6 +169,17 @@ def _build_constraints() -> dict:
                 "output_type": ParamConstraint(dtypes=standard_floats),
             },
             default_devices=triton_devices,
+        ),
+        "stochastic_rounding_fp8": FunctionConstraints(
+            params={
+                "x": ParamConstraint(dtypes=standard_floats),
+                "rng": ParamConstraint(dtypes=frozenset({torch.uint8})),
+                "output_type": ParamConstraint(
+                    dtypes=frozenset({torch.float8_e4m3fn, torch.float8_e5m2}),
+                ),
+            },
+            default_devices=cuda_devices,
+            min_compute_capability=(8, 9),  # Native FP8 conversion requires Ada or newer.
         ),
         "quantize_nvfp4": FunctionConstraints(
             params={

--- a/comfy_kitchen/backends/triton/quantization.py
+++ b/comfy_kitchen/backends/triton/quantization.py
@@ -157,6 +157,129 @@ def dequantize_per_tensor_fp8(
 
 
 @triton.jit
+def stochastic_rounding_fp8_kernel_tl(
+    x_ptr,
+    rng_ptr,
+    output_ptr,
+    n_elements,
+    fp8_max: tl.constexpr,
+    exponent_max: tl.constexpr,
+    exponent_bias: tl.constexpr,
+    mantissa_bits: tl.constexpr,
+    block_size: tl.constexpr,
+):
+    """Round values to FP8 using one random byte per element.
+
+    The RNG buffer is also the output buffer. Every lane consumes its byte before
+    replacing it with the encoded FP8 value, matching the native CUDA kernel.
+    """
+    # Keep address arithmetic valid for tensors with more than 2**31 elements.
+    pid = tl.program_id(0).to(tl.int64)
+    block_start = pid * block_size
+    offsets = block_start + tl.arange(0, block_size)
+    mask = offsets < n_elements
+
+    # Match native CUDA: round the input through FP16, then use FP32 arithmetic.
+    x = tl.load(x_ptr + offsets, mask=mask, other=0.0).to(tl.float16).to(tl.float32)
+    random = tl.load(rng_ptr + offsets, mask=mask, other=0).to(tl.float32) / 256.0
+
+    # Split the magnitude into an FP8 exponent and a normal/subnormal mantissa.
+    abs_x = tl.abs(x)
+    sign = tl.where(x > 0.0, 1.0, tl.where(x < 0.0, -1.0, 0.0))
+    exponent = tl.floor(tl.log2(abs_x)) + exponent_bias
+    exponent = tl.maximum(tl.minimum(exponent, exponent_max), 0.0)
+    normal = exponent != 0.0
+
+    mantissa_levels = 2**mantissa_bits
+    exponent_scale = tl.exp2(exponent - exponent_bias)
+    normal_mantissa = (abs_x / exponent_scale - 1.0) * mantissa_levels
+    subnormal_mantissa = abs_x / (2.0 ** (-exponent_bias + 1 - mantissa_bits))
+
+    # Adding rng / 256 before floor selects the upper value with the fractional
+    # mantissa probability, without generating random numbers inside the kernel.
+    mantissa = tl.floor(tl.where(normal, normal_mantissa, subnormal_mantissa) + random)
+    mantissa /= mantissa_levels
+
+    # Reconstruct the rounded value, saturate it, and retain NaNs across targets
+    # whose min/max instructions otherwise replace NaN with a finite operand.
+    normal_value = exponent_scale * (1.0 + mantissa)
+    subnormal_value = (2.0 ** (-exponent_bias + 1)) * mantissa
+    rounded = sign * tl.where(normal, normal_value, subnormal_value)
+    rounded = tl.maximum(tl.minimum(rounded, fp8_max), -fp8_max)
+    rounded = tl.where(x != x, x, rounded)
+    tl.store(output_ptr + offsets, rounded, mask=mask)
+
+
+def stochastic_rounding_fp8(
+    x: torch.Tensor,
+    rng: torch.Tensor,
+    output_type: torch.dtype = torch.float8_e4m3fn,
+) -> torch.Tensor:
+    """Stochastically round x to FP8 using bytes from rng.
+
+    A contiguous RNG tensor is overwritten and returned as an FP8 view, avoiding
+    a separate output allocation. Non-contiguous inputs follow the CUDA wrapper
+    convention and are materialized before launch.
+    """
+    if output_type == torch.float8_e4m3fn:
+        fp8_max = F8_E4M3_MAX
+        exponent_max, exponent_bias, mantissa_bits = 15, 7, 3
+    elif output_type == torch.float8_e5m2:
+        fp8_max = F8_E5M2_MAX
+        exponent_max, exponent_bias, mantissa_bits = 31, 15, 2
+    else:
+        raise ValueError(
+            f"Unsupported output_type: {output_type}. Expected torch.float8_e4m3fn "
+            "or torch.float8_e5m2"
+        )
+
+    if x.device != rng.device:
+        raise ValueError(f"x and rng must be on the same device, got {x.device} and {rng.device}")
+    if x.shape != rng.shape:
+        raise ValueError(f"x and rng must have the same shape, got {x.shape} and {rng.shape}")
+    if rng.dtype != torch.uint8:
+        raise ValueError(f"rng must have dtype torch.uint8, got {rng.dtype}")
+
+    if not x.is_contiguous():
+        x = x.contiguous()
+    if not rng.is_contiguous():
+        rng = rng.contiguous()
+
+    orig_shape = x.shape
+    x_flat = x.flatten()
+    rng_flat = rng.flatten()
+    n_elements = x_flat.numel()
+    output = rng_flat.view(output_type)
+
+    if n_elements == 0:
+        return output.view(orig_shape)
+
+    if n_elements < 32768:  # < 32K elements
+        block_size = 128
+    elif n_elements < 131072:  # < 128K elements
+        block_size = 256
+    elif n_elements < 524288:  # < 512K elements
+        block_size = 512
+    else:
+        block_size = 1024
+
+    grid = (triton.cdiv(n_elements, block_size),)
+    stochastic_rounding_fp8_kernel_tl[grid](
+        x_flat,
+        rng_flat,
+        output,
+        n_elements,
+        fp8_max=fp8_max,
+        exponent_max=exponent_max,
+        exponent_bias=exponent_bias,
+        mantissa_bits=mantissa_bits,
+        block_size=block_size,
+    )
+
+    return output.view(orig_shape)
+
+
+@triton.jit
 def _compute_swizzled_scale_offset(
     in_row,
     in_col,

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -261,6 +261,14 @@ class TestRegistryConstraintValidation:
         assert "x" in constraints.params
         assert torch.float32 in constraints.params["x"].dtypes
 
+    def test_triton_stochastic_fp8_requires_native_fp8_support(self):
+        """Triton FP8 conversion starts with Ada (SM89)."""
+        pytest.importorskip("triton")
+        from comfy_kitchen.backends.triton import _build_constraints
+
+        constraints = _build_constraints()["stochastic_rounding_fp8"]
+        assert constraints.min_compute_capability == (8, 9)
+
 
 class TestIntegrationWithBackends:
     """Integration tests for constraint validation with actual backends."""

--- a/tests/test_qdq.py
+++ b/tests/test_qdq.py
@@ -130,6 +130,120 @@ class TestQuantizeFP8MisalignedView:
             assert torch.equal(out_view.view(torch.uint8), out_contig.view(torch.uint8))
 
 
+def _stochastic_rounding_fp8_reference(x, rng, output_dtype):
+    """Mirror the CUDA kernel's FP16 input conversion and FP32 arithmetic."""
+    if output_dtype == torch.float8_e4m3fn:
+        exponent_bits, mantissa_bits, exponent_bias = 4, 3, 7
+    else:
+        exponent_bits, mantissa_bits, exponent_bias = 5, 2, 15
+
+    x = x.half().float()
+    sign = torch.sign(x)
+    abs_x = x.abs()
+    sign = torch.where(abs_x == 0, 0, sign)
+    exponent = torch.clamp(
+        torch.floor(torch.log2(abs_x)) + exponent_bias,
+        0,
+        2**exponent_bits - 1,
+    )
+    normal = exponent != 0
+    mantissa_levels = 2**mantissa_bits
+    mantissa = torch.where(
+        normal,
+        (abs_x / torch.exp2(exponent - exponent_bias) - 1.0) * mantissa_levels,
+        abs_x / (2.0 ** (-exponent_bias + 1 - mantissa_bits)),
+    )
+    mantissa = torch.floor(mantissa + rng.float() / 256.0) / mantissa_levels
+    rounded = sign * torch.where(
+        normal,
+        torch.exp2(exponent - exponent_bias) * (1.0 + mantissa),
+        (2.0 ** (-exponent_bias + 1)) * mantissa,
+    )
+    info = torch.finfo(output_dtype)
+    return torch.clamp(rounded, min=info.min, max=info.max).to(output_dtype)
+
+
+class TestStochasticRoundingFP8:
+    @pytest.fixture
+    def triton_backend(self, device):
+        if "triton" not in get_capable_backends("stochastic_rounding_fp8", device):
+            pytest.skip(f"Triton stochastic_rounding_fp8 is not supported on {device}")
+        return "triton"
+
+    @pytest.mark.parametrize("input_dtype", [torch.float32, torch.float16, torch.bfloat16])
+    @pytest.mark.parametrize("output_dtype", [torch.float8_e4m3fn, torch.float8_e5m2])
+    @pytest.mark.parametrize("numel", [17, 32769, 131073, 524289])
+    def test_matches_reference(self, triton_backend, device, seed, input_dtype, output_dtype, numel):
+        x = torch.randn(numel, device=device, dtype=input_dtype) * 10
+        rng = torch.randint(0, 256, x.shape, dtype=torch.uint8, device=device)
+
+        expected = _stochastic_rounding_fp8_reference(x, rng, output_dtype)
+        with ck.use_backend(triton_backend):
+            actual = ck.stochastic_rounding_fp8(x, rng.clone(), output_dtype)
+
+        assert torch.equal(actual.view(torch.uint8), expected.view(torch.uint8))
+
+    @pytest.mark.parametrize("input_dtype", [torch.float32, torch.float16, torch.bfloat16])
+    @pytest.mark.parametrize("output_dtype", [torch.float8_e4m3fn, torch.float8_e5m2])
+    def test_edge_values(self, triton_backend, device, input_dtype, output_dtype):
+        values = [
+            float("nan"),
+            -float("nan"),
+            float("inf"),
+            -float("inf"),
+            1e30,
+            -1e30,
+            57344.0,
+            -57344.0,
+            448.0,
+            -448.0,
+            0.0,
+            -0.0,
+            1.0,
+            1e-9,
+        ]
+        x = torch.tensor(values, device=device, dtype=input_dtype)
+        rng = torch.arange(len(values), device=device, dtype=torch.uint8) * 17
+
+        expected = _stochastic_rounding_fp8_reference(x, rng, output_dtype)
+        with ck.use_backend(triton_backend):
+            actual = ck.stochastic_rounding_fp8(x, rng.clone(), output_dtype)
+
+        nan = torch.isnan(x.float())
+        assert torch.equal(actual.view(torch.uint8)[~nan], expected.view(torch.uint8)[~nan])
+        assert torch.isnan(actual.float()[nan]).all()
+
+    def test_noncontiguous_inputs_and_buffer_reuse(self, triton_backend, device, seed):
+        x = torch.randn(8, 32, device=device, dtype=torch.bfloat16)[:, ::2]
+        rng = torch.randint(0, 256, (8, 32), dtype=torch.uint8, device=device)[:, ::2]
+
+        expected = _stochastic_rounding_fp8_reference(
+            x.contiguous(), rng.contiguous(), torch.float8_e4m3fn
+        )
+        with ck.use_backend(triton_backend):
+            actual = ck.stochastic_rounding_fp8(x, rng, torch.float8_e4m3fn)
+
+        assert torch.equal(actual.view(torch.uint8), expected.view(torch.uint8))
+
+        contiguous_rng = rng.contiguous()
+        with ck.use_backend(triton_backend):
+            actual = ck.stochastic_rounding_fp8(
+                x.contiguous(), contiguous_rng, torch.float8_e4m3fn
+            )
+        assert actual.data_ptr() == contiguous_rng.data_ptr()
+
+    def test_empty_input(self, triton_backend, device):
+        x = torch.empty((0, 8), device=device, dtype=torch.float16)
+        rng = torch.empty_like(x, dtype=torch.uint8)
+
+        with ck.use_backend(triton_backend):
+            output = ck.stochastic_rounding_fp8(x, rng)
+
+        assert output.shape == x.shape
+        assert output.dtype == torch.float8_e4m3fn
+        assert output.data_ptr() == rng.data_ptr()
+
+
 class TestDequantizePerTensorFP8:
     """FP8 dequantization tests."""
 

--- a/tests/test_qdq.py
+++ b/tests/test_qdq.py
@@ -166,6 +166,8 @@ def _stochastic_rounding_fp8_reference(x, rng, output_dtype):
 class TestStochasticRoundingFP8:
     @pytest.fixture
     def triton_backend(self, device):
+        if device != "cuda" or torch.cuda.get_device_capability() < (8, 9):
+            pytest.skip("Triton stochastic_rounding_fp8 requires CUDA SM 8.9+")
         if "triton" not in get_capable_backends("stochastic_rounding_fp8", device):
             pytest.skip(f"Triton stochastic_rounding_fp8 is not supported on {device}")
         return "triton"


### PR DESCRIPTION
## Summary

Add a Triton implementation of `stochastic_rounding_fp8` for NVIDIA GPUs with native FP8 support (compute capability 8.9+). This avoids the slow, memory-heavy eager fallback reported in Comfy-Org/ComfyUI#15311 when the native CUDA backend is unavailable.

## Changes

- Match the CUDA path: FP16 input rounding followed by FP32 stochastic-rounding arithmetic.
- Support FP32, FP16, and BF16 input with E4M3FN or E5M2 output.
- Reuse the contiguous `uint8` RNG buffer as output, avoiding an additional output allocation.
- Use adaptive block sizes and 64-bit offsets for large tensors.
- Register the operation for CUDA devices with compute capability >= 8.9 and add tests.

## Correctness and compatibility

- Exhaustive finite-value check: all 65,536 FP16 bit patterns x 256 RNG values, with zero Triton/CUDA mismatches for both FP8 formats.
- Offline compilation: 96 combinations across SM89, SM90, SM100, SM120, all input/output types, and all block sizes.
- Every compiled variant uses 4 warps, 0 bytes shared memory, and 0 bytes global scratch memory.

## RTX 5090 performance

BF16 to E4M3FN, warmed kernels, median latency, rotating working set >= 256 MiB:

| Elements | CUDA | Triton | Eager | Triton vs CUDA | Triton vs Eager |
|---:|---:|---:|---:|---:|---:|
| 1,048,576 | 0.0136 ms | 0.0266 ms | 0.3538 ms | 1.95x slower | 13.3x faster |
| 8,388,608 | 0.0329 ms | 0.0263 ms | 0.3696 ms | 1.25x faster | 14.1x faster |
| 16,777,216 | 0.0628 ms | 0.0415 ms | 0.8942 ms | 1.51x faster | 21.5x faster |

For 16,777,216 contiguous BF16 elements, both CUDA and Triton add 0 MiB of peak PyTorch-allocated memory because the output aliases the RNG buffer. Eager adds 240 MiB.

## Validation

```text
118 passed, 4 skipped
ruff: All checks passed
git diff --check: passed
```
