### PR TITLE
Remove the torch._dynamo import, dead since #3 removed its only user

### DIFF
--- a/comfy_kitchen/tensor/base.py
+++ b/comfy_kitchen/tensor/base.py
@@ -10,7 +10,6 @@ from functools import lru_cache
 from typing import Any
 
 import torch
-import torch._dynamo
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
    $ grep -rn "torch\._dynamo" comfy_kitchen/ tests/
    comfy_kitchen/tensor/base.py:13:import torch._dynamo

That is the only reference left in the package. The `@torch._dynamo.disable()`
decorator that needed it went away in #3 (06651e3).

`_dynamo` is in torch's `_lazy_modules`, so `torch.compile` and the
`torch._disable_dynamo` wrapper still import it themselves on first use, and compiled
and exported results are bit identical with and without the line on torch 2.8 and
2.11. Dropping it takes `import comfy_kitchen` from 1981 loaded modules to 1179 on
torch 2.8, for every process that imports the package without running a kernel.

`ruff check .` clean. `pytest tests/` on CPU: 616 passed, same single pre-existing
torch 2.8 failure as unmodified main.
