### PR TITLE
HIP port of #156: Sol-Attn token routing, plus a folded fp16 rounding and the test gate that hid it

### DIFF
--- a/comfy_kitchen/__init__.py
+++ b/comfy_kitchen/__init__.py
@@ -179,8 +179,8 @@ def sol_attn(
             ``gate * softmax(q_mean k_mean^T * scale) v_mean`` is added per block.
         token_aug: 0, or a multiple of 64 up to 256: up to that many tokens per
             query block are routed individually, the highest-scoring ones outside
-            the routed blocks, and attended exactly. CUDA only; other backends
-            run without it.
+            the routed blocks, and attended exactly. The eager reference ignores
+            it.
 
     Returns:
         ``(B, T, H, 128)`` attention output.

--- a/comfy_kitchen/backends/cuda/__init__.py
+++ b/comfy_kitchen/backends/cuda/__init__.py
@@ -2478,8 +2478,7 @@ def sol_attn(
     block's centroid scores highest (whole histogram bins only, so the set
     never depends on scheduling; a flat score profile may admit none), and the
     remaining tail is exact for the centroid instead of pooled per block.
-    CUDA only: the HIP backend runs without it (one warning), the eager
-    reference ignores it.
+    The eager reference ignores it.
     """
     batch, t, h, d = q.shape
     if q.dtype not in (torch.bfloat16, torch.float16):

--- a/comfy_kitchen/backends/hip/CMakeLists.txt
+++ b/comfy_kitchen/backends/hip/CMakeLists.txt
@@ -169,6 +169,7 @@ set(HIP_SOURCES
     sage_attention/sol_attn_producer.hip
     sage_attention/sol_attn_route.hip
     sage_attention/sol_attn_exact.hip
+    sage_attention/sol_attn_token.hip
     ops/apply_rope.hip
     ops/flash_decode.hip
     ops/rms_rope.hip

--- a/comfy_kitchen/backends/hip/__init__.py
+++ b/comfy_kitchen/backends/hip/__init__.py
@@ -218,16 +218,6 @@ def is_available() -> bool:
     return _EXT_AVAILABLE and _unsupported_arch_reason(_visible_gfx_arches()) is None
 
 
-_token_aug_warned = False
-
-
-def _warn_token_aug_once() -> None:
-    global _token_aug_warned
-    if not _token_aug_warned:
-        _token_aug_warned = True
-        logger.warning("sol_attn: token_aug is not implemented on the HIP backend; running without it")
-
-
 def has_wmma() -> bool:
     """Whether the GEMM kernels can run: every visible device has matrix cores.
 
@@ -1886,9 +1876,12 @@ def sol_attn(
     ``topk_ratio`` > 0 switches selection from the tau threshold to SLA-style
     per-query-block top-k: keep that fraction of key blocks per query block (sinks
     and the diagonal still ride on top). tau is ignored then.
+
+    ``token_aug`` (0, or a multiple of 64 up to 256): on top of the routed blocks,
+    every row attends up to that many unrouted tokens its query block's centroid
+    scores highest, and the remaining tail is exact for the centroid instead of
+    pooled per block.
     """
-    if token_aug:
-        _warn_token_aug_once()
     batch, t, h, d = q.shape
     if q.dtype not in (torch.bfloat16, torch.float16):
         raise ValueError(f"sol_attn: q/k/v must be bfloat16 or float16, got {q.dtype}")
@@ -1927,7 +1920,7 @@ def sol_attn(
         kb = _normalize_key_bias(key_bias, batch, t, q.device)
         kb = (kb * _LOG2E).expand(batch, t).contiguous()
     out = torch.empty(q.shape, dtype=q.dtype, device=q.device)
-    p = _C.sol_attn_plan(batch, t, h)
+    p = _C.sol_attn_plan(batch, t, h, token_aug=int(token_aug))
     workspace = torch.empty(p["total"], dtype=torch.uint8, device=q.device)
     _C.sol_attn(
         _dl(q), _dl(k), _dl(v), _dl(out), _dl(workspace),
@@ -1938,7 +1931,7 @@ def sol_attn(
         key_bias=None if kb is None else _dl(kb),
         threshold=None if thr is None else _dl(thr),
         block_len=None if block_len is None else _dl(block_len),
-        tail=bool(tail),
+        tail=bool(tail), token_aug=int(token_aug),
     )
     if coarse_gate is not None:
         add_coarse_(out, coarse_output(*_ws_block_means(workspace, p, batch * h, lengths), scale),
@@ -1967,14 +1960,12 @@ def sol_attn_chunked(
 ):
     """Chunked-producer Sol-Attn over fused qkv projection chunks ([M, 3*H*128]
     bf16, 64-aligned starts, B=1); full Q/K/V are never materialised.
-    ``tail`` / ``block_len`` / ``coarse_gate`` as in ``sol_attn``.
+    ``tail`` / ``block_len`` / ``coarse_gate`` / ``token_aug`` as in ``sol_attn``.
 
     ``qkv_chunks``: an iterable of chunks or a zero-arg callable returning one.
     ``kmean``/``vscale`` are LAST step's statistics ([H,128] f32); when None the
     producer runs twice (measure, then quantize), so pass a callable to stream on
     the first call. Returns ``(out[1,T,H,128] bf16, kmean_next, vscale_next)``."""
-    if token_aug:
-        _warn_token_aug_once()
     d = _SOL_HD
     rot = rope_freqs.shape[-3] * 2
     # the fused rope pairs channels across lanes of 4: rot/2 must be lane-aligned
@@ -1995,13 +1986,13 @@ def sol_attn_chunked(
     if factory is None and (kmean is None or vscale is None):
         qkv_chunks = list(qkv_chunks)          # need two passes over it
         factory = lambda: iter(qkv_chunks)     # noqa: E731
-    p = _C.sol_attn_plan(1, t, h)
+    p = _C.sol_attn_plan(1, t, h, token_aug=int(token_aug))
     ws = torch.empty(p["total"], dtype=torch.uint8, device=dev)
     stream = torch.cuda.current_stream(dev).cuda_stream
     width = 3 * h * d
 
     def produce(km, vsc):
-        _C.sol_producer_begin(_dl(ws), 1, t, h, stream)
+        _C.sol_producer_begin(_dl(ws), 1, t, h, stream, token_aug=int(token_aug))
         t0 = 0
         for chunk in (factory() if factory is not None else qkv_chunks):
             m = chunk.shape[-2]
@@ -2015,7 +2006,8 @@ def sol_attn_chunked(
             _C.sol_producer_chunk(
                 _dl(ws), _dl(chunk.contiguous()), _dl(fab), _dl(qw), _dl(kw), _dl(km), _dl(vsc),
                 float(rope_eps), rot, t0, m, 1, t, h, stream,
-                block_len=None if block_len is None else _dl(block_len))
+                block_len=None if block_len is None else _dl(block_len),
+                token_aug=int(token_aug))
             t0 += m
         if t0 != t:
             raise ValueError(f"sol_attn_chunked: chunks cover {t0} tokens, T={t}")
@@ -2043,7 +2035,8 @@ def sol_attn_chunked(
         _dl(ws), _dl(out), _dl(vscale), _dl(kmean_next), _dl(vamax),
         1, t, h, float(tau), float(scale), sb[0], sb[1], sq[0], sq[1], stream,
         threshold=None if threshold is None else _dl(threshold),
-        block_len=None if block_len is None else _dl(block_len), tail=bool(tail))
+        block_len=None if block_len is None else _dl(block_len), tail=bool(tail),
+        token_aug=int(token_aug))
     if coarse_gate is not None:
         add_coarse_(out, coarse_output(*_ws_block_means(ws, p, h, lengths), scale), coarse_gate)
     return out, kmean_next, vscale_of(vamax)

--- a/comfy_kitchen/backends/hip/dlpack_bindings.cpp
+++ b/comfy_kitchen/backends/hip/dlpack_bindings.cpp
@@ -1557,11 +1557,11 @@ static void sol_check_block_len(const nb::ndarray<>& b, int64_t seq_len, const c
 }
 
 static void sol_need_workspace(const nb::ndarray<>& ws, int64_t batch, int64_t seq_len,
-                               int64_t num_heads, const char* fn) {
-    int64_t v[32];
+                               int64_t num_heads, int64_t token_aug, const char* fn) {
+    int64_t v[48];
     const int n = sol_attn_plan(static_cast<int>(batch), static_cast<int>(seq_len),
-                                static_cast<int>(num_heads), v, 32);
-    if (n > 32 || static_cast<int64_t>(ws.size()) < v[n - 1]) {  // last slot is "total"
+                                static_cast<int>(num_heads), static_cast<int>(token_aug), v, 48);
+    if (n > 48 || static_cast<int64_t>(ws.size()) < v[n - 1]) {  // last slot is "total"
         throw std::runtime_error(std::string(fn) + ": workspace too small for this shape");
     }
     // sol_attn_plan reports byte offsets and the Python layer slices the workspace
@@ -1612,11 +1612,12 @@ static void sol_need_contiguous(const nb::ndarray<>& a, const char* fn, const ch
 }
 
 // Workspace dims and slot byte offsets, from the C++ Plan (the one definition).
-nb::dict sol_attn_plan_py(int64_t batch, int64_t seq_len, int64_t num_heads) {
-    int64_t v[32];
+nb::dict sol_attn_plan_py(int64_t batch, int64_t seq_len, int64_t num_heads,
+                          int64_t token_aug = 0) {
+    int64_t v[48];
     const int n = sol_attn_plan(static_cast<int>(batch), static_cast<int>(seq_len),
-                                static_cast<int>(num_heads), v, 32);
-    if (n > 32) throw std::runtime_error("sol_attn_plan: Plan grew past the binding's buffer");
+                                static_cast<int>(num_heads), static_cast<int>(token_aug), v, 48);
+    if (n > 48) throw std::runtime_error("sol_attn_plan: Plan grew past the binding's buffer");
     nb::dict d;
     for (int i = 0; i < n && sol_attn_plan_names[i]; ++i) d[sol_attn_plan_names[i]] = v[i];
     return d;
@@ -1627,7 +1628,7 @@ void sol_attn(nb::ndarray<> q, nb::ndarray<> k, nb::ndarray<> v, nb::ndarray<> o
               int64_t head_dim, float tau, float scale, int64_t sink_start, int64_t sink_end,
               int64_t sink_q_start, int64_t sink_q_end, uintptr_t stream_ptr,
               OptArray key_bias = std::nullopt, OptArray threshold = std::nullopt,
-              OptArray block_len = std::nullopt, bool tail = true) {
+              OptArray block_len = std::nullopt, bool tail = true, int64_t token_aug = 0) {
     constexpr const char* kFn = "sol_attn";
     auto stream = reinterpret_cast<hipStream_t>(stream_ptr);
     sol_need_extents(batch, seq_len, num_heads, kFn);
@@ -1647,7 +1648,7 @@ void sol_attn(nb::ndarray<> q, nb::ndarray<> k, nb::ndarray<> v, nb::ndarray<> o
     sol_need_staging_layout(k, kFn, "k");
     sol_need_staging_layout(v, kFn, "v");
     sol_need_contiguous(out, kFn, "out");
-    sol_need_workspace(workspace, batch, seq_len, num_heads, kFn);
+    sol_need_workspace(workspace, batch, seq_len, num_heads, token_aug, kFn);
     if (key_bias) sol_need_elems(*key_bias, batch * seq_len, 0, kFn, "key_bias");
     // Explicit strides: only the last dim must be contiguous (BHND views go in as-is).
     launch_sol_attn(q.data(), k.data(), v.data(), out.data(), workspace.data(),
@@ -1657,16 +1658,17 @@ void sol_attn(nb::ndarray<> q, nb::ndarray<> k, nb::ndarray<> v, nb::ndarray<> o
                     static_cast<int>(sink_start), static_cast<int>(sink_end),
                     static_cast<int>(sink_q_start), static_cast<int>(sink_q_end), q.stride(0),
                     q.stride(1), q.stride(2), k.stride(0), k.stride(1), k.stride(2), v.stride(0),
-                    v.stride(1), v.stride(2), stream);
+                    v.stride(1), v.stride(2), static_cast<int>(token_aug), stream);
     check_hip_launch();
 }
 
 void sol_producer_begin_py(nb::ndarray<> workspace, int64_t batch, int64_t seq_len,
-                           int64_t num_heads, uintptr_t stream_ptr) {
+                           int64_t num_heads, uintptr_t stream_ptr, int64_t token_aug = 0) {
     sol_need_extents(batch, seq_len, num_heads, "sol_producer_begin");
-    sol_need_workspace(workspace, batch, seq_len, num_heads, "sol_producer_begin");
+    sol_need_workspace(workspace, batch, seq_len, num_heads, token_aug, "sol_producer_begin");
     sol_producer_begin(workspace.data(), static_cast<int>(batch), static_cast<int>(seq_len),
-                       static_cast<int>(num_heads), reinterpret_cast<hipStream_t>(stream_ptr));
+                       static_cast<int>(num_heads), static_cast<int>(token_aug),
+                       reinterpret_cast<hipStream_t>(stream_ptr));
     check_hip_launch();
 }
 
@@ -1674,7 +1676,8 @@ void sol_producer_chunk_py(nb::ndarray<> workspace, nb::ndarray<> qkv, nb::ndarr
                            nb::ndarray<> qw, nb::ndarray<> kw, nb::ndarray<> kmean,
                            nb::ndarray<> vscale, float rope_eps, int64_t rot_dim, int64_t t0,
                            int64_t m, int64_t batch, int64_t seq_len, int64_t num_heads,
-                           uintptr_t stream_ptr, OptArray block_len = std::nullopt) {
+                           uintptr_t stream_ptr, OptArray block_len = std::nullopt,
+                           int64_t token_aug = 0) {
     constexpr const char* kFn = "sol_producer_chunk";
     sol_need_extents(batch, seq_len, num_heads, kFn);
     if (batch != 1) throw std::runtime_error(std::string(kFn) + ": the producer path is B=1 only");
@@ -1688,7 +1691,7 @@ void sol_producer_chunk_py(nb::ndarray<> workspace, nb::ndarray<> qkv, nb::ndarr
             ": chunk [t0, t0 + m) must lie in [0, seq_len] with a 64-aligned start");
     }
     if (block_len) sol_check_block_len(*block_len, seq_len, kFn);
-    sol_need_workspace(workspace, batch, seq_len, num_heads, kFn);
+    sol_need_workspace(workspace, batch, seq_len, num_heads, token_aug, kFn);
     sol_need_elems(qkv, m * 3 * num_heads * 128, 2, kFn, "qkv");
     sol_need_elems(fab, seq_len * rot_dim * 2, 0, kFn, "fab");
     sol_need_elems(qw, 128, 2, kFn, "qw");
@@ -1699,7 +1702,8 @@ void sol_producer_chunk_py(nb::ndarray<> workspace, nb::ndarray<> qkv, nb::ndarr
                        kmean.data(), vscale.data(), opt_data(block_len), rope_eps,
                        static_cast<int>(rot_dim), static_cast<int>(t0), static_cast<int>(m),
                        static_cast<int>(batch), static_cast<int>(seq_len),
-                       static_cast<int>(num_heads), reinterpret_cast<hipStream_t>(stream_ptr));
+                       static_cast<int>(num_heads), static_cast<int>(token_aug),
+                       reinterpret_cast<hipStream_t>(stream_ptr));
     check_hip_launch();
 }
 
@@ -1708,7 +1712,8 @@ void sol_attn_core_py(nb::ndarray<> workspace, nb::ndarray<> out, nb::ndarray<> 
                       int64_t seq_len, int64_t num_heads, float tau, float scale,
                       int64_t sink_start, int64_t sink_end, int64_t sink_q_start,
                       int64_t sink_q_end, uintptr_t stream_ptr, OptArray threshold = std::nullopt,
-                      OptArray block_len = std::nullopt, bool tail = true) {
+                      OptArray block_len = std::nullopt, bool tail = true,
+                      int64_t token_aug = 0) {
     constexpr const char* kFn = "sol_attn_core";
     sol_need_extents(batch, seq_len, num_heads, kFn);
     sol_need_sinks(sink_start, sink_end, kFn, "sink_blocks");
@@ -1721,7 +1726,7 @@ void sol_attn_core_py(nb::ndarray<> workspace, nb::ndarray<> out, nb::ndarray<> 
         sol_need_elems(*threshold, batch * num_heads * ((seq_len + 63) / 64), 0, kFn, "threshold");
     }
     if (block_len) sol_check_block_len(*block_len, seq_len, kFn);
-    sol_need_workspace(workspace, batch, seq_len, num_heads, kFn);
+    sol_need_workspace(workspace, batch, seq_len, num_heads, token_aug, kFn);
     sol_need_elems(out, batch * seq_len * num_heads * 128, 2, kFn, "out");
     launch_sol_attn_core(workspace.data(), out.data(), vscale.data(), kmean_next.data(),
                          vamax_out.data(), opt_data(block_len), tail ? 1 : 0,
@@ -1729,6 +1734,7 @@ void sol_attn_core_py(nb::ndarray<> workspace, nb::ndarray<> out, nb::ndarray<> 
                          static_cast<int>(num_heads), tau, scale, opt_data(threshold),
                          static_cast<int>(sink_start), static_cast<int>(sink_end),
                          static_cast<int>(sink_q_start), static_cast<int>(sink_q_end),
+                         static_cast<int>(token_aug),
                          reinterpret_cast<hipStream_t>(stream_ptr));
     check_hip_launch();
 }
@@ -1736,8 +1742,9 @@ void sol_attn_core_py(nb::ndarray<> workspace, nb::ndarray<> out, nb::ndarray<> 
 NB_MODULE(_C, m) {
     m.doc() = "ComfyKitchen HIP backend native operations (RDNA2-RDNA4, WMMA on gfx11/gfx12)";
     m.def("sol_attn_plan", &sol_attn_plan_py,
-          "Workspace dims, slot byte offsets and total bytes for this shape",
-          nb::arg("batch"), nb::arg("seq_len"), nb::arg("num_heads"));
+          "Workspace dims, slot byte offsets and total bytes for this shape and token budget",
+          nb::arg("batch"), nb::arg("seq_len"), nb::arg("num_heads"),
+          nb::arg("token_aug") = 0);
     m.def("sol_attn", &sol_attn,
           "Sol-Attn training-free sparse attention (BF16 or FP16 in/out, head_dim 128)",
           nb::arg("q"), nb::arg("k"), nb::arg("v"), nb::arg("out"), nb::arg("workspace"),
@@ -1745,22 +1752,24 @@ NB_MODULE(_C, m) {
           nb::arg("tau"), nb::arg("scale"), nb::arg("sink_start"), nb::arg("sink_end"),
           nb::arg("sink_q_start"), nb::arg("sink_q_end"), nb::arg("stream_ptr"),
           nb::arg("key_bias") = nb::none(), nb::arg("threshold") = nb::none(),
-          nb::arg("block_len") = nb::none(), nb::arg("tail") = true);
+          nb::arg("block_len") = nb::none(), nb::arg("tail") = true,
+          nb::arg("token_aug") = 0);
     m.def("sol_producer_begin", &sol_producer_begin_py,
           nb::arg("workspace"), nb::arg("batch"), nb::arg("seq_len"), nb::arg("num_heads"),
-          nb::arg("stream_ptr"));
+          nb::arg("stream_ptr"), nb::arg("token_aug") = 0);
     m.def("sol_producer_chunk", &sol_producer_chunk_py,
           nb::arg("workspace"), nb::arg("qkv"), nb::arg("fab"), nb::arg("qw"), nb::arg("kw"),
           nb::arg("kmean"), nb::arg("vscale"), nb::arg("rope_eps"), nb::arg("rot_dim"),
           nb::arg("t0"), nb::arg("m"), nb::arg("batch"), nb::arg("seq_len"), nb::arg("num_heads"),
-          nb::arg("stream_ptr"), nb::arg("block_len") = nb::none());
+          nb::arg("stream_ptr"), nb::arg("block_len") = nb::none(),
+          nb::arg("token_aug") = 0);
     m.def("sol_attn_core", &sol_attn_core_py,
           nb::arg("workspace"), nb::arg("out"), nb::arg("vscale"), nb::arg("kmean_next"),
           nb::arg("vamax_out"), nb::arg("batch"), nb::arg("seq_len"), nb::arg("num_heads"),
           nb::arg("tau"), nb::arg("scale"), nb::arg("sink_start"), nb::arg("sink_end"),
           nb::arg("sink_q_start"), nb::arg("sink_q_end"), nb::arg("stream_ptr"),
           nb::arg("threshold") = nb::none(), nb::arg("block_len") = nb::none(),
-          nb::arg("tail") = true);
+          nb::arg("tail") = true, nb::arg("token_aug") = 0);
     m.def("quantize_per_tensor_fp8", &quantize_per_tensor_fp8);
     m.def("dequantize_per_tensor_fp8", &dequantize_per_tensor_fp8);
     m.def("stochastic_round_fp8", &stochastic_round_fp8);

--- a/comfy_kitchen/backends/hip/launchers.h
+++ b/comfy_kitchen/backends/hip/launchers.h
@@ -64,23 +64,23 @@ void launch_w4a8_int8_gemm_chunked_kernel(const void* xq, const void* qw, const 
 // Sol-Attn sparse attention -- see sage_attention/sol_attn.hip. The whole pipeline
 // runs over one caller-allocated workspace whose carve-up sol_attn_plan reports.
 extern const char* const sol_attn_plan_names[];  // null-terminated
-int sol_attn_plan(int batch, int seq_len, int num_heads, int64_t* out, int cap);
-void sol_producer_begin(void* workspace, int batch, int seq_len, int num_heads,
+int sol_attn_plan(int batch, int seq_len, int num_heads, int n_tok, int64_t* out, int cap);
+void sol_producer_begin(void* workspace, int batch, int seq_len, int num_heads, int n_tok,
                         hipStream_t stream);
 void sol_producer_chunk(void* workspace, const void* qkv, const void* fab, const void* qw,
                         const void* kw, const void* kmean, const void* vscale, const void* blen,
                         float rope_eps, int rot_dim, int t0, int M, int batch, int seq_len,
-                        int num_heads, hipStream_t stream);
+                        int num_heads, int n_tok, hipStream_t stream);
 void launch_sol_attn_core(void* workspace, void* out, const void* vscale, void* kmean_next,
                           void* vamax_out, const void* blen, int tail, int batch, int seq_len,
                           int num_heads, float tau, float scale, const void* ext_threshold,
                           int sink_start, int sink_end, int sink_q_start, int sink_q_end,
-                          hipStream_t stream);
+                          int n_tok, hipStream_t stream);
 void launch_sol_attn(const void* q, const void* k, const void* v, void* out, void* workspace,
                      int batch, int seq_len, int num_heads, int head_dim, int elem, float tau, float scale,
                      const void* key_bias, const void* ext_threshold, const void* blen, int tail,
                      int sink_start, int sink_end, int sink_q_start, int sink_q_end, int64_t qs_b,
                      int64_t qs_t, int64_t qs_h, int64_t ks_b, int64_t ks_t, int64_t ks_h,
-                     int64_t vs_b, int64_t vs_t, int64_t vs_h, hipStream_t stream);
+                     int64_t vs_b, int64_t vs_t, int64_t vs_h, int n_tok, hipStream_t stream);
 
 }  // extern "C"

--- a/comfy_kitchen/backends/hip/rope_math.h
+++ b/comfy_kitchen/backends/hip/rope_math.h
@@ -29,10 +29,15 @@ __forceinline__ __device__ float round_bf16(float x) {
     return __uint_as_float(u & 0xffff0000u);
 }
 
-// Round a finite fp32 to fp16 and widen back. __float2half_rn is an intrinsic
-// conversion, so unlike a __bf16 cast it is not folded under -ffast-math.
+// Round fp32 to fp16 (round to nearest, ties to even) and widen back.
+// `__half2float(__float2half_rn(x))` does not survive -ffast-math: clang sees
+// fpext(fptrunc(x)), drops the pair, then contracts the multiply it guarded into
+// the following add. Inline asm is opaque to that, the way round_bf16's integer
+// arithmetic is. These two converts are base VALU on every target built here.
 __forceinline__ __device__ float round_fp16(float x) {
-    return __half2float(__float2half_rn(x));
+    float r;
+    asm("v_cvt_f16_f32 %0, %1\n\tv_cvt_f32_f16 %0, %0" : "=v"(r) : "v"(x));
+    return r;
 }
 
 // Round to the storage type of T without storing. rms_rope needs this for the

--- a/comfy_kitchen/backends/hip/sage_attention/sol_attn.hip
+++ b/comfy_kitchen/backends/hip/sage_attention/sol_attn.hip
@@ -5,7 +5,9 @@
 //   preprocess  quantize Q/K/V, pool K/V per block, routing threshold
 //   vtranspose  INT8 V^T for the exact stage's PV operand
 //   route       choose the routed blocks; approximate tail from the centroids
-//   exact       walk each routed list, resuming route's online softmax
+//   token       token_aug > 0 only: list the top unrouted tokens per centroid and
+//               replace route's pooled tail for the blocks they came from
+//   exact       walk each routed list, then the token list, resuming the softmax
 // Entry paths: `launch_sol_attn` (post-rope q/k/v) or the chunked producer
 // (`sol_producer_begin/chunk`, then `launch_sol_attn_core`). Tensors are
 // (B, T, H, 128) bf16 or fp16 (the chunked producer takes bf16 only) and the
@@ -33,18 +35,24 @@ void launch_sol_preprocess(const void*, const void*, const void*, void*, void*, 
 size_t sol_preprocess_scratch_bytes(int, int, int);
 void launch_sol_producer(const void*, const void*, const void*, const void*, const void*,
                          const void*, void*, void*, void*, void*, void*, void*, void*, void*,
-                         void*, void*, void*, const void*, float, int, int, int, int, int, int,
-                         int, int, hipStream_t);
+                         void*, void*, void*, void*, const void*, float, int, int, int, int, int,
+                         int, int, int, hipStream_t);
 void launch_sol_finish(void*, void*, void*, void*, const void*, const void*, void*, const void*,
                        int, int, int, int, int, int, float, float, hipStream_t);
-void launch_sol_vtranspose(const void*, const void*, void*, int, int, int, int, int64_t, int64_t,
-                           int64_t, int, hipStream_t);
+void launch_sol_vtranspose(const void*, const void*, void*, void*, int, int, int, int, int64_t,
+                           int64_t, int64_t, int, hipStream_t);
 void launch_sol_route(const void*, const void*, const void*, const void*, const void*, const void*,
-                      const void*, void*, void*, void*, void*, void*, const void*, int, int, int,
-                      int, int, int, int, int, int, int, int, float, hipStream_t);
+                      const void*, void*, void*, void*, void*, void*, void*, void*, const void*,
+                      int, int, int, int, int, int, int, int, int, int, int, float, hipStream_t);
 void launch_sol_exact(const void*, const void*, const void*, const void*, const void*,
                       const void*, const void*, const void*, const void*, const void*,
-                      const void*, void*, int, int, int, int, int, int, float, int, hipStream_t);
+                      const void*, const void*, const void*, const void*, int, void*, int, int,
+                      int, int, int, int, float, int, hipStream_t);
+void launch_sol_token(const void*, const void*, const void*, void*, void*, void*, void*,
+                      const void*, const void*, const void*, void*, void*, void*, void*, void*,
+                      void*, void*, void*, void*, void*, void*, int, int, int, int, int, int, int,
+                      int, int, int, float, hipStream_t);
+int sol_token_splits(int, int, int);
 
 namespace {
 
@@ -53,13 +61,16 @@ constexpr int BLK = comfy::hip_backend::sol::kBlock;
 
 inline size_t align16(size_t n) { return (n + 15u) & ~static_cast<size_t>(15u); }
 
-// Workspace carve-up, a pure function of the shape; exported by sol_attn_plan.
+// Workspace carve-up, a function of the shape and the token budget; exported by
+// sol_attn_plan.
 struct Plan {
     int Tp, NTB, NPAD, NQ;
     size_t qiP, qs, kiP, ksb, vTi, vsc, kciP, kcs, vcT, thr, cen8, cens;
-    size_t idx, cnt, oPart, mPart, lPart, statsV, qmean, scratch, total;
+    size_t idx, cnt, oPart, mPart, lPart, statsV, qmean, vRow, tokIdx, tokCnt, tokRef, tokHist;
+    size_t tokBits, tokTiles, tokTileCnt, gCen8, gCens, gRef, gBits;
+    size_t tokPartO, tokPartM, tokPartL, scratch, total;
 
-    Plan(int B, int T, int H) {
+    Plan(int B, int T, int H, int n_tok) {
         NTB = (T + BLK - 1) / BLK;
         Tp = NTB * BLK;
         NPAD = ((NTB + 63) / 64) * 64;  // route reads pooled keys in 64-block groups
@@ -91,10 +102,40 @@ struct Plan {
         lPart = take(bh * NQ * sizeof(float));
         statsV = take(bh * HD * sizeof(float));         // producer vamax accumulator
         qmean = take(bh * NPAD * HD * sizeof(float));   // f32 query-block means (coarse branch)
+        // token routing (empty at n_tok 0)
+        const size_t on = n_tok > 0 ? 1 : 0;
+        const size_t NG = (NQ + comfy::hip_backend::sol::kTokGroup - 1) /
+                          comfy::hip_backend::sol::kTokGroup;
+        const size_t W = (NTB + 31) / 32;
+        vRow = take(on * bh * Tp * HD);
+        tokRef = take(on * bh * NQ * sizeof(float));   // per query block (route)
+        tokBits = take(on * bh * NQ * W * sizeof(uint32_t));
+        gCen8 = take(on * bh * NG * HD);               // per group
+        gCens = take(on * bh * NG * sizeof(float));
+        gRef = take(on * bh * NG * sizeof(float));
+        gBits = take(on * bh * NG * W * sizeof(uint32_t));
+        tokIdx = take(on * bh * NG * n_tok * sizeof(uint32_t));
+        tokCnt = take(on * bh * NG * sizeof(int32_t));
+        tokHist = take(on * bh * NG * comfy::hip_backend::sol::kTokHistBins * sizeof(uint32_t));
+        const size_t groups = static_cast<size_t>((NG + 63) / 64) * bh;   // workgroups of 64 rows
+        tokTiles = take(on * groups * NTB * sizeof(uint16_t));
+        tokTileCnt = take(on * groups * sizeof(int32_t));
+        const size_t parts =
+            static_cast<size_t>(sol_token_splits(B, H, static_cast<int>(NG))) * bh * NG;
+        tokPartO = take(on * parts * HD * sizeof(uint16_t));   // bf16 partial o
+        tokPartM = take(on * parts * sizeof(float));
+        tokPartL = take(on * parts * sizeof(float));
         scratch = take(sol_preprocess_scratch_bytes(B, H, NPAD));
         total = o;
     }
 };
+
+void validate_token_aug(int n_tok) {
+    if (n_tok < 0 || n_tok > comfy::hip_backend::sol::kNTokMax || n_tok % BLK)
+        throw std::runtime_error("sol_attn: token_aug must be a multiple of 64 up to " +
+                                 std::to_string(comfy::hip_backend::sol::kNTokMax) + ", got " +
+                                 std::to_string(n_tok));
+}
 
 void validate_shape(int batch, int seq_len, int num_heads) {
     if ((seq_len + BLK - 1) / BLK > 65535)
@@ -110,16 +151,27 @@ void validate_shape(int batch, int seq_len, int num_heads) {
 void run_route_exact(const Plan& p, char* w, const void* ext_threshold, void* out,
                      const void* blen, int tail, int batch, int seq_len, int num_heads,
                      int sink_start, int sink_end, int sink_q_start, int sink_q_end,
-                     float scale_log2, int elem, hipStream_t stream) {
+                     float scale_log2, int elem, int n_tok, hipStream_t stream) {
     // top-k mode: the caller supplies the per-query-block threshold
     const void* thr = ext_threshold ? ext_threshold : static_cast<const void*>(w + p.thr);
+    // with token routing route also flags the unrouted blocks and leaves their tail
+    // to the token stage
     launch_sol_route(w + p.cen8, w + p.cens, w + p.kciP, w + p.kcs, w + p.vcT, w + p.vsc, thr,
-                     w + p.idx, w + p.cnt, w + p.oPart, w + p.mPart, w + p.lPart, blen, tail,
+                     w + p.idx, w + p.cnt, w + p.oPart, w + p.mPart, w + p.lPart,
+                     n_tok ? w + p.tokRef : nullptr, n_tok ? w + p.tokBits : nullptr, blen, tail,
                      batch, seq_len, num_heads, p.NTB, p.NPAD, p.NQ, sink_start, sink_end,
                      sink_q_start, sink_q_end, scale_log2, stream);
+    if (n_tok)
+        launch_sol_token(w + p.qmean, w + p.tokRef, w + p.tokBits, w + p.gCen8, w + p.gCens,
+                         w + p.gRef, w + p.gBits, w + p.kiP, w + p.ksb, w + p.vTi, w + p.tokTiles,
+                         w + p.tokTileCnt, w + p.tokHist, w + p.tokIdx, w + p.tokCnt,
+                         w + p.tokPartO, w + p.tokPartM, w + p.tokPartL, w + p.oPart, w + p.mPart,
+                         w + p.lPart, batch, p.Tp, num_heads, p.NQ, p.NPAD, p.NTB, n_tok, tail,
+                         sink_q_start, sink_q_end, scale_log2, stream);
     launch_sol_exact(w + p.qiP, w + p.qs, w + p.kiP, w + p.ksb, w + p.vTi, w + p.vsc, w + p.idx,
-                     w + p.cnt, w + p.oPart, w + p.mPart, w + p.lPart, out, batch, seq_len, p.Tp,
-                     num_heads, p.NQ, p.NTB, scale_log2, elem, stream);
+                     w + p.cnt, w + p.oPart, w + p.mPart, w + p.lPart, w + p.vRow, w + p.tokIdx,
+                     w + p.tokCnt, n_tok, out, batch, seq_len, p.Tp, num_heads, p.NQ, p.NTB,
+                     scale_log2, elem, stream);
     const hipError_t err = hipGetLastError();
     if (err != hipSuccess)
         throw std::runtime_error(std::string("sol_attn: kernel launch failed: ") +
@@ -132,15 +184,20 @@ using comfy::hip_backend::sol::sol_check;
 
 // Plan dims and slot offsets, in the order sol_attn_plan_names lists them.
 extern "C" const char* const sol_attn_plan_names[] = {
-    "Tp",   "NTB",  "NPAD", "NQ",     "qiP",   "qs",    "kiP",     "ksb",   "vTi",
-    "vsc",  "kciP", "kcs",  "vcT",    "thr",   "cen8",  "cens",    "idx",   "cnt",
-    "oPart", "mPart", "lPart", "statsV", "qmean", "scratch", "total", nullptr,
+    "Tp",      "NTB",      "NPAD",       "NQ",       "qiP",      "qs",       "kiP",
+    "ksb",     "vTi",      "vsc",        "kciP",     "kcs",      "vcT",      "thr",
+    "cen8",    "cens",     "idx",        "cnt",      "oPart",    "mPart",    "lPart",
+    "statsV",  "qmean",    "vRow",       "tokIdx",   "tokCnt",   "tokRef",   "tokHist",
+    "tokBits", "tokTiles", "tokTileCnt", "gCen8",    "gCens",    "gRef",     "gBits",
+    "tokPartO", "tokPartM", "tokPartL",  "scratch",  "total",    nullptr,
 };
 
 // Writes the values into out[0..count) and returns count; writes nothing if
 // cap < count, so a caller with a fixed buffer can detect a grown Plan.
-extern "C" int sol_attn_plan(int batch, int seq_len, int num_heads, int64_t* out, int cap) {
-    const Plan p(batch, seq_len, num_heads);
+extern "C" int sol_attn_plan(int batch, int seq_len, int num_heads, int n_tok, int64_t* out,
+                             int cap) {
+    validate_token_aug(n_tok);
+    const Plan p(batch, seq_len, num_heads, n_tok);
     const int64_t v[] = {
         p.Tp, p.NTB, p.NPAD, p.NQ,
         static_cast<int64_t>(p.qiP), static_cast<int64_t>(p.qs), static_cast<int64_t>(p.kiP),
@@ -150,6 +207,14 @@ extern "C" int sol_attn_plan(int batch, int seq_len, int num_heads, int64_t* out
         static_cast<int64_t>(p.idx), static_cast<int64_t>(p.cnt), static_cast<int64_t>(p.oPart),
         static_cast<int64_t>(p.mPart), static_cast<int64_t>(p.lPart),
         static_cast<int64_t>(p.statsV), static_cast<int64_t>(p.qmean),
+        static_cast<int64_t>(p.vRow), static_cast<int64_t>(p.tokIdx),
+        static_cast<int64_t>(p.tokCnt), static_cast<int64_t>(p.tokRef),
+        static_cast<int64_t>(p.tokHist), static_cast<int64_t>(p.tokBits),
+        static_cast<int64_t>(p.tokTiles), static_cast<int64_t>(p.tokTileCnt),
+        static_cast<int64_t>(p.gCen8), static_cast<int64_t>(p.gCens),
+        static_cast<int64_t>(p.gRef), static_cast<int64_t>(p.gBits),
+        static_cast<int64_t>(p.tokPartO), static_cast<int64_t>(p.tokPartM),
+        static_cast<int64_t>(p.tokPartL),
         static_cast<int64_t>(p.scratch), static_cast<int64_t>(p.total),
     };
     const int count = static_cast<int>(sizeof(v) / sizeof(v[0]));
@@ -160,9 +225,10 @@ extern "C" int sol_attn_plan(int batch, int seq_len, int num_heads, int64_t* out
 
 // ---- chunked producer path ----
 extern "C" void sol_producer_begin(void* workspace, int batch, int seq_len, int num_heads,
-                                   hipStream_t stream) {
+                                   int n_tok, hipStream_t stream) {
     validate_shape(batch, seq_len, num_heads);
-    const Plan p(batch, seq_len, num_heads);
+    validate_token_aug(n_tok);
+    const Plan p(batch, seq_len, num_heads, n_tok);
     char* w = reinterpret_cast<char*>(workspace);
     const size_t bh = static_cast<size_t>(batch) * num_heads;
     // route reads vcT's pad columns; statsV is an atomicMax accumulator
@@ -176,11 +242,13 @@ extern "C" void sol_producer_chunk(void* workspace, const void* qkv, const void*
                                    const void* qw, const void* kw, const void* kmean,
                                    const void* vscale, const void* blen, float rope_eps,
                                    int rot_dim, int t0, int M, int batch, int seq_len,
-                                   int num_heads, hipStream_t stream) {
-    const Plan p(batch, seq_len, num_heads);
+                                   int num_heads, int n_tok, hipStream_t stream) {
+    validate_token_aug(n_tok);
+    const Plan p(batch, seq_len, num_heads, n_tok);
     char* w = reinterpret_cast<char*>(workspace);
     launch_sol_producer(qkv, fab, qw, kw, kmean, vscale, w + p.qiP, w + p.qs, w + p.kiP,
-                        w + p.ksb, w + p.vTi, w + p.vcT, w + p.scratch, w + p.cen8, w + p.cens,
+                        w + p.ksb, w + p.vTi, n_tok ? w + p.vRow : nullptr, w + p.vcT,
+                        w + p.scratch, w + p.cen8, w + p.cens,
                         w + p.qmean, w + p.statsV, blen, rope_eps, rot_dim, t0, M, seq_len, p.Tp,
                         num_heads, p.NPAD, p.NQ, stream);
 }
@@ -191,9 +259,11 @@ extern "C" void launch_sol_attn_core(void* workspace, void* out, const void* vsc
                                      void* kmean_next, void* vamax_out, const void* blen, int tail,
                                      int batch, int seq_len, int num_heads, float tau, float scale,
                                      const void* ext_threshold, int sink_start, int sink_end,
-                                     int sink_q_start, int sink_q_end, hipStream_t stream) {
+                                     int sink_q_start, int sink_q_end, int n_tok,
+                                     hipStream_t stream) {
     validate_shape(batch, seq_len, num_heads);
-    const Plan p(batch, seq_len, num_heads);
+    validate_token_aug(n_tok);
+    const Plan p(batch, seq_len, num_heads, n_tok);
     char* w = reinterpret_cast<char*>(workspace);
     const float scale_log2 = scale * 1.4426950408889634f;
     const size_t stats_bytes = static_cast<size_t>(batch) * num_heads * HD * sizeof(float);
@@ -204,7 +274,7 @@ extern "C" void launch_sol_attn_core(void* workspace, void* out, const void* vsc
                       scale_log2, stream);
     run_route_exact(p, w, ext_threshold, out, blen, tail, batch, seq_len, num_heads, sink_start,
                     sink_end, sink_q_start, sink_q_end, scale_log2,
-                    comfy::hip_backend::sol::kSolBf16, stream);
+                    comfy::hip_backend::sol::kSolBf16, n_tok, stream);
     sol_check(hipMemcpyAsync(vamax_out, w + p.statsV, stats_bytes, hipMemcpyDeviceToDevice, stream),
               "reading back the V absmax");
 }
@@ -217,12 +287,13 @@ extern "C" void launch_sol_attn(const void* q, const void* k, const void* v, voi
                                 int sink_start, int sink_end, int sink_q_start, int sink_q_end,
                                 int64_t qs_b, int64_t qs_t, int64_t qs_h, int64_t ks_b,
                                 int64_t ks_t, int64_t ks_h, int64_t vs_b, int64_t vs_t,
-                                int64_t vs_h, hipStream_t stream) {
+                                int64_t vs_h, int n_tok, hipStream_t stream) {
     if (head_dim != HD)
         throw std::runtime_error("sol_attn supports head_dim 128, got " + std::to_string(head_dim));
     validate_shape(batch, seq_len, num_heads);
+    validate_token_aug(n_tok);
 
-    const Plan p(batch, seq_len, num_heads);
+    const Plan p(batch, seq_len, num_heads, n_tok);
     char* w = reinterpret_cast<char*>(workspace);
     const float scale_log2 = scale * 1.4426950408889634f;
     launch_sol_preprocess(q, k, v, w + p.qiP, w + p.qs, w + p.kiP, w + p.ksb, w + p.kciP,
@@ -230,8 +301,8 @@ extern "C" void launch_sol_attn(const void* q, const void* k, const void* v, voi
                           w + p.qmean, w + p.scratch, key_bias, blen, batch, seq_len, p.Tp,
                           num_heads, p.NTB, p.NPAD, p.NQ, qs_b, qs_t, qs_h, ks_b, ks_t, ks_h,
                           vs_b, vs_t, vs_h, tau, scale_log2, elem, stream);
-    launch_sol_vtranspose(v, w + p.vsc, w + p.vTi, batch, seq_len, p.Tp, num_heads, vs_b, vs_t,
-                          vs_h, elem, stream);
+    launch_sol_vtranspose(v, w + p.vsc, w + p.vTi, n_tok ? w + p.vRow : nullptr, batch, seq_len,
+                          p.Tp, num_heads, vs_b, vs_t, vs_h, elem, stream);
     run_route_exact(p, w, ext_threshold, out, blen, tail, batch, seq_len, num_heads, sink_start,
-                    sink_end, sink_q_start, sink_q_end, scale_log2, elem, stream);
+                    sink_end, sink_q_start, sink_q_end, scale_log2, elem, n_tok, stream);
 }

--- a/comfy_kitchen/backends/hip/sage_attention/sol_attn_exact.hip
+++ b/comfy_kitchen/backends/hip/sage_attention/sol_attn_exact.hip
@@ -1,8 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
-// Sol-Attn exact branch: each query block walks its routed key-block list,
-// resuming the online softmax (o / m / l) from route's handover.
+// Sol-Attn exact branch: each query block walks its routed key-block list, then
+// the token list sol_attn_token.hip left for its group, resuming the online
+// softmax (o / m / l) from the handover.
 //
 // All-INT8, and transposed like int8_attn.hip: S^T = K @ Q^T puts one query on a
 // lane with eight keys in its accumulator, so the softmax is scalar per lane and
@@ -48,8 +49,10 @@ __global__ __launch_bounds__(kThreads) void sol_exact_kernel(
     const float2* __restrict__ ksb, const int8_t* __restrict__ vT, const float* __restrict__ vsc,
     const uint16_t* __restrict__ blk_idx, const int32_t* __restrict__ blk_cnt,
     const __bf16* __restrict__ o_part, const float* __restrict__ m_part,
-    const float* __restrict__ l_part, TOut* __restrict__ out, int T, int Tp, int H, int NTB,
-    float scale_log2) {
+    const float* __restrict__ l_part,
+    const int8_t* __restrict__ vRow,  // [B*H, Tp, D] int8, row-major (gathered token tiles)
+    const uint32_t* __restrict__ tok_idx, const int32_t* __restrict__ tok_cnt, int n_tok,
+    TOut* __restrict__ out, int T, int Tp, int H, int NTB, float scale_log2) {
     __shared__ __attribute__((aligned(16))) int8_t sK[BK * kStrideK];
     __shared__ __attribute__((aligned(16))) int8_t sVt[HD * kStrideV];
     __shared__ float2 sKsb[BK];
@@ -89,23 +92,8 @@ __global__ __launch_bounds__(kThreads) void sol_exact_kernel(
     }
     float m_r = m_part[qb_s], l_r = l_part[qb_s], c_r = m_r;   // c_r: scale o_acc / l_r are carried in
 
-    for (int kb = 0; kb < n_blocks; ++kb) {
-        const int64_t k0 = static_cast<int64_t>(my_idx[kb]) * BK;
-
-        __syncthreads();
-        for (int idx = tid; idx < BK * (HD / 8); idx += kThreads) {
-            const int p = idx / (HD / 8), c8 = (idx % (HD / 8)) * 8;
-            *reinterpret_cast<uint2*>(sK + p * kStrideK + c8) =
-                *reinterpret_cast<const uint2*>(ki + kd_base + (k0 + p) * HD + c8);
-        }
-        for (int idx = tid; idx < HD * (BK / 8); idx += kThreads) {
-            const int c = idx / (BK / 8), part = (idx % (BK / 8)) * 8;
-            *reinterpret_cast<uint2*>(sVt + c * kStrideV + part) = *reinterpret_cast<const uint2*>(
-                vT + vT_base + static_cast<int64_t>(c) * Tp + k0 + part);
-        }
-        for (int idx = tid; idx < BK; idx += kThreads) sKsb[idx] = ksb[kp_base + k0 + idx];
-        __syncthreads();
-
+    // A staged tile is the same shape either way, so both walks end in this body.
+    auto compute_tile = [&]() {
         typename MmaInt8::Acc s_acc[KT];
 #pragma unroll
         for (int kt = 0; kt < KT; ++kt) {
@@ -169,6 +157,65 @@ __global__ __launch_bounds__(kThreads) void sol_exact_kernel(
                 o_acc[nt][e] = fmaf(o_acc[nt][e], alpha, static_cast<float>(partial[e]));
             }
         }
+    };
+
+    for (int kb = 0; kb < n_blocks; ++kb) {
+        const int64_t k0 = static_cast<int64_t>(my_idx[kb]) * BK;
+
+        __syncthreads();
+        for (int idx = tid; idx < BK * (HD / 8); idx += kThreads) {
+            const int p = idx / (HD / 8), c8 = (idx % (HD / 8)) * 8;
+            *reinterpret_cast<uint2*>(sK + p * kStrideK + c8) =
+                *reinterpret_cast<const uint2*>(ki + kd_base + (k0 + p) * HD + c8);
+        }
+        for (int idx = tid; idx < HD * (BK / 8); idx += kThreads) {
+            const int c = idx / (BK / 8), part = (idx % (BK / 8)) * 8;
+            *reinterpret_cast<uint2*>(sVt + c * kStrideV + part) = *reinterpret_cast<const uint2*>(
+                vT + vT_base + static_cast<int64_t>(c) * Tp + k0 + part);
+        }
+        for (int idx = tid; idx < BK; idx += kThreads) sKsb[idx] = ksb[kp_base + k0 + idx];
+        __syncthreads();
+        compute_tile();
+    }
+
+    // No perm_key here, so a listed token id indexes ki / ksb / vRow directly.
+    if (n_tok > 0) {
+        const int NG = (gridDim.x + kTokGroup - 1) / kTokGroup;   // one list per group
+        const size_t qs_tok = static_cast<size_t>(bh) * NG + q_block / kTokGroup;
+        const int n_sel = imin(tok_cnt[qs_tok], n_tok);
+        const uint32_t* my_tok = tok_idx + qs_tok * n_tok;
+        for (int ti = 0; ti < (n_sel + BK - 1) / BK; ++ti) {
+            const int nvalid = imin(BK, n_sel - ti * BK);
+            __syncthreads();
+            for (int idx = tid; idx < BK * (HD / 8); idx += kThreads) {
+                const int p = idx / (HD / 8), c8 = (idx % (HD / 8)) * 8;
+                uint2 val = make_uint2(0u, 0u);
+                if (p < nvalid) {
+                    val = *reinterpret_cast<const uint2*>(
+                        ki + kd_base + static_cast<int64_t>(my_tok[ti * BK + p]) * HD + c8);
+                }
+                *reinterpret_cast<uint2*>(sK + p * kStrideK + c8) = val;
+            }
+            // a padded slot carries a zero scale and a kNeg bias, like a dead key
+            for (int idx = tid; idx < BK; idx += kThreads) {
+                sKsb[idx] = idx < nvalid ? ksb[kp_base + my_tok[ti * BK + idx]]
+                                         : make_float2(0.f, kNeg);
+            }
+            // V^T wants keys contiguous per channel, so an arbitrary token set has
+            // to come from the row-major copy and be scattered byte by byte
+            for (int idx = tid; idx < (HD / 16) * BK; idx += kThreads) {
+                const int c16 = (idx / BK) * 16, p = idx % BK;
+                __attribute__((aligned(16))) int8_t raw[16] = {0};
+                if (p < nvalid) {
+                    *reinterpret_cast<uint4*>(raw) = *reinterpret_cast<const uint4*>(
+                        vRow + (static_cast<int64_t>(bh) * Tp + my_tok[ti * BK + p]) * HD + c16);
+                }
+#pragma unroll
+                for (int i = 0; i < 16; ++i) sVt[(c16 + i) * kStrideV + p] = raw[i];
+            }
+            __syncthreads();
+            compute_tile();
+        }
     }
 
     if (q_row >= T) return;
@@ -193,9 +240,10 @@ using namespace comfy::hip_backend::sol;
 
 void launch_sol_exact(const void* qi, const void* qs, const void* ki, const void* ksb,
                       const void* vT, const void* vsc, const void* blk_idx, const void* blk_cnt,
-                      const void* o_part, const void* m_part, const void* l_part, void* out, int B,
-                      int T, int Tp, int H, int NQ, int NTB, float scale_log2, int elem,
-                      hipStream_t stream) {
+                      const void* o_part, const void* m_part, const void* l_part,
+                      const void* vRow, const void* tok_idx, const void* tok_cnt, int n_tok,
+                      void* out, int B, int T, int Tp, int H, int NQ, int NTB, float scale_log2,
+                      int elem, hipStream_t stream) {
     dim3 grid(NQ, B * H);
 #define SOLX_LAUNCH(TOut)                                                                    \
     sol_exact_kernel<TOut><<<grid, kThreads, 0, stream>>>(                                   \
@@ -204,7 +252,9 @@ void launch_sol_exact(const void* qi, const void* qs, const void* ki, const void
         static_cast<const int8_t*>(vT), static_cast<const float*>(vsc),                      \
         static_cast<const uint16_t*>(blk_idx), static_cast<const int32_t*>(blk_cnt),         \
         static_cast<const __bf16*>(o_part), static_cast<const float*>(m_part),               \
-        static_cast<const float*>(l_part), static_cast<TOut*>(out), T, Tp, H, NTB, scale_log2)
+        static_cast<const float*>(l_part), static_cast<const int8_t*>(vRow),                 \
+        static_cast<const uint32_t*>(tok_idx), static_cast<const int32_t*>(tok_cnt), n_tok,  \
+        static_cast<TOut*>(out), T, Tp, H, NTB, scale_log2)
     if (elem == kSolFp16) {
         SOLX_LAUNCH(_Float16);
     } else {

--- a/comfy_kitchen/backends/hip/sage_attention/sol_attn_producer.hip
+++ b/comfy_kitchen/backends/hip/sage_attention/sol_attn_producer.hip
@@ -29,7 +29,8 @@ __global__ __launch_bounds__(HD) void sol_producer_kernel(
     const float* __restrict__ kmean,   // [H, HD] stale (may be zeros)
     const float* __restrict__ vscale,  // [H, HD] stale V scale
     int8_t* __restrict__ qi, float* __restrict__ qs, int8_t* __restrict__ ki,
-    float2* __restrict__ ksb, int8_t* __restrict__ vT, __bf16* __restrict__ vcT,
+    float2* __restrict__ ksb, int8_t* __restrict__ vT, int8_t* __restrict__ vRow,
+    __bf16* __restrict__ vcT,
     float* __restrict__ ksum,  // [H, NPAD, HD] block K sums (post-rope)
     int8_t* __restrict__ cen8, float* __restrict__ cens,
     float* __restrict__ qmean,       // [H, NPAD, HD] f32 block means (post-rope)
@@ -99,6 +100,13 @@ __global__ __launch_bounds__(HD) void sol_producer_kernel(
                 col[j] = q8(x, inv);
             }
             *reinterpret_cast<uint4*>(vT + vbase + c0) = *reinterpret_cast<const uint4*>(col);
+            // row-major copy for the gathered token tiles (token routing)
+            if (vRow) {
+#pragma unroll
+                for (int j = 0; j < 16; ++j) {
+                    vRow[(static_cast<size_t>(h) * Tp + nblk * BLK + c0 + j) * HD + d] = col[j];
+                }
+            }
         }
         vcT[(static_cast<size_t>(h) * HD + d) * NPAD + nblk] = static_cast<__bf16>(sv);
         atomicMax(reinterpret_cast<unsigned int*>(&vamax_next[static_cast<size_t>(h) * HD + d]),
@@ -113,7 +121,8 @@ using namespace comfy::hip_backend::sol;
 
 void launch_sol_producer(const void* qkv, const void* fab, const void* qw, const void* kw,
                          const void* kmean, const void* vscale, void* qi, void* qs, void* ki,
-                         void* ksb, void* vT, void* vcT, void* ksum, void* cen8, void* cens,
+                         void* ksb, void* vT, void* vRow, void* vcT, void* ksum, void* cen8,
+                         void* cens,
                          void* qmean, void* vamax_next, const void* blen, float rope_eps, int rot,
                          int t0, int M, int T, int Tp, int H, int NPAD, int NQ,
                          hipStream_t stream) {
@@ -124,7 +133,8 @@ void launch_sol_producer(const void* qkv, const void* fab, const void* qw, const
         static_cast<const __bf16*>(qw), static_cast<const __bf16*>(kw),
         static_cast<const float*>(kmean), static_cast<const float*>(vscale),
         static_cast<int8_t*>(qi), static_cast<float*>(qs), static_cast<int8_t*>(ki),
-        static_cast<float2*>(ksb), static_cast<int8_t*>(vT), static_cast<__bf16*>(vcT),
+        static_cast<float2*>(ksb), static_cast<int8_t*>(vT), static_cast<int8_t*>(vRow),
+        static_cast<__bf16*>(vcT),
         static_cast<float*>(ksum), static_cast<int8_t*>(cen8), static_cast<float*>(cens),
         static_cast<float*>(qmean), static_cast<float*>(vamax_next),
         static_cast<const int32_t*>(blen), rope_eps, rot, t0, M, T, Tp, H, NPAD, NQ);

--- a/comfy_kitchen/backends/hip/sage_attention/sol_attn_route.hip
+++ b/comfy_kitchen/backends/hip/sage_attention/sol_attn_route.hip
@@ -47,7 +47,11 @@ __global__ __launch_bounds__(kThreads) void sol_route_kernel(
     const __bf16* __restrict__ vcT, const float* __restrict__ vsc,
     const float* __restrict__ threshold, uint16_t* __restrict__ blk_idx,
     int32_t* __restrict__ blk_cnt, __bf16* __restrict__ o_part, float* __restrict__ m_part,
-    float* __restrict__ l_part, const int32_t* __restrict__ blen, int tail, int T, int NTB,
+    float* __restrict__ l_part,
+    // token routing, or null: the best pooled score this row left unrouted, and
+    // the [B*H, NQ, ceil(NTB/32)] bitmap of the blocks it left
+    float* __restrict__ tok_ref, uint32_t* __restrict__ cand_bits,
+    const int32_t* __restrict__ blen, int tail, int T, int NTB,
     int NPAD, int NQ, int sink_s, int sink_e, int sink_qs, int sink_qe, float scale_log2) {
     __shared__ __attribute__((aligned(16))) int8_t sKc[BN * kStrideKc];
     __shared__ __attribute__((aligned(16))) __bf16 sVcT[HD * kStrideVc];
@@ -93,6 +97,8 @@ __global__ __launch_bounds__(kThreads) void sol_route_kernel(
 #pragma unroll
     for (int nt = 0; nt < NT; ++nt) o_acc[nt] = MmaBf16::zero();
     float m_r = kNeg, l_r = 0.f;
+    float refm = kNeg;
+    const int W = (NTB + 31) >> 5;
 
     for (int gs = 0; gs < NTB; gs += BN) {
         __syncthreads();
@@ -129,6 +135,9 @@ __global__ __launch_bounds__(kThreads) void sol_route_kernel(
         // Routing decision, and the pooled score of every block that stays in the tail.
         float pv[KT][8];
         uint32_t mask_lo = 0u, mask_hi = 0u;
+        // Blocks this row leaves unrouted, bit kt * 8 + e. A mask rather than 32
+        // live scores: the exchange below needs the whole tile before any is folded.
+        uint32_t unr = 0u;
 #pragma unroll
         for (int kt = 0; kt < KT; ++kt) {
 #pragma unroll
@@ -148,9 +157,48 @@ __global__ __launch_bounds__(kThreads) void sol_route_kernel(
                         mask_hi |= 1u << (slot - 32);
                     }
                 }
-                // exact-routed and sink blocks leave the tail; tail == 0 hands the
-                // exact kernel an empty state (softmax over the routed blocks only)
-                pv[kt][e] = (tail && valid && !(pre || cand)) ? score : kNeg;
+                if (valid && !pre && !cand) unr |= 1u << (kt * 8 + e);
+                pv[kt][e] = score;
+            }
+        }
+
+        // A block neither this row nor its kTokGroup partner routed goes to the
+        // token passes instead of the pooled tail. The partner is query block
+        // qb ^ 1, which is lane ^ 1 since qb's low bit is frag_row's. Every other
+        // kTokGroup use is generic arithmetic; this pairing is the one that is not.
+        static_assert(kTokGroup == 2, "the qb ^ 1 exchange covers a group of exactly two");
+        uint32_t tokb = 0u;
+        if (cand_bits) {
+            const uint32_t peer = __shfl_xor(unr, 1, 32);
+            const int peer_live = __shfl_xor(static_cast<int>(live), 1, 32);
+            tokb = unr & (peer_live ? peer : 0xffffffffu);
+        }
+        // exact-routed, sink and token-routed blocks leave the tail; tail == 0 hands
+        // the exact kernel an empty state (softmax over the routed blocks only)
+        const uint32_t keep = (tail ? unr : 0u) & ~tokb;
+        uint32_t cbits[2] = {0u, 0u};
+#pragma unroll
+        for (int kt = 0; kt < KT; ++kt) {
+#pragma unroll
+            for (int e = 0; e < 8; ++e) {
+                const uint32_t bit = 1u << (kt * 8 + e);
+                if (tokb & bit) {
+                    refm = fmaxf(refm, pv[kt][e]);
+                    const int slot = kt * 16 + acc_row(lane, e);
+                    cbits[slot >> 5] |= 1u << (slot & 31);
+                }
+                if (!(keep & bit)) pv[kt][e] = kNeg;
+            }
+        }
+        if (cand_bits) {
+            // the half-wave partner holds this row's other 32 blocks of the group
+#pragma unroll
+            for (int wd = 0; wd < 2; ++wd) {
+                const uint32_t b = cbits[wd] | swap_half_wave_b32(cbits[wd]);
+                const int word = (gs >> 5) + wd;
+                if (half == 0 && live && word < W) {
+                    cand_bits[(static_cast<size_t>(bh) * NQ + qb) * W + word] = b;
+                }
             }
         }
 
@@ -212,10 +260,12 @@ __global__ __launch_bounds__(kThreads) void sol_route_kernel(
         }
     }
 
+    refm = fmaxf(refm, swap_half_wave(refm));
     if (!live) return;
     const size_t qs = static_cast<size_t>(bh) * NQ + qb;
     if (half == 0) {
         blk_cnt[qs] = cnt;
+        if (tok_ref) tok_ref[qs] = refm;
         m_part[qs] = m_r;
         l_part[qs] = l_r * 255.0f;
     }
@@ -241,7 +291,8 @@ using namespace comfy::hip_backend::sol;
 
 void launch_sol_route(const void* cen8, const void* cens, const void* kci, const void* kcs,
                       const void* vcT, const void* vsc, const void* threshold, void* blk_idx,
-                      void* blk_cnt, void* o_part, void* m_part, void* l_part,
+                      void* blk_cnt, void* o_part, void* m_part, void* l_part, void* tok_ref,
+                      void* cand_bits,
                       // NQ (query blocks) and NTB (key blocks) coincide today; kept
                       // separate so a query prefix needs no kernel change
                       const void* blen, int tail, int B, int T, int H, int NTB, int NPAD, int NQ,
@@ -254,6 +305,7 @@ void launch_sol_route(const void* cen8, const void* cens, const void* kci, const
         static_cast<const __bf16*>(vcT), static_cast<const float*>(vsc),
         static_cast<const float*>(threshold), static_cast<uint16_t*>(blk_idx),
         static_cast<int32_t*>(blk_cnt), static_cast<__bf16*>(o_part), static_cast<float*>(m_part),
-        static_cast<float*>(l_part), static_cast<const int32_t*>(blen), tail, T, NTB, NPAD, NQ,
-        sink_s, sink_e, sink_qs, sink_qe, scale_log2);
+        static_cast<float*>(l_part), static_cast<float*>(tok_ref),
+        static_cast<uint32_t*>(cand_bits), static_cast<const int32_t*>(blen), tail, T, NTB, NPAD,
+        NQ, sink_s, sink_e, sink_qs, sink_qe, scale_log2);
 }

--- a/comfy_kitchen/backends/hip/sage_attention/sol_attn_token.hip
+++ b/comfy_kitchen/backends/hip/sage_attention/sol_attn_token.hip
@@ -1,0 +1,518 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Sol-Attn token routing: a centroid shared by kTokGroup neighbouring query blocks
+// scores every token in the blocks none of them routed. 64 centroids per
+// workgroup, the tile list split over gridDim.y:
+//   pass 1  per-centroid score histogram (ref = route's best unrouted score)
+//   pass 2  the threshold admits whole bins until n_tok would overflow, so the
+//           selected set does not depend on scheduling; the tokens above it are
+//           listed for the exact kernel and the rest replace route's pooled tail
+// The sort makes each list deterministic and the merge folds the splits' states
+// into the exact kernel's handover buffers.
+//
+// Transposed like the rest of the port: S^T = K @ Cen^T, so a lane owns one
+// centroid and eight tokens per tile, and the two half-waves of a lane pair split
+// each 16-token tile. No perm_key here, so a listed id indexes ki / vRow directly.
+#include <hip/hip_runtime.h>
+
+#include <algorithm>
+#include <cstdint>
+
+#include "sol_common.h"
+
+namespace comfy::hip_backend::sol {
+namespace {
+
+constexpr int HD = kHeadDim;
+constexpr int BQ = 64;  // centroid rows per workgroup
+constexpr int BK = kBlock;
+constexpr int NWAVE = BQ / 16, kThreads = NWAVE * 32;
+constexpr int DT = HD / 16;  // contraction tiles for S = K Cen^T
+constexpr int KT = BK / 16;  // score token tiles
+constexpr int NT = HD / 16;  // output channel tiles
+
+#if defined(COMFY_MMA_GFX11)
+constexpr int kLdsPad = 16;
+#else
+constexpr int kLdsPad = 8;
+#endif
+constexpr int kStrideK = HD + kLdsPad;
+constexpr int kStrideV = BK + kLdsPad;
+
+constexpr int NB = kTokHistBins;         // histogram bins, 16-bit counts packed in pairs
+constexpr float HLO = 8.f, HW = 0.25f;   // window below ref / fine bin width, log2 units
+constexpr int NB_FINE = 96;              // fine bins cover [ref - 8, ref + 16); coarse ones above
+constexpr float HW_COARSE = 2.f;         // coarse bin width: 32 bins up to ref + 80
+constexpr int P1_MAX_TILES = 1023;       // tiles per pass-1 split, bounded by nsplit1
+// A lane counts BK tokens per tile into one bin, and the counts are packed two to a
+// word, so both of these decide whether a bin can wrap without anything failing.
+static_assert(P1_MAX_TILES * BK <= 0xffff, "a pass-1 split must fit a 16-bit histogram bin");
+static_assert(NB % 2 == 0, "bins are packed in pairs, so NB must be even");
+
+// bin index for a score `rel` log2 units above (ref - HLO), and the lower edge of a bin
+__forceinline__ __device__ int hist_bin(float rel) {
+    const float fine = static_cast<float>(NB_FINE) * HW;
+    return rel < fine ? static_cast<int>(rel / HW)
+                      : imin(NB - 1, NB_FINE + static_cast<int>((rel - fine) / HW_COARSE));
+}
+__forceinline__ __device__ float hist_edge(int b) {
+    return b <= NB_FINE ? static_cast<float>(b) * HW
+                        : static_cast<float>(NB_FINE) * HW +
+                              static_cast<float>(b - NB_FINE) * HW_COARSE;
+}
+
+// per group of kTokGroup query blocks: centroid (quantized like the producer's),
+// best unrouted pooled score, and the blocks unrouted by every member
+__global__ __launch_bounds__(HD) void sol_token_group_kernel(
+    const float* __restrict__ qmean,    // [B*H, NPAD, HD]
+    const float* __restrict__ tok_ref,  // [B*H, NQ]
+    const uint32_t* __restrict__ bits,  // [B*H, NQ, W] unrouted
+    int8_t* __restrict__ gcen8, float* __restrict__ gcens, float* __restrict__ gref,
+    uint32_t* __restrict__ gbits, int NQ, int NPAD, int NG, int W) {
+    __shared__ __attribute__((aligned(16))) float sred[HD];
+    const int grp = blockIdx.x, bh = blockIdx.y, d = threadIdx.x;
+    const int qb0 = grp * kTokGroup, qb1 = imin(NQ, qb0 + kTokGroup);
+    float c = 0.f;
+    for (int qb = qb0; qb < qb1; ++qb) c += qmean[(static_cast<size_t>(bh) * NPAD + qb) * HD + d];
+    c /= static_cast<float>(qb1 - qb0);
+    const float csc = fmaxf(block_max128(fabsf(c), sred) / 127.0f, 1e-8f);
+    const size_t gs = static_cast<size_t>(bh) * NG + grp;
+    gcen8[gs * HD + d] = q8(c, 1.f / csc);
+    if (d == 0) {
+        gcens[gs] = csc;
+        float r = kNeg;
+        for (int qb = qb0; qb < qb1; ++qb) r = fmaxf(r, tok_ref[static_cast<size_t>(bh) * NQ + qb]);
+        gref[gs] = r;
+    }
+    for (int w = d; w < W; w += HD) {
+        uint32_t u = 0xffffffffu;
+        for (int qb = qb0; qb < qb1; ++qb) u &= bits[(static_cast<size_t>(bh) * NQ + qb) * W + w];
+        gbits[gs * W + w] = u;
+    }
+}
+
+// per workgroup of 64 groups: the union of the rows' unrouted blocks as a tile list
+__global__ __launch_bounds__(128) void sol_token_tiles_kernel(const uint32_t* __restrict__ bits,
+                                                              uint16_t* __restrict__ tiles,
+                                                              int32_t* __restrict__ tile_cnt,
+                                                              int NG, int NTB, int W) {
+    __shared__ uint32_t su[2048];  // NTB <= 65535 blocks
+    const int grp = blockIdx.x, bh = blockIdx.y, g0 = grp * BQ;
+    for (int w = threadIdx.x; w < W; w += blockDim.x) {
+        uint32_t u = 0u;
+        for (int r = 0; r < BQ && g0 + r < NG; ++r) {
+            u |= bits[(static_cast<size_t>(bh) * NG + g0 + r) * W + w];
+        }
+        su[w] = u;
+    }
+    __syncthreads();
+    uint16_t* out = tiles + (static_cast<size_t>(bh) * gridDim.x + grp) * NTB;
+    if (threadIdx.x == 0) {  // in order, so the walk streams K/V sequentially
+        int n = 0;
+        for (int w = 0; w < W; ++w) {
+            uint32_t u = su[w];
+            while (u) {
+                const int b = __builtin_ctz(u);
+                u &= u - 1;
+                out[n++] = static_cast<uint16_t>(w * 32 + b);
+            }
+        }
+        tile_cnt[static_cast<size_t>(bh) * gridDim.x + grp] = n;
+    }
+}
+
+template <int PASS>
+__global__ __launch_bounds__(kThreads) void sol_token_kernel(
+    const int8_t* __restrict__ gcen8, const float* __restrict__ gcens,
+    const int8_t* __restrict__ ki, const float2* __restrict__ ksb,
+    const int8_t* __restrict__ vT, const uint32_t* __restrict__ gbits,
+    const uint16_t* __restrict__ tiles, const int32_t* __restrict__ tile_cnt,
+    const float* __restrict__ gref, uint32_t* __restrict__ tok_hist,
+    uint32_t* __restrict__ tok_idx, int32_t* __restrict__ tok_cnt,
+    __bf16* __restrict__ part_o, float* __restrict__ part_m, float* __restrict__ part_l, int Tp,
+    int NG, int NTB, int n_tok, int tail, int NQB, int sink_q_start, int sink_q_end,
+    float scale_log2) {
+    __shared__ __attribute__((aligned(16))) int8_t sK[BK * kStrideK];
+    __shared__ float2 sKsb[BK];
+    // pass 1: BQ x NB counts, packed 16 bits to a half word; pass 2: the V^T tile
+    // followed by the per-row thresholds
+    constexpr int kVWords = (HD * kStrideV + 3) / 4;
+    __shared__ __attribute__((aligned(16)))
+    uint32_t sAux[PASS == 1 ? BQ * NB / 2 : kVWords + BQ];
+    uint32_t* hist = sAux;
+    int8_t* sVt = reinterpret_cast<int8_t*>(sAux);
+    float* sthr = reinterpret_cast<float*>(sAux + kVWords);
+
+    const int tid = threadIdx.x, wave = tid >> 5, lane = tid & 31;
+    const int r = frag_row(lane), half = lane >> 4;
+    const int bh = blockIdx.z, split = blockIdx.y, nsplit = gridDim.y;
+    const int W = (NTB + 31) >> 5;
+    const int g0 = blockIdx.x * BQ;
+    const int hrow = wave * 16 + r;   // this lane's row within the workgroup
+    const int row = g0 + hrow;        // and the centroid row (a group of query blocks) it is
+    const int row_clamped = imin(row, NG - 1);
+    // a group is dense only when every member block is a sink_q row
+    const int m0 = row * kTokGroup, m1 = imin(NQB, m0 + kTokGroup) - 1;
+    const bool active = row < NG && !(m0 >= sink_q_start && m1 < sink_q_end);
+
+    const uint16_t* my_tiles = tiles + (static_cast<size_t>(bh) * gridDim.x + blockIdx.x) * NTB;
+    const int n_tiles = tile_cnt[static_cast<size_t>(bh) * gridDim.x + blockIdx.x];
+    const int chunk = (n_tiles + nsplit - 1) / nsplit;
+    const int kb_begin = split * chunk, kb_end = imin(n_tiles, kb_begin + chunk);
+
+    const int64_t vT_base = static_cast<int64_t>(bh) * HD * Tp;
+    const int64_t kp_base = static_cast<int64_t>(bh) * Tp;
+    const int64_t kd_base = static_cast<int64_t>(bh) * Tp * HD;
+
+    typename MmaInt8::Frag cen_frag[DT];
+    {
+        const int8_t* crow = gcen8 + (static_cast<size_t>(bh) * NG + row_clamped) * HD;
+#pragma unroll
+        for (int dt = 0; dt < DT; ++dt) {
+            cen_frag[dt] = MmaInt8::load_aligned(crow, 0, dt * 16, 0, lane);
+        }
+    }
+    const float qsc = gcens[static_cast<size_t>(bh) * NG + row_clamped] * scale_log2;
+    const float ref = active ? gref[static_cast<size_t>(bh) * NG + row_clamped] : kNeg;
+    const uint32_t* bmrow = gbits + (static_cast<size_t>(bh) * NG + row_clamped) * W;
+
+    if (PASS == 1) {
+        for (int i = tid; i < BQ * NB / 2; i += kThreads) hist[i] = 0u;
+    }
+    if (PASS == 2 && tid < BQ) {
+        // threshold: admit whole bins from the top until the next would overflow n_tok
+        const int gr = g0 + tid;
+        const int b0 = gr * kTokGroup, b1 = imin(NQB, b0 + kTokGroup) - 1;
+        float t = 3.0e38f;
+        if (gr < NG && !(b0 >= sink_q_start && b1 < sink_q_end)) {
+            const uint32_t* h = tok_hist + (static_cast<size_t>(bh) * NG + gr) * NB;
+            uint32_t acc = 0u;
+            int b = NB - 1;
+            for (; b >= 0; --b) {
+                acc += h[b];
+                if (acc > static_cast<uint32_t>(n_tok)) break;
+            }
+            // if every bin fits, nothing below the window is admitted: it was never counted
+            t = gref[static_cast<size_t>(bh) * NG + gr] - HLO + hist_edge(b + 1);
+        }
+        sthr[tid] = t;
+    }
+    __syncthreads();
+    const float thr = PASS == 2 ? sthr[wave * 16 + r] : 3.0e38f;
+
+    float o_acc[NT][8];
+#pragma unroll
+    for (int nt = 0; nt < NT; ++nt) {
+#pragma unroll
+        for (int e = 0; e < 8; ++e) o_acc[nt][e] = 0.f;
+    }
+    float m_r = kNeg, l_r = 0.f, c_r = kNeg;
+
+    for (int kb = kb_begin; kb < kb_end; ++kb) {
+        const int j = my_tiles[kb];
+        const int64_t k0 = static_cast<int64_t>(j) * BK;
+
+        __syncthreads();
+        for (int idx = tid; idx < BK * (HD / 8); idx += kThreads) {
+            const int p = idx / (HD / 8), c8 = (idx % (HD / 8)) * 8;
+            *reinterpret_cast<uint2*>(sK + p * kStrideK + c8) =
+                *reinterpret_cast<const uint2*>(ki + kd_base + (k0 + p) * HD + c8);
+        }
+        for (int idx = tid; idx < BK; idx += kThreads) sKsb[idx] = ksb[kp_base + k0 + idx];
+        if (PASS == 2) {
+            for (int idx = tid; idx < HD * (BK / 8); idx += kThreads) {
+                const int c = idx / (BK / 8), part = (idx % (BK / 8)) * 8;
+                *reinterpret_cast<uint2*>(sVt + c * kStrideV + part) =
+                    *reinterpret_cast<const uint2*>(vT + vT_base + static_cast<int64_t>(c) * Tp +
+                                                    k0 + part);
+            }
+        }
+        __syncthreads();
+
+        // Skip only when the whole wave's rows are routed here: the exchanges below
+        // need every lane. Both syncs are behind us, so a wave may skip alone.
+        const bool masked = !active || !((bmrow[j >> 5] >> (j & 31)) & 1u);
+        if (__all(masked)) continue;
+
+        typename MmaInt8::Acc s_acc[KT];
+#pragma unroll
+        for (int kt = 0; kt < KT; ++kt) {
+            s_acc[kt] = MmaInt8::zero();
+#pragma unroll
+            for (int dt = 0; dt < DT; ++dt) {
+                s_acc[kt] = MmaInt8::mma(
+                    MmaInt8::load_aligned(sK, kt * 16 + r, dt * 16, kStrideK, lane), cen_frag[dt],
+                    s_acc[kt]);
+            }
+        }
+
+        float p_val[KT][8];
+        uint32_t sel = 0u;  // PASS 2: bit kt * 8 + e is this lane's selected token
+#pragma unroll
+        for (int kt = 0; kt < KT; ++kt) {
+#pragma unroll
+            for (int e = 0; e < 8; ++e) {
+                const float2 kb2 = sKsb[kt * 16 + acc_row(lane, e)];
+                // A dead key carries a zero scale and a kNeg bias, so its score is kNeg.
+                float s =
+                    masked ? kNeg : fmaf(static_cast<float>(s_acc[kt][e]), qsc * kb2.x, kb2.y);
+                if (s > kTileMasked) {
+                    if (PASS == 1) {
+                        // below the window: not counted, so never admitted
+                        const float rel = s - ref + HLO;
+                        if (rel >= 0.f) {
+                            const int bin = hist_bin(rel);
+                            const int idx = hrow * NB + bin;
+                            atomicAdd(&hist[idx >> 1], (bin & 1) ? 0x10000u : 1u);
+                        }
+                    } else if (s >= thr) {
+                        sel |= 1u << (kt * 8 + e);
+                    }
+                }
+                p_val[kt][e] = s;
+            }
+        }
+
+        if (PASS == 2 && sel) {
+            // The threshold fixes the set, so only the order varies and the sort
+            // below settles that. Static indexing: a computed p_val index spills.
+            const uint32_t base = static_cast<uint32_t>(
+                atomicAdd(&tok_cnt[static_cast<size_t>(bh) * NG + row], __popc(sel)));
+#pragma unroll
+            for (int kt = 0; kt < KT; ++kt) {
+#pragma unroll
+                for (int e = 0; e < 8; ++e) {
+                    const uint32_t bit = 1u << (kt * 8 + e);
+                    if (sel & bit) {
+                        const uint32_t slot = base + __popc(sel & (bit - 1u));
+                        // Only a token that made the list leaves the tail. The
+                        // threshold keeps the count inside n_tok except through the
+                        // clamped top bin, and a surplus there must stay pooled
+                        // rather than fall out of both branches.
+                        if (slot < static_cast<uint32_t>(n_tok)) {
+                            tok_idx[(static_cast<size_t>(bh) * NG + row) * n_tok + slot] =
+                                static_cast<uint32_t>(j * BK + kt * 16 + acc_row(lane, e));
+                            p_val[kt][e] = kNeg;
+                        }
+                    }
+                }
+            }
+        }
+        if (PASS == 1 || !tail) continue;
+
+        // Online softmax over what is left, in the exact kernel's units. A lane
+        // with no live score keeps its state (alpha 1, P 0).
+        float bmax = m_r - 20.f;
+        bool has = false;
+#pragma unroll
+        for (int kt = 0; kt < KT; ++kt) {
+#pragma unroll
+            for (int e = 0; e < 8; ++e) {
+                if (p_val[kt][e] > kTileMasked) {
+                    has = true;
+                    bmax = fmaxf(bmax, p_val[kt][e]);
+                }
+            }
+        }
+        bmax = fmaxf(bmax, swap_half_wave(bmax));
+        has = has || swap_half_wave_b32(static_cast<uint32_t>(has)) != 0u;
+        if (!has) bmax = c_r;
+        const float alpha = exp2f(c_r - bmax);
+        c_r = bmax;
+        m_r = fmaxf(m_r, bmax);
+
+        const float m_off = has ? bmax - kProbU8Offset : 3.0e38f;
+        typename MmaInt8::Frag p_frag[KT];
+        uint32_t li = 0u;
+#pragma unroll
+        for (int kt = 0; kt < KT; ++kt) {
+            uint32_t packed[8];
+#pragma unroll
+            for (int e = 0; e < 8; ++e) {
+                packed[e] = prob_to_u8(exp2f(p_val[kt][e] - m_off));
+                li += packed[e];
+            }
+            p_frag[kt] = pack_prob_frag(packed, lane);
+        }
+        li += swap_half_wave_b32(li);
+        l_r = fmaf(l_r, alpha, static_cast<float>(li));
+
+#pragma unroll
+        for (int nt = 0; nt < NT; ++nt) {
+            typename MmaInt8::Acc partial = MmaInt8::zero();
+#pragma unroll
+            for (int kt = 0; kt < KT; ++kt) {
+                partial = MmaInt8::mma_ub(
+                    MmaInt8::load_aligned(sVt, nt * 16 + r, kt * 16, kStrideV, lane), p_frag[kt],
+                    partial);
+            }
+#pragma unroll
+            for (int e = 0; e < 8; ++e) {
+                o_acc[nt][e] = fmaf(o_acc[nt][e], alpha, static_cast<float>(partial[e]));
+            }
+        }
+    }
+
+    if (PASS == 1) {
+        // this split's counts join the global histogram
+        __syncthreads();
+        for (int i = tid; i < BQ * NB; i += kThreads) {
+            const int gr = g0 + i / NB;
+            const uint32_t cnt = (hist[i >> 1] >> ((i & 1) ? 16 : 0)) & 0xffffu;
+            if (gr < NG && cnt) {
+                atomicAdd(&tok_hist[(static_cast<size_t>(bh) * NG + gr) * NB + (i % NB)], cnt);
+            }
+        }
+        return;
+    }
+
+    if (row >= NG) return;
+    // rescaled to m_r, which is what the merge exponentiates against
+    const size_t qs = (static_cast<size_t>(split) * gridDim.z + bh) * NG + row;
+    const float f = m_r > kTileMasked ? exp2f(c_r - m_r) : 1.f;
+    if (half == 0) {
+        part_m[qs] = m_r;
+        part_l[qs] = l_r * f;
+    }
+    __bf16* orow = part_o + qs * HD;
+#pragma unroll
+    for (int nt = 0; nt < NT; ++nt) {
+        float vals[8];
+#pragma unroll
+        for (int e = 0; e < 8; ++e) vals[e] = o_acc[nt][e] * f;
+        store_o_tile<__bf16>(orow, nt * 16, vals, lane);
+    }
+}
+
+// sort each list so the exact kernel's order is deterministic: a bitonic network
+// padded with a max sentinel (n_tok need not be a power of two)
+__global__ __launch_bounds__(kNTokMax) void sol_token_sort_kernel(
+    uint32_t* __restrict__ tok_idx, const int32_t* __restrict__ tok_cnt, int NG, int n_tok) {
+    // The sentinel below pads a ragged n_tok, but the network itself sorts only a
+    // power-of-two length; a bad kNTokMax would leave the list partly ordered.
+    static_assert((kNTokMax & (kNTokMax - 1)) == 0, "the bitonic network needs a power of two");
+    __shared__ uint32_t s[kNTokMax];
+    const size_t qs = static_cast<size_t>(blockIdx.y) * NG + blockIdx.x;
+    const int n = imin(tok_cnt[qs], n_tok), t = threadIdx.x;
+    uint32_t* row = tok_idx + qs * n_tok;
+    s[t] = t < n ? row[t] : 0xffffffffu;
+    __syncthreads();
+    for (int k = 2; k <= kNTokMax; k <<= 1) {
+        for (int j = k >> 1; j > 0; j >>= 1) {
+            const int p = t ^ j;
+            if (p > t) {
+                const bool up = (t & k) == 0;
+                const uint32_t a = s[t], b = s[p];
+                if ((a > b) == up) {
+                    s[t] = b;
+                    s[p] = a;
+                }
+            }
+            __syncthreads();
+        }
+    }
+    if (t < n) row[t] = s[t];
+}
+
+// merge the split states into the exact kernel's handover buffers
+__global__ __launch_bounds__(HD) void sol_token_merge_kernel(
+    const __bf16* __restrict__ part_o, const float* __restrict__ part_m,
+    const float* __restrict__ part_l, __bf16* __restrict__ o_part, float* __restrict__ m_part,
+    float* __restrict__ l_part, int NQ, int NG, int nsplit) {
+    const int qb = blockIdx.x, bh = blockIdx.y, c = threadIdx.x;
+    const size_t qs = static_cast<size_t>(bh) * NQ + qb;
+    const size_t qg = static_cast<size_t>(bh) * NG + qb / kTokGroup;
+    const size_t stride = static_cast<size_t>(gridDim.y) * NG;
+    // route's pooled tail joins as one more split
+    const float rm = m_part[qs], rl = l_part[qs];
+    const float ro = static_cast<float>(o_part[qs * HD + c]);
+    float m = rm;
+    for (int s = 0; s < nsplit; ++s) m = fmaxf(m, part_m[qg + s * stride]);
+    float l = 0.f, o = 0.f;
+    if (m > kTileMasked) {
+        if (rm > kTileMasked) {
+            const float w = exp2f(rm - m);
+            l += rl * w;
+            o += ro * w;
+        }
+        for (int s = 0; s < nsplit; ++s) {
+            const size_t p = qg + s * stride;
+            const float w = part_m[p] > kTileMasked ? exp2f(part_m[p] - m) : 0.f;
+            l += part_l[p] * w;
+            o += static_cast<float>(part_o[p * HD + c]) * w;
+        }
+    }
+    __syncthreads();  // every thread has read route's m/l before thread 0 overwrites them
+    o_part[qs * HD + c] = static_cast<__bf16>(o);
+    if (c == 0) {
+        m_part[qs] = m;
+        l_part[qs] = l;
+    }
+}
+
+}  // namespace
+}  // namespace comfy::hip_backend::sol
+
+using namespace comfy::hip_backend::sol;
+
+// Splits of the tile list: enough workgroups that short sequences fill the GPU and
+// a head's K/V stays in cache. A function of the shape only, so the plan can size
+// the slots. Mirrors the CUDA sol_token_splits.
+int sol_token_splits(int B, int H, int NG) {
+    (void)B;
+    (void)H;
+    const int groups = (NG + BQ - 1) / BQ;  // workgroups of 64 rows over the NG centroid rows
+    return std::max(1, std::min(8, (512 + groups - 1) / groups));
+}
+
+void launch_sol_token(const void* qmean, const void* tok_ref, const void* cand_bits, void* gcen8,
+                      void* gcens, void* gref, void* gbits, const void* ki, const void* ksb,
+                      const void* vT, void* tok_tiles, void* tok_tilecnt, void* tok_hist,
+                      void* tok_idx, void* tok_cnt, void* part_o, void* part_m, void* part_l,
+                      void* o_part, void* m_part, void* l_part, int B, int Tp, int H, int NQ,
+                      int NPAD, int NTB, int n_tok, int tail, int sink_q_start, int sink_q_end,
+                      float scale_log2, hipStream_t stream) {
+    const int bh = B * H;
+    const int W = (NTB + 31) / 32;
+    const int NG = (NQ + kTokGroup - 1) / kTokGroup;
+    const int nsplit = sol_token_splits(B, H, NG);
+    const int nctas = (NG + BQ - 1) / BQ;
+    dim3 grid(nctas, nsplit, bh);
+    sol_token_group_kernel<<<dim3(NG, bh), HD, 0, stream>>>(
+        static_cast<const float*>(qmean), static_cast<const float*>(tok_ref),
+        static_cast<const uint32_t*>(cand_bits), static_cast<int8_t*>(gcen8),
+        static_cast<float*>(gcens), static_cast<float*>(gref), static_cast<uint32_t*>(gbits), NQ,
+        NPAD, NG, W);
+    sol_token_tiles_kernel<<<dim3(nctas, bh), 128, 0, stream>>>(
+        static_cast<const uint32_t*>(gbits), static_cast<uint16_t*>(tok_tiles),
+        static_cast<int32_t*>(tok_tilecnt), NG, NTB, W);
+    sol_check(hipMemsetAsync(tok_hist, 0,
+                             static_cast<size_t>(bh) * NG * kTokHistBins * sizeof(uint32_t),
+                             stream),
+              "clearing the token histogram");
+    sol_check(hipMemsetAsync(tok_cnt, 0, static_cast<size_t>(bh) * NG * sizeof(int32_t), stream),
+              "clearing the token counts");
+    // pass 1 has no partial state, so it may split further to keep the 16-bit bins
+    // from overflowing
+    const int nsplit1 = std::max(nsplit, (NTB + P1_MAX_TILES - 1) / P1_MAX_TILES);
+    dim3 grid1(nctas, nsplit1, bh);
+#define SOLT_ARGS                                                                                 \
+    static_cast<const int8_t*>(gcen8), static_cast<const float*>(gcens),                          \
+        static_cast<const int8_t*>(ki), static_cast<const float2*>(ksb),                          \
+        static_cast<const int8_t*>(vT), static_cast<const uint32_t*>(gbits),                      \
+        static_cast<const uint16_t*>(tok_tiles), static_cast<const int32_t*>(tok_tilecnt),        \
+        static_cast<const float*>(gref), static_cast<uint32_t*>(tok_hist),                        \
+        static_cast<uint32_t*>(tok_idx), static_cast<int32_t*>(tok_cnt),                          \
+        static_cast<__bf16*>(part_o), static_cast<float*>(part_m), static_cast<float*>(part_l),   \
+        Tp, NG, NTB, n_tok, tail, NQ, sink_q_start, sink_q_end, scale_log2
+    sol_token_kernel<1><<<grid1, kThreads, 0, stream>>>(SOLT_ARGS);
+    sol_token_kernel<2><<<grid, kThreads, 0, stream>>>(SOLT_ARGS);
+#undef SOLT_ARGS
+    sol_token_sort_kernel<<<dim3(NG, bh), kNTokMax, 0, stream>>>(
+        static_cast<uint32_t*>(tok_idx), static_cast<const int32_t*>(tok_cnt), NG, n_tok);
+    sol_token_merge_kernel<<<dim3(NQ, bh), HD, 0, stream>>>(
+        static_cast<const __bf16*>(part_o), static_cast<const float*>(part_m),
+        static_cast<const float*>(part_l), static_cast<__bf16*>(o_part),
+        static_cast<float*>(m_part), static_cast<float*>(l_part), NQ, NG, nsplit);
+}

--- a/comfy_kitchen/backends/hip/sage_attention/sol_attn_vtranspose.hip
+++ b/comfy_kitchen/backends/hip/sage_attention/sol_attn_vtranspose.hip
@@ -21,7 +21,8 @@ constexpr int kLdsPad = HD + 16;  // must be a multiple of 16: phase 1 writes 16
 template <int TT, typename E>
 __global__ __launch_bounds__(kThreads) void vquant_transpose(const E* __restrict__ v,
                                                              const float* __restrict__ vsc,
-                                                             int8_t* __restrict__ vT, int T,
+                                                             int8_t* __restrict__ vT,
+                                                             int8_t* __restrict__ vRow, int T,
                                                              int Tp, int H, int64_t sb, int64_t st,
                                                              int64_t sh) {
     __shared__ __attribute__((aligned(16))) int8_t sV[TT * kLdsPad];
@@ -42,6 +43,11 @@ __global__ __launch_bounds__(kThreads) void vquant_transpose(const E* __restrict
         } else {
 #pragma unroll
             for (int j = 0; j < 16; ++j) out[j] = 0;
+        }
+        // row-major copy for the gathered token tiles (token routing)
+        if (vRow && t0 + t < Tp) {
+            *reinterpret_cast<uint4*>(vRow + (static_cast<int64_t>(bh) * Tp + t0 + t) * HD + c16) =
+                *reinterpret_cast<uint4*>(out);
         }
         *reinterpret_cast<uint4*>(sV + t * kLdsPad + c16) = *reinterpret_cast<uint4*>(out);
     }
@@ -78,16 +84,17 @@ __global__ __launch_bounds__(kThreads) void vquant_transpose(const E* __restrict
 
 using namespace comfy::hip_backend::sol;
 
-void launch_sol_vtranspose(const void* v, const void* vsc, void* vT, int B, int T, int Tp, int H,
-                           int64_t sb, int64_t st, int64_t sh, int elem, hipStream_t stream) {
+void launch_sol_vtranspose(const void* v, const void* vsc, void* vT, void* vRow, int B, int T,
+                           int Tp, int H, int64_t sb, int64_t st, int64_t sh, int elem,
+                           hipStream_t stream) {
     dim3 grid((T + 255) / 256, B * H);
     if (elem == kSolFp16) {
         vquant_transpose<256, _Float16><<<grid, kThreads, 0, stream>>>(
             static_cast<const _Float16*>(v), static_cast<const float*>(vsc),
-            static_cast<int8_t*>(vT), T, Tp, H, sb, st, sh);
+            static_cast<int8_t*>(vT), static_cast<int8_t*>(vRow), T, Tp, H, sb, st, sh);
     } else {
         vquant_transpose<256, __bf16><<<grid, kThreads, 0, stream>>>(
             static_cast<const __bf16*>(v), static_cast<const float*>(vsc),
-            static_cast<int8_t*>(vT), T, Tp, H, sb, st, sh);
+            static_cast<int8_t*>(vT), static_cast<int8_t*>(vRow), T, Tp, H, sb, st, sh);
     }
 }

--- a/comfy_kitchen/backends/hip/sage_attention/sol_common.h
+++ b/comfy_kitchen/backends/hip/sage_attention/sol_common.h
@@ -41,6 +41,18 @@ constexpr int kBlock = 64;     // Sol-Attn's routing granularity, in tokens
 // sol::NEG, so both backends drop the same blocks.
 constexpr float kNeg = -3.0e38f;
 
+// Scores at or below this are masked. kNeg lands here, and so does any score a
+// dead key produces (a zero scale and a kNeg bias). Same value as the CUDA
+// sol::TILE_MASKED.
+constexpr float kTileMasked = -1.0e37f;
+
+// Token routing, all mirroring the CUDA sol:: constants of the same name: the
+// largest token budget, the histogram bins one centroid scores into, and the
+// query blocks that share a centroid.
+constexpr int kNTokMax = 256;
+constexpr int kTokHistBins = 128;
+constexpr int kTokGroup = 2;
+
 // 16-bit row stride of a staged tile; keeps the 16-byte stores aligned.
 constexpr int kLdTile = kHeadDim + 8;
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,7 +103,7 @@ def get_capable_backends(func_name: str, device: str | None = None) -> list[str]
     capable = []
     backends = ck.list_backends()
 
-    for backend_name in ["cuda", "triton", "eager"]:
+    for backend_name in ["cuda", "hip", "triton", "eager"]:
         if not backends.get(backend_name, {}).get("available", False):
             continue
 
@@ -125,7 +125,7 @@ def get_supported_devices(func_name: str) -> set[str]:
     devices = set()
     backends = ck.list_backends()
 
-    for backend_name in ["cuda", "triton", "eager"]:
+    for backend_name in ["cuda", "hip", "triton", "eager"]:
         if not backends.get(backend_name, {}).get("available", False):
             continue
 

--- a/tests/test_adaln.py
+++ b/tests/test_adaln.py
@@ -45,7 +45,7 @@ def _scale_shift(shape, dtype, device):
 # ---------------------------------------------------------------------------
 
 class TestAdaLN:
-    @pytest.mark.parametrize("backend", ["cuda", "triton", "eager"])
+    @pytest.mark.parametrize("backend", ["cuda", "hip", "triton", "eager"])
     @pytest.mark.parametrize("dtype", _DTYPES)
     @pytest.mark.parametrize("shape", _SHAPES)
     def test_forward(self, backend, dtype, shape, seed, cuda_available):
@@ -76,7 +76,7 @@ class TestAdaLN:
         assert_values_close(out.float(), ref.float(), rtol=rtol, atol=atol,
                             name=f"adaln[{backend}/{dtype}]")
 
-    @pytest.mark.parametrize("backend", ["cuda", "triton"])
+    @pytest.mark.parametrize("backend", ["cuda", "hip", "triton"])
     @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
     def test_vs_eager(self, backend, dtype, seed, cuda_available):
         """Non-eager backends must match the appropriate dtype reference."""
@@ -144,7 +144,7 @@ class TestAdaLN:
 
         assert_values_close(out, ref, rtol=1e-4, atol=1e-5, name="adaln[no-op scale/shift]")
 
-    @pytest.mark.parametrize("backend", ["cuda", "triton", "eager"])
+    @pytest.mark.parametrize("backend", ["cuda", "hip", "triton", "eager"])
     def test_contiguous_output(self, backend, cuda_available):
         """Output must always be contiguous."""
         device = "cuda" if cuda_available else "cpu"
@@ -162,7 +162,7 @@ class TestAdaLN:
 
 
 class TestRMSAdaLN:
-    @pytest.mark.parametrize("backend", ["cuda", "triton", "eager"])
+    @pytest.mark.parametrize("backend", ["cuda", "hip", "triton", "eager"])
     @pytest.mark.parametrize("dtype", _DTYPES)
     @pytest.mark.parametrize("shape", _SHAPES)
     def test_forward(self, backend, dtype, shape, seed, cuda_available):
@@ -193,7 +193,7 @@ class TestRMSAdaLN:
         assert_values_close(out.float(), ref.float(), rtol=rtol, atol=atol,
                             name=f"rms_adaln[{backend}/{dtype}]")
 
-    @pytest.mark.parametrize("backend", ["cuda", "triton", "eager"])
+    @pytest.mark.parametrize("backend", ["cuda", "hip", "triton", "eager"])
     @pytest.mark.parametrize("batch", [1, 2, 3])
     def test_per_sample_modulation_broadcast(self, backend, batch, seed, cuda_available):
         """scale/shift of shape (B, 1, D) must broadcast per sample, not per row.
@@ -219,7 +219,7 @@ class TestRMSAdaLN:
         assert_values_close(out, ref, rtol=1e-4, atol=1e-5,
                             name=f"rms_adaln[{backend}/per-sample B={batch}]")
 
-    @pytest.mark.parametrize("backend", ["cuda", "triton", "eager"])
+    @pytest.mark.parametrize("backend", ["cuda", "hip", "triton", "eager"])
     def test_per_token_modulation(self, backend, seed, cuda_available):
         """Fully materialized per-token scale/shift (no broadcast) must also work."""
         device = "cuda" if cuda_available else "cpu"
@@ -239,7 +239,7 @@ class TestRMSAdaLN:
         assert_values_close(out, ref, rtol=1e-4, atol=1e-5,
                             name=f"rms_adaln[{backend}/per-token]")
 
-    @pytest.mark.parametrize("backend", ["cuda", "triton", "eager"])
+    @pytest.mark.parametrize("backend", ["cuda", "hip", "triton", "eager"])
     @pytest.mark.parametrize("dim", [1, 31, 129, 4096])
     def test_odd_and_large_dims(self, backend, dim, seed, cuda_available):
         """Non-vectorizable and large hidden dims take the scalar tail / block loop."""
@@ -259,7 +259,7 @@ class TestRMSAdaLN:
         assert_values_close(out, ref, rtol=1e-4, atol=1e-5,
                             name=f"rms_adaln[{backend}/D={dim}]")
 
-    @pytest.mark.parametrize("backend", ["cuda", "triton", "eager"])
+    @pytest.mark.parametrize("backend", ["cuda", "hip", "triton", "eager"])
     @pytest.mark.parametrize("rows", [512, 2048])
     def test_warp_and_block_kernel_paths(self, backend, rows, seed, cuda_available):
         """The CUDA backend switches kernels at N == 1024; cover both sides."""
@@ -296,7 +296,7 @@ class TestRMSAdaLN:
         assert_values_close(rms_out, _ref_rms_adaln(x, scale, shift, 1e-6),
                             rtol=1e-4, atol=1e-5, name="rms_adaln[vs adaln]")
 
-    @pytest.mark.parametrize("backend", ["cuda", "triton", "eager"])
+    @pytest.mark.parametrize("backend", ["cuda", "hip", "triton", "eager"])
     def test_contiguous_output(self, backend, cuda_available):
         device = "cuda" if cuda_available else "cpu"
         capable = get_capable_backends("rms_adaln", device)

--- a/tests/test_hip_wmma.py
+++ b/tests/test_hip_wmma.py
@@ -1129,8 +1129,11 @@ def test_rms_adaln_is_not_adaln(hip):
 
 
 @pytest.mark.parametrize("split_half", [False, True])
-@pytest.mark.parametrize("freqs_dtype", [torch.float32, torch.bfloat16])
+@pytest.mark.parametrize("freqs_dtype", [torch.float32, torch.float16, torch.bfloat16])
 def test_rope_matches_eager(split_half, freqs_dtype):
+    """The kernel rotates in fp32 and rounds like eager, which evaluates in the
+    freqs dtype, so a narrow freqs dtype has to come out bit-identical. Loose
+    tolerances hid a folded round_fp16 that left the fp16 path a rounding short."""
     torch.manual_seed(0)
     batch, heads, seq, dim = 2, 8, 128, 64
     xq = torch.randn(batch, heads, seq, dim, device=DEV, dtype=torch.bfloat16)
@@ -1143,8 +1146,14 @@ def test_rope_matches_eager(split_half, freqs_dtype):
     with ck.use_backend("eager"):
         qr, kr = pair(xq, xk, freqs)
 
-    torch.testing.assert_close(q.float(), qr.float(), rtol=2e-2, atol=2e-2)
-    torch.testing.assert_close(k.float(), kr.float(), rtol=2e-2, atol=2e-2)
+    if freqs_dtype is torch.float32:
+        # -ffast-math contracts the split-half add into an fma, one rounding fewer
+        # than eager's separate products; immaterial at fp32 width
+        torch.testing.assert_close(q.float(), qr.float(), rtol=2e-2, atol=2e-2)
+        torch.testing.assert_close(k.float(), kr.float(), rtol=2e-2, atol=2e-2)
+    else:
+        assert torch.equal(q, qr)
+        assert torch.equal(k, kr)
 
 
 # (in-place name, functional sibling, takes a q/k pair, takes a norm weight)

--- a/tests/test_int8_input_act.py
+++ b/tests/test_int8_input_act.py
@@ -80,7 +80,7 @@ class TestInputActQuantizer:
 
 
 class TestInt8LinearInputAct:
-    @pytest.mark.parametrize("backend", ["cuda", "triton", "eager"])
+    @pytest.mark.parametrize("backend", ["cuda", "hip", "triton", "eager"])
     def test_matches_eager_activation(self, backend, seed, cuda_available):
         """int8_linear(x, input_act=a) == int8_linear(a(x)) on every backend."""
         device = "cuda" if cuda_available else "cpu"
@@ -218,7 +218,7 @@ class TestSwiGLUInputAct:
         assert fused_q.dtype == torch.int8
         assert fused_s.shape == (m, 1)
 
-    @pytest.mark.parametrize("backend", ["cuda", "triton", "eager"])
+    @pytest.mark.parametrize("backend", ["cuda", "hip", "triton", "eager"])
     def test_matches_eager_activation(self, backend, seed, cuda_available):
         """int8_linear(x, input_act="swiglu") == int8_linear(swiglu(x)) everywhere."""
         device = "cuda" if cuda_available else "cpu"

--- a/tests/test_rope.py
+++ b/tests/test_rope.py
@@ -28,7 +28,7 @@ def _reference_apply_rope(
 class TestApplyRope:
     """RoPE (Rotary Position Embedding) tests."""
     @pytest.mark.parametrize("op_name", ["apply_rope", "apply_rope1"])
-    @pytest.mark.parametrize("backend", ["cuda", "triton", "eager"])
+    @pytest.mark.parametrize("backend", ["cuda", "hip", "triton", "eager"])
     @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16], ids=["bf16", "fp16"])
     @pytest.mark.parametrize("freqs_dtype", [torch.float32, torch.float16, torch.bfloat16], ids=["freqs_fp32", "freqs_fp16", "freqs_bf16"])
     @pytest.mark.parametrize("config_name,layout,config", [
@@ -93,7 +93,7 @@ class TestApplyRopeSplitHalf:
     """Tests for apply_rope_split_half and apply_rope_split_half1."""
 
     @pytest.mark.parametrize("op_name", ["apply_rope_split_half", "apply_rope_split_half1"])
-    @pytest.mark.parametrize("backend", ["cuda", "triton", "eager"])
+    @pytest.mark.parametrize("backend", ["cuda", "hip", "triton", "eager"])
     @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16], ids=["bf16", "fp16"])
     @pytest.mark.parametrize("freqs_dtype", [torch.float32, torch.float16, torch.bfloat16], ids=["freqs_fp32", "freqs_fp16", "freqs_bf16"])
     @pytest.mark.parametrize("config_name,layout,config", [
@@ -159,7 +159,7 @@ def _max_mismatch(freqs_dtype, dtype):
     return 1e-5
 
 
-@pytest.mark.parametrize("backend", ["cuda", "triton", "eager"])
+@pytest.mark.parametrize("backend", ["cuda", "hip", "triton", "eager"])
 @pytest.mark.parametrize("split_half", [False, True])
 def test_apply_rope_broadcasts_single_frequency(backend, split_half, device):
     op_name = "apply_rope_split_half1" if split_half else "apply_rope1"
@@ -174,7 +174,7 @@ def test_apply_rope_broadcasts_single_frequency(backend, split_half, device):
     torch.testing.assert_close(actual, reference, rtol=1e-3, atol=1e-3)
 
 
-@pytest.mark.parametrize("backend", ["cuda", "triton", "eager"])
+@pytest.mark.parametrize("backend", ["cuda", "hip", "triton", "eager"])
 @pytest.mark.parametrize(
     "q_seq_len,k_seq_len",
     [(3, 3), (3, 5)],
@@ -201,7 +201,7 @@ def test_apply_rope_trims_excess_sequence_frequencies(
         torch.testing.assert_close(result, expected, rtol=1e-3, atol=1e-3)
 
 
-@pytest.mark.parametrize("backend", ["cuda", "triton", "eager"])
+@pytest.mark.parametrize("backend", ["cuda", "hip", "triton", "eager"])
 @pytest.mark.parametrize("split_half", [False, True])
 @pytest.mark.parametrize("last_dim_strided", [False, True])
 def test_apply_rope_strided_views(backend, split_half, last_dim_strided, device):
@@ -248,7 +248,7 @@ def test_apply_rope_triton_expanded_input(device):
         "apply_rope_split_half_",
     ],
 )
-@pytest.mark.parametrize("backend", ["cuda", "triton"])
+@pytest.mark.parametrize("backend", ["cuda", "hip", "triton"])
 @pytest.mark.parametrize("layout", ["BHND", "BNHD"])
 def test_apply_rope_gqa_different_qk_shapes(op_name, backend, layout, device):
     if backend not in get_capable_backends(op_name, device):
@@ -293,7 +293,7 @@ def test_apply_rope_gqa_different_qk_shapes(op_name, backend, layout, device):
         "apply_rope_split_half_",
     ],
 )
-@pytest.mark.parametrize("backend", ["cuda", "triton"])
+@pytest.mark.parametrize("backend", ["cuda", "hip", "triton"])
 def test_apply_rope_paired_different_strides(op_name, backend, device):
     if backend not in get_capable_backends(op_name, device):
         pytest.skip(f"{backend} does not support {op_name} on {device}")
@@ -330,7 +330,7 @@ def test_apply_rope_paired_different_strides(op_name, backend, device):
         "apply_rope_split_half1_",
     ],
 )
-@pytest.mark.parametrize("backend", ["cuda", "triton", "eager"])
+@pytest.mark.parametrize("backend", ["cuda", "hip", "triton", "eager"])
 def test_apply_rope_inplace_storage(op_name, backend, device):
     if backend not in get_capable_backends(op_name, device):
         pytest.skip(f"{backend} does not support {op_name} on {device}")
@@ -356,7 +356,7 @@ def test_apply_rope_inplace_storage(op_name, backend, device):
 
 
 @pytest.mark.parametrize("op_name", ["apply_rope1_", "rms_rope1_"])
-@pytest.mark.parametrize("backend", ["cuda", "triton", "eager"])
+@pytest.mark.parametrize("backend", ["cuda", "hip", "triton", "eager"])
 def test_inplace_backends_reject_autograd(op_name, backend, device):
     if backend not in get_capable_backends(op_name, device):
         pytest.skip(f"{backend} does not support {op_name} on {device}")

--- a/tests/test_sol_attn.py
+++ b/tests/test_sol_attn.py
@@ -467,10 +467,6 @@ def _token_routing_case(t=4096 + 5, h=8, seed=7):
     return tuple(x[None].to(torch.bfloat16) for x in (q, k, v))
 
 
-cuda_only = pytest.mark.skipif(backend is not cuda_backend, reason="token routing is a CUDA-backend stage")
-
-
-@cuda_only
 @pytest.mark.parametrize("mode", [{"tau": 1.4}, {"topk_ratio": 0.1}])
 def test_token_aug_improves_exactness(mode):
     """A larger token budget brings the output closer to dense and shrinks the DC bias."""
@@ -486,7 +482,6 @@ def test_token_aug_improves_exactness(mode):
     assert bias[256] < bias[0], bias
 
 
-@cuda_only
 def test_token_aug_is_deterministic():
     """Reruns and strided views are bit-identical."""
     q, k, v = _token_routing_case(seed=3)
@@ -497,7 +492,35 @@ def test_token_aug_is_deterministic():
     assert torch.equal(a, ck.sol_attn(qb, kb, vb, topk_ratio=0.1, token_aug=256))
 
 
-@cuda_only
+def test_token_aug_surplus_over_the_budget_stays_in_the_tail():
+    """A token the budget cannot list must stay pooled, not fall out of both branches.
+
+    Keys alternate +c*u / -c*u per block, so each block mean is zero and the pooled
+    score routing sees is ~0, while every token scores +-c^2*scale*log2e. That puts
+    half of every unrouted block into the clamped top histogram bin, whose count the
+    threshold walk cannot bound, so the reservation runs past n_tok (measured: 1952
+    reserved against 256). Dropping the surplus from the tail as well as the list
+    loses its mass and costs an order of magnitude of accuracy.
+    """
+    t, h, c = 4096, 2, 30.0
+    g = torch.Generator(device="cuda").manual_seed(0)
+    u = torch.randn(h, HD, device="cuda", generator=g)
+    u = u / u.norm(dim=-1, keepdim=True)
+    sign = torch.where(torch.arange(t, device="cuda") % 2 == 0, 1.0, -1.0)
+    q = (c * u)[None].expand(t, h, HD)
+    k = (c * u)[None] * sign[:, None, None]
+    v = torch.randn(t, h, HD, device="cuda", generator=g)
+    q, k, v = (x[None].to(torch.bfloat16).contiguous() for x in (q, k, v))
+
+    ref = _dense(q, k, v)
+    aug = ck.sol_attn(q, k, v, tau=4.0, token_aug=256)
+    assert torch.isfinite(aug.float()).all()
+    # measured: 4.64 for the pooled tail alone, 2.20 when the surplus is dropped,
+    # 0.13 when it is kept, so the cut sits an order of magnitude either side
+    no_aug = _rel(ck.sol_attn(q, k, v, tau=4.0), ref)
+    assert _rel(aug, ref) < 0.15 * no_aug, (_rel(aug, ref), no_aug)
+
+
 def test_token_aug_chunked_matches_direct():
     """The chunked path runs the same token stage."""
     c = _chunked_case(seed=13, rot=96, v_scale=0.02)
@@ -511,7 +534,6 @@ def test_token_aug_chunked_matches_direct():
     assert _rel(out, _dense(c["q"], c["k"], c["v"])) < _rel(plain, _dense(c["q"], c["k"], c["v"]))
 
 
-@cuda_only
 def test_token_aug_validation_and_no_tail():
     """Bad budgets are rejected; identical keys admit nothing (one score bin, over budget);
     dense rows are untouched; the stage works without the tail and with a budget that is


### PR DESCRIPTION
Ports token routing from #156 to HIP, making `token_aug` work on RDNA instead of warning and running without it.

- Adds `sage_attention/sol_attn_token.hip` with the five CUDA-equivalent kernels: centroids, tile list, two scoring passes, sort, and merge.
- `route` now outputs the unrouted-block bitmap and best unrouted score.
- `vtranspose` and the chunked producer write the row-major int8 V copy consumed by gathered token tiles.
- The exact kernel walks each group's token list after routed blocks.
- HIP workspace slots now match `sol_attn.cu`, so Python uses one plan for both backends.

This is a correctness port. RDNA WMMA already exposes a contiguous K slice, so token IDs index `ki` / `ksb` / `vRow` directly without CUDA's `sol::perm_key` permutation.

On a routing-adversarial synthetic case (T=16384, H=8, bf16), `token_aug=256` improves dense-attention relative error from 0.648 -> 0.132 and DC bias from 0.165 -> 0.014, at 7.1 -> 8.1 ms. The selected tokens were independently re-derived from workspace centroid scores and verified sorted, within budget, candidate-only, and correctly cut at the histogram boundary.

The second commit fixes HIP `round_fp16` under `-ffast-math`. Clang was folding the float -> half -> float round away, causing `apply_rope` to differ from eager by up to 9% of elements. Two inline-asm conversions restore exact rounding; fp16-freq cases are now bit-identical. The 2x24x4096x128 case goes 865 -> 1024 us; fp32/bf16 paths are unchanged and VGPR use drops by one. `test_hip_wmma.py::test_rope_matches_eager` now covers fp16 freqs and checks bit identity.

The third commit enables HIP in the test backend/device lists. This activates ~130 additional cases across AdaLN, RMS AdaLN, NA3D, FP8 quantization, int8 activations, and RoPE. All pass; non-HIP machines simply skip them.

`test_rms_rope.py` remains unchanged because its existing tolerance bands are already exceeded by eager on some seeds, while HIP tracks eager within 0.001 percentage points. Coverage remains in `test_hip_wmma.py`.

Suite result: 1483 passing vs 1349 before, with failures unchanged at 101 and none in HIP paths. Compile-verified on gfx1100/gfx1200 with no scratch spills; run-verified on gfx1200. All five `token_aug` tests in `tests/test_sol_attn.py` now run and pass.